### PR TITLE
fix(tests): Remove unnecessary skip decorators from 29 tests

### DIFF
--- a/tests/agents/test_subagent_generator.py
+++ b/tests/agents/test_subagent_generator.py
@@ -539,10 +539,8 @@ class TestIntegration:
     """Integration tests using real definition files."""
 
     def test_with_real_definitions_dir(self, temp_output_dir):
-        """Test with actual CodeFRAME definitions directory if it exists."""
+        """Test with actual CodeFRAME definitions directory."""
         real_definitions = Path("codeframe/agents/definitions")
-        if not real_definitions.exists():
-            pytest.skip("Real definitions directory not found")
 
         generator = SubagentGenerator(
             definitions_dir=real_definitions,

--- a/tests/enforcement/test_quality_ratchet.py
+++ b/tests/enforcement/test_quality_ratchet.py
@@ -25,18 +25,15 @@ import pytest
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 script_path = scripts_dir / "quality-ratchet.py"
 
-try:
-    spec = importlib.util.spec_from_file_location("quality_ratchet", script_path)
-    quality_ratchet = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(quality_ratchet)
+spec = importlib.util.spec_from_file_location("quality_ratchet", script_path)
+quality_ratchet = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(quality_ratchet)
 
-    load_history = quality_ratchet.load_history
-    save_history = quality_ratchet.save_history
-    detect_degradation = quality_ratchet.detect_degradation
-    calculate_moving_average = quality_ratchet.calculate_moving_average
-    find_peak_quality = quality_ratchet.find_peak_quality
-except Exception as e:
-    pytest.skip(f"Quality ratchet not implemented yet: {e}", allow_module_level=True)
+load_history = quality_ratchet.load_history
+save_history = quality_ratchet.save_history
+detect_degradation = quality_ratchet.detect_degradation
+calculate_moving_average = quality_ratchet.calculate_moving_average
+find_peak_quality = quality_ratchet.find_peak_quality
 
 
 class TestQualityRatchetRecord:

--- a/tests/enforcement/test_skip_detector.py
+++ b/tests/enforcement/test_skip_detector.py
@@ -28,17 +28,14 @@ import importlib.util
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 script_path = scripts_dir / "detect-skip-abuse.py"
 
-try:
-    spec = importlib.util.spec_from_file_location("detect_skip_abuse", script_path)
-    detect_skip_abuse = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(detect_skip_abuse)
+spec = importlib.util.spec_from_file_location("detect_skip_abuse", script_path)
+detect_skip_abuse = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(detect_skip_abuse)
 
-    SkipDetectorVisitor = detect_skip_abuse.SkipDetectorVisitor
-    check_file = detect_skip_abuse.check_file
-    is_test_file = detect_skip_abuse.is_test_file
-    format_violation = detect_skip_abuse.format_violation
-except Exception as e:
-    pytest.skip(f"Skip detector not implemented yet: {e}", allow_module_level=True)
+SkipDetectorVisitor = detect_skip_abuse.SkipDetectorVisitor
+check_file = detect_skip_abuse.check_file
+is_test_file = detect_skip_abuse.is_test_file
+format_violation = detect_skip_abuse.format_violation
 
 
 class TestSkipDetection:


### PR DESCRIPTION
## Summary

Reviewed all skipped tests in the codebase and removed skip decorators where functionality now exists. This enables 29 previously skipped tests to run.

## Changes

### Tests Re-enabled (29 total)

1. **test_quality_ratchet.py** (14 tests)
   - Removed defensive module-level skip
   - Script `scripts/quality-ratchet.py` exists and works

2. **test_skip_detector.py** (14 tests)
   - Removed defensive module-level skip
   - Script `scripts/detect-skip-abuse.py` exists and works

3. **test_subagent_generator.py** (1 test)
   - Removed directory existence check
   - Directory `codeframe/agents/definitions` exists

### All Tests Pass ✅

```bash
pytest tests/enforcement/test_quality_ratchet.py   # 14/14 passed
pytest tests/enforcement/test_skip_detector.py      # 14/14 passed
pytest tests/agents/test_subagent_generator.py      # 1/1 passed
```

## Remaining Skipped Tests

Created GitHub issues for genuinely missing features:

- **Backend**: #40 (database error test redesign needed)
- **Frontend**: #41 (SWR timing issues), #42 (task dependencies)
- **E2E**: #43-47 (UI features not yet implemented)

## Testing

- ✅ All modified tests pass individually
- ✅ All modified tests pass in full suite
- ✅ No regressions in existing tests

## Related Issues

Closes none (this enables tests; issues #40-47 track remaining work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite initialization to remove conditional skip guards, ensuring tests now execute consistently without runtime dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->