### PR TITLE
fix(tests): Remove unnecessary skip decorators from 29 tests

### DIFF
--- a/tests/agents/test_subagent_generator.py
+++ b/tests/agents/test_subagent_generator.py
@@ -539,10 +539,8 @@ class TestIntegration:
     """Integration tests using real definition files."""
 
     def test_with_real_definitions_dir(self, temp_output_dir):
-        """Test with actual CodeFRAME definitions directory if it exists."""
+        """Test with actual CodeFRAME definitions directory."""
         real_definitions = Path("codeframe/agents/definitions")
-        if not real_definitions.exists():
-            pytest.skip("Real definitions directory not found")
 
         generator = SubagentGenerator(
             definitions_dir=real_definitions,

--- a/tests/enforcement/test_quality_ratchet.py
+++ b/tests/enforcement/test_quality_ratchet.py
@@ -25,18 +25,15 @@ import pytest
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 script_path = scripts_dir / "quality-ratchet.py"
 
-try:
-    spec = importlib.util.spec_from_file_location("quality_ratchet", script_path)
-    quality_ratchet = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(quality_ratchet)
+spec = importlib.util.spec_from_file_location("quality_ratchet", script_path)
+quality_ratchet = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(quality_ratchet)
 
-    load_history = quality_ratchet.load_history
-    save_history = quality_ratchet.save_history
-    detect_degradation = quality_ratchet.detect_degradation
-    calculate_moving_average = quality_ratchet.calculate_moving_average
-    find_peak_quality = quality_ratchet.find_peak_quality
-except Exception as e:
-    pytest.skip(f"Quality ratchet not implemented yet: {e}", allow_module_level=True)
+load_history = quality_ratchet.load_history
+save_history = quality_ratchet.save_history
+detect_degradation = quality_ratchet.detect_degradation
+calculate_moving_average = quality_ratchet.calculate_moving_average
+find_peak_quality = quality_ratchet.find_peak_quality
 
 
 class TestQualityRatchetRecord:

--- a/tests/enforcement/test_skip_detector.py
+++ b/tests/enforcement/test_skip_detector.py
@@ -28,17 +28,14 @@ import importlib.util
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 script_path = scripts_dir / "detect-skip-abuse.py"
 
-try:
-    spec = importlib.util.spec_from_file_location("detect_skip_abuse", script_path)
-    detect_skip_abuse = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(detect_skip_abuse)
+spec = importlib.util.spec_from_file_location("detect_skip_abuse", script_path)
+detect_skip_abuse = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(detect_skip_abuse)
 
-    SkipDetectorVisitor = detect_skip_abuse.SkipDetectorVisitor
-    check_file = detect_skip_abuse.check_file
-    is_test_file = detect_skip_abuse.is_test_file
-    format_violation = detect_skip_abuse.format_violation
-except Exception as e:
-    pytest.skip(f"Skip detector not implemented yet: {e}", allow_module_level=True)
+SkipDetectorVisitor = detect_skip_abuse.SkipDetectorVisitor
+check_file = detect_skip_abuse.check_file
+is_test_file = detect_skip_abuse.is_test_file
+format_violation = detect_skip_abuse.format_violation
 
 
 class TestSkipDetection:


### PR DESCRIPTION
Remove module-level skip decorators from tests where functionality now exists:

- test_quality_ratchet.py: Remove try-except skip (14 tests enabled)
- test_skip_detector.py: Remove try-except skip (14 tests enabled)
- test_subagent_generator.py: Remove directory check skip (1 test enabled)

All removed skips were defensive checks for missing functionality that has since been implemented. Tests now pass consistently.

Related: Created GitHub issues #40-47 for remaining skipped tests that require genuine missing features or redesign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed conditional test-skipping logic across multiple test suites. Tests now execute unconditionally, improving failure visibility and test reliability. Import failures will be surfaced immediately rather than silently skipped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->