### PR TITLE
fix(e2e): E2E test database isolation - Fixes #89

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import * as path from 'path';
 
 /**
  * Playwright configuration for E2E tests.
@@ -85,7 +86,7 @@ export default defineConfig({
     : [
         // Backend FastAPI server
         {
-          command: 'cd ../.. && uv run uvicorn codeframe.ui.server:app --port 8080',
+          command: `cd ../.. && DATABASE_PATH=${path.join(__dirname, '.codeframe', 'state.db')} uv run uvicorn codeframe.ui.server:app --port 8080`,
           url: 'http://localhost:8080/health',
           reuseExistingServer: !process.env.CI,
           timeout: 120000,


### PR DESCRIPTION
## Summary
Fixed E2E test database isolation by configuring backend to use test database instead of production database during Playwright test runs.

## Root Cause
E2E tests were seeding data to test DB but backend server was using production DB, causing checkpoint creation tests to fail with project_id mismatch.

## Fix
Set `DATABASE_PATH` environment variable in `playwright.config.ts` to point backend at test database using absolute path.

## Test Results
- 157/190 tests passing (83%)
- Checkpoint database bug resolved
- Remaining failures are UI issues tracked in #84-#88

## Review
Code review approved - see `docs/code-review/2025-12-12-issue-89-database-path-fix.md`

Fixes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to improve backend server initialization with proper database resource setup during end-to-end testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->