### PR TITLE
Fix discovery questions repeating in staging

### DIFF
--- a/codeframe/agents/lead_agent.py
+++ b/codeframe/agents/lead_agent.py
@@ -554,6 +554,9 @@ Keep your question concise and conversational. Don't number it or add preamble -
 
         if next_question:
             self._current_question_id = next_question["id"]
+            # CRITICAL: Update the question text to the next question's text
+            # Without this, the old AI-generated question text would be displayed
+            self._current_question_text = next_question["text"]
             self._save_discovery_state()
             return next_question["text"]
         else:


### PR DESCRIPTION
The discovery flow was showing the same question 5 times because _current_question_text was not updated in process_discovery_answer() when transitioning from one question to the next.

Root cause: After processing an answer, only _current_question_id was updated to the next question's ID, but _current_question_text retained the old AI-generated question text. When get_discovery_status() was called, it would override the framework question's text with the stale _current_question_text value.

Fix: In process_discovery_answer(), also update _current_question_text to the next question's text when advancing to the next question.

Added 5 new integration tests to prevent regression:
- test_question_text_changes_after_each_answer
- test_question_id_and_text_match_after_answer
- test_all_framework_questions_shown_in_order
- test_question_text_persists_across_agent_restart
- test_no_duplicate_questions_full_discovery_flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where discovery question text could mismatch with the displayed question during progression through the discovery flow, ensuring correct text is shown consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->