### PR TITLE
feat(agents): broadcast agent status changes via WebSocket

### DIFF
--- a/codeframe/ui/websocket_broadcasts.py
+++ b/codeframe/ui/websocket_broadcasts.py
@@ -81,6 +81,7 @@ async def broadcast_agent_status(
     current_task_id: Optional[int] = None,
     current_task_title: Optional[str] = None,
     progress: Optional[int] = None,
+    tasks_completed: Optional[int] = None,
 ) -> None:
     """
     Broadcast agent status change to connected clients.
@@ -93,6 +94,7 @@ async def broadcast_agent_status(
         current_task_id: Optional ID of current task
         current_task_title: Optional title of current task
         progress: Optional progress percentage (0-100)
+        tasks_completed: Optional count of tasks completed by this agent
     """
     message = {
         "type": "agent_status_changed",
@@ -110,6 +112,9 @@ async def broadcast_agent_status(
 
     if progress is not None:
         message["progress"] = progress
+
+    if tasks_completed is not None:
+        message["tasks_completed"] = tasks_completed
 
     try:
         await manager.broadcast(message, project_id=project_id)

--- a/tests/agents/test_agent_pool_manager.py
+++ b/tests/agents/test_agent_pool_manager.py
@@ -541,4 +541,4 @@ class TestAgentStatusBroadcasting:
         # Get the last idle broadcast
         last_call = mock_broadcast.call_args_list[-1]
         assert last_call.kwargs["status"] == "idle"
-        # Note: tasks_completed may be in progress field or metadata
+        assert last_call.kwargs["tasks_completed"] == 3


### PR DESCRIPTION
## Summary

- Add real-time agent status broadcasting when agents transition between states (idle → working → blocked → idle)
- Connect `AgentPoolManager` status methods to the existing `broadcast_agent_status` function
- Enable real-time UI updates for agent activity without additional frontend changes

## Changes

- Import `broadcast_agent_status` in `agent_pool_manager.py`
- Extend `_broadcast_async()` to handle `agent_status_changed` events
- Add broadcasts in `mark_agent_busy()` with `status="working"`
- Add broadcasts in `mark_agent_idle()` with `status="idle"`
- Add broadcasts in `mark_agent_blocked()` with `status="blocked"`
- Add 5 unit tests for broadcasting behavior

## Test plan

- [x] All 34 agent_pool_manager tests pass
- [x] All 385 agent tests pass
- [x] All 66 WebSocket broadcast tests pass
- [x] Ruff linting passes
- [ ] Manual verification: Start agent, observe real-time status updates in UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent status updates now broadcast in real-time with richer payloads: status (working/idle/blocked), current task info, and optional tasks_completed counts.
* **Tests**
  * Added comprehensive tests verifying status broadcasts across state transitions and that broadcasts are omitted without a WebSocket manager.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->