### PR TITLE
feat(api): add token usage timeseries endpoint for metrics charting

### DIFF
--- a/codeframe/ui/routers/metrics.py
+++ b/codeframe/ui/routers/metrics.py
@@ -10,7 +10,7 @@ Endpoints:
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -156,10 +156,8 @@ def _parse_date(date_str: str) -> datetime:
 
     # Try date-only format (yyyy-MM-dd)
     try:
-        from datetime import timezone as tz
-
         parsed = datetime.strptime(date_str, "%Y-%m-%d")
-        return parsed.replace(tzinfo=tz.utc)
+        return parsed.replace(tzinfo=timezone.utc)
     except ValueError:
         raise ValueError(
             f"Invalid date format: '{date_str}'. "

--- a/tests/api/test_api_metrics.py
+++ b/tests/api/test_api_metrics.py
@@ -536,6 +536,42 @@ class TestProjectTokenTimeSeriesEndpoint:
 
         assert response.status_code == 200
 
+    def test_invalid_month_returns_400(self, api_client, project_with_token_usage):
+        """Test that invalid month (13) returns 400 Bad Request."""
+        project_id, _ = project_with_token_usage
+
+        response = api_client.get(
+            f"/api/projects/{project_id}/metrics/tokens/timeseries"
+            f"?start_date=2025-13-01&end_date=2025-01-07"
+        )
+
+        assert response.status_code == 400
+        assert "Invalid date format" in response.json()["detail"]
+
+    def test_invalid_day_returns_400(self, api_client, project_with_token_usage):
+        """Test that invalid day (32) returns 400 Bad Request."""
+        project_id, _ = project_with_token_usage
+
+        response = api_client.get(
+            f"/api/projects/{project_id}/metrics/tokens/timeseries"
+            f"?start_date=2025-01-32&end_date=2025-01-07"
+        )
+
+        assert response.status_code == 400
+        assert "Invalid date format" in response.json()["detail"]
+
+    def test_malformed_date_returns_400(self, api_client, project_with_token_usage):
+        """Test that malformed date string returns 400 Bad Request."""
+        project_id, _ = project_with_token_usage
+
+        response = api_client.get(
+            f"/api/projects/{project_id}/metrics/tokens/timeseries"
+            f"?start_date=not-a-date&end_date=2025-01-07"
+        )
+
+        assert response.status_code == 400
+        assert "Invalid date format" in response.json()["detail"]
+
 
 class TestProjectCostMetricsDateFiltering:
     """Test date filtering on GET /api/projects/{id}/metrics/costs endpoint."""


### PR DESCRIPTION
## Summary
- Add new `/api/projects/{id}/metrics/tokens/timeseries` endpoint that returns token usage data aggregated by time intervals (hour, day, week) for visualization in CostDashboard charts
- Add date filtering support to existing `/metrics/costs` endpoint for consistency
- Add flexible date parsing that accepts both ISO 8601 (`2026-01-01T00:00:00Z`) and simple date (`2026-01-01`) formats for frontend compatibility

## Problem
The frontend `CostDashboard` component calls a non-existent `/api/projects/{project_id}/metrics/tokens/timeseries` endpoint when users select date range filters (last-7-days or last-30-days), causing 404 errors and breaking the date filtering functionality.

## Solution
Implemented the missing endpoint leveraging the existing `TokenRepository.get_token_usage()` method with date filters, then grouping results by timestamp intervals.

## Changes
| File | Changes |
|------|---------|
| `codeframe/lib/metrics_tracker.py` | Added `get_token_usage_timeseries()` method and `_get_bucket_key()` helper; updated `get_project_costs()` to accept date params |
| `codeframe/ui/routers/metrics.py` | Added `/tokens/timeseries` endpoint and `_parse_date()` helper; added date filtering to costs endpoint |
| `tests/api/test_api_metrics.py` | Added 13 new TDD tests for timeseries and costs date filtering |

## Test plan
- [x] Run `uv run pytest tests/api/test_api_metrics.py` - 27 tests pass
- [x] Run `uv run pytest tests/api/` - 209 tests pass (no regressions)
- [x] Run `uv run ruff check` - All checks passed
- [x] Run `uv run mypy` - No issues found
- [ ] Manual test: Select "Last 7 days" filter in CostDashboard and verify chart renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage time-series endpoint with hourly, daily, and weekly aggregation
  * Date-range filtering for project cost metrics queries

* **Improvements**
  * Date parsing/validation for ISO 8601 and date-only inputs; clear 400 responses for invalid/missing dates
  * Interval validation with proper error handling

* **Tests**
  * Comprehensive tests for timeseries endpoint and date-filtered cost metrics (intervals, formats, edge cases)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->