### PR TITLE
fix(e2e): add race condition guards to checkpoint UI tests

### DIFF
--- a/tests/e2e/test_checkpoint_ui.spec.ts
+++ b/tests/e2e/test_checkpoint_ui.spec.ts
@@ -280,6 +280,9 @@ test.describe('Checkpoint UI Workflow', () => {
     const checkpointItems = page.locator('[data-testid^="checkpoint-item-"]');
     const emptyState = page.locator('[data-testid="checkpoint-empty-state"]');
 
+    // Wait for either checkpoint items OR empty state to be visible (prevents race condition)
+    await expect(checkpointItems.first().or(emptyState)).toBeVisible({ timeout: TIMEOUTS.DOM_UPDATE });
+
     const count = await checkpointItems.count();
 
     if (count > 0) {
@@ -309,6 +312,9 @@ test.describe('Checkpoint UI Workflow', () => {
   test('should display checkpoint diff preview', async ({ page }) => {
     const checkpointItems = page.locator('[data-testid^="checkpoint-item-"]');
     const emptyState = page.locator('[data-testid="checkpoint-empty-state"]');
+
+    // Wait for either checkpoint items OR empty state to be visible (prevents race condition)
+    await expect(checkpointItems.first().or(emptyState)).toBeVisible({ timeout: TIMEOUTS.DOM_UPDATE });
 
     const count = await checkpointItems.count();
 
@@ -352,6 +358,9 @@ test.describe('Checkpoint UI Workflow', () => {
     const checkpointItems = page.locator('[data-testid^="checkpoint-item-"]');
     const emptyState = page.locator('[data-testid="checkpoint-empty-state"]');
 
+    // Wait for either checkpoint items OR empty state to be visible (prevents race condition)
+    await expect(checkpointItems.first().or(emptyState)).toBeVisible({ timeout: TIMEOUTS.DOM_UPDATE });
+
     const count = await checkpointItems.count();
 
     if (count > 0) {
@@ -378,6 +387,9 @@ test.describe('Checkpoint UI Workflow', () => {
   test('should allow deleting checkpoint', async ({ page }) => {
     const checkpointItems = page.locator('[data-testid^="checkpoint-item-"]');
     const emptyState = page.locator('[data-testid="checkpoint-empty-state"]');
+
+    // Wait for either checkpoint items OR empty state to be visible (prevents race condition)
+    await expect(checkpointItems.first().or(emptyState)).toBeVisible({ timeout: TIMEOUTS.DOM_UPDATE });
 
     const count = await checkpointItems.count();
 


### PR DESCRIPTION
## Summary
- Fix race condition in 4 checkpoint UI tests where `count()` was called before React rendered
- Tests now wait for checkpoint items OR empty state to be visible before checking count
- Improves test reliability from intermittent failures to consistent passes

## Changes
Added `await expect(checkpointItems.first().or(emptyState)).toBeVisible()` before `count()` calls in:
- `should show restore confirmation dialog`
- `should display checkpoint diff preview`
- `should display checkpoint metadata`
- `should allow deleting checkpoint`

## Test Results
| Browser | Before | After |
|---------|--------|-------|
| Chromium | 9/10 | 10/10 ✅ |
| Firefox | 9/10 | 10/10 ✅ |
| WebKit | 8/10 | 9/10 |
| Mobile Safari | 8/10 | 9/10 |
| **Total** | 34/40 | **48/50** |

Remaining 2 failures are WebKit login timeouts tracked in #230 (not checkpoint-specific).

## Test plan
- [x] Run `npx playwright test test_checkpoint_ui.spec.ts --project=chromium` - 10/10 pass
- [x] Run full test suite - 48/50 pass (96%)
- [x] Verify remaining failures are WebKit login issues (#230), not checkpoint bugs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and stability by adding synchronization mechanisms to checkpoint UI tests, preventing potential race conditions during automated testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->