### PR TITLE
fix(ui): keep filter buttons visible when BlockerPanel filter returns empty results

### DIFF
--- a/web-ui/__tests__/components/BlockerPanel.test.tsx
+++ b/web-ui/__tests__/components/BlockerPanel.test.tsx
@@ -311,6 +311,114 @@ describe('BlockerPanel', () => {
     });
   });
 
+  describe('type filtering', () => {
+    it('keeps filter buttons visible when ASYNC filter returns 0 results', () => {
+      // Render with only SYNC blockers
+      render(<BlockerPanel blockers={[mockSyncBlocker]} />);
+
+      // Click ASYNC filter
+      fireEvent.click(screen.getByRole('button', { name: 'ASYNC' }));
+
+      // All three filter buttons should still be visible
+      expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'SYNC' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ASYNC' })).toBeInTheDocument();
+
+      // Count should show 0
+      expect(screen.getByText('(0)')).toBeInTheDocument();
+
+      // Empty message should be displayed
+      expect(screen.getByText('No ASYNC blockers found')).toBeInTheDocument();
+      expect(screen.getByText('Try selecting a different filter')).toBeInTheDocument();
+    });
+
+    it('keeps filter buttons visible when SYNC filter returns 0 results', () => {
+      // Render with only ASYNC blockers
+      render(<BlockerPanel blockers={[mockAsyncBlocker]} />);
+
+      // Click SYNC filter
+      fireEvent.click(screen.getByRole('button', { name: 'SYNC' }));
+
+      // All three filter buttons should still be visible
+      expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'SYNC' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ASYNC' })).toBeInTheDocument();
+
+      // Count should show 0
+      expect(screen.getByText('(0)')).toBeInTheDocument();
+
+      // Empty message should be displayed
+      expect(screen.getByText('No SYNC blockers found')).toBeInTheDocument();
+    });
+
+    it('allows switching back to ALL filter after seeing empty filtered results', () => {
+      // Render with only SYNC blockers
+      render(<BlockerPanel blockers={[mockSyncBlocker]} />);
+
+      // Click ASYNC filter (should show 0 results)
+      fireEvent.click(screen.getByRole('button', { name: 'ASYNC' }));
+      expect(screen.getByText('(0)')).toBeInTheDocument();
+
+      // Click ALL filter
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+
+      // SYNC blocker should now be visible
+      expect(screen.getByText(mockSyncBlocker.question)).toBeInTheDocument();
+
+      // Count should show 1
+      expect(screen.getByText('(1)')).toBeInTheDocument();
+    });
+
+    it('shows empty state without buttons only when truly no pending blockers', () => {
+      // Render with only resolved/expired blockers
+      render(<BlockerPanel blockers={[mockResolvedBlocker, mockExpiredBlocker]} />);
+
+      // Empty state message should be shown
+      expect(screen.getByText('No blockers - agents are running smoothly!')).toBeInTheDocument();
+
+      // Filter buttons should NOT be present
+      expect(screen.queryByRole('button', { name: 'All' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'SYNC' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'ASYNC' })).not.toBeInTheDocument();
+    });
+
+    it('shows empty state without buttons when blockers array is empty', () => {
+      render(<BlockerPanel blockers={mockEmptyBlockersList} />);
+
+      // Empty state message should be shown
+      expect(screen.getByText('No blockers - agents are running smoothly!')).toBeInTheDocument();
+
+      // Filter buttons should NOT be present
+      expect(screen.queryByRole('button', { name: 'All' })).not.toBeInTheDocument();
+    });
+
+    it('switches between filter states correctly', () => {
+      // Render with both SYNC and ASYNC blockers
+      render(<BlockerPanel blockers={[mockSyncBlocker, mockAsyncBlocker]} />);
+
+      // Initially ALL filter, both visible
+      expect(screen.getByText('(2)')).toBeInTheDocument();
+      expect(screen.getByText(mockSyncBlocker.question)).toBeInTheDocument();
+      expect(screen.getByText(mockAsyncBlocker.question)).toBeInTheDocument();
+
+      // Click SYNC filter
+      fireEvent.click(screen.getByRole('button', { name: 'SYNC' }));
+      expect(screen.getByText('(1)')).toBeInTheDocument();
+      expect(screen.getByText(mockSyncBlocker.question)).toBeInTheDocument();
+      expect(screen.queryByText(mockAsyncBlocker.question)).not.toBeInTheDocument();
+
+      // Click ASYNC filter
+      fireEvent.click(screen.getByRole('button', { name: 'ASYNC' }));
+      expect(screen.getByText('(1)')).toBeInTheDocument();
+      expect(screen.queryByText(mockSyncBlocker.question)).not.toBeInTheDocument();
+      expect(screen.getByText(mockAsyncBlocker.question)).toBeInTheDocument();
+
+      // Click ALL filter again
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+      expect(screen.getByText('(2)')).toBeInTheDocument();
+    });
+  });
+
   describe('UI styling and structure', () => {
     it('applies hover styles to blocker buttons', () => {
       render(<BlockerPanel blockers={[mockSyncBlocker]} />);


### PR DESCRIPTION
## Summary

- **Bug**: Filter buttons (All/SYNC/ASYNC) disappeared when the selected type filter returned 0 results, leaving users unable to switch back to other filters
- **Root cause**: Early return at `BlockerPanel.tsx:68` checked `filteredBlockers.length === 0` after type filtering was applied, rendering empty state without buttons
- **Fix**: Separate rendering logic into three distinct states: truly empty, filtered empty (with buttons), and has results

## Changes

| File | Description |
|------|-------------|
| `web-ui/src/components/BlockerPanel.tsx` | Added `allPendingBlockers` memo, split conditional rendering into 3 states |
| `web-ui/__tests__/components/BlockerPanel.test.tsx` | Added 6 new tests in `type filtering` describe block |

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes with no warnings
- [x] All 43 BlockerPanel tests pass (37 existing + 6 new)
- [ ] Manual verification: Click ASYNC filter when only SYNC blockers exist → buttons remain visible
- [ ] Manual verification: Click ALL filter to see blockers reappear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refactored filter controls into a dedicated filter UI and preserved previous behavior.
  * Dynamic filter name shown in empty-state messages.

* **Bug Fixes**
  * Improved blocker type filtering (All, SYNC, ASYNC) to correctly display results and handle empty states.
  * Show/hide filter controls when no pending items exist.

* **Tests**
  * Added extensive tests for filter behavior and empty states (includes duplicated test blocks).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->