### PR TITLE
fix: return non-zero exit codes from work retry and batch run

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2529,6 +2529,9 @@ def work_retry(
             console.print("[red]Task execution failed[/red]")
             console.print("  Use 'codeframe work diagnose' for analysis")
 
+        if state.status in (AgentStatus.BLOCKED, AgentStatus.FAILED):
+            raise typer.Exit(1)
+
     except FileNotFoundError:
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
@@ -2986,6 +2989,9 @@ def batch_run(
                     console.print("\n[bold yellow]⚠ Some verification gates failed[/bold yellow]")
             else:
                 console.print("\n[dim]Skipping review - not all tasks completed successfully[/dim]")
+
+        if failed > 0 or blocked > 0:
+            raise typer.Exit(1)
 
     except FileNotFoundError:
         console.print(f"[red]Error:[/red] No workspace found at {path}")

--- a/tests/cli/test_work_exit_codes.py
+++ b/tests/cli/test_work_exit_codes.py
@@ -1,10 +1,13 @@
-"""Tests that `cf work start --execute` returns non-zero exit codes for BLOCKED/FAILED.
+"""Tests for CLI exit codes on work commands (start, retry, batch run).
 
-Issue #374: CLI was returning exit code 0 even when the agent state was
+Issue #375: CLI was returning exit code 0 even when the agent state was
 BLOCKED or FAILED, causing false positives in test automation.
+
+Covers: work start (issue #374), work retry, and batch run.
 """
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +16,7 @@ from typer.testing import CliRunner
 from codeframe.cli.app import app
 from codeframe.core.agent import AgentStatus
 from codeframe.core import tasks
+from codeframe.core.conductor import BatchRun, BatchStatus, OnFailure
 from codeframe.core.state_machine import TaskStatus
 from codeframe.core.workspace import create_or_load_workspace
 
@@ -40,6 +44,36 @@ def workspace_with_ready_task(tmp_path, monkeypatch):
                         status=TaskStatus.READY)
 
     return repo, task.id[:8]
+
+
+@pytest.fixture
+def workspace_with_failed_task(tmp_path, monkeypatch):
+    """Workspace with one FAILED task, API key set."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-fake")
+
+    ws = create_or_load_workspace(repo)
+    task = tasks.create(ws, title="Retry task", description="A task to retry",
+                        status=TaskStatus.FAILED)
+
+    return ws, repo, task.id[:8], task.id
+
+
+@pytest.fixture
+def workspace_with_two_ready_tasks(tmp_path, monkeypatch):
+    """Workspace with two READY tasks for batch execution."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-fake")
+
+    ws = create_or_load_workspace(repo)
+    t1 = tasks.create(ws, title="Batch task 1", description="First batch task",
+                      status=TaskStatus.READY)
+    t2 = tasks.create(ws, title="Batch task 2", description="Second batch task",
+                      status=TaskStatus.READY)
+
+    return ws, repo, t1.id[:8], t2.id[:8], t1.id, t2.id
 
 
 class TestWorkStartExitCodes:
@@ -80,3 +114,97 @@ class TestWorkStartExitCodes:
 
         assert result.exit_code == 1, f"Expected 1 for BLOCKED: {result.output}"
         assert "blocked" in result.output.lower()
+
+
+class TestWorkRetryExitCodes:
+    """Verify work retry returns correct exit codes."""
+
+    def test_retry_completed_returns_exit_zero(self, workspace_with_failed_task):
+        ws, repo, tid, full_id = workspace_with_failed_task
+        fake_state = _FakeAgentState(status=AgentStatus.COMPLETED)
+
+        with patch("codeframe.core.runtime.execute_agent", return_value=fake_state):
+            result = runner.invoke(
+                app, ["work", "retry", tid, "-w", str(repo)]
+            )
+
+        assert result.exit_code == 0, f"Expected 0 for COMPLETED: {result.output}"
+        assert "completed successfully" in result.output.lower()
+
+    def test_retry_failed_returns_exit_one(self, workspace_with_failed_task):
+        ws, repo, tid, full_id = workspace_with_failed_task
+        fake_state = _FakeAgentState(status=AgentStatus.FAILED)
+
+        with patch("codeframe.core.runtime.execute_agent", return_value=fake_state):
+            result = runner.invoke(
+                app, ["work", "retry", tid, "-w", str(repo)]
+            )
+
+        assert result.exit_code == 1, f"Expected 1 for FAILED: {result.output}"
+        assert "failed" in result.output.lower()
+
+    def test_retry_blocked_returns_exit_one(self, workspace_with_failed_task):
+        ws, repo, tid, full_id = workspace_with_failed_task
+        fake_state = _FakeAgentState(status=AgentStatus.BLOCKED)
+
+        with patch("codeframe.core.runtime.execute_agent", return_value=fake_state):
+            result = runner.invoke(
+                app, ["work", "retry", tid, "-w", str(repo)]
+            )
+
+        assert result.exit_code == 1, f"Expected 1 for BLOCKED: {result.output}"
+        assert "blocked" in result.output.lower()
+
+
+def _make_batch(ws, task_ids, results):
+    """Helper to create a fake BatchRun with given results."""
+    return BatchRun(
+        id="batch-test-1234",
+        workspace_id=ws.id if hasattr(ws, 'id') else "test-ws",
+        task_ids=task_ids,
+        status=BatchStatus.COMPLETED if all(v == "COMPLETED" for v in results.values())
+               else BatchStatus.PARTIAL,
+        strategy="serial",
+        max_parallel=1,
+        on_failure=OnFailure.CONTINUE,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+        results=results,
+    )
+
+
+class TestBatchRunExitCodes:
+    """Verify batch run returns correct exit codes."""
+
+    def test_batch_all_completed_returns_exit_zero(self, workspace_with_two_ready_tasks):
+        ws, repo, tid1, tid2, fid1, fid2 = workspace_with_two_ready_tasks
+        batch = _make_batch(ws, [fid1, fid2], {fid1: "COMPLETED", fid2: "COMPLETED"})
+
+        with patch("codeframe.core.conductor.start_batch", return_value=batch):
+            result = runner.invoke(
+                app, ["work", "batch", "run", tid1, tid2, "-w", str(repo)]
+            )
+
+        assert result.exit_code == 0, f"Expected 0 for all COMPLETED: {result.output}"
+
+    def test_batch_with_failure_returns_exit_one(self, workspace_with_two_ready_tasks):
+        ws, repo, tid1, tid2, fid1, fid2 = workspace_with_two_ready_tasks
+        batch = _make_batch(ws, [fid1, fid2], {fid1: "COMPLETED", fid2: "FAILED"})
+
+        with patch("codeframe.core.conductor.start_batch", return_value=batch):
+            result = runner.invoke(
+                app, ["work", "batch", "run", tid1, tid2, "-w", str(repo)]
+            )
+
+        assert result.exit_code == 1, f"Expected 1 for FAILED batch: {result.output}"
+
+    def test_batch_with_blocked_returns_exit_one(self, workspace_with_two_ready_tasks):
+        ws, repo, tid1, tid2, fid1, fid2 = workspace_with_two_ready_tasks
+        batch = _make_batch(ws, [fid1, fid2], {fid1: "COMPLETED", fid2: "BLOCKED"})
+
+        with patch("codeframe.core.conductor.start_batch", return_value=batch):
+            result = runner.invoke(
+                app, ["work", "batch", "run", tid1, tid2, "-w", str(repo)]
+            )
+
+        assert result.exit_code == 1, f"Expected 1 for BLOCKED batch: {result.output}"


### PR DESCRIPTION
## Summary
- `work retry` now returns exit code 1 when the agent state is BLOCKED or FAILED (was returning 0)
- `batch run` now returns exit code 1 when any tasks in the batch failed or were blocked (was returning 0)
- Extended test coverage from 3 → 9 tests in `test_work_exit_codes.py`

## Changes
- **`codeframe/cli/app.py`**: 2 additions (3 lines each), matching the existing `work_start` exit code pattern
- **`tests/cli/test_work_exit_codes.py`**: Added `TestWorkRetryExitCodes` (3 tests) and `TestBatchRunExitCodes` (3 tests)

## Test plan
- [x] TDD: wrote failing tests first, then added minimal code to make them pass
- [x] All 9 exit code tests pass
- [x] Full v2 test suite: 1787 passed, 0 failures
- [x] Ruff lint: clean

Closes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI work commands now properly return exit code 1 when tasks end in failed or blocked states, enabling correct failure signaling to external systems and scripts.

* **Tests**
  * Added comprehensive test coverage for CLI exit codes across work commands (start, retry, batch run) with multiple task outcome scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->