### PR TITLE
[Phase 2.5-F] Wire engine parameter through v2 API routes (#354)

### DIFF
--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -16,7 +16,7 @@ existing web UI until Phase 3 (Web UI Rebuild).
 
 import logging
 import threading
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
@@ -586,7 +586,7 @@ async def start_single_task(
     execute: bool = Query(False, description="Run agent execution (requires ANTHROPIC_API_KEY)"),
     dry_run: bool = Query(False, description="Preview changes without making them"),
     verbose: bool = Query(False, description="Show detailed progress output"),
-    engine: str = Query("plan", description="Execution engine: 'plan' (default) or 'react' (ReAct loop)"),
+    engine: Literal["plan", "react"] = Query("plan", description="Execution engine: 'plan' (default) or 'react' (ReAct loop)"),
     workspace: Workspace = Depends(get_v2_workspace),
 ) -> dict[str, Any]:
     """Start a single task run.
@@ -611,17 +611,6 @@ async def start_single_task(
             - 404: Task not found
             - 500: Execution error
     """
-    valid_engines = ("plan", "react")
-    if engine not in valid_engines:
-        raise HTTPException(
-            status_code=400,
-            detail=api_error(
-                "Invalid engine",
-                ErrorCodes.VALIDATION_ERROR,
-                f"Engine must be one of: {', '.join(valid_engines)}",
-            ),
-        )
-
     try:
         # Start the run
         run = runtime.start_task_run(workspace, task_id)


### PR DESCRIPTION
## Summary
- Add `engine` parameter (`"plan"` default, `"react"` supported) to all three task execution API endpoints
- Fix pre-existing bug: `retry_count` → `max_retries` parameter name mismatch in `/execute` endpoint
- Add 9 integration tests covering validation, defaults, and passthrough on all endpoints

## Changes
- `POST /api/v2/tasks/execute` — accepts `engine` in request body, passes to `conductor.start_batch()`, returns in response
- `POST /api/v2/tasks/approve` — accepts `engine` in request body, passes to `conductor.start_batch()` when `start_execution=true`
- `POST /api/v2/tasks/{id}/start` — accepts `engine` as query parameter, passes to `runtime.execute_agent()`
- Pydantic model validators reject invalid engine values (422 for body fields, 400 for query params)

## Acceptance Criteria
- [x] API endpoint accepts engine parameter
- [x] `codeframe/ui/routers/tasks_v2.py` updated with engine field in execution request models
- [x] `tasks_v2.py` passes engine to runtime/conductor
- [x] SSE streaming works with ReAct engine events (already compatible — no changes needed)
- [x] Integration tests for engine parameter validation and passthrough
- [x] All existing API tests pass (1854 v2 tests, 0 failures)
- [x] Linting clean (ruff)

## Test Plan
- [x] 9 new integration tests in `tests/integration/test_tasks_v2_engine.py`
- [x] Full v2 test suite passes (1854 tests)
- [x] Ruff linting clean

## Bug Fix
Fixed `retry_count=body.retry_count` → `max_retries=body.retry_count` in the `/execute` endpoint. The old code would have caused a `TypeError` at runtime since `conductor.start_batch()` expects `max_retries`, not `retry_count`.

Closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can specify an execution engine ("plan" or "react") when running or approving tasks (default: "plan"); chosen engine is returned in execution responses and used across batch and single-task flows.

* **Bug Fixes**
  * Invalid engine values are now rejected with a clear error response.

* **Tests**
  * Added integration tests validating engine defaulting, propagation, and validation across task endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->