### PR TITLE
fix(stall): validate --stall-action at CLI and cleanup (#401)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -17,6 +17,7 @@ Examples:
 from pathlib import Path
 from typing import Optional
 
+import click
 import typer
 from dotenv import load_dotenv
 from rich.console import Console
@@ -2007,6 +2008,7 @@ def work_start(
         "blocker",
         "--stall-action",
         help="Recovery action on stall: 'blocker' (default), 'retry', or 'fail'",
+        click_type=click.Choice(["blocker", "retry", "fail"], case_sensitive=False),
     ),
 ) -> None:
     """Start working on a task.
@@ -2884,6 +2886,7 @@ def batch_run(
         "blocker",
         "--stall-action",
         help="Recovery action on stall: 'blocker' (default), 'retry', or 'fail'",
+        click_type=click.Choice(["blocker", "retry", "fail"], case_sensitive=False),
     ),
 ) -> None:
     """Execute multiple tasks in batch.

--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -249,8 +249,7 @@ class ReactAgent:
             finally:
                 self._stall_monitor.stop()
         except StallDetectedError:
-            self._stall_monitor.stop()
-            raise  # Let runtime handle retry
+            raise  # Monitor stopped by finally above; let runtime handle retry
         except Exception:
             logger.exception("ReactAgent.run() failed for task %s", task_id)
             self._emit(EventType.AGENT_FAILED, {

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -614,6 +614,8 @@ def execute_agent(
         fix_coordinator: Optional coordinator for global fixes (for parallel execution)
         event_publisher: Optional EventPublisher for SSE streaming (real-time events)
         engine: Agent engine to use ("react" for ReactAgent (default), "plan" for legacy Agent)
+        stall_timeout_s: Seconds without tool activity before stall detection (0 = disabled)
+        stall_action: Recovery action on stall ("blocker", "retry", or "fail")
 
     Returns:
         Final AgentState after execution


### PR DESCRIPTION
## Summary

Follow-up polish from code review on #425:

- Validate `--stall-action` at CLI layer with `click.Choice` (prevents unhelpful ValueError deep in runtime)
- Remove redundant `stall_monitor.stop()` in `StallDetectedError` handler (finally block already handles it)
- Update `execute_agent` docstring with `stall_timeout_s` and `stall_action` parameters

## Test plan

- [x] 46 stall-related tests pass
- [x] Ruff lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added input validation to stall-action CLI option, restricting choices to: blocker, retry, fail
  * Introduced configurable stall timeout and recovery action parameters for enhanced fault tolerance

* **Improvements**
  * Refined stall detection and recovery mechanism to improve system stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->