### PR TITLE
test(cli): integration tests for all cf proof commands (#455)

### DIFF
--- a/tests/cli/test_proof_commands.py
+++ b/tests/cli/test_proof_commands.py
@@ -51,7 +51,8 @@ def ws(tmp_path: Path):
 def ws_with_req(ws):
     """Workspace that already has one captured requirement (REQ-0001)."""
     workspace, workspace_path = ws
-    runner.invoke(app, ["proof", "capture", "-w", str(workspace_path)] + _CAPTURE_ARGS)
+    result = runner.invoke(app, ["proof", "capture", "-w", str(workspace_path)] + _CAPTURE_ARGS)
+    assert result.exit_code == 0, f"Fixture setup failed: {result.output}"
     return workspace, workspace_path
 
 
@@ -203,7 +204,7 @@ class TestWaive:
         assert req.waiver.expires is None
 
     def test_waive_nonexistent_req_exits_nonzero(self, ws):
-        """waive on a REQ that was never captured should exit 1."""
+        """waive on a REQ that was never captured should exit 1 with not-found message."""
         _, workspace_path = ws
         result = runner.invoke(app, [
             "proof", "waive", "REQ-9999",
@@ -211,6 +212,7 @@ class TestWaive:
             "--reason", "Does not exist",
         ])
         assert result.exit_code == 1
+        assert "not found" in result.output.lower()
 
     def test_waive_invalid_date_exits_nonzero(self, ws_with_req):
         """waive with a non-ISO expires value should exit 1 and explain format."""
@@ -239,23 +241,25 @@ class TestStatus:
         assert "No proof requirements" in result.output
 
     def test_status_shows_open_count(self, ws_with_req):
-        """status after one capture should show Open: 1."""
+        """status after one capture should show Open: 1 on its summary line."""
         _, workspace_path = ws_with_req
         result = runner.invoke(app, ["proof", "status", "-w", str(workspace_path)])
         assert result.exit_code == 0, result.output
-        assert "Open" in result.output
+        assert "Open:" in result.output
         assert "1" in result.output
 
     def test_status_shows_waived_count(self, ws_with_req):
-        """status after waiving a REQ should show Waived: 1."""
+        """status after waiving a REQ should show Waived: 1 on its summary line."""
         _, workspace_path = ws_with_req
-        runner.invoke(app, [
+        waive_result = runner.invoke(app, [
             "proof", "waive", "REQ-0001", "-w", str(workspace_path),
             "--reason", "Accepted",
         ])
+        assert waive_result.exit_code == 0, waive_result.output
+
         result = runner.invoke(app, ["proof", "status", "-w", str(workspace_path)])
         assert result.exit_code == 0, result.output
-        assert "Waived" in result.output
+        assert "Waived:" in result.output
         assert "1" in result.output
 
     def test_status_expired_waiver_reverts_to_open(self, ws_with_req):
@@ -270,6 +274,7 @@ class TestStatus:
         result = runner.invoke(app, ["proof", "status", "-w", str(workspace_path)])
         assert result.exit_code == 0, result.output
         assert "Expired" in result.output
+        assert "Open:" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +314,10 @@ class TestClosedLoop:
         assert "PASS" in result.output
         assert "All obligations satisfied" in result.output
 
-        # Step 5 — verify evidence was recorded via ledger
+        # Step 5 — verify evidence was recorded and req status is satisfied
         evidence = ledger.list_evidence(workspace, "REQ-0001")
         assert len(evidence) >= 1
         assert any(ev.satisfied for ev in evidence)
+
+        req = ledger.get_requirement(workspace, "REQ-0001")
+        assert req.status == ReqStatus.SATISFIED


### PR DESCRIPTION
## Summary

Closes #455. Adds `tests/cli/test_proof_commands.py` — 17 integration tests covering the complete `cf proof` CLI surface area through the Typer `CliRunner` against real SQLite workspaces.

## Acceptance criteria

- [x] CLI integration test: `cf proof capture` creates a REQ and persists it
- [x] CLI integration test: `cf proof run` evaluates workspace against open REQs
- [x] CLI integration test: `cf proof waive` marks a REQ waived with expiry
- [x] CLI integration test: `cf proof status` shows correct summary
- [x] Closed loop: capture → run (fail) → run (pass) → evidence recorded

## What's in the test file

| Class | Tests | Coverage |
|-------|-------|----------|
| `TestCapture` | 4 | Creates REQ, increments IDs, rejects invalid severity/source |
| `TestRun` | 4 | PASS/FAIL exits, no-obligations, invalid gate — `_run_gate` patched |
| `TestWaive` | 4 | With/without expiry, missing REQ exit 1, bad date format |
| `TestStatus` | 4 | Empty workspace, open count, waived count, expired waiver reverts |
| `TestClosedLoop` | 1 | Full capture → fail run → pass run → evidence recorded |

## Design decisions

- `_run_gate` is patched at `codeframe.core.proof.runner._run_gate` — same pattern as `TestRunner` in `tests/core/test_proof9.py`
- Persistence verified directly via `ledger.get_requirement` / `ledger.list_evidence` — output checks alone are insufficient
- Each test class gets an isolated `tmp_path` workspace via `create_or_load_workspace`
- No production code changes required — all commands were already correctly implemented

## Test plan

- [x] 17/17 tests pass locally
- [x] `uv run ruff check` clean
- [x] 59/59 (proof CLI + proof unit tests) pass together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the proof CLI covering capture, run, waive, and status flows. Verifies requirement ID generation and display, run outcomes (pass/fail/none found), waiver persistence and expiry handling, error messages for invalid input, and end-to-end status/evidence transitions across failing → passing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->