### PR TITLE
docs(readme): remove stale [planned] markers and add shipped features (#452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ CodeFRAME owns the **edges** of the pipeline -- everything that happens before a
 
 ## Think. Build. Prove. Ship.
 
-```
+```text
 THINK    What are you building? How should it be broken down?
            cf prd generate         Socratic requirements gathering
            cf prd stress-test      Recursive decomposition, surface ambiguities
@@ -90,6 +90,9 @@ cf tasks generate
 # Execute (delegates to the agent engine)
 cf work start <task-id> --execute
 
+# Prove quality gates
+cf proof run
+
 # Ship
 cf pr create
 ```
@@ -113,7 +116,7 @@ That is the entire workflow. Everything else is optional.
   +-BUILD---------------------------------------------+
   |  cf work start --engine <agent>                    |
   |                                                    |
-  |  +-- Claude Code / Codex / OpenCode / Kilocode / ReactAgent   |
+  |  +-- Claude Code / Codex / OpenCode / Kilocode / ReAct        |
   |  |                                                 |
   |  +-- Verification gates (ruff, pytest, BUILD)      |
   |  +-- Self-correction loop (up to 5 retries)        |


### PR DESCRIPTION
## Summary

Closes #452. Removes all stale `[planned]` markers for shipped features and brings the README up to date with Phases 4–6 deliverables.

## Changes

### Removed `[planned]` markers (4 locations)
- `cf prd stress-test` (line 29)
- `cf proof run` (line 37)
- `cf proof capture` (line 38)
- Architecture diagram PROVE block (line 121)

### Added Kilocode to engine lists (3 locations)
- Prose description (line 22)
- THINK/BUILD block example (line 33)
- Architecture diagram BUILD box (line 112)

### Expanded PROVE CLI reference
Added all shipped `cf proof` subcommands (`list`, `status`, `show`, `waive`), plus `cf work replay` and `cf tui`.

### Updated "What Works Today"
- Changed "Phase 2.5" → "Phases 1–6 complete"
- Added PROVE bullet (PROOF9 quality memory system)
- Added Engine adapters bullet (Claude Code, Codex, OpenCode, Kilocode, ReAct)
- Added replay/debug mode, TUI dashboard, dynamic config reload to BUILD
- Updated Web UI to include PROOF9 views
- Updated server layer router count from 15 to 16+

### Updated Roadmap
- THINK: marked `cf prd stress-test` and multi-round PRD refinement `[x]`
- BUILD: marked agent adapters, worktree isolation, reconciliation, replay, TUI, dynamic config `[x]`
- PROVE: marked PROOF9, proof capture, quality compounding `[x]`; moved proof report/merge gating here as remaining work
- Web UI: added PROOF9 views, workspace/PRD/tasks/blockers/review views as `[x]`

## Test plan
- [x] `git diff README.md` reviewed — all changes are factually accurate
- [x] No `[planned]` markers remain in the file
- [x] All mentioned commands exist in `codeframe/cli/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Kilocode to supported engines and updated engine selection docs.
  * Introduced new CLI references: proof list, proof status, proof show, proof waive, work replay, tui; promoted proof run and proof capture to active workflow steps.
  * Added “Prove quality gates” to Quick Start and expanded PROVE reference.
  * Reframed workflow as Think–Build–Prove–Ship, marked multiple roadmap items complete, and expanded server/UI capability descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->