### PR TITLE
docs(readme): quickstart rewrite with numbered steps and v0.1.0 release (#454)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 ![Coverage](https://img.shields.io/badge/coverage-88%25-brightgreen)
 [![Follow on X](https://img.shields.io/twitter/follow/FrankBria18044?style=social)](https://x.com/FrankBria18044)
 
-> ⚠️ **Prerequisite:** CodeFRAME requires an `ANTHROPIC_API_KEY` from [console.anthropic.com](https://console.anthropic.com/). Get your key before running any `cf` command.
+> [!WARNING]
+> **Prerequisite:** CodeFRAME requires an `ANTHROPIC_API_KEY` from [console.anthropic.com](https://console.anthropic.com/). Get your key before running any `cf` command.
+
+---
 
 > **The IDE of the future is not a better text editor with AI autocomplete. It is a project delivery system where writing code is a subprocess.**
 


### PR DESCRIPTION
## Summary

Closes #454. Fixes the new-user experience by restructuring the Quick Start and making the API key requirement impossible to miss.

## Changes

### README.md

1. **API key prerequisite callout** — Added immediately after the badge row, before "The Problem". New users see it before reading anything else.

2. **Quick Start rewritten as 5 numbered steps**:
   - Step 1: Install (git clone, uv sync) + smoke test `uv run cf --help`
   - Step 2: Set API key (prominent, with link to console.anthropic.com)
   - Step 3: Initialize project (`uv run cf init /path --detect`)
   - Step 4: Think — `uv run cf prd generate` + `cf tasks generate` + `cf tasks list`
   - Step 5: Build/Prove/Ship — batch run + proof run + pr create

3. **CLI Reference note** — Added `uv run` guidance at the top of the section so users don't get confused if their venv isn't active.

### GitHub Release

v0.1.0 pre-release created (matches `pyproject.toml` version) with quickstart in release notes — will be created after merge.

## Acceptance criteria

- [x] README install instructions use `git clone + uv sync` (not `pip install`)
- [x] API key requirement is visible in the quickstart (Step 2, not buried)
- [x] 5-step quickstart shows the full Think → Build → Prove → Ship pipeline
- [ ] Tagged v0.1.0 GitHub Release (created after merge)

## Test plan
- [x] Quick Start commands verified locally (`uv run cf --help` works)
- [x] No broken markdown links or formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prominent prerequisite reminder to set ANTHROPIC_API_KEY before running commands.
  * Revamped Quick Start into a concise 5-step flow: install and smoke-test, export API key, initialize a project with detection, generate/list PRD and tasks, then batch-run READY tasks, proof run, and create a PR.
  * Clarified CLI usage: examples assume an active virtual environment; prefix commands with "uv run" when not active.
  * Improved readability and first-time setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->