### PR TITLE
feat(web-ui): surface PROOF9 gate link in execution completion banner (#469)

### DIFF
--- a/web-ui/src/app/execution/[taskId]/page.tsx
+++ b/web-ui/src/app/execution/[taskId]/page.tsx
@@ -10,7 +10,8 @@ import { ExecutionHeader } from '@/components/execution/ExecutionHeader';
 import { ProgressIndicator } from '@/components/execution/ProgressIndicator';
 import { EventStream } from '@/components/execution/EventStream';
 import { ChangesSidebar } from '@/components/execution/ChangesSidebar';
-import type { Task } from '@/types';
+import { Button } from '@/components/ui/button';
+import type { Task, CompletionBannerProps } from '@/types';
 
 export default function ExecutionPage() {
   const params = useParams<{ taskId: string }>();
@@ -164,14 +165,7 @@ function CompletionBanner({
   onViewChanges,
   onBackToTasks,
   onViewBlockers,
-}: {
-  status: 'completed' | 'failed' | 'blocked' | null;
-  duration: number | null;
-  onViewProof: () => void;
-  onViewChanges: () => void;
-  onBackToTasks: () => void;
-  onViewBlockers: () => void;
-}) {
+}: CompletionBannerProps) {
   const durationText = duration !== null ? `${Math.round(duration)}s` : '';
 
   if (status === 'completed') {
@@ -181,24 +175,15 @@ function CompletionBanner({
           Execution complete{durationText && ` in ${durationText}`}. Run PROOF9 gates to verify quality before shipping.
         </p>
         <div className="flex gap-2">
-          <button
-            onClick={onViewProof}
-            className="rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700"
-          >
+          <Button onClick={onViewProof} size="sm">
             Verify with PROOF9
-          </button>
-          <button
-            onClick={onViewChanges}
-            className="rounded-md border border-green-300 px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100 dark:border-green-800 dark:text-green-300 dark:hover:bg-green-900/40"
-          >
+          </Button>
+          <Button onClick={onViewChanges} variant="outline" size="sm">
             View Changes
-          </button>
-          <button
-            onClick={onBackToTasks}
-            className="rounded-md border border-green-300 px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100 dark:border-green-800 dark:text-green-300 dark:hover:bg-green-900/40"
-          >
+          </Button>
+          <Button onClick={onBackToTasks} variant="outline" size="sm">
             Back to Tasks
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -211,12 +196,9 @@ function CompletionBanner({
           Execution failed{durationText && ` after ${durationText}`}. Check the
           event stream for details.
         </p>
-        <button
-          onClick={onBackToTasks}
-          className="rounded-md border border-red-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-100 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/40"
-        >
+        <Button onClick={onBackToTasks} variant="outline" size="sm">
           Back to Tasks
-        </button>
+        </Button>
       </div>
     );
   }
@@ -229,18 +211,12 @@ function CompletionBanner({
           stream below to continue.
         </p>
         <div className="flex gap-2">
-          <button
-            onClick={onViewBlockers}
-            className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-600"
-          >
+          <Button onClick={onViewBlockers} size="sm">
             View Blockers
-          </button>
-          <button
-            onClick={onBackToTasks}
-            className="rounded-md border border-amber-300 px-3 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-800 dark:text-amber-300 dark:hover:bg-amber-900/40"
-          >
+          </Button>
+          <Button onClick={onBackToTasks} variant="outline" size="sm">
             Back to Tasks
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -339,6 +339,16 @@ export interface WaiveRequest {
 }
 
 
+// Completion banner props (execution page)
+export interface CompletionBannerProps {
+  status: 'completed' | 'failed' | 'blocked' | null;
+  duration: number | null;
+  onViewProof: () => void;
+  onViewChanges: () => void;
+  onBackToTasks: () => void;
+  onViewBlockers: () => void;
+}
+
 // Pipeline progress types
 export interface PhaseStatus {
   isComplete: boolean;


### PR DESCRIPTION
## Summary

- Adds **"Verify with PROOF9"** as the primary CTA in the completed state banner, linking to `/proof`
- Demotes "View Changes" to secondary (outline) styling
- Updates completion message: *"Execution complete. Run PROOF9 gates to verify quality before shipping."*
- Adds **"View Blockers"** as primary CTA in the blocked state banner, linking to `/blockers`
- Demotes "Back to Tasks" to secondary on blocked state

Closes #469

## Test plan

- [ ] Complete a task execution — banner shows "Verify with PROOF9" (filled green) first, then "View Changes" (outline), then "Back to Tasks"
- [ ] "Verify with PROOF9" navigates to `/proof`
- [ ] Blocked state shows "View Blockers" (filled amber) and "Back to Tasks" (outline)
- [ ] "View Blockers" navigates to `/blockers`
- [ ] Build passes (`npm run build` clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Verify with PROOF9" primary action to completed executions to verify quality before shipping
  * Added "View Blockers" action when tasks are blocked for quick access to blocker details
  * Updated completion messaging to guide users to run PROOF9 verification gates
  * Improved button layout and consistent button styling across completed/blocked/failed banners
<!-- end of auto-generated comment: release notes by coderabbit.ai -->