### PR TITLE
feat(web-ui): blocker lifecycle explanation and recovery guidance (#473)

### DIFF
--- a/web-ui/src/components/blockers/BlockerCard.tsx
+++ b/web-ui/src/components/blockers/BlockerCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { Alert02Icon, Loading03Icon, CheckmarkCircle01Icon } from '@hugeicons/react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -22,16 +22,8 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isOpen = blocker.status === 'OPEN';
-
-  // Clean up timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
 
   const handleSubmit = async () => {
     if (!answer.trim() || isSubmitting) return;
@@ -40,7 +32,6 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
     try {
       await blockersApi.answer(workspacePath, blocker.id, answer.trim());
       setSubmitted(true);
-      timerRef.current = setTimeout(() => onAnswered(), 1500);
     } catch (err) {
       const apiErr = err as ApiError;
       setError(apiErr.detail || 'Failed to submit answer');
@@ -63,7 +54,7 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
             </p>
           </div>
           <Button size="sm" variant="outline" asChild>
-            <Link href="/tasks">Go to Tasks</Link>
+            <Link href="/tasks" onClick={onAnswered}>Go to Tasks</Link>
           </Button>
         </CardContent>
       </Card>

--- a/web-ui/src/components/blockers/BlockerResolutionView.tsx
+++ b/web-ui/src/components/blockers/BlockerResolutionView.tsx
@@ -84,9 +84,9 @@ export function BlockerResolutionView({ workspacePath }: BlockerResolutionViewPr
 
       {/* Info banner — shown only when there are open blockers */}
       {openBlockers.length > 0 && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm dark:border-amber-800 dark:bg-amber-950/30">
-          <p className="font-medium text-amber-900 dark:text-amber-200">AI execution is paused.</p>
-          <p className="mt-0.5 text-amber-800 dark:text-amber-300">
+        <div className="rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm">
+          <p className="font-medium text-foreground">AI execution is paused.</p>
+          <p className="mt-0.5 text-muted-foreground">
             Blockers pause agent execution until you provide the requested information. Answer the question below, then go to Tasks to restart execution.
           </p>
         </div>


### PR DESCRIPTION
## Summary

- **Info banner** in `BlockerResolutionView` (shown only when open blockers exist): *"AI execution is paused. Blockers pause agent execution until you provide the requested information. Answer below, then go to Tasks to restart execution."*
- **Task context link** in `BlockerCard`: "Raised by Task {id}" links to `/tasks` so users can navigate to the originating task
- **Post-answer confirmation** updated: *"Answer recorded. Go to Tasks and restart execution to resume the agent."* + "Go to Tasks" button for direct navigation

Closes #473

## Test plan

- [ ] Blockers page with open blockers shows amber info banner explaining lifecycle
- [ ] Blockers page with no open blockers shows no banner (clean state)
- [ ] BlockerCard shows "Raised by Task <id>" as a link to /tasks
- [ ] After answering, confirmation reads "Answer recorded. Go to Tasks and restart execution..."
- [ ] "Go to Tasks" button navigates to /tasks
- [ ] Build passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation links to the Tasks page from blocker cards.
  * New info banner displays when AI execution is paused, instructing users to answer questions and restart execution.

* **Improvements**
  * Updated messaging to clarify action steps for resolving blockers.
  * Task ID references now link directly to the Tasks page for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->