### PR TITLE
feat(web-ui): link failed tasks to PROOF9 gate failure for root cause (#474)

### DIFF
--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -204,7 +204,7 @@ function ProofPageContent() {
               {gateFilter && (
                 <span className="flex items-center gap-1.5 rounded-full border bg-muted px-2.5 py-0.5 text-xs font-medium text-foreground">
                   Filtered by gate: {gateFilter}
-                  <Link href="/proof" className="text-muted-foreground hover:text-foreground">✕</Link>
+                  <Link href="/proof" aria-label={`Clear gate filter ${gateFilter}`} className="text-muted-foreground hover:text-foreground">✕</Link>
                 </span>
               )}
             </div>

--- a/web-ui/src/components/tasks/TaskDetailModal.tsx
+++ b/web-ui/src/components/tasks/TaskDetailModal.tsx
@@ -278,33 +278,42 @@ export function TaskDetailModal({
                   Execute
                 </Button>
               )}
-              {task.status === 'FAILED' && (
-                <>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={isUpdating}
-                    onClick={handleMarkReady}
-                  >
-                    {isUpdating ? (
-                      <Loading03Icon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <CheckmarkCircle01Icon className="mr-1.5 h-3.5 w-3.5" />
-                    )}
-                    Reset to Ready
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      onClose();
-                      router.push('/proof');
-                    }}
-                  >
-                    <CheckListIcon className="mr-1.5 h-3.5 w-3.5" />
-                    View PROOF9 Gates
-                  </Button>
-                </>
-              )}
+              {task.status === 'FAILED' && (() => {
+                // Derive the best proof link from requirement obligations if available
+                let proofLink = '/proof';
+                for (const reqId of (task.requirement_ids ?? [])) {
+                  const req = requirementsMap.get(reqId);
+                  const gate = req?.obligations?.[0]?.gate?.toLowerCase();
+                  if (gate) { proofLink = `/proof?gate=${encodeURIComponent(gate)}`; break; }
+                }
+                return (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isUpdating}
+                      onClick={handleMarkReady}
+                    >
+                      {isUpdating ? (
+                        <Loading03Icon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <CheckmarkCircle01Icon className="mr-1.5 h-3.5 w-3.5" />
+                      )}
+                      Reset to Ready
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        onClose();
+                        router.push(proofLink);
+                      }}
+                    >
+                      <CheckListIcon className="mr-1.5 h-3.5 w-3.5" />
+                      View PROOF9 Gates
+                    </Button>
+                  </>
+                );
+              })()}
             </DialogFooter>
           </>
         )}


### PR DESCRIPTION
## Summary

- **TaskDetailModal FAILED state**: adds destructive guidance panel + "View PROOF9 Gates" (primary) + "Reset to Ready" (outline) footer buttons
- **Proof page `?gate=` filter**: `useSearchParams` reads `?gate=` param and filters the requirements table to show only requirements with matching obligation gate names (pytest, ruff, build, custom)
- Filter indicator badge with clear link shown when active
- Empty-state row when no requirements match the filter
- Proof page wrapped in `<Suspense>` for Next.js `useSearchParams` compatibility

Closes #474

## Test plan

- [ ] FAILED task modal shows red guidance panel + footer buttons
- [ ] "View PROOF9 Gates" navigates to /proof
- [ ] "Reset to Ready" transitions FAILED → READY
- [ ] `/proof?gate=pytest` filters table to pytest-obligation requirements
- [ ] `/proof?gate=ruff` filters to ruff-obligation requirements
- [ ] No-match shows "No requirements match gate X" row
- [ ] Build passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gate filtering to the requirements table with a visible "Filtered by gate" pill and clear-filter action; empty-state reflects active filters.
  * Added a failed-task guidance panel and contextual actions including "Reset to Ready" and "View PROOF9 Gates" to navigate to related gate results.
  * Improved top summary layout to wrap responsively for better display on narrow screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->