### PR TITLE
feat(web-ui): compress and summarize verbose execution event stream (#475)

### DIFF
--- a/web-ui/src/components/execution/EventStream.tsx
+++ b/web-ui/src/components/execution/EventStream.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/react';
 import { Button } from '@/components/ui/button';
+import { editGroupBadgeStyles } from '@/lib/eventStyles';
 import { EventItem } from './EventItem';
 import type { ExecutionEvent } from '@/hooks/useTaskStream';
 
@@ -122,7 +123,7 @@ function EditGroupRow({ group }: { group: Extract<EventGroup, { type: 'edit_grou
       <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
         {new Date(group.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
       </span>
-      <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-blue-800 dark:bg-blue-900/40 dark:text-blue-300">
+      <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none ${editGroupBadgeStyles}`}>
         edit
       </span>
       <p className="text-sm">
@@ -150,8 +151,11 @@ export function EventStream({ events, workspacePath, onBlockerAnswered }: EventS
   const prevEventCountRef = useRef(events.length);
 
   // Filter out heartbeat events for display
-  const displayEvents = events.filter((e) => e.event_type !== 'heartbeat');
-  const groups = groupEvents(displayEvents);
+  const displayEvents = useMemo(
+    () => events.filter((e) => e.event_type !== 'heartbeat'),
+    [events]
+  );
+  const groups = useMemo(() => groupEvents(displayEvents), [displayEvents]);
 
   // Detect new events while scrolled up
   useEffect(() => {

--- a/web-ui/src/lib/eventStyles.ts
+++ b/web-ui/src/lib/eventStyles.ts
@@ -82,6 +82,9 @@ export const agentStateBadgeStyles: Record<UIAgentState, string> = {
   DISCONNECTED: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
 };
 
+/** Badge style for the edit-group summary row in the EventStream. */
+export const editGroupBadgeStyles = 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+
 /** Human-readable labels for each agent state. */
 export const agentStateLabels: Record<UIAgentState, string> = {
   CONNECTING: 'Connecting',


### PR DESCRIPTION
## Summary

- `groupEvents()` transforms raw event arrays into grouped `EventGroup[]` for the smart view
- **Consecutive file-read events** → collapsible `ReadGroupRow` ("Read N files: x, y, z") with expand affordance
- **Consecutive file edit/create/delete events** → `EditGroupRow` single summary line ("Modified N files: …")
- **Smart view** (default) renders grouped events; **"Show all events"** toggle reveals every raw event unmodified
- Stream header added with view toggle button
- All other event types (planning, verification, blockers, completion) pass through unchanged

Closes #475

## Test plan

- [ ] Smart view shows "Read N files" collapsed rows for consecutive reads
- [ ] Clicking expand row reveals individual read events
- [ ] Consecutive file edits show single "Modified N files" row
- [ ] "Show all events" toggle shows every event individually
- [ ] "Smart view" toggle returns to grouped view
- [ ] Non-read/non-edit events render unchanged
- [ ] Build passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent grouping of related read and edit operations in the event stream for improved clarity.
  * Added a header with a view toggle to switch between grouped summary view (default) and a detailed view of all individual events.
  * Collapsible read operation summaries provide quick overviews while maintaining access to full details.
  * Added a compact badge-style summary for edit groups to improve scannability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->