### PR TITLE
feat(web-ui): empty state with task generation CTA on task board (#477)

### DIFF
--- a/web-ui/src/components/tasks/TaskBoardView.tsx
+++ b/web-ui/src/components/tasks/TaskBoardView.tsx
@@ -383,16 +383,20 @@ export function TaskBoardView({ workspacePath }: TaskBoardViewProps) {
             )}
           </p>
           <div className="mt-6 flex gap-3">
-            <Button asChild>
-              <Link href="/prd">
-                Generate from PRD →
-              </Link>
-            </Button>
-            <Button variant="outline" asChild>
-              <Link href="/prd">
-                View PRD
-              </Link>
-            </Button>
+            {hasPrd ? (
+              <>
+                <Button asChild>
+                  <Link href="/prd">Generate from PRD →</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/prd">View PRD</Link>
+                </Button>
+              </>
+            ) : (
+              <Button asChild>
+                <Link href="/prd">Create PRD →</Link>
+              </Button>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Empty state renders when `tasks.length === 0` after loading completes (no flash — guarded by existing `isLoading` skeleton)
- Task01Icon + explanatory text + PRD availability context dot
- **PRD found**: green dot — "PRD found — ready to generate tasks"
- **No PRD**: muted dot — "No PRD yet — create one first"
- Primary CTA: **Generate from PRD →** → `/prd`
- Secondary CTA: **View PRD** (outline) → `/prd`
- `TaskBoardContent` conditionally rendered only when `tasks.length > 0`
- PRD existence via `useSWR` + `prdApi.getAll()` (separate cache key)

Closes #477

## Test plan

- [ ] Empty workspace shows empty state card with both CTAs
- [ ] Empty state shows "PRD found" context when workspace has a PRD
- [ ] Empty state shows "No PRD yet" context when no PRD exists
- [ ] Both CTAs navigate to /prd
- [ ] No flash during initial load (skeleton shows first, then empty state)
- [ ] Board with tasks shows normal kanban (empty state hidden)
- [ ] Build passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task Board now shows a PRD-aware empty state when there are no tasks, with contextual messaging and tailored quick-action buttons to help users get started or navigate to related areas.
  * Kanban board content is rendered only when tasks exist, keeping the interface cleaner for empty projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->