### PR TITLE
fix(web-ui): SplitPane a11y, logic bugs, and test coverage

### DIFF
--- a/web-ui/src/__tests__/components/sessions/SplitPane.test.tsx
+++ b/web-ui/src/__tests__/components/sessions/SplitPane.test.tsx
@@ -433,10 +433,10 @@ describe('SplitPane', () => {
       expect(screen.getByTestId('split-pane-container').className).toContain('flex-col');
     });
 
-    it('hides divider on mobile', () => {
+    it('hides divider track on mobile', () => {
       mockMatchMedia(false);
       renderSplitPane();
-      expect(screen.getByTestId('split-pane-divider').className).toContain('hidden');
+      expect(screen.getByTestId('split-pane-divider-track').className).toContain('hidden');
     });
 
     it('switches to desktop layout when viewport widens', () => {

--- a/web-ui/src/components/sessions/SplitPane.tsx
+++ b/web-ui/src/components/sessions/SplitPane.tsx
@@ -252,26 +252,38 @@ export function SplitPane({
         {left}
       </div>
 
-      {/* Divider — role="separator" exposes collapse buttons to AT */}
+      {/*
+        Divider track — positions separator and collapse buttons as siblings.
+        WAI-ARIA 1.2 §6.8: a focusable separator is a widget and must not
+        contain interactive descendants; buttons live here, not inside the
+        role="separator" element.
+      */}
       <div
-        data-testid="split-pane-divider"
-        onMouseDown={onDividerMouseDown}
-        onKeyDown={onDividerKeyDown}
-        role="separator"
-        aria-orientation="vertical"
-        aria-valuenow={splitPct}
-        aria-valuemin={splitPct === 0 ? 0 : minPanePercent}
-        aria-valuemax={splitPct === 100 ? 100 : 100 - minPanePercent}
-        aria-label="Resize panes"
-        tabIndex={0}
+        data-testid="split-pane-divider-track"
         className={cn(
-          'relative flex-shrink-0 w-1 bg-border hover:bg-primary cursor-col-resize',
-          'flex flex-col items-center justify-center',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          'relative flex-shrink-0 w-1',
           isMobile && 'hidden',
         )}
       >
-        {/* Left collapse button */}
+        {/* Resize handle */}
+        <div
+          data-testid="split-pane-divider"
+          onMouseDown={onDividerMouseDown}
+          onKeyDown={onDividerKeyDown}
+          role="separator"
+          aria-orientation="vertical"
+          aria-valuenow={splitPct}
+          aria-valuemin={splitPct === 0 ? 0 : minPanePercent}
+          aria-valuemax={splitPct === 100 ? 100 : 100 - minPanePercent}
+          aria-label="Resize panes"
+          tabIndex={0}
+          className={cn(
+            'w-full h-full bg-border hover:bg-primary cursor-col-resize',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          )}
+        />
+
+        {/* Left collapse button — sibling of separator, not child */}
         <button
           type="button"
           data-testid="collapse-left"
@@ -292,7 +304,7 @@ export function SplitPane({
           )}
         </button>
 
-        {/* Right collapse button */}
+        {/* Right collapse button — sibling of separator, not child */}
         <button
           type="button"
           data-testid="collapse-right"


### PR DESCRIPTION
Follow-up to #507 — addresses all 8 issues from code review.

## Fixes

| # | Issue | Fix |
|---|-------|-----|
| 1 | `aria-hidden` on divider hid collapse buttons from screen readers | Replaced with `role="separator"` + `aria-orientation="vertical"` |
| 2 | `lastNonCollapsed` corrupted when cross-collapsing panes | Guard: only save restore point when `splitPct` is in valid expanded range |
| 3 | `isMobile` caused hydration flash | Return `null` until `matchMedia` effect resolves |
| 4 | No keyboard resize (WCAG 2.1.1) | Added `ArrowLeft`/`ArrowRight` on divider, 5% step, clamped |
| 5 | Collapsed positions (0/100) written to localStorage caused reload drift | Don't write collapsed values; clamp `readStorage` to valid range |
| 6 | Missing test: reload while collapsed | Added |
| 7 | Missing test: cross-collapse restore | Added |
| 8 | `matchMedia` change event untested | Added viewport-widen test via triggered handler |

## Test plan

- [x] 29 tests, all passing (up from 15)
- [x] No new test suite failures (`npm test`)
- [x] TypeScript build passes (`npm run build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard resizing of panes with Arrow keys; divider is now keyboard-interactive and focusable.

* **Bug Fixes**
  * Defer layout until mobile detection completes to prevent hydration issues.
  * Ignore invalid persisted split values, clamp stored/default splits to bounds, and avoid writing collapsed sentinel values.
  * Prevent no-op divider clicks from committing or reopening panes.

* **Improvements**
  * Better collapse/expand restore behavior, precise drag commit semantics, and hidden/stacked mobile layout handling.
  * Enhanced accessibility: semantic divider role, ARIA orientation/values/labels, and proper button markup.

* **Tests**
  * Reorganized and expanded tests covering keyboard, drag, storage edge cases, accessibility, mobile layout, and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->