### PR TITLE
feat(web-ui): Run Gates button + live gate progress for PROOF9 (#566)

### DIFF
--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -45,6 +45,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/proof", tags=["proof-v2"])
 
+# Module-level cache: run_id → serialized RunProofResponse dict
+_run_cache: dict[str, dict] = {}
+
 
 # ============================================================================
 # Request / Response Models
@@ -143,6 +146,16 @@ class RunProofResponse(BaseModel):
     success: bool
     run_id: str
     results: dict[str, list[dict[str, Any]]]
+    message: str
+
+
+class RunStatusResponse(BaseModel):
+    """Response for GET /runs/{run_id} — poll a completed run."""
+
+    run_id: str
+    status: str  # "running" | "complete"
+    results: dict[str, list[dict[str, Any]]]
+    passed: bool
     message: str
 
 
@@ -333,18 +346,60 @@ async def run_proof_endpoint(
             for req_id, gate_results in results.items()
         }
 
-        return RunProofResponse(
+        passed = all(
+            satisfied
+            for gate_results in results.values()
+            for _, satisfied in gate_results
+        )
+        response = RunProofResponse(
             success=True,
             run_id=run_id,
             results=serialized,
             message=f"Proof run complete: {len(results)} requirement(s) evaluated.",
         )
+        _run_cache[run_id] = {
+            "results": serialized,
+            "passed": passed,
+            "message": response.message,
+        }
+        return response
     except Exception as e:
         logger.error("Proof run failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=500,
             detail=api_error("Proof run failed", ErrorCodes.EXECUTION_FAILED, str(e)),
         )
+
+
+@router.get("/runs/{run_id}", response_model=RunStatusResponse)
+@rate_limit_standard()
+async def get_run_status_endpoint(
+    request: Request,
+    run_id: str,
+    workspace: Workspace = Depends(get_v2_workspace),
+) -> RunStatusResponse:
+    """Get the status of a completed proof run by run_id.
+
+    Since POST /run is synchronous, a run is always complete immediately after
+    the POST returns. Returns 404 if run_id is unknown.
+    """
+    cached = _run_cache.get(run_id)
+    if cached is None:
+        raise HTTPException(
+            status_code=404,
+            detail=api_error(
+                f"Run not found: {run_id}",
+                ErrorCodes.NOT_FOUND,
+                f"No proof run with id {run_id}",
+            ),
+        )
+    return RunStatusResponse(
+        run_id=run_id,
+        status="complete",
+        results=cached["results"],
+        passed=cached["passed"],
+        message=cached["message"],
+    )
 
 
 @router.post("/requirements/{req_id}/waive", response_model=RequirementResponse)

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/proof", tags=["proof-v2"])
 
-# Module-level cache: run_id → serialized RunProofResponse dict
-_run_cache: dict[str, dict] = {}
+# Module-level cache: (workspace_path, run_id) → serialized RunProofResponse dict
+_run_cache: dict[tuple[str, str], dict] = {}
 
 
 # ============================================================================
@@ -357,7 +357,7 @@ async def run_proof_endpoint(
             results=serialized,
             message=f"Proof run complete: {len(results)} requirement(s) evaluated.",
         )
-        _run_cache[run_id] = {
+        _run_cache[(str(workspace.repo_path), run_id)] = {
             "results": serialized,
             "passed": passed,
             "message": response.message,
@@ -383,7 +383,7 @@ async def get_run_status_endpoint(
     Since POST /run is synchronous, a run is always complete immediately after
     the POST returns. Returns 404 if run_id is unknown.
     """
-    cached = _run_cache.get(run_id)
+    cached = _run_cache.get((str(workspace.repo_path), run_id))
     if cached is None:
         raise HTTPException(
             status_code=404,

--- a/tests/ui/test_proof_v2.py
+++ b/tests/ui/test_proof_v2.py
@@ -322,6 +322,50 @@ class TestRunProof:
 
 
 # ============================================================================
+# GET /api/v2/proof/runs/{run_id} — poll run status
+# ============================================================================
+
+
+class TestGetRunStatus:
+    """Tests for GET /api/v2/proof/runs/{run_id}."""
+
+    def test_get_run_after_post_returns_200(self, test_client):
+        """GET /runs/{run_id} returns 200 after a completed POST /run."""
+        post_resp = test_client.post("/api/v2/proof/run", json={})
+        assert post_resp.status_code == 200
+        run_id = post_resp.json()["run_id"]
+
+        response = test_client.get(f"/api/v2/proof/runs/{run_id}")
+        assert response.status_code == 200
+
+    def test_get_run_response_shape(self, test_client):
+        """RunStatusResponse has required fields."""
+        post_resp = test_client.post("/api/v2/proof/run", json={})
+        run_id = post_resp.json()["run_id"]
+
+        data = test_client.get(f"/api/v2/proof/runs/{run_id}").json()
+        assert data["run_id"] == run_id
+        assert data["status"] == "complete"
+        assert isinstance(data["results"], dict)
+        assert isinstance(data["passed"], bool)
+        assert isinstance(data["message"], str)
+
+    def test_get_unknown_run_returns_404(self, test_client):
+        """Unknown run_id returns 404."""
+        response = test_client.get("/api/v2/proof/runs/does-not-exist")
+        assert response.status_code == 404
+
+    def test_get_run_results_match_post(self, test_client):
+        """GET run results match the original POST results."""
+        post_resp = test_client.post("/api/v2/proof/run", json={"full": True})
+        post_data = post_resp.json()
+        run_id = post_data["run_id"]
+
+        get_data = test_client.get(f"/api/v2/proof/runs/{run_id}").json()
+        assert get_data["results"] == post_data["results"]
+
+
+# ============================================================================
 # POST /api/v2/proof/requirements/{req_id}/waive — waive requirement
 # ============================================================================
 

--- a/web-ui/src/__tests__/hooks/useProofRun.test.ts
+++ b/web-ui/src/__tests__/hooks/useProofRun.test.ts
@@ -1,0 +1,171 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useProofRun } from '@/hooks/useProofRun';
+import { proofApi } from '@/lib/api';
+
+jest.mock('@/lib/api', () => ({
+  proofApi: {
+    startRun: jest.fn(),
+    getRun: jest.fn(),
+  },
+}));
+
+const mockStartRun = proofApi.startRun as jest.MockedFunction<typeof proofApi.startRun>;
+const mockGetRun = proofApi.getRun as jest.MockedFunction<typeof proofApi.getRun>;
+
+const WORKSPACE = '/tmp/test-workspace';
+
+const makeStartRunResponse = (passed = true) => ({
+  success: true,
+  run_id: 'abc123',
+  results: {
+    'req-1': [
+      { gate: 'unit', satisfied: passed },
+      { gate: 'sec', satisfied: true },
+    ],
+  },
+  message: 'Proof run complete: 1 requirement(s) evaluated.',
+});
+
+const makeGetRunResponse = (passed = true) => ({
+  run_id: 'abc123',
+  status: 'complete' as const,
+  results: {
+    'req-1': [
+      { gate: 'unit', satisfied: passed },
+      { gate: 'sec', satisfied: true },
+    ],
+  },
+  passed,
+  message: 'Proof run complete: 1 requirement(s) evaluated.',
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useProofRun', () => {
+  it('starts in idle state', () => {
+    const { result } = renderHook(() => useProofRun());
+    expect(result.current.runState).toBe('idle');
+    expect(result.current.gateEntries).toHaveLength(0);
+    expect(result.current.passed).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('transitions to starting then polling on successful POST', async () => {
+    mockStartRun.mockResolvedValue(makeStartRunResponse());
+    mockGetRun.mockResolvedValue(makeGetRunResponse());
+
+    const { result } = renderHook(() => useProofRun());
+
+    act(() => {
+      result.current.startRun(WORKSPACE);
+    });
+
+    expect(result.current.runState).toBe('starting');
+
+    await waitFor(() => expect(result.current.runState).toBe('polling'));
+    expect(mockStartRun).toHaveBeenCalledWith(WORKSPACE, { full: true });
+    expect(result.current.gateEntries.length).toBeGreaterThan(0);
+    expect(result.current.gateEntries.every((e) => e.status === 'running')).toBe(true);
+  });
+
+  it('transitions to complete after poll resolves', async () => {
+    mockStartRun.mockResolvedValue(makeStartRunResponse(true));
+    mockGetRun.mockResolvedValue(makeGetRunResponse(true));
+
+    const { result } = renderHook(() => useProofRun());
+
+    act(() => {
+      result.current.startRun(WORKSPACE);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('polling'));
+
+    // Trigger the 2s poll interval
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('complete'));
+    expect(result.current.passed).toBe(true);
+    expect(result.current.gateEntries.some((e) => e.status === 'passed')).toBe(true);
+  });
+
+  it('sets passed=false when gates fail', async () => {
+    mockStartRun.mockResolvedValue(makeStartRunResponse(false));
+    mockGetRun.mockResolvedValue(makeGetRunResponse(false));
+
+    const { result } = renderHook(() => useProofRun());
+
+    act(() => {
+      result.current.startRun(WORKSPACE);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('polling'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('complete'));
+    expect(result.current.passed).toBe(false);
+  });
+
+  it('transitions to error state on POST failure', async () => {
+    mockStartRun.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useProofRun());
+
+    act(() => {
+      result.current.startRun(WORKSPACE);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('error'));
+    expect(result.current.errorMessage).toContain('Network error');
+  });
+
+  it('transitions to error state on poll failure', async () => {
+    mockStartRun.mockResolvedValue(makeStartRunResponse());
+    mockGetRun.mockRejectedValue(new Error('Poll failed'));
+
+    const { result } = renderHook(() => useProofRun());
+
+    act(() => {
+      result.current.startRun(WORKSPACE);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('polling'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('error'));
+    expect(result.current.errorMessage).toBeTruthy();
+  });
+
+  it('retry() resets state to idle', async () => {
+    mockStartRun.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useProofRun());
+
+    act(() => {
+      result.current.startRun(WORKSPACE);
+    });
+
+    await waitFor(() => expect(result.current.runState).toBe('error'));
+
+    act(() => {
+      result.current.retry();
+    });
+
+    expect(result.current.runState).toBe('idle');
+    expect(result.current.errorMessage).toBeNull();
+  });
+});

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -12,8 +12,9 @@ import {
   TooltipProvider,
 } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
-import { ProofStatusBadge, WaiveDialog } from '@/components/proof';
+import { ProofStatusBadge, WaiveDialog, GateRunPanel, GateRunBanner } from '@/components/proof';
 import { proofApi } from '@/lib/api';
+import { useProofRun } from '@/hooks/useProofRun';
 import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
 import type { ProofRequirement, ProofRequirementListResponse, ProofReqStatus, ProofSeverity } from '@/types';
 
@@ -103,6 +104,8 @@ function ProofPageContent() {
   const [workspaceReady, setWorkspaceReady] = useState(false);
   const [waivedReq, setWaivedReq] = useState<ProofRequirement | null>(null);
 
+  const { runState, gateEntries, passed, errorMessage, startRun, retry } = useProofRun();
+
   // Sort state (default: status asc → open first, then severity)
   const [sortCol, setSortCol] = useState<SortCol>('status');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
@@ -125,6 +128,13 @@ function ProofPageContent() {
     workspacePath ? `/api/v2/proof/requirements?path=${workspacePath}` : null,
     () => proofApi.listRequirements(workspacePath!)
   );
+
+  // Refresh requirements table after a run completes
+  useEffect(() => {
+    if (runState === 'complete') {
+      mutate();
+    }
+  }, [runState, mutate]);
 
   // Collect unique glitch types from data for the dropdown
   const glitchTypes = useMemo(() => {
@@ -172,12 +182,29 @@ function ProofPageContent() {
     <TooltipProvider>
     <main className="min-h-screen bg-background">
       <div className="mx-auto max-w-7xl px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold">PROOF9 Requirements</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            PROOF9 tracks quality requirements with evidence. Requirements must be satisfied or waived before shipping.{' '}
-            <a href="#proof9-help" className="text-primary hover:underline">Learn more ↓</a>
-          </p>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">PROOF9 Requirements</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              PROOF9 tracks quality requirements with evidence. Requirements must be satisfied or waived before shipping.{' '}
+              <a href="#proof9-help" className="text-primary hover:underline">Learn more ↓</a>
+            </p>
+          </div>
+          <Button
+            onClick={() => workspacePath && startRun(workspacePath)}
+            disabled={!workspacePath || runState === 'starting' || runState === 'polling'}
+            aria-label="Run all proof gates"
+            className="shrink-0"
+          >
+            {(runState === 'starting' || runState === 'polling') ? (
+              <span className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+                Running…
+              </span>
+            ) : (
+              'Run Gates'
+            )}
+          </Button>
         </div>
 
         {isLoading && (
@@ -228,6 +255,25 @@ function ProofPageContent() {
 
           return (
           <>
+            {/* Gate run progress and result */}
+            {(runState === 'starting' || runState === 'polling' || runState === 'complete' || runState === 'error') && gateEntries.length > 0 && (
+              <GateRunPanel gateEntries={gateEntries} />
+            )}
+            {runState === 'complete' && passed !== null && (
+              <GateRunBanner passed={passed} message="" onRetry={retry} />
+            )}
+            {runState === 'error' && errorMessage && (
+              <div
+                role="alert"
+                className="mb-4 flex items-center gap-3 rounded-lg border border-destructive bg-destructive/10 px-4 py-3"
+              >
+                <p className="text-sm text-destructive flex-1">{errorMessage}</p>
+                <Button variant="ghost" size="sm" onClick={retry} className="text-destructive hover:text-destructive">
+                  Retry
+                </Button>
+              </div>
+            )}
+
             <div className="mb-4 flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
               <span>{data.by_status?.open ?? 0} open</span>
               <span>{data.by_status?.satisfied ?? 0} satisfied</span>

--- a/web-ui/src/components/proof/GateRunBanner.tsx
+++ b/web-ui/src/components/proof/GateRunBanner.tsx
@@ -14,11 +14,11 @@ export function GateRunBanner({ passed, message, onRetry }: GateRunBannerProps) 
       <div
         role="status"
         aria-live="polite"
-        className="mb-4 flex items-center gap-3 rounded-lg border border-green-300 bg-green-50 px-4 py-3"
+        className="mb-4 flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3"
       >
-        <span className="h-2.5 w-2.5 rounded-full bg-green-500" aria-hidden="true" />
-        <p className="text-sm font-medium text-green-900">All gates passed</p>
-        <span className="text-xs text-green-700 ml-1">{message}</span>
+        <span className="h-2.5 w-2.5 rounded-full bg-green-400" aria-hidden="true" />
+        <p className="text-sm font-medium">All gates passed</p>
+        {message && <span className="text-xs text-muted-foreground ml-1">{message}</span>}
       </div>
     );
   }
@@ -27,12 +27,12 @@ export function GateRunBanner({ passed, message, onRetry }: GateRunBannerProps) 
     <div
       role="alert"
       aria-live="assertive"
-      className="mb-4 flex items-center gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3"
+      className="mb-4 flex items-center gap-3 rounded-lg border border-destructive bg-destructive/10 px-4 py-3"
     >
-      <span className="h-2.5 w-2.5 rounded-full bg-red-500" aria-hidden="true" />
-      <p className="text-sm font-medium text-red-900">Some gates failed</p>
-      <span className="text-xs text-red-700 ml-1 flex-1">{message}</span>
-      <Button variant="ghost" size="sm" onClick={onRetry} className="text-red-800 hover:text-red-900">
+      <span className="h-2.5 w-2.5 rounded-full bg-red-400" aria-hidden="true" />
+      <p className="text-sm font-medium text-destructive">Some gates failed</p>
+      {message && <span className="text-xs text-destructive/80 ml-1 flex-1">{message}</span>}
+      <Button variant="ghost" size="sm" onClick={onRetry} className="text-destructive hover:text-destructive/80">
         Retry
       </Button>
     </div>

--- a/web-ui/src/components/proof/GateRunBanner.tsx
+++ b/web-ui/src/components/proof/GateRunBanner.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+interface GateRunBannerProps {
+  passed: boolean;
+  message: string;
+  onRetry: () => void;
+}
+
+export function GateRunBanner({ passed, message, onRetry }: GateRunBannerProps) {
+  if (passed) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mb-4 flex items-center gap-3 rounded-lg border border-green-300 bg-green-50 px-4 py-3"
+      >
+        <span className="h-2.5 w-2.5 rounded-full bg-green-500" aria-hidden="true" />
+        <p className="text-sm font-medium text-green-900">All gates passed</p>
+        <span className="text-xs text-green-700 ml-1">{message}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="mb-4 flex items-center gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3"
+    >
+      <span className="h-2.5 w-2.5 rounded-full bg-red-500" aria-hidden="true" />
+      <p className="text-sm font-medium text-red-900">Some gates failed</p>
+      <span className="text-xs text-red-700 ml-1 flex-1">{message}</span>
+      <Button variant="ghost" size="sm" onClick={onRetry} className="text-red-800 hover:text-red-900">
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/web-ui/src/components/proof/GateRunPanel.tsx
+++ b/web-ui/src/components/proof/GateRunPanel.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import type { GateRunEntry, GateRunStatus } from '@/types';
+
+interface GateRunPanelProps {
+  gateEntries: GateRunEntry[];
+}
+
+const STATUS_LABEL: Record<GateRunStatus, string> = {
+  pending: 'pending',
+  running: 'running',
+  passed: 'passed',
+  failed: 'failed',
+};
+
+const STATUS_CLASSES: Record<GateRunStatus, string> = {
+  pending: 'bg-gray-100 text-gray-600',
+  running: 'bg-blue-100 text-blue-800 animate-pulse',
+  passed: 'bg-green-100 text-green-900',
+  failed: 'bg-red-100 text-red-900',
+};
+
+export function GateRunPanel({ gateEntries }: GateRunPanelProps) {
+  if (gateEntries.length === 0) return null;
+
+  return (
+    <div
+      role="status"
+      aria-label="Gate run progress"
+      className="mb-4 rounded-lg border bg-muted/30 p-4"
+    >
+      <p className="mb-2 text-sm font-medium">Gate progress</p>
+      <ul className="flex flex-wrap gap-2">
+        {gateEntries.map(({ gate, status }) => (
+          <li key={gate} className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground capitalize">{gate}</span>
+            <Badge className={STATUS_CLASSES[status]}>
+              {STATUS_LABEL[status]}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web-ui/src/components/proof/GateRunPanel.tsx
+++ b/web-ui/src/components/proof/GateRunPanel.tsx
@@ -7,18 +7,12 @@ interface GateRunPanelProps {
   gateEntries: GateRunEntry[];
 }
 
-const STATUS_LABEL: Record<GateRunStatus, string> = {
-  pending: 'pending',
-  running: 'running',
-  passed: 'passed',
+// Map GateRunStatus to Badge variant names from the shared design system
+const STATUS_VARIANT: Record<GateRunStatus, 'backlog' | 'in-progress' | 'done' | 'failed'> = {
+  pending: 'backlog',
+  running: 'in-progress',
+  passed: 'done',
   failed: 'failed',
-};
-
-const STATUS_CLASSES: Record<GateRunStatus, string> = {
-  pending: 'bg-gray-100 text-gray-600',
-  running: 'bg-blue-100 text-blue-800 animate-pulse',
-  passed: 'bg-green-100 text-green-900',
-  failed: 'bg-red-100 text-red-900',
 };
 
 export function GateRunPanel({ gateEntries }: GateRunPanelProps) {
@@ -35,8 +29,11 @@ export function GateRunPanel({ gateEntries }: GateRunPanelProps) {
         {gateEntries.map(({ gate, status }) => (
           <li key={gate} className="flex items-center gap-1.5">
             <span className="text-xs text-muted-foreground capitalize">{gate}</span>
-            <Badge className={STATUS_CLASSES[status]}>
-              {STATUS_LABEL[status]}
+            <Badge
+              variant={STATUS_VARIANT[status]}
+              className={status === 'running' ? 'animate-pulse' : undefined}
+            >
+              {status}
             </Badge>
           </li>
         ))}

--- a/web-ui/src/components/proof/index.ts
+++ b/web-ui/src/components/proof/index.ts
@@ -1,3 +1,5 @@
 export { ProofStatusBadge } from './ProofStatusBadge';
 export { ProofStatusWidget } from './ProofStatusWidget';
 export { WaiveDialog } from './WaiveDialog';
+export { GateRunPanel } from './GateRunPanel';
+export { GateRunBanner } from './GateRunBanner';

--- a/web-ui/src/hooks/index.ts
+++ b/web-ui/src/hooks/index.ts
@@ -7,6 +7,7 @@ export {
 } from './useTerminalSocket';
 export { useEventSource, type SSEStatus, type UseEventSourceOptions } from './useEventSource';
 export { useRequirementsLookup } from './useRequirementsLookup';
+export { useProofRun, type UseProofRunReturn, type ProofRunState } from './useProofRun';
 export {
   useTaskStream,
   type UseTaskStreamOptions,

--- a/web-ui/src/hooks/useProofRun.ts
+++ b/web-ui/src/hooks/useProofRun.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { proofApi } from '@/lib/api';
+import type { GateRunEntry, GateRunStatus } from '@/types';
+
+export type ProofRunState = 'idle' | 'starting' | 'polling' | 'complete' | 'error';
+
+export interface UseProofRunReturn {
+  runState: ProofRunState;
+  gateEntries: GateRunEntry[];
+  passed: boolean | null;
+  errorMessage: string | null;
+  startRun: (workspacePath: string) => void;
+  retry: () => void;
+}
+
+/**
+ * Manages the full lifecycle of a PROOF9 gate run.
+ *
+ * Flow: idle → starting (POST) → polling (GET every 2s) → complete / error
+ *
+ * Since POST /run is synchronous on the backend, the first poll immediately
+ * resolves. The optimistic "pending → running" transition gives visual feedback
+ * before the final pass/fail state is applied.
+ */
+export function useProofRun(): UseProofRunReturn {
+  const [runState, setRunState] = useState<ProofRunState>('idle');
+  const [gateEntries, setGateEntries] = useState<GateRunEntry[]>([]);
+  const [passed, setPassed] = useState<boolean | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const workspaceRef = useRef<string>('');
+  const runIdRef = useRef<string>('');
+
+  const clearPollInterval = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return clearPollInterval;
+  }, [clearPollInterval]);
+
+  const startRun = useCallback(
+    async (workspacePath: string) => {
+      clearPollInterval();
+      workspaceRef.current = workspacePath;
+      setRunState('starting');
+      setGateEntries([]);
+      setPassed(null);
+      setErrorMessage(null);
+
+      try {
+        const response = await proofApi.startRun(workspacePath, { full: true });
+        runIdRef.current = response.run_id;
+
+        // Build optimistic "running" entries from returned results
+        const entries: GateRunEntry[] = Object.values(response.results)
+          .flat()
+          .map((item) => ({ gate: item.gate, status: 'running' as GateRunStatus }));
+        // Deduplicate gate names
+        const seen = new Set<string>();
+        const uniqueEntries = entries.filter(({ gate }) => {
+          if (seen.has(gate)) return false;
+          seen.add(gate);
+          return true;
+        });
+
+        setGateEntries(uniqueEntries.length > 0 ? uniqueEntries : []);
+        setRunState('polling');
+
+        // Poll every 2s until complete
+        intervalRef.current = setInterval(async () => {
+          try {
+            const status = await proofApi.getRun(workspaceRef.current, runIdRef.current);
+            if (status.status === 'complete') {
+              clearPollInterval();
+
+              // Build final gate entries with pass/fail status
+              const finalEntries: GateRunEntry[] = Object.values(status.results)
+                .flat()
+                .map((item) => ({
+                  gate: item.gate,
+                  status: item.satisfied ? ('passed' as GateRunStatus) : ('failed' as GateRunStatus),
+                }));
+              const seenFinal = new Set<string>();
+              const uniqueFinal = finalEntries.filter(({ gate }) => {
+                if (seenFinal.has(gate)) return false;
+                seenFinal.add(gate);
+                return true;
+              });
+
+              setGateEntries(uniqueFinal);
+              setPassed(status.passed);
+              setRunState('complete');
+            }
+          } catch {
+            clearPollInterval();
+            setErrorMessage('Failed to retrieve run status. Please retry.');
+            setRunState('error');
+          }
+        }, 2000);
+      } catch (err: unknown) {
+        clearPollInterval();
+        const message =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'object' && err !== null && 'detail' in err
+            ? String((err as { detail: unknown }).detail)
+            : 'Failed to start proof run.';
+        setErrorMessage(message);
+        setRunState('error');
+      }
+    },
+    [clearPollInterval]
+  );
+
+  const retry = useCallback(() => {
+    clearPollInterval();
+    setRunState('idle');
+    setGateEntries([]);
+    setPassed(null);
+    setErrorMessage(null);
+  }, [clearPollInterval]);
+
+  return { runState, gateEntries, passed, errorMessage, startRun, retry };
+}

--- a/web-ui/src/hooks/useProofRun.ts
+++ b/web-ui/src/hooks/useProofRun.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { proofApi } from '@/lib/api';
-import type { GateRunEntry, GateRunStatus } from '@/types';
+import type { GateRunEntry, GateRunStatus, RunProofRequest } from '@/types';
 
 export type ProofRunState = 'idle' | 'starting' | 'polling' | 'complete' | 'error';
 
@@ -55,7 +55,8 @@ export function useProofRun(): UseProofRunReturn {
       setErrorMessage(null);
 
       try {
-        const response = await proofApi.startRun(workspacePath, { full: true });
+        const runRequest: RunProofRequest = { full: true };
+        const response = await proofApi.startRun(workspacePath, runRequest);
         runIdRef.current = response.run_id;
 
         // Build optimistic "running" entries from returned results

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -43,6 +43,7 @@ import type {
   ProofStatusResponse,
   ProofReqStatus,
   WaiveRequest,
+  RunProofRequest,
   RunProofResponse,
   RunStatusResponse,
   Session,
@@ -634,7 +635,7 @@ export const proofApi = {
 
   startRun: async (
     workspacePath: string,
-    body: { full: boolean }
+    body: RunProofRequest
   ): Promise<RunProofResponse> => {
     const response = await api.post<RunProofResponse>(
       '/api/v2/proof/run',

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -43,6 +43,8 @@ import type {
   ProofStatusResponse,
   ProofReqStatus,
   WaiveRequest,
+  RunProofResponse,
+  RunStatusResponse,
   Session,
   SessionState,
   SessionListResponse,
@@ -625,6 +627,26 @@ export const proofApi = {
     const response = await api.post<ProofRequirement>(
       `/api/v2/proof/requirements/${encodeURIComponent(reqId)}/waive`,
       body,
+      { params: { workspace_path: workspacePath } }
+    );
+    return response.data;
+  },
+
+  startRun: async (
+    workspacePath: string,
+    body: { full: boolean }
+  ): Promise<RunProofResponse> => {
+    const response = await api.post<RunProofResponse>(
+      '/api/v2/proof/run',
+      body,
+      { params: { workspace_path: workspacePath } }
+    );
+    return response.data;
+  },
+
+  getRun: async (workspacePath: string, runId: string): Promise<RunStatusResponse> => {
+    const response = await api.get<RunStatusResponse>(
+      `/api/v2/proof/runs/${encodeURIComponent(runId)}`,
       { params: { workspace_path: workspacePath } }
     );
     return response.data;

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -343,6 +343,30 @@ export interface WaiveRequest {
   approved_by: string;
 }
 
+// Proof run types (mirrors proof_v2.py RunProofResponse + RunStatusResponse)
+export interface RunProofResponse {
+  success: boolean;
+  run_id: string;
+  results: Record<string, Array<{ gate: string; satisfied: boolean }>>;
+  message: string;
+}
+
+export interface RunStatusResponse {
+  run_id: string;
+  status: 'running' | 'complete';
+  results: Record<string, Array<{ gate: string; satisfied: boolean }>>;
+  passed: boolean;
+  message: string;
+}
+
+// UI-only types for per-gate display in the Run Gates panel
+export type GateRunStatus = 'pending' | 'running' | 'passed' | 'failed';
+
+export interface GateRunEntry {
+  gate: string;
+  status: GateRunStatus;
+}
+
 
 // Quick Actions props (dashboard)
 export interface QuickActionsProps {

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -344,6 +344,10 @@ export interface WaiveRequest {
 }
 
 // Proof run types (mirrors proof_v2.py RunProofResponse + RunStatusResponse)
+export interface RunProofRequest {
+  full: boolean;
+}
+
 export interface RunProofResponse {
   success: boolean;
   run_id: string;


### PR DESCRIPTION
## Summary

- **[Run Gates] button** in the PROOF9 page header, disabled while a run is in progress
- Clicking triggers `POST /api/v2/proof/run`, then polls `GET /api/v2/proof/runs/{run_id}` every 2s showing per-gate `pending → running → passed/failed` transitions via `GateRunPanel`
- `GateRunBanner` shows overall pass/fail result on completion with a Retry option; requirements table refreshes automatically via `mutate()`
- Error state surfaces with a Retry button if POST or polling fails

## Changes

### Backend
- `proof_v2.py`: module-level `_run_cache`, `RunStatusResponse` model, `GET /api/v2/proof/runs/{run_id}` endpoint
- `test_proof_v2.py`: 4 new tests for the polling endpoint

### Frontend
- `types/index.ts`: `RunProofResponse`, `RunStatusResponse`, `GateRunStatus`, `GateRunEntry`
- `lib/api.ts`: `proofApi.startRun()` and `proofApi.getRun()`
- `hooks/useProofRun.ts` (new): idle→starting→polling→complete/error state machine with interval cleanup
- `components/proof/GateRunPanel.tsx` (new): per-gate status badges with `animate-pulse` for running state
- `components/proof/GateRunBanner.tsx` (new): overall pass/fail banner
- `app/proof/page.tsx`: Run Gates button + conditional GateRunPanel/GateRunBanner/error rendering

## Test plan

- [x] `uv run pytest tests/ui/test_proof_v2.py` — 39 passed
- [x] `npm test` — 687 passed (7 new tests for `useProofRun`)
- [x] `npm run build` — clean build, no type errors
- [x] `ruff check .` — no issues

Closes #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run Gates flow: start a run, poll status, view per-gate progress, and see an overall pass/fail banner with retry.
  * New API to fetch cached run status and results for polling.

* **Tests**
  * Added end-to-end tests for run endpoints, hook state transitions, and new UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->