### PR TITLE
feat(web-ui): Glitch Capture entry point and form for PROOF9 (#568)

### DIFF
--- a/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
+++ b/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CaptureGlitchModal } from '@/components/proof/CaptureGlitchModal';
+import { proofApi } from '@/lib/api';
+import type { ProofRequirement } from '@/types';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/api', () => ({
+  proofApi: {
+    capture: jest.fn(),
+  },
+}));
+
+const mockCapture = proofApi.capture as jest.MockedFunction<typeof proofApi.capture>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const WORKSPACE = '/home/user/project';
+
+const DEFAULT_PROPS = {
+  open: true,
+  workspacePath: WORKSPACE,
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+};
+
+const MOCK_REQ: ProofRequirement = {
+  id: 'REQ-001',
+  title: 'Test glitch',
+  description: 'Something broke in production',
+  severity: 'high',
+  source: 'production',
+  status: 'open',
+  glitch_type: null,
+  obligations: [],
+  evidence_rules: [],
+  waiver: null,
+  created_at: '2026-04-09T00:00:00Z',
+  satisfied_at: null,
+  created_by: 'human',
+  source_issue: null,
+  related_reqs: [],
+};
+
+function setup(props = DEFAULT_PROPS) {
+  return render(<CaptureGlitchModal {...props} />);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('CaptureGlitchModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders dialog with title and description when open', () => {
+      setup();
+      expect(screen.getByRole('heading', { name: 'Capture Glitch' })).toBeInTheDocument();
+      expect(screen.getByText(/Convert a production failure/i)).toBeInTheDocument();
+    });
+
+    it('renders all form fields', () => {
+      setup();
+      expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Where was it found/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Scope/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Severity/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Expiry/i)).toBeInTheDocument();
+    });
+
+    it('renders all 9 gate checkboxes', () => {
+      setup();
+      const gates = ['unit', 'contract', 'e2e', 'visual', 'a11y', 'perf', 'sec', 'demo', 'manual'];
+      for (const gate of gates) {
+        expect(screen.getByRole('checkbox', { name: gate })).toBeInTheDocument();
+      }
+    });
+
+    it('renders Cancel and Capture Glitch buttons', () => {
+      setup();
+      expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Capture Glitch/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('validation', () => {
+    it('shows error when description is empty on submit', async () => {
+      setup();
+      // Check at least one gate
+      fireEvent.click(screen.getByRole('checkbox', { name: 'unit' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+      await waitFor(() => {
+        expect(screen.getByText(/Description is required/i)).toBeInTheDocument();
+      });
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it('shows error when no gates selected on submit', async () => {
+      setup();
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: 'Something broke' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+      await waitFor(() => {
+        expect(screen.getByText(/Select at least one gate/i)).toBeInTheDocument();
+      });
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submission', () => {
+    it('calls proofApi.capture with correct fields and calls onSuccess', async () => {
+      mockCapture.mockResolvedValue(MOCK_REQ);
+      setup();
+
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: 'Something broke in production' },
+      });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'unit' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        expect(mockCapture).toHaveBeenCalledWith(
+          WORKSPACE,
+          expect.objectContaining({
+            title: 'Something broke in production',
+            description: 'Something broke in production',
+            severity: 'high',
+            source: 'production',
+            created_by: 'human',
+          })
+        );
+      });
+      await waitFor(() => {
+        expect(DEFAULT_PROPS.onSuccess).toHaveBeenCalledWith(MOCK_REQ);
+      });
+    });
+
+    it('truncates description to 80 chars for title', async () => {
+      mockCapture.mockResolvedValue(MOCK_REQ);
+      setup();
+
+      const longDesc = 'A'.repeat(100);
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: longDesc },
+      });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'sec' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        expect(mockCapture).toHaveBeenCalledWith(
+          WORKSPACE,
+          expect.objectContaining({ title: 'A'.repeat(80) })
+        );
+      });
+    });
+
+    it('shows inline error and keeps modal open on API failure', async () => {
+      mockCapture.mockRejectedValue(new Error('Network error'));
+      setup();
+
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: 'Something broke' },
+      });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'demo' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to capture glitch/i)).toBeInTheDocument();
+      });
+      expect(DEFAULT_PROPS.onSuccess).not.toHaveBeenCalled();
+      // Modal still open
+      expect(screen.getByRole('heading', { name: 'Capture Glitch' })).toBeInTheDocument();
+    });
+
+    it('disables submit button while submitting', async () => {
+      let resolve!: (v: ProofRequirement) => void;
+      mockCapture.mockReturnValue(new Promise((r) => { resolve = r; }));
+      setup();
+
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: 'Something broke' },
+      });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'manual' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Capturing…/i)).toBeInTheDocument();
+      });
+      resolve(MOCK_REQ);
+    });
+  });
+
+  describe('cancel', () => {
+    it('calls onClose when Cancel is clicked', () => {
+      setup();
+      fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+      expect(DEFAULT_PROPS.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('state reset on reopen', () => {
+    it('clears form state when modal is reopened', () => {
+      const { rerender } = setup({ ...DEFAULT_PROPS, open: false });
+      rerender(<CaptureGlitchModal {...DEFAULT_PROPS} open={true} />);
+      expect((screen.getByLabelText(/Description/i) as HTMLTextAreaElement).value).toBe('');
+    });
+  });
+});

--- a/web-ui/src/__tests__/components/proof/ProofPage.test.tsx
+++ b/web-ui/src/__tests__/components/proof/ProofPage.test.tsx
@@ -25,7 +25,9 @@ jest.mock('@/components/proof', () => ({
   WaiveDialog: () => null,
   GateRunPanel: () => null,
   GateRunBanner: () => null,
+  GateEvidencePanel: () => null,
   RunHistoryPanel: () => null,
+  CaptureGlitchModal: () => null,
 }));
 jest.mock('next/link', () => {
   const MockLink = ({ href, children }: { href: string; children: React.ReactNode }) => (

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -12,7 +12,7 @@ import {
   TooltipProvider,
 } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
-import { ProofStatusBadge, WaiveDialog, GateRunPanel, GateRunBanner, RunHistoryPanel, GateEvidencePanel } from '@/components/proof';
+import { ProofStatusBadge, WaiveDialog, GateRunPanel, GateRunBanner, RunHistoryPanel, GateEvidencePanel, CaptureGlitchModal } from '@/components/proof';
 import { proofApi } from '@/lib/api';
 import { useProofRun } from '@/hooks/useProofRun';
 import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
@@ -103,6 +103,7 @@ function ProofPageContent() {
   const [workspacePath, setWorkspacePath] = useState<string | null>(null);
   const [workspaceReady, setWorkspaceReady] = useState(false);
   const [waivedReq, setWaivedReq] = useState<ProofRequirement | null>(null);
+  const [captureOpen, setCaptureOpen] = useState(false);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
 
   const { runState, gateEntries, passed, runMessage, errorMessage, startRun, retry } = useProofRun();
@@ -199,21 +200,30 @@ function ProofPageContent() {
               <a href="#proof9-help" className="text-primary hover:underline">Learn more ↓</a>
             </p>
           </div>
-          <Button
-            onClick={() => workspacePath && startRun(workspacePath)}
-            disabled={!workspacePath || runState === 'starting' || runState === 'polling'}
-            aria-label="Run all proof gates"
-            className="shrink-0"
-          >
-            {(runState === 'starting' || runState === 'polling') ? (
-              <span className="flex items-center gap-2">
-                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
-                Running…
-              </span>
-            ) : (
-              'Run Gates'
-            )}
-          </Button>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setCaptureOpen(true)}
+              disabled={!workspacePath}
+              aria-label="Capture a glitch as a new PROOF9 requirement"
+            >
+              Capture Glitch
+            </Button>
+            <Button
+              onClick={() => workspacePath && startRun(workspacePath)}
+              disabled={!workspacePath || runState === 'starting' || runState === 'polling'}
+              aria-label="Run all proof gates"
+            >
+              {(runState === 'starting' || runState === 'polling') ? (
+                <span className="flex items-center gap-2">
+                  <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+                  Running…
+                </span>
+              ) : (
+                'Run Gates'
+              )}
+            </Button>
+          </div>
         </div>
 
         {isLoading && (
@@ -506,6 +516,18 @@ function ProofPageContent() {
             onClose={() => setWaivedReq(null)}
             onSuccess={() => {
               setWaivedReq(null);
+              mutate();
+            }}
+          />
+        )}
+
+        {workspacePath && (
+          <CaptureGlitchModal
+            open={captureOpen}
+            workspacePath={workspacePath}
+            onClose={() => setCaptureOpen(false)}
+            onSuccess={() => {
+              setCaptureOpen(false);
               mutate();
             }}
           />

--- a/web-ui/src/components/proof/CaptureGlitchModal.tsx
+++ b/web-ui/src/components/proof/CaptureGlitchModal.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { proofApi } from '@/lib/api';
+import type { ProofRequirement, ProofSeverity, CaptureGlitchRequest } from '@/types';
+
+// The 9 PROOF9 gate types (mirrors Gate enum in codeframe/core/proof/models.py)
+const GATE_LIST = ['unit', 'contract', 'e2e', 'visual', 'a11y', 'perf', 'sec', 'demo', 'manual'] as const;
+
+const SOURCE_OPTIONS: { value: CaptureGlitchRequest['source']; label: string }[] = [
+  { value: 'production', label: 'Production' },
+  { value: 'qa', label: 'QA' },
+  { value: 'dogfooding', label: 'Dogfooding' },
+  { value: 'monitoring', label: 'Monitoring' },
+  { value: 'user_report', label: 'User Report' },
+];
+
+const SEVERITY_OPTIONS: { value: ProofSeverity; label: string }[] = [
+  { value: 'critical', label: 'Critical' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+];
+
+export interface CaptureGlitchModalProps {
+  open: boolean;
+  workspacePath: string;
+  onClose: () => void;
+  onSuccess: (req: ProofRequirement) => void;
+}
+
+export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: CaptureGlitchModalProps) {
+  const [description, setDescription] = useState('');
+  const [source, setSource] = useState<CaptureGlitchRequest['source']>('production');
+  const [scopeText, setScopeText] = useState('');
+  const [selectedGates, setSelectedGates] = useState<Set<string>>(new Set());
+  const [severity, setSeverity] = useState<ProofSeverity>('high');
+  const [expires, setExpires] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset all state when the modal opens
+  useEffect(() => {
+    if (open) {
+      setDescription('');
+      setSource('production');
+      setScopeText('');
+      setSelectedGates(new Set());
+      setSeverity('high');
+      setExpires('');
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [open]);
+
+  function toggleGate(gate: string) {
+    setSelectedGates((prev) => {
+      const next = new Set(prev);
+      if (next.has(gate)) {
+        next.delete(gate);
+      } else {
+        next.add(gate);
+      }
+      return next;
+    });
+  }
+
+  async function handleSubmit() {
+    // Validate
+    if (!description.trim()) {
+      setError('Description is required');
+      return;
+    }
+    if (selectedGates.size === 0) {
+      setError('Select at least one gate');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    // Derive title from first line of description (max 80 chars)
+    const title = description.trim().split('\n')[0].slice(0, 80);
+
+    // Derive `where` from scope lines, falling back to source
+    const scopeLines = scopeText.split('\n').map((l) => l.trim()).filter(Boolean);
+    const where = scopeLines.length > 0 ? scopeLines.join(', ') : source;
+
+    const body: CaptureGlitchRequest = {
+      title,
+      description: description.trim(),
+      where,
+      severity,
+      source,
+      created_by: 'human',
+    };
+
+    try {
+      const result = await proofApi.capture(workspacePath, body);
+      onSuccess(result);
+    } catch (err: unknown) {
+      const detail = (err as { detail?: string })?.detail;
+      setError(detail ?? 'Failed to capture glitch. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Capture Glitch</DialogTitle>
+          <DialogDescription>
+            Convert a production failure into a permanent PROOF9 requirement.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Description */}
+          <div>
+            <label htmlFor="capture-description" className="mb-1 block text-sm font-medium">
+              Description <span aria-hidden="true" className="text-destructive">*</span>
+            </label>
+            <Textarea
+              id="capture-description"
+              aria-label="Description"
+              rows={4}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe the failure…"
+            />
+          </div>
+
+          {/* Where found */}
+          <div>
+            <label htmlFor="capture-source" className="mb-1 block text-sm font-medium">
+              Where was it found? <span aria-hidden="true" className="text-destructive">*</span>
+            </label>
+            <Select value={source} onValueChange={(v) => setSource(v as CaptureGlitchRequest['source'])}>
+              <SelectTrigger id="capture-source" aria-label="Where was it found?">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SOURCE_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Scope */}
+          <div>
+            <label htmlFor="capture-scope" className="mb-1 block text-sm font-medium">
+              Scope <span className="text-muted-foreground font-normal">(affected files, routes, components — one per line)</span>
+            </label>
+            <Textarea
+              id="capture-scope"
+              aria-label="Scope"
+              rows={3}
+              value={scopeText}
+              onChange={(e) => setScopeText(e.target.value)}
+              placeholder={`src/components/Foo.tsx\n/api/v2/bar`}
+            />
+          </div>
+
+          {/* Gates */}
+          <div>
+            <p className="mb-2 text-sm font-medium">
+              PROOF9 Gates Required <span aria-hidden="true" className="text-destructive">*</span>
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {GATE_LIST.map((gate) => (
+                <label key={gate} className="flex cursor-pointer items-center gap-2 text-sm">
+                  <Checkbox
+                    aria-label={gate}
+                    checked={selectedGates.has(gate)}
+                    onCheckedChange={() => toggleGate(gate)}
+                  />
+                  {gate}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Severity */}
+          <div>
+            <label htmlFor="capture-severity" className="mb-1 block text-sm font-medium">
+              Severity <span aria-hidden="true" className="text-destructive">*</span>
+            </label>
+            <Select value={severity} onValueChange={(v) => setSeverity(v as ProofSeverity)}>
+              <SelectTrigger id="capture-severity" aria-label="Severity">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SEVERITY_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Expiry */}
+          <div>
+            <label htmlFor="capture-expires" className="mb-1 block text-sm font-medium">
+              Expiry date <span className="text-muted-foreground font-normal">(optional)</span>
+            </label>
+            <Input
+              id="capture-expires"
+              aria-label="Expiry"
+              type="date"
+              value={expires}
+              onChange={(e) => setExpires(e.target.value)}
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? (
+              <span className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+                Capturing…
+              </span>
+            ) : (
+              'Capture Glitch'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web-ui/src/components/proof/index.ts
+++ b/web-ui/src/components/proof/index.ts
@@ -5,3 +5,4 @@ export { GateRunPanel } from './GateRunPanel';
 export { GateRunBanner } from './GateRunBanner';
 export { GateEvidencePanel } from './GateEvidencePanel';
 export { RunHistoryPanel } from './RunHistoryPanel';
+export { CaptureGlitchModal } from './CaptureGlitchModal';

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -43,6 +43,7 @@ import type {
   ProofStatusResponse,
   ProofReqStatus,
   WaiveRequest,
+  CaptureGlitchRequest,
   RunProofRequest,
   RunProofResponse,
   RunStatusResponse,
@@ -617,6 +618,18 @@ export const proofApi = {
   getEvidence: async (workspacePath: string, reqId: string): Promise<ProofEvidence[]> => {
     const response = await api.get<ProofEvidence[]>(
       `/api/v2/proof/requirements/${encodeURIComponent(reqId)}/evidence`,
+      { params: { workspace_path: workspacePath } }
+    );
+    return response.data;
+  },
+
+  capture: async (
+    workspacePath: string,
+    body: CaptureGlitchRequest
+  ): Promise<ProofRequirement> => {
+    const response = await api.post<ProofRequirement>(
+      '/api/v2/proof/requirements',
+      body,
       { params: { workspace_path: workspacePath } }
     );
     return response.data;

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -343,6 +343,15 @@ export interface WaiveRequest {
   approved_by: string;
 }
 
+export interface CaptureGlitchRequest {
+  title: string;
+  description: string;
+  where: string;
+  severity: ProofSeverity;
+  source: 'production' | 'qa' | 'dogfooding' | 'monitoring' | 'user_report';
+  created_by: string;
+}
+
 // Proof run types (mirrors proof_v2.py RunProofResponse + RunStatusResponse)
 export interface RunProofRequest {
   full: boolean;


### PR DESCRIPTION
## Summary

Closes #568 — Phase 3.5C: Glitch Capture web UI

- **[Capture Glitch] button** added to PROOF9 page header, alongside [Run Gates]
- **Full modal form** with: description (required), where-found dropdown, scope textarea, 9-gate checkbox list (≥1 required), severity dropdown, optional expiry date
- **Calls `POST /api/v2/proof/requirements`** — backend was already ready
- **On success**: modal closes, `mutate()` re-fetches the requirements table so the new REQ appears immediately
- **On error**: inline error shown, modal stays open
- Form state resets cleanly on reopen

## Changes

| File | Change |
|------|--------|
| `web-ui/src/components/proof/CaptureGlitchModal.tsx` | New component |
| `web-ui/src/components/proof/index.ts` | Export added |
| `web-ui/src/lib/api.ts` | `proofApi.capture()` method added |
| `web-ui/src/types/index.ts` | `CaptureGlitchRequest` type added |
| `web-ui/src/app/proof/page.tsx` | Button + modal wired in |
| `web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx` | 12 new tests |
| `web-ui/src/__tests__/components/proof/ProofPage.test.tsx` | Mock updated (CaptureGlitchModal + GateEvidencePanel were missing) |

## Test plan

- [x] 12 new unit tests covering: rendering, form field presence, 9-gate checkboxes, validation (empty description, no gates), successful submit with correct payload, title truncation, API error handling, disabled state during submit, cancel, state reset on reopen
- [x] All 715 tests pass (`npm test`)
- [x] `npm run build` succeeds — all routes clean
- [x] Python: `uv run ruff check .` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Capture Glitch" functionality to convert production failures into PROOF9 requirements.
  * New modal dialog with form fields for description, scope, gates, severity, and expiry.
  * Integrated form validation and error handling for improved user feedback.

* **Tests**
  * Added comprehensive test coverage for the new Capture Glitch modal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->