### PR TITLE
fix(web-ui): address CodeRabbit review feedback on Glitch Capture (#568)

### DIFF
--- a/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
+++ b/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
@@ -130,7 +130,9 @@ describe('CaptureGlitchModal', () => {
           WORKSPACE,
           expect.objectContaining({
             title: 'Something broke in production',
-            description: 'Something broke in production\n\nRequired gates: unit, sec',
+            description: expect.stringMatching(
+              /^Something broke in production\n\nRequired gates: (unit, sec|sec, unit)$/
+            ),
             severity: 'high',
             source: 'production',
             created_by: 'human',

--- a/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
+++ b/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
@@ -55,7 +55,7 @@ describe('CaptureGlitchModal', () => {
   });
 
   describe('rendering', () => {
-    it('renders dialog with title and description when open', () => {
+    it('renders slide-over panel with title and description when open', () => {
       setup();
       expect(screen.getByRole('heading', { name: 'Capture Glitch' })).toBeInTheDocument();
       expect(screen.getByText(/Convert a production failure/i)).toBeInTheDocument();
@@ -67,7 +67,11 @@ describe('CaptureGlitchModal', () => {
       expect(screen.getByLabelText(/Where was it found/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/Scope/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/Severity/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/Expiry/i)).toBeInTheDocument();
+    });
+
+    it('does not render an expiry date field (expiry is set at waiver time)', () => {
+      setup();
+      expect(screen.queryByLabelText(/Expiry/i)).not.toBeInTheDocument();
     });
 
     it('renders all 9 gate checkboxes', () => {
@@ -88,7 +92,6 @@ describe('CaptureGlitchModal', () => {
   describe('validation', () => {
     it('shows error when description is empty on submit', async () => {
       setup();
-      // Check at least one gate
       fireEvent.click(screen.getByRole('checkbox', { name: 'unit' }));
       fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
       await waitFor(() => {
@@ -111,7 +114,7 @@ describe('CaptureGlitchModal', () => {
   });
 
   describe('submission', () => {
-    it('calls proofApi.capture with correct fields and calls onSuccess', async () => {
+    it('appends selected gates to description and calls onSuccess', async () => {
       mockCapture.mockResolvedValue(MOCK_REQ);
       setup();
 
@@ -119,6 +122,7 @@ describe('CaptureGlitchModal', () => {
         target: { value: 'Something broke in production' },
       });
       fireEvent.click(screen.getByRole('checkbox', { name: 'unit' }));
+      fireEvent.click(screen.getByRole('checkbox', { name: 'sec' }));
       fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
 
       await waitFor(() => {
@@ -126,7 +130,7 @@ describe('CaptureGlitchModal', () => {
           WORKSPACE,
           expect.objectContaining({
             title: 'Something broke in production',
-            description: 'Something broke in production',
+            description: 'Something broke in production\n\nRequired gates: unit, sec',
             severity: 'high',
             source: 'production',
             created_by: 'human',
@@ -138,7 +142,7 @@ describe('CaptureGlitchModal', () => {
       });
     });
 
-    it('truncates description to 80 chars for title', async () => {
+    it('truncates long description to 80 chars for title', async () => {
       mockCapture.mockResolvedValue(MOCK_REQ);
       setup();
 
@@ -157,7 +161,24 @@ describe('CaptureGlitchModal', () => {
       });
     });
 
-    it('shows inline error and keeps modal open on API failure', async () => {
+    it('surfaces backend error detail from axios response on failure', async () => {
+      const axiosError = { response: { data: { detail: 'Workspace not found' } } };
+      mockCapture.mockRejectedValue(axiosError);
+      setup();
+
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: 'Something broke' },
+      });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'demo' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Workspace not found')).toBeInTheDocument();
+      });
+      expect(DEFAULT_PROPS.onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('shows fallback error message when axios error has no detail', async () => {
       mockCapture.mockRejectedValue(new Error('Network error'));
       setup();
 
@@ -170,12 +191,9 @@ describe('CaptureGlitchModal', () => {
       await waitFor(() => {
         expect(screen.getByText(/Failed to capture glitch/i)).toBeInTheDocument();
       });
-      expect(DEFAULT_PROPS.onSuccess).not.toHaveBeenCalled();
-      // Modal still open
-      expect(screen.getByRole('heading', { name: 'Capture Glitch' })).toBeInTheDocument();
     });
 
-    it('disables submit button while submitting', async () => {
+    it('shows submitting state while in-flight', async () => {
       let resolve!: (v: ProofRequirement) => void;
       mockCapture.mockReturnValue(new Promise((r) => { resolve = r; }));
       setup();
@@ -197,6 +215,12 @@ describe('CaptureGlitchModal', () => {
     it('calls onClose when Cancel is clicked', () => {
       setup();
       fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+      expect(DEFAULT_PROPS.onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when the × button is clicked', () => {
+      setup();
+      fireEvent.click(screen.getByRole('button', { name: /Close/i }));
       expect(DEFAULT_PROPS.onClose).toHaveBeenCalled();
     });
   });

--- a/web-ui/src/components/proof/CaptureGlitchModal.tsx
+++ b/web-ui/src/components/proof/CaptureGlitchModal.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@/components/ui/dialog';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -54,7 +47,6 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
   const [scopeText, setScopeText] = useState('');
   const [selectedGates, setSelectedGates] = useState<Set<string>>(new Set());
   const [severity, setSeverity] = useState<ProofSeverity>('high');
-  const [expires, setExpires] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -66,7 +58,6 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
       setScopeText('');
       setSelectedGates(new Set());
       setSeverity('high');
-      setExpires('');
       setSubmitting(false);
       setError(null);
     }
@@ -101,13 +92,19 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
     // Derive title from first line of description (max 80 chars)
     const title = description.trim().split('\n')[0].slice(0, 80);
 
+    // Append selected gates to description so the backend LLM uses them when
+    // deriving obligations (CaptureRequirementRequest has no gates field;
+    // obligations are auto-derived from the description).
+    const gateHint = `\n\nRequired gates: ${Array.from(selectedGates).join(', ')}`;
+    const fullDescription = description.trim() + gateHint;
+
     // Derive `where` from scope lines, falling back to source
     const scopeLines = scopeText.split('\n').map((l) => l.trim()).filter(Boolean);
     const where = scopeLines.length > 0 ? scopeLines.join(', ') : source;
 
     const body: CaptureGlitchRequest = {
       title,
-      description: description.trim(),
+      description: fullDescription,
       where,
       severity,
       source,
@@ -118,140 +115,155 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
       const result = await proofApi.capture(workspacePath, body);
       onSuccess(result);
     } catch (err: unknown) {
-      const detail = (err as { detail?: string })?.detail;
-      setError(detail ?? 'Failed to capture glitch. Please try again.');
+      // Axios errors carry detail at err.response.data.detail
+      const axiosErr = err as { response?: { data?: { detail?: string } } };
+      const detail = axiosErr?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Failed to capture glitch. Please try again.');
     } finally {
       setSubmitting(false);
     }
   }
 
+  // Slide-over panel using Radix Dialog primitives directly so we can position
+  // it as a right-anchored sheet rather than a centered modal.
   return (
-    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Capture Glitch</DialogTitle>
-          <DialogDescription>
-            Convert a production failure into a permanent PROOF9 requirement.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4">
-          {/* Description */}
-          <div>
-            <label htmlFor="capture-description" className="mb-1 block text-sm font-medium">
-              Description <span aria-hidden="true" className="text-destructive">*</span>
-            </label>
-            <Textarea
-              id="capture-description"
-              aria-label="Description"
-              rows={4}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Describe the failure…"
-            />
+    <DialogPrimitive.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          className="fixed inset-y-0 right-0 z-50 flex h-full w-full flex-col border-l bg-background shadow-xl transition-transform duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-lg"
+          aria-describedby="capture-description-text"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b px-6 py-4">
+            <div>
+              <DialogPrimitive.Title className="text-lg font-semibold">
+                Capture Glitch
+              </DialogPrimitive.Title>
+              <p id="capture-description-text" className="mt-0.5 text-sm text-muted-foreground">
+                Convert a production failure into a permanent PROOF9 requirement.
+              </p>
+            </div>
+            <DialogPrimitive.Close asChild>
+              <button
+                type="button"
+                aria-label="Close"
+                className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M18 6 6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </DialogPrimitive.Close>
           </div>
 
-          {/* Where found */}
-          <div>
-            <label htmlFor="capture-source" className="mb-1 block text-sm font-medium">
-              Where was it found? <span aria-hidden="true" className="text-destructive">*</span>
-            </label>
-            <Select value={source} onValueChange={(v) => setSource(v as CaptureGlitchRequest['source'])}>
-              <SelectTrigger id="capture-source" aria-label="Where was it found?">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SOURCE_OPTIONS.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Scope */}
-          <div>
-            <label htmlFor="capture-scope" className="mb-1 block text-sm font-medium">
-              Scope <span className="text-muted-foreground font-normal">(affected files, routes, components — one per line)</span>
-            </label>
-            <Textarea
-              id="capture-scope"
-              aria-label="Scope"
-              rows={3}
-              value={scopeText}
-              onChange={(e) => setScopeText(e.target.value)}
-              placeholder={`src/components/Foo.tsx\n/api/v2/bar`}
-            />
-          </div>
-
-          {/* Gates */}
-          <div>
-            <p className="mb-2 text-sm font-medium">
-              PROOF9 Gates Required <span aria-hidden="true" className="text-destructive">*</span>
-            </p>
-            <div className="grid grid-cols-3 gap-2">
-              {GATE_LIST.map((gate) => (
-                <label key={gate} className="flex cursor-pointer items-center gap-2 text-sm">
-                  <Checkbox
-                    aria-label={gate}
-                    checked={selectedGates.has(gate)}
-                    onCheckedChange={() => toggleGate(gate)}
-                  />
-                  {gate}
+          {/* Scrollable form body */}
+          <div className="flex-1 overflow-y-auto px-6 py-4">
+            <div className="space-y-5">
+              {/* Description */}
+              <div>
+                <label htmlFor="capture-description" className="mb-1 block text-sm font-medium">
+                  Description <span aria-hidden="true" className="text-destructive">*</span>
                 </label>
-              ))}
+                <Textarea
+                  id="capture-description"
+                  rows={4}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Describe the failure…"
+                />
+              </div>
+
+              {/* Where found */}
+              <div>
+                <label htmlFor="capture-source" className="mb-1 block text-sm font-medium">
+                  Where was it found? <span aria-hidden="true" className="text-destructive">*</span>
+                </label>
+                <Select value={source} onValueChange={(v) => setSource(v as CaptureGlitchRequest['source'])}>
+                  <SelectTrigger id="capture-source">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SOURCE_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Scope */}
+              <div>
+                <label htmlFor="capture-scope" className="mb-1 block text-sm font-medium">
+                  Scope <span className="font-normal text-muted-foreground">(affected files, routes, components — one per line)</span>
+                </label>
+                <Textarea
+                  id="capture-scope"
+                  rows={3}
+                  value={scopeText}
+                  onChange={(e) => setScopeText(e.target.value)}
+                  placeholder={`src/components/Foo.tsx\n/api/v2/bar`}
+                />
+              </div>
+
+              {/* Gates */}
+              <div>
+                <p className="mb-2 text-sm font-medium">
+                  PROOF9 Gates Required <span aria-hidden="true" className="text-destructive">*</span>
+                  <span className="ml-2 font-normal text-muted-foreground text-xs">(appended to description to guide obligation derivation)</span>
+                </p>
+                <div className="grid grid-cols-3 gap-2">
+                  {GATE_LIST.map((gate) => (
+                    <label key={gate} className="flex cursor-pointer items-center gap-2 text-sm">
+                      <Checkbox
+                        aria-label={gate}
+                        checked={selectedGates.has(gate)}
+                        onCheckedChange={() => toggleGate(gate)}
+                      />
+                      {gate}
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {/* Severity */}
+              <div>
+                <label htmlFor="capture-severity" className="mb-1 block text-sm font-medium">
+                  Severity <span aria-hidden="true" className="text-destructive">*</span>
+                </label>
+                <Select value={severity} onValueChange={(v) => setSeverity(v as ProofSeverity)}>
+                  <SelectTrigger id="capture-severity">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SEVERITY_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {error && <p className="text-sm text-destructive">{error}</p>}
             </div>
           </div>
 
-          {/* Severity */}
-          <div>
-            <label htmlFor="capture-severity" className="mb-1 block text-sm font-medium">
-              Severity <span aria-hidden="true" className="text-destructive">*</span>
-            </label>
-            <Select value={severity} onValueChange={(v) => setSeverity(v as ProofSeverity)}>
-              <SelectTrigger id="capture-severity" aria-label="Severity">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SEVERITY_OPTIONS.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          {/* Footer */}
+          <div className="flex justify-end gap-2 border-t px-6 py-4">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSubmit} disabled={submitting}>
+              {submitting ? (
+                <span className="flex items-center gap-2">
+                  <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+                  Capturing…
+                </span>
+              ) : (
+                'Capture Glitch'
+              )}
+            </Button>
           </div>
-
-          {/* Expiry */}
-          <div>
-            <label htmlFor="capture-expires" className="mb-1 block text-sm font-medium">
-              Expiry date <span className="text-muted-foreground font-normal">(optional)</span>
-            </label>
-            <Input
-              id="capture-expires"
-              aria-label="Expiry"
-              type="date"
-              value={expires}
-              onChange={(e) => setExpires(e.target.value)}
-            />
-          </div>
-
-          {error && <p className="text-sm text-destructive">{error}</p>}
-        </div>
-
-        <DialogFooter>
-          <Button type="button" variant="ghost" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleSubmit} disabled={submitting}>
-            {submitting ? (
-              <span className="flex items-center gap-2">
-                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
-                Capturing…
-              </span>
-            ) : (
-              'Capture Glitch'
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }

--- a/web-ui/src/components/proof/CaptureGlitchModal.tsx
+++ b/web-ui/src/components/proof/CaptureGlitchModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { Cancel01Icon } from '@hugeicons/react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -150,9 +151,7 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
                 aria-label="Close"
                 className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M18 6 6 18M6 6l12 12" />
-                </svg>
+                <Cancel01Icon className="h-4 w-4" aria-hidden="true" />
               </button>
             </DialogPrimitive.Close>
           </div>


### PR DESCRIPTION
Fixes three bugs identified by CodeRabbit on #576 after merge.

## Bugs fixed

**Medium — Gates silently discarded**
`selectedGates` was validated (≥1 required) but never included in the API payload. `CaptureRequirementRequest` has no `gates` field — obligations are auto-derived by LLM from the description. Fix: append `\n\nRequired gates: unit, sec, ...` to the description before POSTing, so the LLM uses the selections when deriving obligations.

**Low — Expiry field was dead code**
`expires` state was rendered and collected but `CaptureRequirementRequest` has no `expires` field (that belongs to `WaiveRequirementRequest`). Fix: removed the field from the form and state entirely. Expiry is set at waiver time.

**Low — Axios error detail never surfaced**
`(err as { detail?: string })?.detail` always resolves to `undefined` on Axios errors — the detail is at `err.response.data.detail`. Fix: correct extraction with fallback to generic message.

## Also

Refactored from centered `Dialog` (max-w-lg) to a right-anchored **slide-over** using Radix `DialogPrimitive` directly. The issue spec required "full-screen modal or slide-over" and the form height warrants it.

## Test plan

- [x] New test: `surfaces backend error detail from axios response on failure` — verifies Workspace not found message is shown
- [x] New test: `shows fallback error message when axios error has no detail`
- [x] New test: `does not render an expiry date field`
- [x] Updated: submission test now asserts gates appear in description payload
- [x] 718/718 tests pass, clean build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned capture modal as a right-anchored slide-over panel
  * Removed expiry date field from the capture flow
  * Enhanced gate selection integration in form submission

* **New Features**
  * Improved error handling with backend-provided error details and fallback messaging

* **Tests**
  * Updated test suite to reflect modal UI redesign and submission behavior changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->