### PR TITLE
fix(pr-status): address claude-review feedback post-merge (#571 follow-up)

### DIFF
--- a/web-ui/__tests__/components/review/PRStatusPanel.test.tsx
+++ b/web-ui/__tests__/components/review/PRStatusPanel.test.tsx
@@ -34,6 +34,10 @@ const failingCIChecks = [
   { name: 'tests', status: 'completed', conclusion: 'failure' },
 ];
 
+const pendingCIChecks = [
+  { name: 'tests', status: 'in_progress', conclusion: null },
+];
+
 const basePRStatus = {
   ci_checks: successfulCIChecks,
   review_status: 'approved',
@@ -79,11 +83,20 @@ const proofStatusWithOpenReqs = {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-const setupSWRMock = (prStatus: object, proofStatus: object) => {
+const setupSWRMock = (
+  prStatus: object | undefined,
+  proofStatus: object | undefined,
+  options?: { proofLoading?: boolean; proofError?: unknown }
+) => {
   mockUseSWR.mockImplementation((key: unknown) => {
     const keyStr = typeof key === 'string' ? key : '';
     if (keyStr.includes('/api/v2/proof/status')) {
-      return { data: proofStatus, error: undefined, isLoading: false, mutate: jest.fn() } as any;
+      return {
+        data: proofStatus,
+        error: options?.proofError,
+        isLoading: options?.proofLoading ?? false,
+        mutate: jest.fn(),
+      } as any;
     }
     return { data: prStatus, error: undefined, isLoading: false, mutate: jest.fn() } as any;
   });
@@ -184,5 +197,33 @@ describe('PRStatusPanel — PROOF9-gated merge button', () => {
     render(<PRStatusPanel {...defaultProps} />);
     expect(screen.getByText(/ci checks failing/i)).toBeInTheDocument();
     expect(screen.getByText('Fix critical bug')).toBeInTheDocument();
+  });
+
+  it('shows "Waiting for CI checks" when CI checks are pending', () => {
+    setupSWRMock({ ...basePRStatus, ci_checks: pendingCIChecks }, cleanProofStatus);
+    render(<PRStatusPanel {...defaultProps} />);
+    expect(screen.getByText(/waiting for ci checks/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^merge$/i })).toBeDisabled();
+  });
+
+  it('shows PROOF9 loading skeleton instead of "All clear" while proof data loads', () => {
+    setupSWRMock(basePRStatus, undefined, { proofLoading: true });
+    render(<PRStatusPanel {...defaultProps} />);
+    expect(screen.queryByText(/all clear/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^merge$/i })).toBeDisabled();
+  });
+
+  it('shows PROOF9 error message when proof API fails', () => {
+    setupSWRMock(basePRStatus, undefined, { proofError: new Error('Network error') });
+    render(<PRStatusPanel {...defaultProps} />);
+    expect(screen.getByText(/unable to load proof9 status/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^merge$/i })).toBeDisabled();
+  });
+
+  it('shows success banner when PR was merged externally', () => {
+    setupSWRMock({ ...basePRStatus, merge_state: 'merged' }, cleanProofStatus);
+    render(<PRStatusPanel {...defaultProps} />);
+    expect(screen.getByText(/merged successfully/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /merge/i })).not.toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/review/PRStatusPanel.tsx
+++ b/web-ui/src/components/review/PRStatusPanel.tsx
@@ -97,7 +97,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
     }
   );
 
-  const { data: proofData } = useSWR<ProofStatusResponse>(
+  const { data: proofData, error: proofError, isLoading: proofLoading } = useSWR<ProofStatusResponse>(
     proofKey,
     () => proofApi.getStatus(workspacePath),
     { refreshInterval: merged ? 0 : 15_000 }
@@ -121,6 +121,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
   );
 
   const ciPassing = !ciFailing && !ciPending;
+  const alreadyMerged = merged || data?.merge_state === 'merged';
   const canMerge = !!data && !!proofData && openRequirements.length === 0 && ciPassing;
 
   // ── Merge handler ─────────────────────────────────────────────────────────
@@ -204,7 +205,13 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
           {/* PROOF9 gate section */}
           <div className="flex flex-col gap-1.5">
             <span className="text-sm font-medium">PROOF9</span>
-            {openRequirements.length === 0 ? (
+            {proofLoading ? (
+              <div className="h-4 animate-pulse rounded bg-muted" />
+            ) : proofError && !proofData ? (
+              <p className="text-xs text-muted-foreground">
+                Unable to load PROOF9 status — merge blocked until resolved.
+              </p>
+            ) : openRequirements.length === 0 ? (
               <p className="flex items-center gap-1 text-xs text-muted-foreground">
                 <CheckmarkCircle01Icon className="h-3 w-3 text-green-600" />
                 All clear
@@ -233,7 +240,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
       )}
 
       {/* Blocking messages */}
-      {data && (ciFailing || ciPending) && !merged && (
+      {data && (ciFailing || ciPending) && !alreadyMerged && (
         <p className="text-xs text-amber-600">
           {ciFailing ? 'CI checks failing' : 'Waiting for CI checks'}
         </p>
@@ -247,7 +254,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
       )}
 
       {/* Success banner or Merge button */}
-      {merged ? (
+      {alreadyMerged ? (
         <div className="flex items-center gap-1 rounded bg-green-50 px-3 py-2 text-xs text-green-700">
           <CheckmarkCircle01Icon className="h-3 w-3" />
           PR #{prNumber} merged successfully


### PR DESCRIPTION
## Summary
Addresses claude-review feedback from PR #583 that was posted after merge.

- **Fix misleading "All clear" during PROOF9 loading** — show skeleton pulse instead of green checkmark while `proofData` is loading
- **Surface proof API errors** — show "Unable to load PROOF9 status" when the proof fetch fails, explaining why merge is blocked
- **Handle externally merged PRs** — if `merge_state === 'merged'` (merged via GitHub UI), show success banner and hide merge button instead of leaving it visible
- **Add ciPending test** — covers the "Waiting for CI checks" message path

## Test Plan
- [x] 4 new tests added (760/760 total pass)
- [x] Build clean
- [x] Lint clean on changed files

Relates to #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading indicator while proof status loads
  * Improved merge detection for externally-merged pull requests

* **Bug Fixes**
  * Fixed UI behavior for pending CI checks with appropriate messaging
  * Enhanced error handling when proof status fails to load, displaying user-friendly error message
  * Merge button now correctly disables during proof loading or error states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->