### PR TITLE
feat(pr-history): Report Glitch action and REQ→PR back-link (#573)

### DIFF
--- a/codeframe/git/github_integration.py
+++ b/codeframe/git/github_integration.py
@@ -381,6 +381,8 @@ class GitHubIntegration:
     async def get_pr_files(self, pr_number: int) -> List[str]:
         """Get the list of files changed in a pull request.
 
+        Paginates through all pages (100 per page) to ensure completeness.
+
         Args:
             pr_number: PR number
 
@@ -390,9 +392,21 @@ class GitHubIntegration:
         Raises:
             GitHubAPIError: If API error occurs
         """
-        endpoint = f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/files?per_page=100"
-        data = await self._make_request(method="GET", endpoint=endpoint)
-        return [f["filename"] for f in data]
+        files: List[str] = []
+        page = 1
+        while True:
+            endpoint = (
+                f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/files"
+                f"?per_page=100&page={page}"
+            )
+            data = await self._make_request(method="GET", endpoint=endpoint)
+            if not isinstance(data, list) or not data:
+                break
+            files.extend(f["filename"] for f in data)
+            if len(data) < 100:
+                break
+            page += 1
+        return files
 
     async def get_pr_ci_checks(
         self,

--- a/codeframe/git/github_integration.py
+++ b/codeframe/git/github_integration.py
@@ -390,7 +390,7 @@ class GitHubIntegration:
         Raises:
             GitHubAPIError: If API error occurs
         """
-        endpoint = f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/files"
+        endpoint = f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/files?per_page=100"
         data = await self._make_request(method="GET", endpoint=endpoint)
         return [f["filename"] for f in data]
 

--- a/codeframe/git/github_integration.py
+++ b/codeframe/git/github_integration.py
@@ -378,6 +378,22 @@ class GitHubIntegration:
         logger.info(f"Closed PR #{pr_number}")
         return data.get("state") == "closed"
 
+    async def get_pr_files(self, pr_number: int) -> List[str]:
+        """Get the list of files changed in a pull request.
+
+        Args:
+            pr_number: PR number
+
+        Returns:
+            List of filenames changed in the PR
+
+        Raises:
+            GitHubAPIError: If API error occurs
+        """
+        endpoint = f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/files"
+        data = await self._make_request(method="GET", endpoint=endpoint)
+        return [f["filename"] for f in data]
+
     async def get_pr_ci_checks(
         self,
         pr_number: int,

--- a/codeframe/ui/routers/pr_v2.py
+++ b/codeframe/ui/routers/pr_v2.py
@@ -122,6 +122,12 @@ class PRHistoryItem(BaseModel):
     proof_snapshot: Optional[ProofSnapshotOut]
 
 
+class PRFilesResponse(BaseModel):
+    """Response for PR changed files."""
+
+    files: list[str]
+
+
 class PRHistoryResponse(BaseModel):
     """Response for PR history list."""
 
@@ -385,6 +391,48 @@ async def get_pr_history(
         raise HTTPException(
             status_code=500,
             detail=api_error("Failed to get PR history", ErrorCodes.EXECUTION_FAILED, str(e)),
+        )
+    finally:
+        await client.close()
+
+
+@router.get("/{pr_number}/files", response_model=PRFilesResponse)
+@rate_limit_standard()
+async def get_pr_files(
+    request: Request,
+    pr_number: int,
+    workspace: Workspace = Depends(get_v2_workspace),
+) -> PRFilesResponse:
+    """Get the list of files changed in a pull request.
+
+    Args:
+        pr_number: PR number
+        workspace: v2 Workspace (for context)
+
+    Returns:
+        List of changed filenames
+    """
+    client = _get_github_client()
+    try:
+        files = await client.get_pr_files(pr_number)
+        return PRFilesResponse(files=files)
+    except GitHubAPIError as e:
+        if e.status_code == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=api_error("PR not found", ErrorCodes.NOT_FOUND, f"No PR #{pr_number}"),
+            )
+        raise HTTPException(
+            status_code=e.status_code,
+            detail=api_error("GitHub API error", ErrorCodes.EXECUTION_FAILED, e.message),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get files for PR #{pr_number}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=api_error("Failed to get PR files", ErrorCodes.EXECUTION_FAILED, str(e)),
         )
     finally:
         await client.close()

--- a/tests/ui/test_pr_history.py
+++ b/tests/ui/test_pr_history.py
@@ -1,7 +1,7 @@
-"""Tests for GET /api/v2/pr/history endpoint (pr_v2 router).
+"""Tests for PR v2 router endpoints: history and files.
 
-These tests verify the PR history endpoint by mocking GitHubIntegration
-so no real GitHub API calls are made.
+These tests verify the PR history and PR files endpoints by mocking
+GitHubIntegration so no real GitHub API calls are made.
 """
 
 import shutil
@@ -254,3 +254,54 @@ class TestGetPrHistory:
 
         assert resp.status_code == 200
         assert resp.json()["pull_requests"][0]["author"] == "bob"
+
+
+class TestGetPrFiles:
+    """Tests for GET /api/v2/pr/{pr_number}/files."""
+
+    def test_returns_file_list(self, test_client):
+        """Endpoint returns the list of changed files for a PR."""
+        mock_client = _make_mock_client()
+        mock_client.get_pr_files = AsyncMock(return_value=["src/app.py", "tests/test_app.py"])
+
+        with patch("codeframe.ui.routers.pr_v2._get_github_client", return_value=mock_client):
+            resp = test_client.get("/api/v2/pr/42/files?workspace_path=/tmp")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["files"] == ["src/app.py", "tests/test_app.py"]
+
+    def test_returns_empty_list(self, test_client):
+        """Endpoint returns empty list when PR has no file changes."""
+        mock_client = _make_mock_client()
+        mock_client.get_pr_files = AsyncMock(return_value=[])
+
+        with patch("codeframe.ui.routers.pr_v2._get_github_client", return_value=mock_client):
+            resp = test_client.get("/api/v2/pr/1/files?workspace_path=/tmp")
+
+        assert resp.status_code == 200
+        assert resp.json()["files"] == []
+
+    def test_pr_not_found(self, test_client):
+        """Endpoint returns 404 when PR does not exist."""
+        from codeframe.git.github_integration import GitHubAPIError
+
+        mock_client = _make_mock_client()
+        mock_client.get_pr_files = AsyncMock(
+            side_effect=GitHubAPIError(404, "Not Found"),
+        )
+
+        with patch("codeframe.ui.routers.pr_v2._get_github_client", return_value=mock_client):
+            resp = test_client.get("/api/v2/pr/99999/files?workspace_path=/tmp")
+
+        assert resp.status_code == 404
+
+    def test_client_close_called(self, test_client):
+        """Client.close() is always called."""
+        mock_client = _make_mock_client()
+        mock_client.get_pr_files = AsyncMock(return_value=[])
+
+        with patch("codeframe.ui.routers.pr_v2._get_github_client", return_value=mock_client):
+            test_client.get("/api/v2/pr/1/files?workspace_path=/tmp")
+
+        mock_client.close.assert_awaited_once()

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -326,6 +326,7 @@ class TestGetPrFiles:
         call_kwargs = mock_request.call_args.kwargs
         assert call_kwargs["method"] == "GET"
         assert "/pulls/42/files" in call_kwargs["endpoint"]
+        assert "per_page=100" in call_kwargs["endpoint"]
 
     @pytest.mark.asyncio
     async def test_returns_empty_list_for_no_files(self, github):

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -299,6 +299,53 @@ class TestGitHubIntegration:
             assert exc_info.value.status_code == 403
 
 
+class TestGetPrFiles:
+    """Tests for GitHubIntegration.get_pr_files."""
+
+    @pytest.fixture
+    def github(self):
+        return GitHubIntegration(
+            token="ghp_test_token_12345",
+            repo="owner/test-repo",
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_list_of_filenames(self, github):
+        """get_pr_files returns a list of filename strings."""
+        mock_response = [
+            {"filename": "src/app.py", "status": "modified"},
+            {"filename": "tests/test_app.py", "status": "added"},
+        ]
+
+        with patch.object(github, "_make_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            files = await github.get_pr_files(42)
+
+        assert files == ["src/app.py", "tests/test_app.py"]
+        mock_request.assert_called_once()
+        call_kwargs = mock_request.call_args.kwargs
+        assert call_kwargs["method"] == "GET"
+        assert "/pulls/42/files" in call_kwargs["endpoint"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_for_no_files(self, github):
+        """get_pr_files returns empty list when PR has no file changes."""
+        with patch.object(github, "_make_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = []
+            files = await github.get_pr_files(1)
+
+        assert files == []
+
+    @pytest.mark.asyncio
+    async def test_propagates_api_error(self, github):
+        """get_pr_files propagates GitHubAPIError."""
+        with patch.object(github, "_make_request", new_callable=AsyncMock) as mock_request:
+            mock_request.side_effect = GitHubAPIError(404, "Not Found")
+            with pytest.raises(GitHubAPIError) as exc_info:
+                await github.get_pr_files(99999)
+        assert exc_info.value.status_code == 404
+
+
 class TestGitHubAPIError:
     """Tests for GitHubAPIError exception."""
 

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -299,6 +299,7 @@ class TestGitHubIntegration:
             assert exc_info.value.status_code == 403
 
 
+@pytest.mark.v2
 class TestGetPrFiles:
     """Tests for GitHubIntegration.get_pr_files."""
 

--- a/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
+++ b/web-ui/src/__tests__/components/proof/CaptureGlitchModal.test.tsx
@@ -234,4 +234,60 @@ describe('CaptureGlitchModal', () => {
       expect((screen.getByLabelText(/Description/i) as HTMLTextAreaElement).value).toBe('');
     });
   });
+
+  describe('pre-population from PR', () => {
+    const PR_PROPS = {
+      ...DEFAULT_PROPS,
+      prNumber: 42,
+      prTitle: 'Fix login timeout',
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      initialScope: 'src/auth.py\nsrc/utils.py',
+    };
+
+    it('pre-fills description with PR reference when prNumber is provided', () => {
+      setup(PR_PROPS);
+      const textarea = screen.getByLabelText(/Description/i) as HTMLTextAreaElement;
+      expect(textarea.value).toBe('Reported from PR #42: Fix login timeout');
+    });
+
+    it('pre-fills scope with initialScope', () => {
+      setup(PR_PROPS);
+      const textarea = screen.getByLabelText(/Scope/i) as HTMLTextAreaElement;
+      expect(textarea.value).toBe('src/auth.py\nsrc/utils.py');
+    });
+
+    it('includes source_issue in submission payload', async () => {
+      mockCapture.mockResolvedValue(MOCK_REQ);
+      setup(PR_PROPS);
+
+      // Fill required fields
+      fireEvent.click(screen.getByRole('checkbox', { name: 'unit' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        expect(mockCapture).toHaveBeenCalledWith(
+          WORKSPACE,
+          expect.objectContaining({
+            source_issue: 'https://github.com/owner/repo/pull/42',
+          })
+        );
+      });
+    });
+
+    it('does not include source_issue when prUrl is not provided', async () => {
+      mockCapture.mockResolvedValue(MOCK_REQ);
+      setup();
+
+      fireEvent.change(screen.getByLabelText(/Description/i), {
+        target: { value: 'Something broke' },
+      });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'unit' }));
+      fireEvent.click(screen.getByRole('button', { name: /Capture Glitch/i }));
+
+      await waitFor(() => {
+        const callArgs = mockCapture.mock.calls[0][1];
+        expect(callArgs.source_issue).toBeUndefined();
+      });
+    });
+  });
 });

--- a/web-ui/src/__tests__/components/proof/ProofDetailPage.test.tsx
+++ b/web-ui/src/__tests__/components/proof/ProofDetailPage.test.tsx
@@ -282,3 +282,42 @@ describe('ProofDetailPage — combined filters', () => {
     expect(evidenceRows()).toHaveLength(1);
   });
 });
+
+describe('ProofDetailPage — source_issue rendering', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function setupWithReq(reqOverrides: Partial<ProofRequirement>) {
+    const req = { ...REQ, ...reqOverrides };
+    mockGetWorkspace.mockReturnValue(WORKSPACE);
+    mockUseSWR.mockImplementation((key: unknown) => {
+      if (!key) {
+        return { data: undefined, error: undefined, isLoading: false, mutate: jest.fn() } as unknown as ReturnType<typeof useSWR>;
+      }
+      const k = String(key);
+      if (k.includes('/evidence')) {
+        return { data: [], error: undefined, isLoading: false, mutate: jest.fn() } as unknown as ReturnType<typeof useSWR>;
+      }
+      return { data: req, error: undefined, isLoading: false, mutate: jest.fn() } as unknown as ReturnType<typeof useSWR>;
+    });
+    render(<ProofDetailPage />);
+  }
+
+  it('renders source_issue as a clickable link when it is a GitHub URL', () => {
+    setupWithReq({ source_issue: 'https://github.com/owner/repo/pull/42' });
+    const link = screen.getByRole('link', { name: /github\.com/i });
+    expect(link).toHaveAttribute('href', 'https://github.com/owner/repo/pull/42');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders source_issue as plain text when it is not a URL', () => {
+    setupWithReq({ source_issue: 'JIRA-123' });
+    expect(screen.getByText(/JIRA-123/)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /JIRA-123/ })).not.toBeInTheDocument();
+  });
+
+  it('does not render source_issue when it is null', () => {
+    setupWithReq({ source_issue: null });
+    expect(screen.queryByText(/Source PR/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Issue:/)).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/__tests__/components/review/PRHistoryPanel.test.tsx
+++ b/web-ui/src/__tests__/components/review/PRHistoryPanel.test.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import useSWR from 'swr';
 import { PRHistoryPanel } from '@/components/review/PRHistoryPanel';
+import { prApi } from '@/lib/api';
 import type { PRHistoryResponse } from '@/types';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────
 
 jest.mock('swr');
 jest.mock('@/lib/api', () => ({
-  prApi: { getHistory: jest.fn() },
+  prApi: { getHistory: jest.fn(), getFiles: jest.fn() },
+  proofApi: { capture: jest.fn() },
 }));
+
+const mockGetFiles = prApi.getFiles as jest.MockedFunction<typeof prApi.getFiles>;
 
 const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
 
@@ -231,6 +235,42 @@ describe('PRHistoryPanel', () => {
 
       const [key] = mockUseSWR.mock.calls[0];
       expect(key).toBeNull();
+    });
+  });
+
+  describe('Report Glitch button', () => {
+    it('renders a Report Glitch button for each PR row', () => {
+      withData(SAMPLE_HISTORY);
+      render(<PRHistoryPanel workspacePath={WORKSPACE} />);
+
+      const buttons = screen.getAllByRole('button', { name: /Report Glitch/i });
+      expect(buttons).toHaveLength(2);
+    });
+
+    it('fetches PR files when Report Glitch is clicked', async () => {
+      mockGetFiles.mockResolvedValue(['src/auth.py', 'tests/test_auth.py']);
+      withData(SAMPLE_HISTORY);
+      render(<PRHistoryPanel workspacePath={WORKSPACE} />);
+
+      const buttons = screen.getAllByRole('button', { name: /Report Glitch/i });
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(mockGetFiles).toHaveBeenCalledWith(WORKSPACE, 10);
+      });
+    });
+
+    it('opens the capture modal after files are fetched', async () => {
+      mockGetFiles.mockResolvedValue(['src/auth.py']);
+      withData(SAMPLE_HISTORY);
+      render(<PRHistoryPanel workspacePath={WORKSPACE} />);
+
+      const buttons = screen.getAllByRole('button', { name: /Report Glitch/i });
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Capture Glitch' })).toBeInTheDocument();
+      });
     });
   });
 });

--- a/web-ui/src/app/proof/[req_id]/page.tsx
+++ b/web-ui/src/app/proof/[req_id]/page.tsx
@@ -260,8 +260,13 @@ export default function ProofDetailPage() {
               <div className="mt-3 flex flex-wrap gap-4 text-xs text-muted-foreground">
                 {req.created_at && <span>Created {new Date(req.created_at).toLocaleDateString()}</span>}
                 {req.source && <span>Source: {req.source}</span>}
-                {req.source_issue && (
-                  req.source_issue.startsWith('https://github.com') ? (
+                {req.source_issue && (() => {
+                  let isGitHubPr = false;
+                  try {
+                    const u = new URL(req.source_issue);
+                    isGitHubPr = u.protocol === 'https:' && u.hostname === 'github.com';
+                  } catch { /* not a valid URL */ }
+                  return isGitHubPr ? (
                     <span>
                       Source PR:{' '}
                       <a
@@ -275,8 +280,8 @@ export default function ProofDetailPage() {
                     </span>
                   ) : (
                     <span>Issue: {req.source_issue}</span>
-                  )
-                )}
+                  );
+                })()}
                 {req.created_by && <span>By: {req.created_by}</span>}
                 {req.waiver?.expires && <span>Waiver expires: {req.waiver.expires}</span>}
               </div>

--- a/web-ui/src/app/proof/[req_id]/page.tsx
+++ b/web-ui/src/app/proof/[req_id]/page.tsx
@@ -260,7 +260,23 @@ export default function ProofDetailPage() {
               <div className="mt-3 flex flex-wrap gap-4 text-xs text-muted-foreground">
                 {req.created_at && <span>Created {new Date(req.created_at).toLocaleDateString()}</span>}
                 {req.source && <span>Source: {req.source}</span>}
-                {req.source_issue && <span>Issue: {req.source_issue}</span>}
+                {req.source_issue && (
+                  req.source_issue.startsWith('https://github.com') ? (
+                    <span>
+                      Source PR:{' '}
+                      <a
+                        href={req.source_issue}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      >
+                        {req.source_issue}
+                      </a>
+                    </span>
+                  ) : (
+                    <span>Issue: {req.source_issue}</span>
+                  )
+                )}
                 {req.created_by && <span>By: {req.created_by}</span>}
                 {req.waiver?.expires && <span>Waiver expires: {req.waiver.expires}</span>}
               </div>

--- a/web-ui/src/components/proof/CaptureGlitchModal.tsx
+++ b/web-ui/src/components/proof/CaptureGlitchModal.tsx
@@ -40,9 +40,26 @@ export interface CaptureGlitchModalProps {
   workspacePath: string;
   onClose: () => void;
   onSuccess: (req: ProofRequirement) => void;
+  /** Pre-populate from a PR: PR number */
+  prNumber?: number;
+  /** Pre-populate from a PR: PR title */
+  prTitle?: string;
+  /** Pre-populate from a PR: GitHub PR URL (stored as source_issue) */
+  prUrl?: string;
+  /** Pre-populate scope with changed files (newline-joined) */
+  initialScope?: string;
 }
 
-export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: CaptureGlitchModalProps) {
+export function CaptureGlitchModal({
+  open,
+  workspacePath,
+  onClose,
+  onSuccess,
+  prNumber,
+  prTitle,
+  prUrl,
+  initialScope,
+}: CaptureGlitchModalProps) {
   const [description, setDescription] = useState('');
   const [source, setSource] = useState<CaptureGlitchRequest['source']>('production');
   const [scopeText, setScopeText] = useState('');
@@ -51,18 +68,20 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset all state when the modal opens
+  // Reset all state when the modal opens, pre-filling from PR props if provided
   useEffect(() => {
     if (open) {
-      setDescription('');
+      setDescription(
+        prNumber ? `Reported from PR #${prNumber}: ${prTitle ?? ''}` : ''
+      );
       setSource('production');
-      setScopeText('');
+      setScopeText(initialScope ?? '');
       setSelectedGates(new Set());
       setSeverity('high');
       setSubmitting(false);
       setError(null);
     }
-  }, [open]);
+  }, [open, prNumber, prTitle, initialScope]);
 
   function toggleGate(gate: string) {
     setSelectedGates((prev) => {
@@ -110,6 +129,7 @@ export function CaptureGlitchModal({ open, workspacePath, onClose, onSuccess }: 
       severity,
       source,
       created_by: 'human',
+      ...(prUrl ? { source_issue: prUrl } : {}),
     };
 
     try {

--- a/web-ui/src/components/review/PRHistoryPanel.tsx
+++ b/web-ui/src/components/review/PRHistoryPanel.tsx
@@ -18,7 +18,6 @@ import { CaptureGlitchModal } from '@/components/proof';
 import type {
   PRHistoryResponse,
   PRHistoryItem,
-  ProofRequirement,
   ProofSnapshot,
   GateBreakdownItem,
 } from '@/types';
@@ -71,7 +70,8 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
       const files = await prApi.getFiles(workspacePath, pr.number);
       setGlitchTarget({ pr, files });
     } catch {
-      setGlitchTarget({ pr, files: [] });
+      // Open the modal with a note so the user knows scope couldn't be loaded
+      setGlitchTarget({ pr, files: ['# Could not load changed files — enter scope manually'] });
     } finally {
       setLoadingFiles(null);
     }
@@ -203,7 +203,7 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
       )}
       {glitchTarget && (
         <CaptureGlitchModal
-          open={!!glitchTarget}
+          open
           workspacePath={workspacePath}
           prNumber={glitchTarget.pr.number}
           prTitle={glitchTarget.pr.title}

--- a/web-ui/src/components/review/PRHistoryPanel.tsx
+++ b/web-ui/src/components/review/PRHistoryPanel.tsx
@@ -145,7 +145,7 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                   variant="ghost"
                   size="sm"
                   className="shrink-0 gap-1.5 text-xs"
-                  disabled={loadingFiles === pr.number}
+                  disabled={loadingFiles !== null}
                   onClick={() => handleReportGlitch(pr)}
                 >
                   {loadingFiles === pr.number ? (

--- a/web-ui/src/components/review/PRHistoryPanel.tsx
+++ b/web-ui/src/components/review/PRHistoryPanel.tsx
@@ -8,13 +8,17 @@ import {
   ArrowUpRight01Icon,
   CheckmarkCircle01Icon,
   Cancel01Icon,
+  Alert02Icon,
 } from '@hugeicons/react';
 import { prApi } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { CaptureGlitchModal } from '@/components/proof';
 import type {
   PRHistoryResponse,
   PRHistoryItem,
+  ProofRequirement,
   ProofSnapshot,
   GateBreakdownItem,
 } from '@/types';
@@ -42,6 +46,11 @@ export interface PRHistoryPanelProps {
 
 export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
   const [expandedPR, setExpandedPR] = useState<number | null>(null);
+  const [loadingFiles, setLoadingFiles] = useState<number | null>(null);
+  const [glitchTarget, setGlitchTarget] = useState<{
+    pr: PRHistoryItem;
+    files: string[];
+  } | null>(null);
 
   const swrKey = workspacePath
     ? `/api/v2/pr/history?workspace_path=${encodeURIComponent(workspacePath)}`
@@ -54,6 +63,18 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
 
   const toggleExpand = (prNumber: number) => {
     setExpandedPR((prev) => (prev === prNumber ? null : prNumber));
+  };
+
+  const handleReportGlitch = async (pr: PRHistoryItem) => {
+    setLoadingFiles(pr.number);
+    try {
+      const files = await prApi.getFiles(workspacePath, pr.number);
+      setGlitchTarget({ pr, files });
+    } catch {
+      setGlitchTarget({ pr, files: [] });
+    } finally {
+      setLoadingFiles(null);
+    }
   };
 
   return (
@@ -120,6 +141,20 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                     )}
                   </div>
                 </button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 gap-1.5 text-xs"
+                  disabled={loadingFiles === pr.number}
+                  onClick={() => handleReportGlitch(pr)}
+                >
+                  {loadingFiles === pr.number ? (
+                    <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+                  ) : (
+                    <Alert02Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                  )}
+                  Report Glitch
+                </Button>
                 <a
                   href={pr.url}
                   target="_blank"
@@ -165,6 +200,18 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
             </div>
           ))}
         </div>
+      )}
+      {glitchTarget && (
+        <CaptureGlitchModal
+          open={!!glitchTarget}
+          workspacePath={workspacePath}
+          prNumber={glitchTarget.pr.number}
+          prTitle={glitchTarget.pr.title}
+          prUrl={glitchTarget.pr.url}
+          initialScope={glitchTarget.files.join('\n')}
+          onClose={() => setGlitchTarget(null)}
+          onSuccess={() => setGlitchTarget(null)}
+        />
       )}
     </Card>
   );

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -53,6 +53,7 @@ import type {
   ProofRunSummary,
   ProofRunDetail,
   PRHistoryResponse,
+  PRFilesResponse,
   Session,
   SessionState,
   SessionListResponse,
@@ -724,6 +725,13 @@ export const prApi = {
       params: { workspace_path: workspacePath, ...(limit ? { limit } : {}) },
     });
     return response.data;
+  },
+
+  getFiles: async (workspacePath: string, prNumber: number): Promise<string[]> => {
+    const response = await api.get<PRFilesResponse>(`/api/v2/pr/${prNumber}/files`, {
+      params: { workspace_path: workspacePath },
+    });
+    return response.data.files;
   },
 };
 

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -383,6 +383,11 @@ export interface CaptureGlitchRequest {
   severity: ProofSeverity;
   source: 'production' | 'qa' | 'dogfooding' | 'monitoring' | 'user_report';
   created_by: string;
+  source_issue?: string;
+}
+
+export interface PRFilesResponse {
+  files: string[];
 }
 
 // Proof run types (mirrors proof_v2.py RunProofResponse + RunStatusResponse)


### PR DESCRIPTION
## Summary

- Adds **[Report Glitch]** button to each merged PR row in the PR History panel on the Review page
- Clicking it fetches the PR's changed files via a new `GET /api/v2/pr/{number}/files` endpoint, then opens the Capture Glitch modal pre-populated with scope, source, and a PR reference note
- REQs created from a PR store the GitHub PR URL as `source_issue`, which now renders as a clickable link on the REQ detail page

Closes #573

## Changes

### Backend (Python)
- `GitHubIntegration.get_pr_files(pr_number)` — fetches changed filenames from GitHub API
- `GET /api/v2/pr/{pr_number}/files` — new endpoint returning `PRFilesResponse { files: string[] }`

### Frontend (TypeScript)
- `CaptureGlitchModal` — new optional props `prNumber`, `prTitle`, `prUrl`, `initialScope` for pre-population; includes `source_issue` in submission payload
- `PRHistoryPanel` — [Report Glitch] button on each row with loading spinner during file fetch
- `proof/[req_id]/page.tsx` — `source_issue` renders as clickable GitHub link when applicable
- `prApi.getFiles()` and `PRFilesResponse` type added

## Test plan
- [x] Backend: 3 unit tests for `get_pr_files` (pass, empty, error propagation)
- [x] Backend: 4 endpoint tests for `GET /api/v2/pr/{number}/files` (200, empty, 404, close)
- [x] Frontend: 4 tests for CaptureGlitchModal pre-population (description, scope, source_issue, no source_issue)
- [x] Frontend: 3 tests for PRHistoryPanel Report Glitch button (render, fetch, modal open)
- [x] Frontend: 3 tests for REQ detail source_issue rendering (link, plain text, null)
- [x] All 32 backend tests pass (`uv run pytest`)
- [x] All 783 frontend tests pass (`npm test`)
- [x] `npm run build` succeeds
- [x] `ruff check .` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Report Glitch" button to each PR row in PR history with loading state while fetching changed files.
  * Glitch report modal now pre-populates description and scope with PR number, title, and fetched file list; falls back to a placeholder scope if file fetch fails.
  * Submissions include the PR URL as the source when available, and PR-originating GitHub links render as clickable "Source PR" links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->