### PR TITLE
feat(settings): /settings page skeleton + agent config (#554)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ At all times: `codeframe --help` works, Golden Path stubs can run, no breaking r
 ### Phase 3 Web UI (actively developed — not legacy)
 Next.js 16 App Router, TypeScript, Shadcn/UI, Tailwind CSS, Hugeicons, XTerm.js, WebSocket + SSE.
 
-Shipped pages: `/`, `/prd`, `/tasks`, `/execution`, `/execution/[taskId]`, `/blockers`, `/proof`, `/proof/[req_id]`, `/review`, `/sessions`, `/sessions/[id]`.
+Shipped pages: `/`, `/prd`, `/tasks`, `/execution`, `/execution/[taskId]`, `/blockers`, `/proof`, `/proof/[req_id]`, `/review`, `/sessions`, `/sessions/[id]`, `/settings`.
 
 Testing: `cd web-ui && npm test` must pass; `npm run build` must succeed. The `frontend-tests` CI job enforces this on every PR.
 

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -163,6 +163,10 @@ class EnvironmentConfig:
     # LLM provider config (workspace-level default; overridden by env vars and CLI flags)
     llm: Optional[LLMConfig] = None
 
+    # Settings page (issue #554) — UI-managed agent settings
+    max_cost_usd: Optional[float] = None
+    agent_type_models: dict[str, str] = dataclass_field(default_factory=dict)
+
     def validate(self) -> list[str]:
         """Validate configuration values.
 

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -221,6 +221,17 @@ class EnvironmentConfig:
         if budget.stall_timeout_s < 0:
             errors.append("agent_budget.stall_timeout_s must be >= 0 (0 = disabled)")
 
+        if self.max_cost_usd is not None and self.max_cost_usd < 0:
+            errors.append("max_cost_usd must be >= 0")
+
+        valid_agent_types = {"claude_code", "codex", "opencode", "react"}
+        invalid_agent_types = sorted(set(self.agent_type_models) - valid_agent_types)
+        if invalid_agent_types:
+            errors.append(
+                "agent_type_models contains unsupported agent types: "
+                + ", ".join(invalid_agent_types)
+            )
+
         return errors
 
     def get_install_command(self, package: str) -> str:

--- a/codeframe/ui/models.py
+++ b/codeframe/ui/models.py
@@ -901,3 +901,45 @@ class ErrorResponse(BaseModel):
     )
 
     detail: str = Field(..., description="Error message describing what went wrong")
+
+
+# ============================================================================
+# Settings (issue #554)
+# ============================================================================
+
+
+AGENT_TYPES = ("claude_code", "codex", "opencode", "react")
+
+
+class AgentTypeModelConfig(BaseModel):
+    """Default model for a single agent type."""
+
+    agent_type: str = Field(
+        ..., description="One of: claude_code, codex, opencode, react"
+    )
+    default_model: str = Field(
+        default="",
+        description="Model identifier (e.g. 'claude-opus-4', 'gpt-4o'); empty string means unset",
+    )
+
+
+class AgentSettings(BaseModel):
+    """Agent settings shared by GET response and PUT request."""
+
+    agent_models: List[AgentTypeModelConfig] = Field(
+        ..., description="Default model per agent type"
+    )
+    max_turns: int = Field(
+        default=20, gt=0, description="Maximum turns per task (must be > 0)"
+    )
+    max_cost_usd: Optional[float] = Field(
+        default=None, ge=0, description="Maximum cost per task in USD"
+    )
+
+
+class AgentSettingsResponse(AgentSettings):
+    """Response shape for GET /api/v2/settings."""
+
+
+class UpdateAgentSettingsRequest(AgentSettings):
+    """Request shape for PUT /api/v2/settings."""

--- a/codeframe/ui/models.py
+++ b/codeframe/ui/models.py
@@ -6,7 +6,7 @@ Enhanced: cf-119 - OpenAPI documentation with examples
 
 from enum import Enum
 from pydantic import BaseModel, Field, model_validator, ConfigDict
-from typing import Optional, List
+from typing import Literal, Optional, List
 
 
 class SourceType(str, Enum):
@@ -908,13 +908,14 @@ class ErrorResponse(BaseModel):
 # ============================================================================
 
 
-AGENT_TYPES = ("claude_code", "codex", "opencode", "react")
+AgentType = Literal["claude_code", "codex", "opencode", "react"]
+AGENT_TYPES: tuple[AgentType, ...] = ("claude_code", "codex", "opencode", "react")
 
 
 class AgentTypeModelConfig(BaseModel):
     """Default model for a single agent type."""
 
-    agent_type: str = Field(
+    agent_type: AgentType = Field(
         ..., description="One of: claude_code, codex, opencode, react"
     )
     default_model: str = Field(
@@ -924,13 +925,17 @@ class AgentTypeModelConfig(BaseModel):
 
 
 class AgentSettings(BaseModel):
-    """Agent settings shared by GET response and PUT request."""
+    """Agent settings shared by GET response and PUT request.
+
+    Defaults match `EnvironmentConfig.agent_budget.max_iterations` so that a
+    fresh workspace round-trips its real defaults through GET.
+    """
 
     agent_models: List[AgentTypeModelConfig] = Field(
         ..., description="Default model per agent type"
     )
     max_turns: int = Field(
-        default=20, gt=0, description="Maximum turns per task (must be > 0)"
+        default=100, gt=0, description="Maximum turns per task (must be > 0)"
     )
     max_cost_usd: Optional[float] = Field(
         default=None, ge=0, description="Maximum cost per task in USD"

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -13,6 +13,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from codeframe.core.config import (
+    AgentBudgetConfig,
     EnvironmentConfig,
     load_environment_config,
     save_environment_config,
@@ -43,9 +44,11 @@ def _config_to_response(config: EnvironmentConfig) -> AgentSettingsResponse:
         )
         for agent_type in AGENT_TYPES
     ]
+    # Guard against legacy YAML where agent_budget may have been removed/nulled.
+    budget = config.agent_budget or AgentBudgetConfig()
     return AgentSettingsResponse(
         agent_models=agent_models,
-        max_turns=config.agent_budget.max_iterations,
+        max_turns=budget.max_iterations,
         max_cost_usd=config.max_cost_usd,
     )
 
@@ -87,11 +90,18 @@ async def update_settings(
     """
     try:
         config = load_environment_config(workspace.repo_path) or EnvironmentConfig()
+        if config.agent_budget is None:
+            config.agent_budget = AgentBudgetConfig()
 
         config.agent_budget.max_iterations = body.max_turns
         config.max_cost_usd = body.max_cost_usd
+        # Skip empty model strings — they're equivalent to "key not present"
+        # in _config_to_response, so persisting them just adds yaml noise.
+        # AgentType Literal in the model already rejects unknown agent_type values.
         config.agent_type_models = {
-            entry.agent_type: entry.default_model for entry in body.agent_models
+            entry.agent_type: entry.default_model
+            for entry in body.agent_models
+            if entry.default_model
         }
 
         save_environment_config(workspace.repo_path, config)

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -1,0 +1,106 @@
+"""V2 Settings router — agent settings managed via the web UI.
+
+Reads/writes a flat AgentSettings shape persisted in
+.codeframe/config.yaml via load_environment_config / save_environment_config.
+
+Routes:
+    GET /api/v2/settings  - Load agent settings (returns defaults if missing)
+    PUT /api/v2/settings  - Save agent settings (merges into existing config)
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from codeframe.core.config import (
+    EnvironmentConfig,
+    load_environment_config,
+    save_environment_config,
+)
+from codeframe.core.workspace import Workspace
+from codeframe.lib.rate_limiter import rate_limit_standard
+from codeframe.ui.dependencies import get_v2_workspace
+from codeframe.ui.models import (
+    AGENT_TYPES,
+    AgentSettingsResponse,
+    AgentTypeModelConfig,
+    UpdateAgentSettingsRequest,
+)
+from codeframe.ui.response_models import ErrorCodes, api_error
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/settings", tags=["settings"])
+
+
+def _config_to_response(config: EnvironmentConfig) -> AgentSettingsResponse:
+    """Map an EnvironmentConfig to the flat AgentSettings response shape."""
+    saved_models = config.agent_type_models or {}
+    agent_models = [
+        AgentTypeModelConfig(
+            agent_type=agent_type,
+            default_model=saved_models.get(agent_type, ""),
+        )
+        for agent_type in AGENT_TYPES
+    ]
+    return AgentSettingsResponse(
+        agent_models=agent_models,
+        max_turns=config.agent_budget.max_iterations,
+        max_cost_usd=config.max_cost_usd,
+    )
+
+
+@router.get("", response_model=AgentSettingsResponse)
+@rate_limit_standard()
+async def get_settings(
+    request: Request,
+    workspace: Workspace = Depends(get_v2_workspace),
+) -> AgentSettingsResponse:
+    """Load agent settings for the workspace.
+
+    Returns defaults if no .codeframe/config.yaml exists.
+    """
+    try:
+        config = load_environment_config(workspace.repo_path) or EnvironmentConfig()
+        return _config_to_response(config)
+    except Exception as e:
+        logger.error(f"Failed to load settings: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=api_error(
+                "Failed to load settings", ErrorCodes.EXECUTION_FAILED, str(e)
+            ),
+        )
+
+
+@router.put("", response_model=AgentSettingsResponse)
+@rate_limit_standard()
+async def update_settings(
+    request: Request,
+    body: UpdateAgentSettingsRequest,
+    workspace: Workspace = Depends(get_v2_workspace),
+) -> AgentSettingsResponse:
+    """Save agent settings.
+
+    Merges into existing EnvironmentConfig so unrelated fields
+    (package_manager, test_framework, etc.) are preserved.
+    """
+    try:
+        config = load_environment_config(workspace.repo_path) or EnvironmentConfig()
+
+        config.agent_budget.max_iterations = body.max_turns
+        config.max_cost_usd = body.max_cost_usd
+        config.agent_type_models = {
+            entry.agent_type: entry.default_model for entry in body.agent_models
+        }
+
+        save_environment_config(workspace.repo_path, config)
+        return _config_to_response(config)
+    except Exception as e:
+        logger.error(f"Failed to save settings: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=api_error(
+                "Failed to save settings", ErrorCodes.EXECUTION_FAILED, str(e)
+            ),
+        )

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -35,6 +35,7 @@ from codeframe.ui.routers import (
     review_v2,
     schedule_v2,
     session_chat_ws,
+    settings_v2,
     terminal_ws,
     streaming_v2,
     tasks_v2,
@@ -496,6 +497,7 @@ app.include_router(prd_v2.router)           # /api/v2/prd
 app.include_router(proof_v2.router)         # /api/v2/proof
 app.include_router(review_v2.router)        # /api/v2/review
 app.include_router(schedule_v2.router)      # /api/v2/schedule
+app.include_router(settings_v2.router)      # /api/v2/settings
 app.include_router(streaming_v2.router)     # /api/v2/tasks/{id}/stream (SSE)
 app.include_router(tasks_v2.router)         # /api/v2/tasks
 app.include_router(templates_v2.router)     # /api/v2/templates

--- a/docs/PRODUCT_ROADMAP.md
+++ b/docs/PRODUCT_ROADMAP.md
@@ -192,7 +192,7 @@ These are items that were considered and excluded because they do not serve the 
 | 3.5C | Glitch capture UI | ✅ Complete | #568, #569 |
 | 4A | PR status + PROOF9 merge gate | ❌ Not started | — |
 | 4B | Post-merge glitch capture loop | ❌ Not started | — |
-| 5.1 | Settings page | ❌ Not started | #554–556 |
+| 5.1 | Settings page (skeleton + agent config) | 🟡 In progress (#554 done; #555–556 next) | #554–556 |
 | 5.2 | Cost analytics | ❌ Not started | #557–558 |
 | 5.3 | Async notifications | ❌ Not started | #559–560 |
 | 5.4 | PRD stress-test web UI | ❌ Not started | #561–562 |

--- a/tests/core/test_environment_config.py
+++ b/tests/core/test_environment_config.py
@@ -108,6 +108,20 @@ class TestEnvironmentConfigValidation:
         errors = config.validate()
         assert len(errors) == 3
 
+    def test_invalid_max_cost_usd(self):
+        """Negative max_cost_usd is rejected."""
+        config = EnvironmentConfig(max_cost_usd=-1.0)
+        errors = config.validate()
+        assert any("max_cost_usd" in e for e in errors)
+
+    def test_invalid_agent_type_in_models(self):
+        """Unknown agent_type keys in agent_type_models are rejected."""
+        config = EnvironmentConfig(
+            agent_type_models={"claude_code": "claude-opus-4", "evil_bot": "x"}
+        )
+        errors = config.validate()
+        assert any("evil_bot" in e for e in errors)
+
 
 class TestEnvironmentConfigCommands:
     """Tests for command generation."""

--- a/tests/ui/test_settings_v2.py
+++ b/tests/ui/test_settings_v2.py
@@ -1,0 +1,201 @@
+"""Integration tests for settings_v2 router.
+
+Tests:
+- GET /api/v2/settings returns defaults for empty workspace
+- PUT /api/v2/settings persists new settings
+- GET after PUT returns the saved settings (round-trip)
+- PUT merges into existing EnvironmentConfig without losing other fields
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def test_workspace():
+    """Create a temporary workspace for testing."""
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "test_workspace"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    from codeframe.core.workspace import create_or_load_workspace
+
+    workspace = create_or_load_workspace(workspace_path)
+
+    yield workspace
+
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def test_client(test_workspace):
+    """Create a FastAPI TestClient with settings_v2 router and workspace override."""
+    from codeframe.ui.routers import settings_v2
+    from codeframe.ui.dependencies import get_v2_workspace
+
+    app = FastAPI()
+    app.include_router(settings_v2.router)
+
+    def get_test_workspace():
+        return test_workspace
+
+    app.dependency_overrides[get_v2_workspace] = get_test_workspace
+
+    client = TestClient(app)
+    client.workspace = test_workspace
+    yield client
+
+
+class TestSettingsV2Get:
+    """Tests for GET /api/v2/settings."""
+
+    def test_returns_defaults_when_no_config(self, test_client):
+        """GET returns default settings for a workspace with no config file."""
+        response = test_client.get("/api/v2/settings")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Maps to EnvironmentConfig.agent_budget.max_iterations (default 100)
+        assert data["max_turns"] == 100
+        assert data["max_cost_usd"] is None
+
+        agent_types = {entry["agent_type"] for entry in data["agent_models"]}
+        assert agent_types == {"claude_code", "codex", "opencode", "react"}
+
+        for entry in data["agent_models"]:
+            assert entry["default_model"] == ""
+
+    def test_returns_existing_config(self, test_client, test_workspace):
+        """GET returns saved settings from .codeframe/config.yaml."""
+        from codeframe.core.config import (
+            EnvironmentConfig,
+            save_environment_config,
+        )
+
+        config = EnvironmentConfig()
+        config.max_cost_usd = 5.50
+        config.agent_type_models = {"claude_code": "claude-opus-4"}
+        config.agent_budget.max_iterations = 42
+        save_environment_config(test_workspace.repo_path, config)
+
+        response = test_client.get("/api/v2/settings")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["max_turns"] == 42
+        assert data["max_cost_usd"] == 5.50
+        cc_entry = next(
+            e for e in data["agent_models"] if e["agent_type"] == "claude_code"
+        )
+        assert cc_entry["default_model"] == "claude-opus-4"
+
+
+class TestSettingsV2Put:
+    """Tests for PUT /api/v2/settings."""
+
+    def test_put_persists_settings(self, test_client, test_workspace):
+        """PUT saves settings to .codeframe/config.yaml."""
+        body = {
+            "agent_models": [
+                {"agent_type": "claude_code", "default_model": "claude-sonnet-4"},
+                {"agent_type": "codex", "default_model": "gpt-4o"},
+                {"agent_type": "opencode", "default_model": ""},
+                {"agent_type": "react", "default_model": "claude-opus-4"},
+            ],
+            "max_turns": 30,
+            "max_cost_usd": 10.0,
+        }
+
+        response = test_client.put("/api/v2/settings", json=body)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["max_turns"] == 30
+        assert data["max_cost_usd"] == 10.0
+
+        # Verify persisted to disk
+        from codeframe.core.config import load_environment_config
+
+        loaded = load_environment_config(test_workspace.repo_path)
+        assert loaded is not None
+        assert loaded.agent_budget.max_iterations == 30
+        assert loaded.max_cost_usd == 10.0
+        assert loaded.agent_type_models["claude_code"] == "claude-sonnet-4"
+        assert loaded.agent_type_models["codex"] == "gpt-4o"
+        assert loaded.agent_type_models["react"] == "claude-opus-4"
+
+    def test_put_round_trip(self, test_client):
+        """GET after PUT returns the saved settings."""
+        body = {
+            "agent_models": [
+                {"agent_type": "claude_code", "default_model": "claude-opus-4"},
+                {"agent_type": "codex", "default_model": ""},
+                {"agent_type": "opencode", "default_model": ""},
+                {"agent_type": "react", "default_model": ""},
+            ],
+            "max_turns": 25,
+            "max_cost_usd": 7.5,
+        }
+        put_resp = test_client.put("/api/v2/settings", json=body)
+        assert put_resp.status_code == 200
+
+        get_resp = test_client.get("/api/v2/settings")
+        assert get_resp.status_code == 200
+        data = get_resp.json()
+        assert data["max_turns"] == 25
+        assert data["max_cost_usd"] == 7.5
+        cc = next(e for e in data["agent_models"] if e["agent_type"] == "claude_code")
+        assert cc["default_model"] == "claude-opus-4"
+
+    def test_put_preserves_unrelated_config(self, test_client, test_workspace):
+        """PUT does not destroy other EnvironmentConfig fields like package_manager."""
+        from codeframe.core.config import (
+            EnvironmentConfig,
+            save_environment_config,
+            load_environment_config,
+        )
+
+        # Pre-existing config with non-default fields
+        existing = EnvironmentConfig()
+        existing.package_manager = "poetry"
+        existing.test_framework = "jest"
+        save_environment_config(test_workspace.repo_path, existing)
+
+        body = {
+            "agent_models": [
+                {"agent_type": "claude_code", "default_model": "claude-opus-4"},
+                {"agent_type": "codex", "default_model": ""},
+                {"agent_type": "opencode", "default_model": ""},
+                {"agent_type": "react", "default_model": ""},
+            ],
+            "max_turns": 50,
+            "max_cost_usd": None,
+        }
+        response = test_client.put("/api/v2/settings", json=body)
+        assert response.status_code == 200
+
+        loaded = load_environment_config(test_workspace.repo_path)
+        assert loaded.package_manager == "poetry"
+        assert loaded.test_framework == "jest"
+        assert loaded.agent_budget.max_iterations == 50
+
+    def test_put_validates_max_turns_positive(self, test_client):
+        """PUT rejects max_turns <= 0."""
+        body = {
+            "agent_models": [
+                {"agent_type": "claude_code", "default_model": ""},
+                {"agent_type": "codex", "default_model": ""},
+                {"agent_type": "opencode", "default_model": ""},
+                {"agent_type": "react", "default_model": ""},
+            ],
+            "max_turns": 0,
+            "max_cost_usd": None,
+        }
+        response = test_client.put("/api/v2/settings", json=body)
+        assert response.status_code == 422

--- a/tests/ui/test_settings_v2.py
+++ b/tests/ui/test_settings_v2.py
@@ -199,3 +199,59 @@ class TestSettingsV2Put:
         }
         response = test_client.put("/api/v2/settings", json=body)
         assert response.status_code == 422
+
+    def test_put_rejects_unknown_agent_type(self, test_client):
+        """Pydantic Literal rejects agent_types outside the supported set."""
+        body = {
+            "agent_models": [
+                {"agent_type": "evil_bot", "default_model": "anything"},
+            ],
+            "max_turns": 20,
+            "max_cost_usd": None,
+        }
+        response = test_client.put("/api/v2/settings", json=body)
+        assert response.status_code == 422
+
+    def test_put_skips_empty_model_strings(self, test_client, test_workspace):
+        """PUT does not persist empty default_model entries to the YAML."""
+        body = {
+            "agent_models": [
+                {"agent_type": "claude_code", "default_model": "claude-opus-4"},
+                {"agent_type": "codex", "default_model": ""},
+                {"agent_type": "opencode", "default_model": ""},
+                {"agent_type": "react", "default_model": ""},
+            ],
+            "max_turns": 20,
+            "max_cost_usd": None,
+        }
+        response = test_client.put("/api/v2/settings", json=body)
+        assert response.status_code == 200
+
+        from codeframe.core.config import load_environment_config
+
+        loaded = load_environment_config(test_workspace.repo_path)
+        # Only the non-empty entry is persisted.
+        assert loaded.agent_type_models == {"claude_code": "claude-opus-4"}
+
+    def test_get_handles_null_agent_budget(self, test_client, test_workspace):
+        """GET tolerates legacy YAML that drops or nulls agent_budget."""
+        from codeframe.core.config import (
+            EnvironmentConfig,
+            save_environment_config,
+        )
+
+        config = EnvironmentConfig()
+        save_environment_config(test_workspace.repo_path, config)
+        # Manually break agent_budget to simulate a hand-edited legacy file.
+        import yaml
+
+        config_path = test_workspace.repo_path / ".codeframe" / "config.yaml"
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+        data["agent_budget"] = None
+        with open(config_path, "w") as f:
+            yaml.dump(data, f)
+
+        response = test_client.get("/api/v2/settings")
+        assert response.status_code == 200
+        assert response.json()["max_turns"] == 100  # AgentBudgetConfig default

--- a/web-ui/src/__tests__/components/settings/SettingsPage.test.tsx
+++ b/web-ui/src/__tests__/components/settings/SettingsPage.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import useSWR from 'swr';
+import { toast } from 'sonner';
+
+import SettingsPage from '@/app/settings/page';
+import { settingsApi } from '@/lib/api';
+import * as storage from '@/lib/workspace-storage';
+import type { AgentSettings } from '@/types';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+jest.mock('swr');
+jest.mock('@/lib/workspace-storage', () => ({
+  getSelectedWorkspacePath: jest.fn(),
+}));
+jest.mock('@/lib/api', () => ({
+  settingsApi: {
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+jest.mock('next/link', () => {
+  const MockLink = ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockGetWorkspace = storage.getSelectedWorkspacePath as jest.MockedFunction<
+  typeof storage.getSelectedWorkspacePath
+>;
+const mockUpdate = settingsApi.update as jest.MockedFunction<typeof settingsApi.update>;
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+const WORKSPACE = '/home/user/project';
+
+const SAMPLE_SETTINGS: AgentSettings = {
+  agent_models: [
+    { agent_type: 'claude_code', default_model: 'claude-opus-4' },
+    { agent_type: 'codex', default_model: '' },
+    { agent_type: 'opencode', default_model: '' },
+    { agent_type: 'react', default_model: '' },
+  ],
+  max_turns: 25,
+  max_cost_usd: 5.0,
+};
+
+function mockSWR(data: AgentSettings | undefined, mutate = jest.fn()) {
+  mockUseSWR.mockReturnValue({
+    data,
+    error: undefined,
+    isLoading: data === undefined,
+    mutate,
+  } as unknown as ReturnType<typeof useSWR>);
+  return mutate;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('without workspace', () => {
+    it('shows workspace prompt when no workspace selected', () => {
+      mockGetWorkspace.mockReturnValue(null);
+      mockSWR(undefined);
+      render(<SettingsPage />);
+      expect(screen.getByText(/No workspace selected/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('with workspace', () => {
+    beforeEach(() => {
+      mockGetWorkspace.mockReturnValue(WORKSPACE);
+    });
+
+    it('renders all four tabs', () => {
+      mockSWR(SAMPLE_SETTINGS);
+      render(<SettingsPage />);
+      expect(screen.getByRole('tab', { name: 'Agent' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'API Keys' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'PROOF9' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Workspace' })).toBeInTheDocument();
+    });
+
+    it('loads settings into form on mount', async () => {
+      mockSWR(SAMPLE_SETTINGS);
+      render(<SettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Max turns per task/i)).toHaveValue(25);
+      });
+      expect(screen.getByLabelText(/Max cost per task/i)).toHaveValue(5);
+    });
+
+    it('saves edited settings via the API', async () => {
+      const mutate = mockSWR(SAMPLE_SETTINGS);
+      mockUpdate.mockResolvedValue({ ...SAMPLE_SETTINGS, max_turns: 30 });
+
+      render(<SettingsPage />);
+
+      const maxTurnsInput = await screen.findByLabelText(/Max turns per task/i);
+      fireEvent.change(maxTurnsInput, { target: { value: '30' } });
+
+      const saveButton = screen.getByRole('button', { name: /Save/i });
+      await act(async () => {
+        fireEvent.click(saveButton);
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        WORKSPACE,
+        expect.objectContaining({ max_turns: 30 })
+      );
+      expect(toast.success).toHaveBeenCalledWith('Settings saved');
+      expect(mutate).toHaveBeenCalled();
+    });
+
+    it('discards changes back to last loaded data', async () => {
+      mockSWR(SAMPLE_SETTINGS);
+      render(<SettingsPage />);
+
+      const maxTurnsInput = await screen.findByLabelText(/Max turns per task/i);
+      fireEvent.change(maxTurnsInput, { target: { value: '99' } });
+      expect(maxTurnsInput).toHaveValue(99);
+
+      const discardButton = screen.getByRole('button', { name: /Discard/i });
+      fireEvent.click(discardButton);
+
+      await waitFor(() => {
+        expect(maxTurnsInput).toHaveValue(25);
+      });
+      expect(toast.info).toHaveBeenCalledWith('Changes discarded');
+    });
+
+    it('exposes triggers for the three stub tabs', () => {
+      mockSWR(SAMPLE_SETTINGS);
+      render(<SettingsPage />);
+
+      // Stub tabs are present even though their panels mount lazily in radix.
+      ['API Keys', 'PROOF9', 'Workspace'].forEach((name) => {
+        expect(screen.getByRole('tab', { name })).toBeInTheDocument();
+      });
+    });
+
+    it('shows error message when SWR errors', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: new Error('boom'),
+        isLoading: false,
+        mutate: jest.fn(),
+      } as unknown as ReturnType<typeof useSWR>);
+      render(<SettingsPage />);
+      expect(screen.getByText(/Failed to load settings/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/web-ui/src/app/settings/page.tsx
+++ b/web-ui/src/app/settings/page.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import useSWR from 'swr';
+import { toast } from 'sonner';
+
+import { settingsApi } from '@/lib/api';
+import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
+import type { AgentSettings, AgentTypeKey, ApiError } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const AGENT_TYPE_LABELS: Record<AgentTypeKey, string> = {
+  claude_code: 'Claude Code',
+  codex: 'Codex',
+  opencode: 'OpenCode',
+  react: 'ReAct',
+};
+
+const MODEL_OPTIONS_BY_AGENT: Record<AgentTypeKey, string[]> = {
+  claude_code: ['claude-opus-4', 'claude-sonnet-4', 'claude-haiku-4'],
+  codex: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini'],
+  opencode: ['claude-opus-4', 'claude-sonnet-4', 'gpt-4o'],
+  react: ['claude-opus-4', 'claude-sonnet-4', 'gpt-4o', 'qwen2.5-coder:7b'],
+};
+
+const UNSET_MODEL_VALUE = '__unset__';
+
+export default function SettingsPage() {
+  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
+  const [workspaceReady, setWorkspaceReady] = useState(false);
+
+  useEffect(() => {
+    setWorkspacePath(getSelectedWorkspacePath());
+    setWorkspaceReady(true);
+  }, []);
+
+  const swrKey = workspacePath ? ['settings', workspacePath] : null;
+  const { data, error, isLoading, mutate } = useSWR<AgentSettings>(
+    swrKey,
+    () => settingsApi.get(workspacePath!)
+  );
+
+  const [draft, setDraft] = useState<AgentSettings | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (data) {
+      setDraft({
+        ...data,
+        agent_models: data.agent_models.map((m) => ({ ...m })),
+      });
+    }
+  }, [data]);
+
+  if (!workspaceReady) return null;
+
+  if (!workspacePath) {
+    return (
+      <main className="min-h-screen bg-background">
+        <div className="mx-auto max-w-5xl px-4 py-8">
+          <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+          <div className="rounded-lg border bg-muted/50 p-6 text-center">
+            <p className="text-muted-foreground">
+              No workspace selected. Use the sidebar to return to{' '}
+              <Link href="/" className="text-primary hover:underline">
+                Workspace
+              </Link>{' '}
+              and select a project.
+            </p>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const updateAgentModel = (agentType: AgentTypeKey, model: string) => {
+    if (!draft) return;
+    setDraft({
+      ...draft,
+      agent_models: draft.agent_models.map((entry) =>
+        entry.agent_type === agentType
+          ? { ...entry, default_model: model }
+          : entry
+      ),
+    });
+  };
+
+  const handleSave = async () => {
+    if (!draft || !workspacePath) return;
+    setSaving(true);
+    try {
+      const saved = await settingsApi.update(workspacePath, draft);
+      await mutate(saved, { revalidate: false });
+      toast.success('Settings saved');
+    } catch (err) {
+      const apiError = err as ApiError;
+      toast.error(apiError.detail || 'Failed to save settings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDiscard = () => {
+    if (!data) return;
+    setDraft({
+      ...data,
+      agent_models: data.agent_models.map((m) => ({ ...m })),
+    });
+    toast.info('Changes discarded');
+  };
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        <h1 className="mb-6 text-2xl font-bold">Settings</h1>
+
+        <Tabs defaultValue="agent" className="w-full">
+          <TabsList className="mb-6">
+            <TabsTrigger value="agent">Agent</TabsTrigger>
+            <TabsTrigger value="api-keys">API Keys</TabsTrigger>
+            <TabsTrigger value="proof9">PROOF9</TabsTrigger>
+            <TabsTrigger value="workspace">Workspace</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="agent">
+            <section className="rounded-lg border bg-card p-6">
+              <h2 className="mb-1 text-lg font-semibold">Agent Settings</h2>
+              <p className="mb-6 text-sm text-muted-foreground">
+                Default model per agent type, plus per-task limits.
+              </p>
+
+              {isLoading && !draft ? (
+                <p className="text-sm text-muted-foreground">Loading…</p>
+              ) : error ? (
+                <p className="text-sm text-destructive">
+                  Failed to load settings.
+                </p>
+              ) : draft ? (
+                <AgentSettingsForm
+                  draft={draft}
+                  onModelChange={updateAgentModel}
+                  onMaxTurnsChange={(v) =>
+                    setDraft({ ...draft, max_turns: v })
+                  }
+                  onMaxCostChange={(v) =>
+                    setDraft({ ...draft, max_cost_usd: v })
+                  }
+                  onSave={handleSave}
+                  onDiscard={handleDiscard}
+                  saving={saving}
+                />
+              ) : (
+                <ComingSoon />
+              )}
+            </section>
+          </TabsContent>
+
+          <TabsContent value="api-keys">
+            <section className="rounded-lg border bg-card p-6">
+              <h2 className="mb-1 text-lg font-semibold">API Keys</h2>
+              <ComingSoon />
+            </section>
+          </TabsContent>
+
+          <TabsContent value="proof9">
+            <section className="rounded-lg border bg-card p-6">
+              <h2 className="mb-1 text-lg font-semibold">PROOF9</h2>
+              <ComingSoon />
+            </section>
+          </TabsContent>
+
+          <TabsContent value="workspace">
+            <section className="rounded-lg border bg-card p-6">
+              <h2 className="mb-1 text-lg font-semibold">Workspace</h2>
+              <ComingSoon />
+            </section>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </main>
+  );
+}
+
+function ComingSoon() {
+  return <p className="text-sm text-muted-foreground">Coming soon</p>;
+}
+
+interface AgentSettingsFormProps {
+  draft: AgentSettings;
+  onModelChange: (agentType: AgentTypeKey, model: string) => void;
+  onMaxTurnsChange: (value: number) => void;
+  onMaxCostChange: (value: number | null) => void;
+  onSave: () => void;
+  onDiscard: () => void;
+  saving: boolean;
+}
+
+function AgentSettingsForm({
+  draft,
+  onModelChange,
+  onMaxTurnsChange,
+  onMaxCostChange,
+  onSave,
+  onDiscard,
+  saving,
+}: AgentSettingsFormProps) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="mb-3 text-sm font-medium">Default model per agent type</h3>
+        <div className="space-y-3">
+          {draft.agent_models.map((entry) => {
+            const label = AGENT_TYPE_LABELS[entry.agent_type as AgentTypeKey] ?? entry.agent_type;
+            const options = MODEL_OPTIONS_BY_AGENT[entry.agent_type as AgentTypeKey] ?? [];
+            const selectValue = entry.default_model || UNSET_MODEL_VALUE;
+            return (
+              <div
+                key={entry.agent_type}
+                className="grid grid-cols-1 items-center gap-2 sm:grid-cols-[180px_1fr]"
+              >
+                <label
+                  htmlFor={`model-${entry.agent_type}`}
+                  className="text-sm text-muted-foreground"
+                >
+                  {label}
+                </label>
+                <Select
+                  value={selectValue}
+                  onValueChange={(value) =>
+                    onModelChange(
+                      entry.agent_type as AgentTypeKey,
+                      value === UNSET_MODEL_VALUE ? '' : value
+                    )
+                  }
+                >
+                  <SelectTrigger id={`model-${entry.agent_type}`}>
+                    <SelectValue placeholder="Select model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={UNSET_MODEL_VALUE}>(default)</SelectItem>
+                    {options.map((model) => (
+                      <SelectItem key={model} value={model}>
+                        {model}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor="max-turns"
+            className="mb-1 block text-sm font-medium"
+          >
+            Max turns per task
+          </label>
+          <Input
+            id="max-turns"
+            type="number"
+            min={1}
+            value={draft.max_turns}
+            onChange={(e) => {
+              const v = Number.parseInt(e.target.value, 10);
+              if (!Number.isNaN(v)) onMaxTurnsChange(v);
+            }}
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="max-cost"
+            className="mb-1 block text-sm font-medium"
+          >
+            Max cost per task (USD)
+          </label>
+          <Input
+            id="max-cost"
+            type="number"
+            min={0}
+            step="0.01"
+            value={draft.max_cost_usd ?? ''}
+            placeholder="No limit"
+            onChange={(e) => {
+              const raw = e.target.value;
+              if (raw === '') {
+                onMaxCostChange(null);
+                return;
+              }
+              const v = Number.parseFloat(raw);
+              if (!Number.isNaN(v)) onMaxCostChange(v);
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 border-t pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onDiscard}
+          disabled={saving}
+        >
+          Discard
+        </Button>
+        <Button type="button" onClick={onSave} disabled={saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/layout/AppSidebar.tsx
+++ b/web-ui/src/components/layout/AppSidebar.tsx
@@ -14,6 +14,7 @@ import {
   GitBranchIcon,
   CheckmarkCircle01Icon,
   Add01Icon,
+  Settings01Icon,
 } from '@hugeicons/react';
 import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
 import { blockersApi, sessionsApi } from '@/lib/api';
@@ -36,6 +37,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/blockers', label: 'Blockers', icon: Alert02Icon, enabled: true },
   { href: '/review', label: 'Review', icon: GitBranchIcon, enabled: true },
   { href: '/proof', label: 'Proof', icon: CheckmarkCircle01Icon, enabled: true },
+  { href: '/settings', label: 'Settings', icon: Settings01Icon, enabled: true },
 ];
 
 export function AppSidebar() {

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -59,6 +59,7 @@ import type {
   SessionListResponse,
   SessionCreateRequest,
   ChatMessage,
+  AgentSettings,
 } from '@/types';
 
 // FastAPI validation error format
@@ -799,6 +800,26 @@ export const sessionsApi = {
    */
   end: async (id: string): Promise<void> => {
     await api.delete(`/api/v2/sessions/${encodeURIComponent(id)}`);
+  },
+};
+
+// Settings API methods (issue #554)
+export const settingsApi = {
+  get: async (workspacePath: string): Promise<AgentSettings> => {
+    const response = await api.get<AgentSettings>('/api/v2/settings', {
+      params: { workspace_path: workspacePath },
+    });
+    return response.data;
+  },
+
+  update: async (
+    workspacePath: string,
+    body: AgentSettings
+  ): Promise<AgentSettings> => {
+    const response = await api.put<AgentSettings>('/api/v2/settings', body, {
+      params: { workspace_path: workspacePath },
+    });
+    return response.data;
   },
 };
 

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -560,3 +560,17 @@ export interface AgentChatState {
 // Proof evidence table sort types
 export type ProofEvidenceSortCol = 'gate' | 'result' | 'run_id' | 'timestamp' | 'artifact';
 export type SortDir = 'asc' | 'desc';
+
+// Settings types — mirrors codeframe/ui/models.py
+export type AgentTypeKey = 'claude_code' | 'codex' | 'opencode' | 'react';
+
+export interface AgentTypeModelConfig {
+  agent_type: AgentTypeKey;
+  default_model: string;
+}
+
+export interface AgentSettings {
+  agent_models: AgentTypeModelConfig[];
+  max_turns: number;
+  max_cost_usd: number | null;
+}


### PR DESCRIPTION
## Summary
- Adds `/settings` page (Phase 5.1) — sidebar nav entry, Radix Tabs (Agent functional; API Keys / PROOF9 / Workspace stubs).
- Backend: new `settings_v2` router with `GET`/`PUT /api/v2/settings`, persisted to `.codeframe/config.yaml` via existing helpers.
- Extends `EnvironmentConfig` with `max_cost_usd` and `agent_type_models` (per-agent-type model overrides).

Closes #554

## Test plan
- [x] Backend: `uv run pytest tests/ui/test_settings_v2.py` (6/6 pass)
- [x] Backend: `uv run pytest tests/ui/` (199/199 pass)
- [x] Backend: `uv run ruff check .` (clean)
- [x] Frontend: `npm test` (790/790 pass; 7 new tests for SettingsPage)
- [x] Frontend: `npm run build` (`/settings` route in output)
- [ ] Demo: load `/settings`, change Claude Code model + max turns, save, reload, verify persistence

## Acceptance criteria (from issue)
- [x] `/settings` renders with sidebar nav
- [x] Agent settings load on mount from the API
- [x] Edits persist after page reload (verified by round-trip test)
- [x] `npm test` and `npm run build` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage agent settings per workspace: per-agent default models, max iterations, and optional USD cost cap; new Settings API + client methods; Settings page with tabs, editable agent controls, save/discard flows, and sidebar link.

* **Tests**
  * Added integration and unit tests covering GET/PUT flows, validation (including non-negative cost and allowed agent types), persistence, and UI behaviors (toasts, error states).

* **Documentation**
  * Roadmap and shipped-pages docs updated to include the Settings page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->