### PR TITLE
feat(workspaces): server-side workspace registry + listing/switcher API (#601)

### DIFF
--- a/codeframe/platform_store/database.py
+++ b/codeframe/platform_store/database.py
@@ -26,6 +26,7 @@ from codeframe.platform_store.repositories import (
     TokenRepository,
     AuditRepository,
     APIKeyRepository,
+    WorkspaceRegistryRepository,
 )
 from codeframe.platform_store.repositories.interactive_sessions import InteractiveSessionRepository
 
@@ -65,6 +66,7 @@ class Database:
         self.audit_logs: Optional[AuditRepository] = None
         self.api_keys: Optional[APIKeyRepository] = None
         self.interactive_sessions: Optional[InteractiveSessionRepository] = None
+        self.workspace_registry: Optional[WorkspaceRegistryRepository] = None
 
     def initialize(self) -> None:
         """Initialize database schema and repositories."""
@@ -97,6 +99,7 @@ class Database:
         self.audit_logs = AuditRepository(sync_conn=self.conn, async_conn=self._async_conn, database=self, sync_lock=self._sync_lock)
         self.api_keys = APIKeyRepository(sync_conn=self.conn, async_conn=self._async_conn, database=self, sync_lock=self._sync_lock)
         self.interactive_sessions = InteractiveSessionRepository(sync_conn=self.conn, async_conn=self._async_conn, database=self, sync_lock=self._sync_lock)
+        self.workspace_registry = WorkspaceRegistryRepository(sync_conn=self.conn, async_conn=self._async_conn, database=self, sync_lock=self._sync_lock)
 
     # Connection management methods
     def close(self) -> None:
@@ -143,7 +146,7 @@ class Database:
 
     def _update_repository_async_connections(self) -> None:
         """Update async connections in all repositories."""
-        for repo in [self.token_usage, self.audit_logs, self.api_keys, self.interactive_sessions]:
+        for repo in [self.token_usage, self.audit_logs, self.api_keys, self.interactive_sessions, self.workspace_registry]:
             if repo:
                 repo._async_conn = self._async_conn
 

--- a/codeframe/platform_store/repositories/__init__.py
+++ b/codeframe/platform_store/repositories/__init__.py
@@ -11,10 +11,14 @@ from codeframe.platform_store.repositories.base import BaseRepository
 from codeframe.platform_store.repositories.token_repository import TokenRepository
 from codeframe.platform_store.repositories.audit_repository import AuditRepository
 from codeframe.platform_store.repositories.api_key_repository import APIKeyRepository
+from codeframe.platform_store.repositories.workspace_registry_repository import (
+    WorkspaceRegistryRepository,
+)
 
 __all__ = [
     "BaseRepository",
     "TokenRepository",
     "AuditRepository",
     "APIKeyRepository",
+    "WorkspaceRegistryRepository",
 ]

--- a/codeframe/platform_store/repositories/workspace_registry_repository.py
+++ b/codeframe/platform_store/repositories/workspace_registry_repository.py
@@ -69,8 +69,13 @@ class WorkspaceRegistryRepository(BaseRepository):
 
         # Re-read so callers always get the canonical row (stable id on conflict).
         entry = self.get_by_path(repo_path)
-        # get_by_path cannot return None right after a successful upsert.
-        assert entry is not None
+        if entry is None:
+            # Should be unreachable right after a successful upsert. Raise a real
+            # error (not assert, which `python -O` strips) so the dict-return
+            # contract holds in every execution mode.
+            raise RuntimeError(
+                f"workspaces_registry upsert succeeded but row not found: {repo_path}"
+            )
         return entry
 
     def list_all(self, owner_user_id: Optional[int] = None) -> List[Dict[str, Any]]:

--- a/codeframe/platform_store/repositories/workspace_registry_repository.py
+++ b/codeframe/platform_store/repositories/workspace_registry_repository.py
@@ -58,9 +58,11 @@ class WorkspaceRegistryRepository(BaseRepository):
             )
             VALUES (?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(repo_path) DO UPDATE SET
-                name = excluded.name,
+                -- COALESCE so a refresh that omits name/tech_stack (None) keeps the
+                -- previously-stored value instead of nulling it.
+                name = COALESCE(excluded.name, workspaces_registry.name),
                 owner_user_id = excluded.owner_user_id,
-                tech_stack = excluded.tech_stack,
+                tech_stack = COALESCE(excluded.tech_stack, workspaces_registry.tech_stack),
                 last_opened_at = excluded.last_opened_at
             """,
             (new_id, repo_path, name, owner_user_id, tech_stack, now, now),

--- a/codeframe/platform_store/repositories/workspace_registry_repository.py
+++ b/codeframe/platform_store/repositories/workspace_registry_repository.py
@@ -1,0 +1,168 @@
+"""Repository for the workspace registry (issue #601).
+
+The registry lives in the global control-plane DB and stores only project
+metadata + a pointer (``repo_path``) to each per-workspace
+``.codeframe/state.db``. It enables server-side listing of "your projects" so
+the web UI switcher can be backed by the server (with a localStorage fallback)
+instead of living purely in the browser.
+
+It is intentionally NOT a revival of the v1 global ``projects`` table — no
+domain data is stored here, only pointers and metadata.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+import logging
+
+from codeframe.platform_store.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class WorkspaceRegistryRepository(BaseRepository):
+    """Repository for workspace registry operations."""
+
+    def upsert(
+        self,
+        repo_path: str,
+        name: Optional[str] = None,
+        tech_stack: Optional[str] = None,
+        owner_user_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Register (or refresh) a workspace by its repo path.
+
+        Idempotent on ``repo_path``: a second call for the same path updates the
+        existing row (name/tech_stack/owner + ``last_opened_at``) instead of
+        creating a duplicate, preserving the original ``id`` and ``created_at``.
+
+        Args:
+            repo_path: Absolute path to the repository (unique key).
+            name: Human-readable display name (defaults to last path segment).
+            tech_stack: Natural-language tech stack description.
+            owner_user_id: Owning user id (nullable until auth is enforced).
+
+        Returns:
+            The registry entry as a dict.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        new_id = str(uuid.uuid4())
+
+        # INSERT ... ON CONFLICT(repo_path) DO UPDATE keeps the original id and
+        # created_at while refreshing the mutable metadata and recency stamp.
+        self._execute(
+            """
+            INSERT INTO workspaces_registry (
+                id, repo_path, name, owner_user_id, tech_stack,
+                created_at, last_opened_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(repo_path) DO UPDATE SET
+                name = excluded.name,
+                owner_user_id = excluded.owner_user_id,
+                tech_stack = excluded.tech_stack,
+                last_opened_at = excluded.last_opened_at
+            """,
+            (new_id, repo_path, name, owner_user_id, tech_stack, now, now),
+        )
+        self._commit()
+
+        # Re-read so callers always get the canonical row (stable id on conflict).
+        entry = self.get_by_path(repo_path)
+        # get_by_path cannot return None right after a successful upsert.
+        assert entry is not None
+        return entry
+
+    def list_all(self, owner_user_id: Optional[int] = None) -> List[Dict[str, Any]]:
+        """List all registered workspaces, optionally filtered by owner.
+
+        Args:
+            owner_user_id: When provided, only entries owned by this user are
+                returned. When ``None``, all entries are returned (the current
+                behaviour until auth is enforced on v2 routers).
+
+        Returns:
+            List of registry entries ordered by ``last_opened_at`` descending.
+        """
+        if owner_user_id is not None:
+            rows = self._fetchall(
+                """
+                SELECT id, repo_path, name, owner_user_id, tech_stack,
+                       created_at, last_opened_at
+                FROM workspaces_registry
+                WHERE owner_user_id = ?
+                ORDER BY last_opened_at DESC
+                """,
+                (owner_user_id,),
+            )
+        else:
+            rows = self._fetchall(
+                """
+                SELECT id, repo_path, name, owner_user_id, tech_stack,
+                       created_at, last_opened_at
+                FROM workspaces_registry
+                ORDER BY last_opened_at DESC
+                """
+            )
+
+        return [self._row_to_workspace_registry(row) for row in rows]
+
+    def get_by_id(self, workspace_id: str) -> Optional[Dict[str, Any]]:
+        """Get a registry entry by its id, or None if not found."""
+        row = self._fetchone(
+            """
+            SELECT id, repo_path, name, owner_user_id, tech_stack,
+                   created_at, last_opened_at
+            FROM workspaces_registry
+            WHERE id = ?
+            """,
+            (workspace_id,),
+        )
+        return self._row_to_workspace_registry(row) if row is not None else None
+
+    def get_by_path(self, repo_path: str) -> Optional[Dict[str, Any]]:
+        """Get a registry entry by its repo path, or None if not found."""
+        row = self._fetchone(
+            """
+            SELECT id, repo_path, name, owner_user_id, tech_stack,
+                   created_at, last_opened_at
+            FROM workspaces_registry
+            WHERE repo_path = ?
+            """,
+            (repo_path,),
+        )
+        return self._row_to_workspace_registry(row) if row is not None else None
+
+    def update_last_opened(self, workspace_id: str) -> None:
+        """Bump ``last_opened_at`` for a registry entry to maintain recency."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._execute(
+            "UPDATE workspaces_registry SET last_opened_at = ? WHERE id = ?",
+            (now, workspace_id),
+        )
+        self._commit()
+
+    def delete(self, workspace_id: str) -> bool:
+        """Deregister a workspace (registry-only — never touches disk files).
+
+        Returns:
+            True if a row was removed, False if the id was not found.
+        """
+        cursor = self._execute(
+            "DELETE FROM workspaces_registry WHERE id = ?",
+            (workspace_id,),
+        )
+        self._commit()
+        return cursor.rowcount > 0
+
+    def _row_to_workspace_registry(self, row) -> Dict[str, Any]:
+        """Convert a database row to a registry dict."""
+        return {
+            "id": row["id"],
+            "repo_path": row["repo_path"],
+            "name": row["name"],
+            "owner_user_id": row["owner_user_id"],
+            "tech_stack": row["tech_stack"],
+            "created_at": self._ensure_rfc3339(row["created_at"]),
+            "last_opened_at": self._ensure_rfc3339(row["last_opened_at"]),
+        }

--- a/codeframe/platform_store/schema_manager.py
+++ b/codeframe/platform_store/schema_manager.py
@@ -214,8 +214,8 @@ class SchemaManager:
                 name TEXT,
                 owner_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
                 tech_stack TEXT,
-                created_at TEXT,
-                last_opened_at TEXT
+                created_at TEXT NOT NULL,
+                last_opened_at TEXT NOT NULL
             )
             """
         )

--- a/codeframe/platform_store/schema_manager.py
+++ b/codeframe/platform_store/schema_manager.py
@@ -43,6 +43,9 @@ class SchemaManager:
         # Interactive session tables
         self._create_interactive_session_tables(cursor)
 
+        # Workspace registry table (issue #601)
+        self._create_workspaces_registry_table(cursor)
+
         # Create indexes
         self._create_indexes(cursor)
 
@@ -195,6 +198,28 @@ class SchemaManager:
             """
         )
 
+    def _create_workspaces_registry_table(self, cursor: sqlite3.Cursor) -> None:
+        """Create the workspaces_registry table (issue #601).
+
+        Stores cross-workspace, cross-device project metadata plus a pointer
+        (``repo_path``) to each per-workspace ``.codeframe/state.db``. It does
+        NOT hold any domain data — per-workspace isolation is unchanged. This is
+        deliberately not a revival of the v1 global ``projects`` table.
+        """
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS workspaces_registry (
+                id TEXT PRIMARY KEY,
+                repo_path TEXT UNIQUE NOT NULL,
+                name TEXT,
+                owner_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+                tech_stack TEXT,
+                created_at TEXT,
+                last_opened_at TEXT
+            )
+            """
+        )
+
     def _create_audit_log_table(self, cursor: sqlite3.Cursor) -> None:
         """Create the audit log table."""
         cursor.execute(
@@ -248,6 +273,16 @@ class SchemaManager:
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id)")
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at)"
+        )
+
+        # Workspace registry indexes (issue #601)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_workspaces_registry_owner "
+            "ON workspaces_registry(owner_user_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_workspaces_registry_last_opened "
+            "ON workspaces_registry(last_opened_at DESC)"
         )
 
     def _ensure_default_admin_user(self) -> None:

--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -356,6 +356,8 @@ async def update_current_workspace(
 
         if body.tech_stack is not None:
             updated = ws.update_workspace_tech_stack(workspace.repo_path, body.tech_stack)
+            # Keep the registry's cached metadata (tech_stack) in sync (#601).
+            _register_workspace(request, updated)
 
         return _workspace_to_response(updated)
 

--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -12,9 +12,9 @@ Routes:
 import json
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field, ValidationError
 
 from codeframe.core import workspace as ws
@@ -56,6 +56,26 @@ class UpdateWorkspaceRequest(BaseModel):
     """Request for updating workspace."""
 
     tech_stack: Optional[str] = Field(None, description="New tech stack description")
+
+
+class WorkspaceRegistryResponse(BaseModel):
+    """A single registered workspace from the server-side registry (issue #601)."""
+
+    id: str
+    repo_path: str
+    name: Optional[str] = None
+    tech_stack: Optional[str] = None
+    created_at: Optional[str] = None
+    last_opened_at: Optional[str] = None
+    path_exists: bool = Field(
+        ..., description="Whether repo_path still exists on disk (computed at list time)."
+    )
+
+
+class WorkspaceListResponse(BaseModel):
+    """Response for listing registered workspaces."""
+
+    workspaces: List[WorkspaceRegistryResponse]
 
 
 # ============================================================================
@@ -123,9 +143,67 @@ def _detect_tech_stack(repo_path: Path) -> Optional[str]:
     return ", ".join(tech_parts) if tech_parts else None
 
 
+def _get_registry(request: Request):
+    """Return the WorkspaceRegistryRepository, or None if unavailable.
+
+    Registry writes are best-effort: when the control-plane DB isn't attached
+    (e.g. lightweight tests that mount only this router), registry tracking is
+    silently skipped so core workspace operations never break.
+    """
+    db = getattr(request.app.state, "db", None)
+    if db is None:
+        return None
+    return getattr(db, "workspace_registry", None)
+
+
+def _register_workspace(request: Request, workspace: Workspace) -> None:
+    """Best-effort upsert of a workspace into the server-side registry."""
+    registry = _get_registry(request)
+    if registry is None:
+        return
+    try:
+        registry.upsert(
+            repo_path=str(workspace.repo_path),
+            name=workspace.repo_path.name,
+            tech_stack=workspace.tech_stack,
+            owner_user_id=None,  # Until auth is enforced on v2 routers.
+        )
+    except Exception as e:  # noqa: BLE001 - tracking must never break the request
+        logger.warning("Failed to register workspace in registry: %s", e)
+
+
 # ============================================================================
 # Endpoints
 # ============================================================================
+
+
+@router.get("", response_model=WorkspaceListResponse)
+@rate_limit_standard()
+async def list_workspaces(request: Request) -> WorkspaceListResponse:
+    """List all registered workspaces (issue #601).
+
+    Returns server-side registry entries ordered by recency, each annotated with
+    a computed ``path_exists`` so clients can flag stale projects. Returns an
+    empty list when the registry is unavailable.
+    """
+    registry = _get_registry(request)
+    if registry is None:
+        return WorkspaceListResponse(workspaces=[])
+
+    entries = registry.list_all()
+    workspaces = [
+        WorkspaceRegistryResponse(
+            id=entry["id"],
+            repo_path=entry["repo_path"],
+            name=entry.get("name"),
+            tech_stack=entry.get("tech_stack"),
+            created_at=entry.get("created_at"),
+            last_opened_at=entry.get("last_opened_at"),
+            path_exists=Path(entry["repo_path"]).exists(),
+        )
+        for entry in entries
+    ]
+    return WorkspaceListResponse(workspaces=workspaces)
 
 
 @router.post("", response_model=WorkspaceResponse, status_code=201)
@@ -191,6 +269,9 @@ async def init_workspace(
         else:
             workspace = ws.create_or_load_workspace(repo_path, tech_stack=tech_stack)
 
+        # Register (or refresh) the workspace in the server-side registry (#601).
+        _register_workspace(request, workspace)
+
         return _workspace_to_response(workspace)
 
     except HTTPException:
@@ -220,6 +301,19 @@ async def get_current_workspace(
     Returns:
         Workspace information
     """
+    # Track access recency in the registry (#601). Auto-register workspaces that
+    # were opened directly by path so they become server-tracked. Best-effort.
+    registry = _get_registry(request)
+    if registry is not None:
+        try:
+            entry = registry.get_by_path(str(workspace.repo_path))
+            if entry is not None:
+                registry.update_last_opened(entry["id"])
+            else:
+                _register_workspace(request, workspace)
+        except Exception as e:  # noqa: BLE001 - tracking must never break the request
+            logger.warning("Failed to track workspace access: %s", e)
+
     return _workspace_to_response(workspace)
 
 
@@ -371,3 +465,47 @@ async def check_workspace_exists(
         "path": str(path),
         "state_dir": str(path / ".codeframe") if ws.workspace_exists(path) else None,
     }
+
+
+@router.delete("/{workspace_id}", status_code=204)
+@rate_limit_standard()
+async def deregister_workspace(
+    request: Request,
+    workspace_id: str,
+) -> Response:
+    """Deregister a workspace from the server-side registry (issue #601).
+
+    Removes only the registry entry — it never deletes the ``.codeframe/``
+    directory or any on-disk state.
+
+    Returns:
+        204 No Content on success.
+
+    Raises:
+        HTTPException:
+            - 404: workspace_id not found in the registry
+            - 503: registry/control-plane DB unavailable
+    """
+    registry = _get_registry(request)
+    if registry is None:
+        raise HTTPException(
+            status_code=503,
+            detail=api_error(
+                "Registry unavailable",
+                ErrorCodes.EXECUTION_FAILED,
+                "Workspace registry is not available on this server.",
+            ),
+        )
+
+    deleted = registry.delete(workspace_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=404,
+            detail=api_error(
+                "Workspace not found",
+                ErrorCodes.NOT_FOUND,
+                f"No registered workspace with id: {workspace_id}",
+            ),
+        )
+
+    return Response(status_code=204)

--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -202,6 +202,9 @@ async def list_workspaces(request: Request) -> WorkspaceListResponse:
         )
 
     entries = registry.list_all()
+    # path_exists is a per-entry blocking stat() inside an async handler. The
+    # registry is recency-scoped and small in practice, so the event-loop cost is
+    # negligible; revisit (e.g. run_in_executor) only if the list grows large.
     workspaces = [
         WorkspaceRegistryResponse(
             id=entry["id"],

--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -183,12 +183,23 @@ async def list_workspaces(request: Request) -> WorkspaceListResponse:
     """List all registered workspaces (issue #601).
 
     Returns server-side registry entries ordered by recency, each annotated with
-    a computed ``path_exists`` so clients can flag stale projects. Returns an
-    empty list when the registry is unavailable.
+    a computed ``path_exists`` so clients can flag stale projects.
+
+    When the control-plane DB / registry is unavailable, responds 503 rather than
+    an empty 200 — clients treat a successful response as authoritative and would
+    otherwise wipe their local fallback list. A genuinely empty registry still
+    returns 200 with ``[]``.
     """
     registry = _get_registry(request)
     if registry is None:
-        return WorkspaceListResponse(workspaces=[])
+        raise HTTPException(
+            status_code=503,
+            detail=api_error(
+                "Registry unavailable",
+                ErrorCodes.EXECUTION_FAILED,
+                "Workspace registry is not available on this server.",
+            ),
+        )
 
     entries = registry.list_all()
     workspaces = [

--- a/tests/platform_store/test_workspace_registry_repository.py
+++ b/tests/platform_store/test_workspace_registry_repository.py
@@ -73,6 +73,16 @@ class TestUpsert:
         )
         assert entry["owner_user_id"] == 1
 
+    def test_upsert_preserves_name_and_tech_stack_when_omitted(self, db):
+        """A refresh upsert that omits name/tech_stack (None) keeps prior values."""
+        db.workspace_registry.upsert(
+            repo_path="/p/alpha", name="alpha", tech_stack="Python"
+        )
+        # e.g. an auto-register/recency path that doesn't carry metadata.
+        refreshed = db.workspace_registry.upsert(repo_path="/p/alpha")
+        assert refreshed["name"] == "alpha"
+        assert refreshed["tech_stack"] == "Python"
+
 
 class TestListAll:
     def test_list_all_empty(self, db):

--- a/tests/platform_store/test_workspace_registry_repository.py
+++ b/tests/platform_store/test_workspace_registry_repository.py
@@ -1,0 +1,140 @@
+"""Tests for WorkspaceRegistryRepository (issue #601).
+
+The workspace registry lives in the global control-plane DB and stores only
+metadata + a pointer (repo_path) to each per-workspace ``.codeframe/state.db``.
+Per-workspace domain data is unaffected.
+
+Following TDD: tests written first, implementation follows.
+"""
+
+import pytest
+
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def db(tmp_path):
+    """In-memory-style control-plane DB on a temp file with the registry table."""
+    db_path = tmp_path / "control_plane.db"
+    db = Database(db_path)
+    db.initialize()
+    yield db
+    db.close()
+
+
+class TestUpsert:
+    def test_upsert_inserts_new_entry(self, db):
+        entry = db.workspace_registry.upsert(
+            repo_path="/home/u/projects/alpha",
+            name="alpha",
+            tech_stack="Python",
+        )
+
+        assert entry["id"]
+        assert entry["repo_path"] == "/home/u/projects/alpha"
+        assert entry["name"] == "alpha"
+        assert entry["tech_stack"] == "Python"
+        assert entry["owner_user_id"] is None
+        assert entry["created_at"]
+        assert entry["last_opened_at"]
+
+    def test_upsert_is_idempotent_on_repo_path(self, db):
+        """A second upsert for the same path updates instead of duplicating."""
+        first = db.workspace_registry.upsert(repo_path="/p/alpha", name="alpha")
+        second = db.workspace_registry.upsert(
+            repo_path="/p/alpha", name="alpha-renamed", tech_stack="Rust"
+        )
+
+        # Same row (stable id), updated fields
+        assert second["id"] == first["id"]
+        assert second["name"] == "alpha-renamed"
+        assert second["tech_stack"] == "Rust"
+
+        all_entries = db.workspace_registry.list_all()
+        assert len(all_entries) == 1
+
+    def test_upsert_bumps_last_opened_at(self, db):
+        first = db.workspace_registry.upsert(repo_path="/p/alpha", name="alpha")
+        # Force a distinct timestamp by writing an older value, then re-upsert.
+        db.conn.execute(
+            "UPDATE workspaces_registry SET last_opened_at = ? WHERE id = ?",
+            ("2000-01-01T00:00:00+00:00", first["id"]),
+        )
+        db.conn.commit()
+
+        second = db.workspace_registry.upsert(repo_path="/p/alpha", name="alpha")
+        assert second["last_opened_at"] > "2000-01-01T00:00:00+00:00"
+
+    def test_upsert_with_owner_user_id(self, db):
+        entry = db.workspace_registry.upsert(
+            repo_path="/p/alpha", name="alpha", owner_user_id=1
+        )
+        assert entry["owner_user_id"] == 1
+
+
+class TestListAll:
+    def test_list_all_empty(self, db):
+        assert db.workspace_registry.list_all() == []
+
+    def test_list_all_returns_all_entries(self, db):
+        db.workspace_registry.upsert(repo_path="/p/a", name="a")
+        db.workspace_registry.upsert(repo_path="/p/b", name="b")
+        db.workspace_registry.upsert(repo_path="/p/c", name="c")
+
+        entries = db.workspace_registry.list_all()
+        assert {e["repo_path"] for e in entries} == {"/p/a", "/p/b", "/p/c"}
+
+    def test_list_all_filters_by_owner(self, db):
+        db.workspace_registry.upsert(repo_path="/p/a", name="a", owner_user_id=1)
+        db.workspace_registry.upsert(repo_path="/p/b", name="b", owner_user_id=1)
+        db.workspace_registry.upsert(repo_path="/p/c", name="c", owner_user_id=None)
+
+        owned = db.workspace_registry.list_all(owner_user_id=1)
+        assert {e["repo_path"] for e in owned} == {"/p/a", "/p/b"}
+
+
+class TestGetters:
+    def test_get_by_id(self, db):
+        created = db.workspace_registry.upsert(repo_path="/p/a", name="a")
+        found = db.workspace_registry.get_by_id(created["id"])
+        assert found is not None
+        assert found["repo_path"] == "/p/a"
+
+    def test_get_by_id_missing(self, db):
+        assert db.workspace_registry.get_by_id("does-not-exist") is None
+
+    def test_get_by_path(self, db):
+        db.workspace_registry.upsert(repo_path="/p/a", name="a")
+        found = db.workspace_registry.get_by_path("/p/a")
+        assert found is not None
+        assert found["name"] == "a"
+
+    def test_get_by_path_missing(self, db):
+        assert db.workspace_registry.get_by_path("/nope") is None
+
+
+class TestUpdateLastOpened:
+    def test_update_last_opened_bumps_timestamp(self, db):
+        created = db.workspace_registry.upsert(repo_path="/p/a", name="a")
+        db.conn.execute(
+            "UPDATE workspaces_registry SET last_opened_at = ? WHERE id = ?",
+            ("2000-01-01T00:00:00+00:00", created["id"]),
+        )
+        db.conn.commit()
+
+        db.workspace_registry.update_last_opened(created["id"])
+
+        refreshed = db.workspace_registry.get_by_id(created["id"])
+        assert refreshed["last_opened_at"] > "2000-01-01T00:00:00+00:00"
+
+
+class TestDelete:
+    def test_delete_existing_returns_true(self, db):
+        created = db.workspace_registry.upsert(repo_path="/p/a", name="a")
+        assert db.workspace_registry.delete(created["id"]) is True
+        assert db.workspace_registry.get_by_id(created["id"]) is None
+
+    def test_delete_missing_returns_false(self, db):
+        assert db.workspace_registry.delete("does-not-exist") is False

--- a/tests/ui/test_workspace_registry_api.py
+++ b/tests/ui/test_workspace_registry_api.py
@@ -118,6 +118,29 @@ class TestCurrentTracksAccess:
         assert workspaces[0]["repo_path"] == str(repo.resolve())
 
 
+class TestRegistryUnavailable:
+    """When no control-plane DB is attached, the registry endpoints must signal
+    unavailability (503) rather than a misleading empty-but-successful response —
+    clients treat a 200 as authoritative and would wipe their local fallback.
+    """
+
+    @pytest.fixture
+    def client_no_db(self):
+        from codeframe.ui.routers import workspace_v2
+
+        app = FastAPI()
+        app.include_router(workspace_v2.router)
+        # Deliberately do NOT set app.state.db.
+        with TestClient(app, raise_server_exceptions=True) as c:
+            yield c
+
+    def test_list_returns_503_without_registry(self, client_no_db):
+        assert client_no_db.get("/api/v2/workspaces").status_code == 503
+
+    def test_delete_returns_503_without_registry(self, client_no_db):
+        assert client_no_db.delete("/api/v2/workspaces/anything").status_code == 503
+
+
 class TestDeleteWorkspace:
     def test_delete_existing_returns_204(self, client, temp_root):
         repo = _make_repo(temp_root, "delta")

--- a/tests/ui/test_workspace_registry_api.py
+++ b/tests/ui/test_workspace_registry_api.py
@@ -95,6 +95,22 @@ class TestListWorkspaces:
         assert workspaces[0]["repo_path"] == str(a.resolve())
 
 
+class TestPatchRefreshesRegistry:
+    def test_tech_stack_edit_updates_registry_metadata(self, client, temp_root):
+        repo = _make_repo(temp_root, "zeta")
+        client.post("/api/v2/workspaces", json={"repo_path": str(repo)})
+
+        resp = client.patch(
+            "/api/v2/workspaces/current",
+            params={"workspace_path": str(repo)},
+            json={"tech_stack": "Python with FastAPI"},
+        )
+        assert resp.status_code == 200
+
+        entry = client.get("/api/v2/workspaces").json()["workspaces"][0]
+        assert entry["tech_stack"] == "Python with FastAPI"
+
+
 class TestCurrentTracksAccess:
     def test_current_auto_registers_untracked_workspace(self, client, temp_root):
         """A workspace opened directly (not via POST) becomes tracked."""

--- a/tests/ui/test_workspace_registry_api.py
+++ b/tests/ui/test_workspace_registry_api.py
@@ -40,6 +40,7 @@ def client(temp_root):
     app.state.db = db
 
     with TestClient(app, raise_server_exceptions=True) as c:
+        c.db = db  # expose for tests that need to pin registry state directly
         yield c
 
 
@@ -87,6 +88,13 @@ class TestListWorkspaces:
         b = _make_repo(temp_root, "b")
         client.post("/api/v2/workspaces", json={"repo_path": str(a)})
         client.post("/api/v2/workspaces", json={"repo_path": str(b)})
+
+        # Pin both to fixed past timestamps so the upcoming /current bump on 'a'
+        # is unambiguously the newest, regardless of sub-second POST timing.
+        client.db.conn.execute(
+            "UPDATE workspaces_registry SET last_opened_at = '2000-01-01T00:00:00+00:00'"
+        )
+        client.db.conn.commit()
 
         # Touch 'a' again so it becomes the most recently opened.
         client.get("/api/v2/workspaces/current", params={"workspace_path": str(a)})

--- a/tests/ui/test_workspace_registry_api.py
+++ b/tests/ui/test_workspace_registry_api.py
@@ -1,0 +1,144 @@
+"""Tests for the workspace registry API endpoints (issue #601).
+
+Covers GET /api/v2/workspaces (list), registration on POST, recency tracking +
+auto-registration on GET /current, and DELETE deregistration. The registry lives
+in the global control-plane DB attached at ``app.state.db``.
+
+Following TDD: tests written first, implementation follows.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def temp_root():
+    root = Path(tempfile.mkdtemp())
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
+
+
+@pytest.fixture
+def client(temp_root):
+    """TestClient with the workspace_v2 router and a real in-memory control-plane DB."""
+    from codeframe.ui.routers import workspace_v2
+
+    app = FastAPI()
+    app.include_router(workspace_v2.router)
+
+    db = Database(":memory:")
+    db.initialize()
+    app.state.db = db
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def _make_repo(temp_root: Path, name: str) -> Path:
+    repo = temp_root / name
+    repo.mkdir(parents=True, exist_ok=True)
+    return repo
+
+
+class TestListWorkspaces:
+    def test_list_empty(self, client):
+        resp = client.get("/api/v2/workspaces")
+        assert resp.status_code == 200
+        assert resp.json() == {"workspaces": []}
+
+    def test_post_registers_and_list_returns_it(self, client, temp_root):
+        repo = _make_repo(temp_root, "alpha")
+
+        post = client.post("/api/v2/workspaces", json={"repo_path": str(repo)})
+        assert post.status_code == 201
+
+        resp = client.get("/api/v2/workspaces")
+        assert resp.status_code == 200
+        workspaces = resp.json()["workspaces"]
+        assert len(workspaces) == 1
+        entry = workspaces[0]
+        assert entry["repo_path"] == str(repo.resolve())
+        assert entry["name"] == "alpha"
+        assert entry["path_exists"] is True
+        assert "id" in entry and "created_at" in entry and "last_opened_at" in entry
+
+    def test_path_exists_false_for_deleted_dir(self, client, temp_root):
+        repo = _make_repo(temp_root, "beta")
+        client.post("/api/v2/workspaces", json={"repo_path": str(repo)})
+
+        # Remove the directory from disk after registration.
+        shutil.rmtree(repo)
+
+        resp = client.get("/api/v2/workspaces")
+        entry = resp.json()["workspaces"][0]
+        assert entry["path_exists"] is False
+
+    def test_list_sorted_by_last_opened_desc(self, client, temp_root):
+        a = _make_repo(temp_root, "a")
+        b = _make_repo(temp_root, "b")
+        client.post("/api/v2/workspaces", json={"repo_path": str(a)})
+        client.post("/api/v2/workspaces", json={"repo_path": str(b)})
+
+        # Touch 'a' again so it becomes the most recently opened.
+        client.get("/api/v2/workspaces/current", params={"workspace_path": str(a)})
+
+        workspaces = client.get("/api/v2/workspaces").json()["workspaces"]
+        assert workspaces[0]["repo_path"] == str(a.resolve())
+
+
+class TestCurrentTracksAccess:
+    def test_current_auto_registers_untracked_workspace(self, client, temp_root):
+        """A workspace opened directly (not via POST) becomes tracked."""
+        repo = _make_repo(temp_root, "gamma")
+        # Initialize the workspace on disk without going through the registry-aware
+        # POST path: use core.workspace directly.
+        from codeframe.core.workspace import create_or_load_workspace
+
+        create_or_load_workspace(repo)
+
+        # Sanity: not yet in registry.
+        assert client.get("/api/v2/workspaces").json()["workspaces"] == []
+
+        resp = client.get(
+            "/api/v2/workspaces/current", params={"workspace_path": str(repo)}
+        )
+        assert resp.status_code == 200
+
+        workspaces = client.get("/api/v2/workspaces").json()["workspaces"]
+        assert len(workspaces) == 1
+        assert workspaces[0]["repo_path"] == str(repo.resolve())
+
+
+class TestDeleteWorkspace:
+    def test_delete_existing_returns_204(self, client, temp_root):
+        repo = _make_repo(temp_root, "delta")
+        client.post("/api/v2/workspaces", json={"repo_path": str(repo)})
+        entry = client.get("/api/v2/workspaces").json()["workspaces"][0]
+
+        resp = client.delete(f"/api/v2/workspaces/{entry['id']}")
+        assert resp.status_code == 204
+
+        assert client.get("/api/v2/workspaces").json()["workspaces"] == []
+
+    def test_delete_missing_returns_404(self, client):
+        resp = client.delete("/api/v2/workspaces/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_delete_does_not_remove_disk_state(self, client, temp_root):
+        repo = _make_repo(temp_root, "epsilon")
+        client.post("/api/v2/workspaces", json={"repo_path": str(repo)})
+        entry = client.get("/api/v2/workspaces").json()["workspaces"][0]
+
+        client.delete(f"/api/v2/workspaces/{entry['id']}")
+
+        # .codeframe state dir must survive deregistration.
+        assert (repo / ".codeframe").exists()

--- a/web-ui/__tests__/components/workspace/WorkspaceSelector.test.tsx
+++ b/web-ui/__tests__/components/workspace/WorkspaceSelector.test.tsx
@@ -1,33 +1,47 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
+import type { WorkspaceRegistryItem } from '@/types';
 
-// Mock the workspace storage module
-jest.mock('@/lib/workspace-storage', () => ({
-  getRecentWorkspaces: jest.fn(() => []),
-  removeFromRecentWorkspaces: jest.fn(),
+// Mock the server-backed workspaces hook (issue #601)
+const mockRemoveWorkspace = jest.fn();
+let mockHookState: {
+  workspaces: WorkspaceRegistryItem[];
+  isLoading: boolean;
+  error: unknown;
+};
+
+jest.mock('@/hooks/useWorkspaces', () => ({
+  useWorkspaces: () => ({
+    workspaces: mockHookState.workspaces,
+    isLoading: mockHookState.isLoading,
+    error: mockHookState.error,
+    refresh: jest.fn(),
+    removeWorkspace: mockRemoveWorkspace,
+  }),
 }));
 
-import {
-  getRecentWorkspaces,
-  removeFromRecentWorkspaces,
-} from '@/lib/workspace-storage';
-
-const mockGetRecentWorkspaces = getRecentWorkspaces as jest.MockedFunction<
-  typeof getRecentWorkspaces
->;
-const mockRemoveFromRecentWorkspaces =
-  removeFromRecentWorkspaces as jest.MockedFunction<
-    typeof removeFromRecentWorkspaces
-  >;
+function makeItem(overrides: Partial<WorkspaceRegistryItem>): WorkspaceRegistryItem {
+  return {
+    id: overrides.repo_path ?? 'id',
+    repo_path: '/home/user/project',
+    name: 'project',
+    tech_stack: null,
+    created_at: '2026-01-01T00:00:00Z',
+    last_opened_at: new Date().toISOString(),
+    path_exists: true,
+    ...overrides,
+  };
+}
 
 describe('WorkspaceSelector', () => {
   const mockOnSelectWorkspace = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetRecentWorkspaces.mockReturnValue([]);
+    mockHookState = { workspaces: [], isLoading: false, error: null };
     mockOnSelectWorkspace.mockResolvedValue(undefined);
+    mockRemoveWorkspace.mockResolvedValue(undefined);
   });
 
   describe('initial render', () => {
@@ -221,21 +235,23 @@ describe('WorkspaceSelector', () => {
   });
 
   describe('recent workspaces', () => {
-    const mockRecentWorkspaces = [
-      {
-        path: '/home/user/project-a',
+    const mockRecentWorkspaces: WorkspaceRegistryItem[] = [
+      makeItem({
+        id: 'id-a',
+        repo_path: '/home/user/project-a',
         name: 'project-a',
-        lastUsed: new Date().toISOString(),
-      },
-      {
-        path: '/home/user/project-b',
+        last_opened_at: new Date().toISOString(),
+      }),
+      makeItem({
+        id: 'id-b',
+        repo_path: '/home/user/project-b',
         name: 'project-b',
-        lastUsed: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
-      },
+        last_opened_at: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
+      }),
     ];
 
     beforeEach(() => {
-      mockGetRecentWorkspaces.mockReturnValue(mockRecentWorkspaces);
+      mockHookState.workspaces = mockRecentWorkspaces;
     });
 
     it('shows recent projects section when there are recent workspaces', () => {
@@ -266,7 +282,7 @@ describe('WorkspaceSelector', () => {
     });
 
     it('shows empty state message when no recent workspaces', () => {
-      mockGetRecentWorkspaces.mockReturnValue([]);
+      mockHookState.workspaces = [];
 
       render(
         <WorkspaceSelector
@@ -337,7 +353,7 @@ describe('WorkspaceSelector', () => {
       });
     });
 
-    it('removes workspace from recent when remove button is clicked', async () => {
+    it('removes workspace via the server-backed hook when remove button is clicked', async () => {
       render(
         <WorkspaceSelector
           onSelectWorkspace={mockOnSelectWorkspace}
@@ -349,9 +365,7 @@ describe('WorkspaceSelector', () => {
       const removeButtons = screen.getAllByTitle(/remove from recent/i);
       await userEvent.click(removeButtons[0]);
 
-      expect(mockRemoveFromRecentWorkspaces).toHaveBeenCalledWith(
-        '/home/user/project-a'
-      );
+      expect(mockRemoveWorkspace).toHaveBeenCalledWith('id-a');
     });
 
     it('does not select workspace when remove button is clicked', async () => {
@@ -399,6 +413,42 @@ describe('WorkspaceSelector', () => {
 
       await userEvent.click(projectA!);
       expect(mockOnSelectWorkspace).not.toHaveBeenCalled();
+    });
+
+    it('shows a loading state while the server list is being fetched', () => {
+      mockHookState.workspaces = [];
+      mockHookState.isLoading = true;
+
+      render(
+        <WorkspaceSelector
+          onSelectWorkspace={mockOnSelectWorkspace}
+          isLoading={false}
+          error={null}
+        />
+      );
+
+      expect(screen.getByTestId('workspaces-loading')).toBeInTheDocument();
+    });
+
+    it('marks workspaces whose path no longer exists as stale', () => {
+      mockHookState.workspaces = [
+        makeItem({
+          id: 'id-stale',
+          repo_path: '/home/user/gone',
+          name: 'gone',
+          path_exists: false,
+        }),
+      ];
+
+      render(
+        <WorkspaceSelector
+          onSelectWorkspace={mockOnSelectWorkspace}
+          isLoading={false}
+          error={null}
+        />
+      );
+
+      expect(screen.getByText('Missing')).toBeInTheDocument();
     });
   });
 });

--- a/web-ui/__tests__/components/workspace/WorkspaceSelector.test.tsx
+++ b/web-ui/__tests__/components/workspace/WorkspaceSelector.test.tsx
@@ -23,7 +23,7 @@ jest.mock('@/hooks/useWorkspaces', () => ({
 
 function makeItem(overrides: Partial<WorkspaceRegistryItem>): WorkspaceRegistryItem {
   return {
-    id: overrides.repo_path ?? 'id',
+    id: 'default-test-id',
     repo_path: '/home/user/project',
     name: 'project',
     tech_stack: null,

--- a/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
+++ b/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
@@ -85,7 +85,7 @@ describe('useWorkspaces', () => {
     expect(result.current.workspaces[0].path_exists).toBe(true);
   });
 
-  it('shows server entries plus browser-only recents while online', async () => {
+  it('is server-authoritative online but preserves local-only recents for offline fallback', async () => {
     // A recent only this browser knows about (e.g. opened before the registry).
     setRecentWorkspaces([
       { path: '/p/local-only', name: 'local-only', lastUsed: '2026-03-01T00:00:00Z' },
@@ -93,13 +93,17 @@ describe('useWorkspaces', () => {
     mockedApi.list.mockResolvedValue(serverItems);
 
     const { result } = renderHook(() => useWorkspaces(), { wrapper });
-    await waitFor(() => expect(result.current.workspaces).toHaveLength(3));
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
 
-    const paths = result.current.workspaces.map((w) => w.repo_path);
-    // Server entries first, then the local-only one (still reachable online).
-    expect(paths).toEqual(['/p/alpha', '/p/beta', '/p/local-only']);
+    // Online list is exactly the server list — local-only is NOT appended here
+    // (appending would resurrect entries deregistered on another device).
+    expect(result.current.workspaces.map((w) => w.repo_path)).toEqual([
+      '/p/alpha',
+      '/p/beta',
+    ]);
 
-    // localStorage mirror preserves the local-only entry, not clobbered.
+    // But the localStorage mirror still keeps the local-only entry, so the
+    // offline fallback retains full history.
     expect(getRecentWorkspaces().map((r) => r.path)).toEqual([
       '/p/alpha',
       '/p/beta',

--- a/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
+++ b/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
@@ -85,7 +85,7 @@ describe('useWorkspaces', () => {
     expect(result.current.workspaces[0].path_exists).toBe(true);
   });
 
-  it('preserves local-only recents when mirroring the server list', async () => {
+  it('shows server entries plus browser-only recents while online', async () => {
     // A recent only this browser knows about (e.g. opened before the registry).
     setRecentWorkspaces([
       { path: '/p/local-only', name: 'local-only', lastUsed: '2026-03-01T00:00:00Z' },
@@ -93,9 +93,13 @@ describe('useWorkspaces', () => {
     mockedApi.list.mockResolvedValue(serverItems);
 
     const { result } = renderHook(() => useWorkspaces(), { wrapper });
-    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(3));
 
-    // Server entries first, then the surviving local-only entry — not clobbered.
+    const paths = result.current.workspaces.map((w) => w.repo_path);
+    // Server entries first, then the local-only one (still reachable online).
+    expect(paths).toEqual(['/p/alpha', '/p/beta', '/p/local-only']);
+
+    // localStorage mirror preserves the local-only entry, not clobbered.
     expect(getRecentWorkspaces().map((r) => r.path)).toEqual([
       '/p/alpha',
       '/p/beta',

--- a/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
+++ b/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { SWRConfig } from 'swr';
+import { useWorkspaces } from '@/hooks/useWorkspaces';
+import { workspaceApi } from '@/lib/api';
+import { getRecentWorkspaces, setRecentWorkspaces } from '@/lib/workspace-storage';
+import type { WorkspaceRegistryItem } from '@/types';
+
+jest.mock('@/lib/api', () => ({
+  workspaceApi: {
+    list: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+const mockedApi = workspaceApi as jest.Mocked<typeof workspaceApi>;
+
+// Fresh SWR cache per render to avoid cross-test bleed.
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), dedupingInterval: 0 } },
+    children
+  );
+}
+
+const serverItems: WorkspaceRegistryItem[] = [
+  {
+    id: 'id-a',
+    repo_path: '/p/alpha',
+    name: 'alpha',
+    tech_stack: 'Python',
+    created_at: '2026-01-01T00:00:00Z',
+    last_opened_at: '2026-05-02T00:00:00Z',
+    path_exists: true,
+  },
+  {
+    id: 'id-b',
+    repo_path: '/p/beta',
+    name: 'beta',
+    tech_stack: null,
+    created_at: '2026-01-01T00:00:00Z',
+    last_opened_at: '2026-05-01T00:00:00Z',
+    path_exists: false,
+  },
+];
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe('useWorkspaces', () => {
+  it('returns the server list on success', async () => {
+    mockedApi.list.mockResolvedValue(serverItems);
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+    expect(result.current.workspaces[0].repo_path).toBe('/p/alpha');
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('mirrors the server list into localStorage recents', async () => {
+    mockedApi.list.mockResolvedValue(serverItems);
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+
+    const recents = getRecentWorkspaces();
+    expect(recents.map((r) => r.path)).toEqual(['/p/alpha', '/p/beta']);
+  });
+
+  it('falls back to localStorage recents on fetch error', async () => {
+    setRecentWorkspaces([
+      { path: '/p/cached', name: 'cached', lastUsed: '2026-04-01T00:00:00Z' },
+    ]);
+    mockedApi.list.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.workspaces).toHaveLength(1);
+    expect(result.current.workspaces[0].repo_path).toBe('/p/cached');
+    expect(result.current.workspaces[0].path_exists).toBe(true);
+  });
+
+  it('removeWorkspace calls the API and refreshes from the server', async () => {
+    // Initial fetch returns both; after deletion the server drops alpha.
+    mockedApi.list
+      .mockResolvedValueOnce(serverItems)
+      .mockResolvedValue([serverItems[1]]);
+    mockedApi.remove.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.removeWorkspace('id-a');
+    });
+
+    expect(mockedApi.remove).toHaveBeenCalledWith('id-a');
+    // Post-refresh, the server list no longer contains the removed workspace.
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(1));
+    expect(result.current.workspaces[0].id).toBe('id-b');
+    expect(getRecentWorkspaces().some((r) => r.path === '/p/alpha')).toBe(false);
+  });
+});

--- a/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
+++ b/web-ui/src/__tests__/hooks/useWorkspaces.test.ts
@@ -85,6 +85,43 @@ describe('useWorkspaces', () => {
     expect(result.current.workspaces[0].path_exists).toBe(true);
   });
 
+  it('preserves local-only recents when mirroring the server list', async () => {
+    // A recent only this browser knows about (e.g. opened before the registry).
+    setRecentWorkspaces([
+      { path: '/p/local-only', name: 'local-only', lastUsed: '2026-03-01T00:00:00Z' },
+    ]);
+    mockedApi.list.mockResolvedValue(serverItems);
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+
+    // Server entries first, then the surviving local-only entry — not clobbered.
+    expect(getRecentWorkspaces().map((r) => r.path)).toEqual([
+      '/p/alpha',
+      '/p/beta',
+      '/p/local-only',
+    ]);
+  });
+
+  it('removes a fallback (offline) entry locally without calling the API', async () => {
+    setRecentWorkspaces([
+      { path: '/p/cached', name: 'cached', lastUsed: '2026-04-01T00:00:00Z' },
+    ]);
+    mockedApi.list.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(1));
+
+    await act(async () => {
+      // In fallback mode the id is the filesystem path.
+      await result.current.removeWorkspace('/p/cached');
+    });
+
+    expect(mockedApi.remove).not.toHaveBeenCalled();
+    expect(getRecentWorkspaces()).toHaveLength(0);
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(0));
+  });
+
   it('removeWorkspace calls the API and refreshes from the server', async () => {
     // Initial fetch returns both; after deletion the server drops alpha.
     mockedApi.list

--- a/web-ui/src/app/page.tsx
+++ b/web-ui/src/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import useSWR from 'swr';
+import useSWR, { mutate as globalMutate } from 'swr';
+import { WORKSPACES_SWR_KEY } from '@/hooks/useWorkspaces';
 import {
   WorkspaceHeader,
   WorkspaceStatsCards,
@@ -150,7 +151,9 @@ export default function WorkspacePage() {
       const exists = await workspaceApi.checkExists(path);
 
       if (exists.exists) {
-        // Workspace exists, just select it
+        // Workspace exists, just select it. Touch /current so the server bumps
+        // recency and tracks it, then refresh the registry list.
+        await workspaceApi.getByPath(path);
         setSelectedWorkspacePath(path);
         setWorkspacePath(path);
       } else {
@@ -160,6 +163,9 @@ export default function WorkspacePage() {
         setWorkspacePath(path);
         setTechStackDialog({ open: true, detectedStack: initialized.tech_stack });
       }
+      // Keep the server-backed workspace list fresh (localStorage dual-write
+      // already happened via setSelectedWorkspacePath → addToRecentWorkspaces).
+      void globalMutate(WORKSPACES_SWR_KEY);
     } catch (error) {
       const apiError = error as ApiError;
       setSelectionError(apiError.detail || 'Failed to open project');

--- a/web-ui/src/app/page.tsx
+++ b/web-ui/src/app/page.tsx
@@ -152,8 +152,9 @@ export default function WorkspacePage() {
 
       if (exists.exists) {
         // Workspace exists, just select it. Touch /current so the server bumps
-        // recency and tracks it, then refresh the registry list.
-        await workspaceApi.getByPath(path);
+        // recency and tracks it — fire-and-forget so a transient error on this
+        // best-effort call can't block opening an accessible workspace.
+        void workspaceApi.getByPath(path).catch(() => {});
         setSelectedWorkspacePath(path);
         setWorkspacePath(path);
       } else {

--- a/web-ui/src/components/workspace/WorkspaceSelector.tsx
+++ b/web-ui/src/components/workspace/WorkspaceSelector.tsx
@@ -52,8 +52,10 @@ export function WorkspaceSelector({
     e.stopPropagation();
     try {
       await removeWorkspace(workspaceId);
-    } catch {
-      // Best-effort: a failed deregister leaves the list unchanged.
+    } catch (err) {
+      // Best-effort: a failed deregister leaves the list unchanged. Surface it in
+      // devtools so the failure isn't completely silent.
+      console.warn('Failed to remove workspace from registry', err);
     }
   };
 

--- a/web-ui/src/components/workspace/WorkspaceSelector.tsx
+++ b/web-ui/src/components/workspace/WorkspaceSelector.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Folder01Icon, Time01Icon, Cancel01Icon, Loading03Icon } from '@hugeicons/react';
+import { useState } from 'react';
+import {
+  Folder01Icon,
+  Time01Icon,
+  Cancel01Icon,
+  Loading03Icon,
+  Alert02Icon,
+} from '@hugeicons/react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  getRecentWorkspaces,
-  removeFromRecentWorkspaces,
-  type RecentWorkspace,
-} from '@/lib/workspace-storage';
+import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { formatDistanceToNow } from 'date-fns';
 
 interface WorkspaceSelectorProps {
@@ -29,13 +31,12 @@ export function WorkspaceSelector({
   error,
 }: WorkspaceSelectorProps) {
   const [inputPath, setInputPath] = useState('');
-  // Initialize empty to avoid hydration mismatch (localStorage isn't available on server)
-  const [recentWorkspaces, setRecentWorkspaces] = useState<RecentWorkspace[]>([]);
-
-  // Load recent workspaces on client only
-  useEffect(() => {
-    setRecentWorkspaces(getRecentWorkspaces());
-  }, []);
+  // Server-backed workspace list with localStorage fallback (issue #601).
+  const {
+    workspaces: recentWorkspaces,
+    isLoading: workspacesLoading,
+    removeWorkspace,
+  } = useWorkspaces();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -47,10 +48,13 @@ export function WorkspaceSelector({
     await onSelectWorkspace(path);
   };
 
-  const handleRemoveRecent = (path: string, e: React.MouseEvent) => {
+  const handleRemoveRecent = async (workspaceId: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    removeFromRecentWorkspaces(path);
-    setRecentWorkspaces(getRecentWorkspaces());
+    try {
+      await removeWorkspace(workspaceId);
+    } catch {
+      // Best-effort: a failed deregister leaves the list unchanged.
+    }
   };
 
   return (
@@ -124,59 +128,87 @@ export function WorkspaceSelector({
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {recentWorkspaces.length === 0 ? (
+            {workspacesLoading && recentWorkspaces.length === 0 ? (
+              <div
+                data-testid="workspaces-loading"
+                className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+              >
+                <Loading03Icon className="h-4 w-4 animate-spin" />
+                Loading projects…
+              </div>
+            ) : recentWorkspaces.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-4">
                 No recent projects. Open a project above to get started.
               </p>
             ) : (
               <ul className="space-y-2">
-                {recentWorkspaces.map((workspace) => (
-                  <li key={workspace.path}>
+                {recentWorkspaces.map((workspace) => {
+                  const displayName =
+                    workspace.name ?? workspace.repo_path.split(/[\\/]/).pop() ?? workspace.repo_path;
+                  const isStale = workspace.path_exists === false;
+                  return (
+                  <li key={workspace.id}>
                     <div
                       role="button"
                       tabIndex={isLoading ? -1 : 0}
-                      onClick={() => !isLoading && handleSelectRecent(workspace.path)}
+                      onClick={() => !isLoading && handleSelectRecent(workspace.repo_path)}
                       onKeyDown={(e) => {
                         if (e.target !== e.currentTarget) return;
                         if ((e.key === 'Enter' || e.key === ' ') && !isLoading) {
                           e.preventDefault();
-                          handleSelectRecent(workspace.path);
+                          handleSelectRecent(workspace.repo_path);
                         }
                       }}
-                      className="w-full flex items-center justify-between p-3 rounded-md border hover:bg-accent transition-colors text-left cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+                      className={`w-full flex items-center justify-between p-3 rounded-md border hover:bg-accent transition-colors text-left cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring aria-disabled:opacity-50 aria-disabled:cursor-not-allowed${
+                        isStale ? ' opacity-60' : ''
+                      }`}
                       aria-disabled={isLoading}
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         <Folder01Icon className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
                         <div className="min-w-0">
-                          <p className="font-medium truncate">{workspace.name}</p>
+                          <p className="font-medium truncate flex items-center gap-1.5">
+                            {displayName}
+                            {isStale && (
+                              <span
+                                className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground"
+                                title="This path no longer exists on disk"
+                              >
+                                <Alert02Icon className="h-3 w-3" />
+                                Missing
+                              </span>
+                            )}
+                          </p>
                           <p className="text-xs text-muted-foreground truncate">
-                            {workspace.path}
+                            {workspace.repo_path}
                           </p>
                         </div>
                       </div>
                       <div className="flex items-center gap-2 flex-shrink-0 ml-4">
-                        <span className="text-xs text-muted-foreground">
-                          {formatDistanceToNow(new Date(workspace.lastUsed), {
-                            addSuffix: true,
-                          })}
-                        </span>
+                        {workspace.last_opened_at && (
+                          <span className="text-xs text-muted-foreground">
+                            {formatDistanceToNow(new Date(workspace.last_opened_at), {
+                              addSuffix: true,
+                            })}
+                          </span>
+                        )}
                         <button
                           type="button"
-                          onClick={(e) => handleRemoveRecent(workspace.path, e)}
+                          onClick={(e) => handleRemoveRecent(workspace.id, e)}
                           onKeyDown={(e) => {
                             if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
                           }}
                           className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive focus:outline-none focus:ring-2 focus:ring-ring"
                           title="Remove from recent"
-                          aria-label={`Remove ${workspace.name} from recent projects`}
+                          aria-label={`Remove ${displayName} from recent projects`}
                         >
                           <Cancel01Icon className="h-4 w-4" />
                         </button>
                       </div>
                     </div>
                   </li>
-                ))}
+                  );
+                })}
               </ul>
             )}
           </CardContent>

--- a/web-ui/src/hooks/useWorkspaces.ts
+++ b/web-ui/src/hooks/useWorkspaces.ts
@@ -83,22 +83,20 @@ export function useWorkspaces(): UseWorkspacesReturn {
     }
   );
 
-  const workspaces = useMemo<WorkspaceRegistryItem[]>(() => {
-    if (data) {
-      // Online: show the authoritative server list, plus any browser-only
-      // recents not yet registered server-side, so they stay reachable (e.g.
-      // projects opened before the registry existed). Server wins on overlap.
-      const serverPaths = new Set(data.map((w) => w.repo_path));
-      const localOnly = recentsToItems(getRecentWorkspaces()).filter(
-        (item) => !serverPaths.has(item.repo_path)
-      );
-      return [...data, ...localOnly];
-    }
-    // Offline/error: fall back to the localStorage mirror entirely.
+  const fallback = useMemo<WorkspaceRegistryItem[]>(() => {
+    // Referenced so this recomputes after a local-only removal bumps it.
+    void localVersion;
+    // Offline/error fallback only.
     return error ? recentsToItems(getRecentWorkspaces()) : [];
-    // localVersion forces recompute after a local-only removal.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, error, localVersion]);
+  }, [error, localVersion]);
+
+  // Online: the server list is authoritative — we do NOT append browser-only
+  // recents here. Doing so would resurrect entries another device deregistered
+  // (the local mirror can't tell "never registered" from "deleted elsewhere").
+  // Local-only projects remain reachable via the "Open Project" path input,
+  // which auto-registers them server-side on open. localStorage stays a faithful
+  // mirror so the offline fallback still shows full history.
+  const workspaces = data ?? fallback;
 
   const removeWorkspace = useCallback(
     async (workspaceId: string) => {

--- a/web-ui/src/hooks/useWorkspaces.ts
+++ b/web-ui/src/hooks/useWorkspaces.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { workspaceApi } from '@/lib/api';
 import {
@@ -30,6 +30,22 @@ function itemsToRecents(items: WorkspaceRegistryItem[]): RecentWorkspace[] {
   }));
 }
 
+/**
+ * Merge the server list into the existing localStorage recents without losing
+ * local-only entries (e.g. projects opened before the registry existed, or only
+ * known to this browser). Server entries win for overlapping paths and keep
+ * their recency order; local-only recents are appended.
+ */
+function mergeRecents(
+  serverItems: WorkspaceRegistryItem[],
+  existing: RecentWorkspace[]
+): RecentWorkspace[] {
+  const serverRecents = itemsToRecents(serverItems);
+  const serverPaths = new Set(serverRecents.map((r) => r.path));
+  const localOnly = existing.filter((r) => !serverPaths.has(r.path));
+  return [...serverRecents, ...localOnly];
+}
+
 /** Map localStorage recents back to registry items for the offline fallback. */
 function recentsToItems(recents: RecentWorkspace[]): WorkspaceRegistryItem[] {
   return recents.map((recent) => ({
@@ -53,33 +69,45 @@ function recentsToItems(recents: RecentWorkspace[]): WorkspaceRegistryItem[] {
  * - On fetch error (network/auth), falls back to the localStorage recents.
  */
 export function useWorkspaces(): UseWorkspacesReturn {
+  // Bumped after a local-only (offline) removal so the fallback list re-renders.
+  const [localVersion, setLocalVersion] = useState(0);
+
   const { data, error, isLoading, mutate } = useSWR<WorkspaceRegistryItem[]>(
     WORKSPACES_SWR_KEY,
     () => workspaceApi.list(),
     {
       onSuccess: (items) => {
-        setRecentWorkspaces(itemsToRecents(items));
+        // Merge (never clobber) so local-only recents survive as offline fallback.
+        setRecentWorkspaces(mergeRecents(items, getRecentWorkspaces()));
       },
     }
   );
 
   const fallback = useMemo<WorkspaceRegistryItem[]>(
-    // Recompute only when an error is present (offline/auth failure).
+    // Recompute when an error is present (offline/auth failure) or after a
+    // local-only removal bumps localVersion.
     () => (error ? recentsToItems(getRecentWorkspaces()) : []),
-    [error]
+    [error, localVersion]
   );
 
   const workspaces = data ?? (error ? fallback : []);
 
   const removeWorkspace = useCallback(
     async (workspaceId: string) => {
-      await workspaceApi.remove(workspaceId);
-      // Keep the localStorage mirror in sync by path.
-      const removed = (data ?? []).find((w) => w.id === workspaceId);
-      if (removed) {
-        removeFromRecentWorkspaces(removed.repo_path);
+      // Server-backed entry: deregister on the server, then sync the local mirror.
+      const serverEntry = (data ?? []).find((w) => w.id === workspaceId);
+      if (serverEntry) {
+        await workspaceApi.remove(workspaceId);
+        removeFromRecentWorkspaces(serverEntry.repo_path);
+        await mutate();
+        return;
       }
-      await mutate();
+
+      // Fallback (offline) entry: its id IS the filesystem path. Remove it from
+      // localStorage directly — calling the unreachable server would only fail
+      // and strand the stale entry in the list.
+      removeFromRecentWorkspaces(workspaceId);
+      setLocalVersion((v) => v + 1);
     },
     [data, mutate]
   );

--- a/web-ui/src/hooks/useWorkspaces.ts
+++ b/web-ui/src/hooks/useWorkspaces.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import useSWR from 'swr';
+import { workspaceApi } from '@/lib/api';
+import {
+  getRecentWorkspaces,
+  setRecentWorkspaces,
+  removeFromRecentWorkspaces,
+  type RecentWorkspace,
+} from '@/lib/workspace-storage';
+import type { WorkspaceRegistryItem } from '@/types';
+
+export const WORKSPACES_SWR_KEY = '/api/v2/workspaces';
+
+export interface UseWorkspacesReturn {
+  workspaces: WorkspaceRegistryItem[];
+  isLoading: boolean;
+  error: unknown;
+  refresh: () => Promise<unknown>;
+  removeWorkspace: (workspaceId: string) => Promise<void>;
+}
+
+/** Map server registry entries to the localStorage recents shape (mirror). */
+function itemsToRecents(items: WorkspaceRegistryItem[]): RecentWorkspace[] {
+  return items.map((item) => ({
+    path: item.repo_path,
+    name: item.name ?? item.repo_path.split(/[\\/]/).pop() ?? item.repo_path,
+    lastUsed: item.last_opened_at ?? item.created_at ?? new Date(0).toISOString(),
+  }));
+}
+
+/** Map localStorage recents back to registry items for the offline fallback. */
+function recentsToItems(recents: RecentWorkspace[]): WorkspaceRegistryItem[] {
+  return recents.map((recent) => ({
+    // Offline entries have no server id; the path is a stable local key.
+    id: recent.path,
+    repo_path: recent.path,
+    name: recent.name,
+    tech_stack: null,
+    created_at: null,
+    last_opened_at: recent.lastUsed,
+    // Optimistic: assume present; the server confirms once reachable.
+    path_exists: true,
+  }));
+}
+
+/**
+ * Server-backed workspace list with a localStorage fallback (issue #601).
+ *
+ * - Fetches the registry from the server via SWR.
+ * - On success, mirrors the list into localStorage so it survives offline.
+ * - On fetch error (network/auth), falls back to the localStorage recents.
+ */
+export function useWorkspaces(): UseWorkspacesReturn {
+  const { data, error, isLoading, mutate } = useSWR<WorkspaceRegistryItem[]>(
+    WORKSPACES_SWR_KEY,
+    () => workspaceApi.list(),
+    {
+      onSuccess: (items) => {
+        setRecentWorkspaces(itemsToRecents(items));
+      },
+    }
+  );
+
+  const fallback = useMemo<WorkspaceRegistryItem[]>(
+    // Recompute only when an error is present (offline/auth failure).
+    () => (error ? recentsToItems(getRecentWorkspaces()) : []),
+    [error]
+  );
+
+  const workspaces = data ?? (error ? fallback : []);
+
+  const removeWorkspace = useCallback(
+    async (workspaceId: string) => {
+      await workspaceApi.remove(workspaceId);
+      // Keep the localStorage mirror in sync by path.
+      const removed = (data ?? []).find((w) => w.id === workspaceId);
+      if (removed) {
+        removeFromRecentWorkspaces(removed.repo_path);
+      }
+      await mutate();
+    },
+    [data, mutate]
+  );
+
+  const refresh = useCallback(() => mutate(), [mutate]);
+
+  return {
+    workspaces,
+    isLoading,
+    error,
+    refresh,
+    removeWorkspace,
+  };
+}

--- a/web-ui/src/hooks/useWorkspaces.ts
+++ b/web-ui/src/hooks/useWorkspaces.ts
@@ -83,14 +83,22 @@ export function useWorkspaces(): UseWorkspacesReturn {
     }
   );
 
-  const fallback = useMemo<WorkspaceRegistryItem[]>(
-    // Recompute when an error is present (offline/auth failure) or after a
-    // local-only removal bumps localVersion.
-    () => (error ? recentsToItems(getRecentWorkspaces()) : []),
-    [error, localVersion]
-  );
-
-  const workspaces = data ?? (error ? fallback : []);
+  const workspaces = useMemo<WorkspaceRegistryItem[]>(() => {
+    if (data) {
+      // Online: show the authoritative server list, plus any browser-only
+      // recents not yet registered server-side, so they stay reachable (e.g.
+      // projects opened before the registry existed). Server wins on overlap.
+      const serverPaths = new Set(data.map((w) => w.repo_path));
+      const localOnly = recentsToItems(getRecentWorkspaces()).filter(
+        (item) => !serverPaths.has(item.repo_path)
+      );
+      return [...data, ...localOnly];
+    }
+    // Offline/error: fall back to the localStorage mirror entirely.
+    return error ? recentsToItems(getRecentWorkspaces()) : [];
+    // localVersion forces recompute after a local-only removal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, error, localVersion]);
 
   const removeWorkspace = useCallback(
     async (workspaceId: string) => {

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -9,6 +9,7 @@ import axios, { AxiosInstance, AxiosError } from 'axios';
 import type {
   WorkspaceResponse,
   WorkspaceExistsResponse,
+  WorkspaceRegistryItem,
   Task,
   TaskStatus,
   TaskListResponse,
@@ -191,6 +192,24 @@ export const workspaceApi = {
       { params: { workspace_path: workspacePath } }
     );
     return response.data;
+  },
+
+  /**
+   * List all server-registered workspaces (issue #601)
+   */
+  list: async (): Promise<WorkspaceRegistryItem[]> => {
+    const response = await api.get<{ workspaces: WorkspaceRegistryItem[] }>(
+      '/api/v2/workspaces'
+    );
+    return response.data.workspaces;
+  },
+
+  /**
+   * Deregister a workspace from the server-side registry (issue #601).
+   * Does not delete any on-disk state.
+   */
+  remove: async (workspaceId: string): Promise<void> => {
+    await api.delete(`/api/v2/workspaces/${workspaceId}`);
   },
 };
 

--- a/web-ui/src/lib/workspace-storage.ts
+++ b/web-ui/src/lib/workspace-storage.ts
@@ -81,6 +81,16 @@ export function addToRecentWorkspaces(path: string): void {
 }
 
 /**
+ * Replace the entire recent-workspaces list (used to mirror the server-backed
+ * registry into localStorage so it stays available offline). Most-recent first.
+ */
+export function setRecentWorkspaces(workspaces: RecentWorkspace[]): void {
+  if (typeof window === 'undefined') return;
+  const trimmed = workspaces.slice(0, MAX_RECENT_WORKSPACES);
+  localStorage.setItem(RECENT_WORKSPACES_KEY, JSON.stringify(trimmed));
+}
+
+/**
  * Get whether the onboarding card has been dismissed for a workspace
  */
 export function getOnboardingDismissed(workspacePath: string): boolean {

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -39,6 +39,17 @@ export interface WorkspaceExistsResponse {
   state_dir: string | null;
 }
 
+// Server-side workspace registry entry (issue #601)
+export interface WorkspaceRegistryItem {
+  id: string;
+  repo_path: string;
+  name: string | null;
+  tech_stack: string | null;
+  created_at: string | null;
+  last_opened_at: string | null;
+  path_exists: boolean;
+}
+
 // Task types
 // Must match backend: codeframe/core/state_machine.py:TaskStatus
 export type TaskStatus =


### PR DESCRIPTION
## Summary
Implements #601: a server-side registry of projects (workspaces) so the web UI's
project list/switcher can be backed by the server instead of living only in the
browser. The registry stores **only metadata + a pointer** (`repo_path`) to each
per-workspace `.codeframe/state.db`; per-workspace state isolation is unchanged
and no v1-style global domain table is reintroduced.

**Backend (`platform_store`)**
- New `workspaces_registry` table in the global control-plane DB (nullable
  `owner_user_id` FK to `users`, multi-tenant-ready) + indexes.
- `WorkspaceRegistryRepository`: `upsert` (idempotent `ON CONFLICT(repo_path)`),
  `list_all(owner_user_id=None)`, `get_by_id`, `get_by_path`,
  `update_last_opened`, `delete`. Wired into `Database`.

**Backend API (`workspace_v2.py`)**
- `GET /api/v2/workspaces` — registry list with computed `path_exists`,
  recency-sorted. Returns **503** (not `200 []`) when the registry is
  unavailable, so clients fall back to localStorage instead of treating an empty
  response as authoritative.
- `POST /api/v2/workspaces` registers on init; `PATCH /current` re-registers so
  cached `tech_stack` stays consistent; `GET /current` bumps recency and
  auto-registers workspaces opened directly by path.
- `DELETE /api/v2/workspaces/{id}` deregisters (204/404; **never** touches disk).
- All registry writes are best-effort — a missing/failed registry never breaks
  core workspace operations.

**Frontend (`web-ui`)**
- `useWorkspaces` hook (SWR): server-authoritative online; mirrors the list into
  localStorage (merge, never clobber) as an offline fallback.
- `WorkspaceSelector` consumes the hook: loading state, stale (`Missing`)
  indicator when `path_exists === false`, server-backed remove. `page.tsx`
  refreshes the registry list after select/init.

## Acceptance Criteria
- [x] `GET /api/v2/workspaces` returns all registered projects with metadata.
- [x] Opening/initializing a workspace registers it server-side and survives a
      server restart (persisted in the global control-plane DB).
- [x] Web UI list/switcher is server-backed with graceful localStorage fallback.
- [x] Per-workspace state isolation unchanged; no v1-style global domain table.

## Test Plan
- [x] Unit tests written first (TDD): repo (14), API (11), hook (6), selector (updated + loading/stale).
- [x] All tests passing — backend focused + 432-test regression set; web-ui 917/917; `npm run build` succeeds.
- [x] Linting clean (`ruff`, `eslint`).
- [x] Internal review folded into the cross-family pass below.
- [x] Cross-family review pass: **codex** (3 rounds). Rounds 1–2 findings fixed (offline remove, 503-on-unavailable, merge-preserve, PATCH registry refresh). Round-3 findings addressed/deferred (below).
- [x] Test mutation sanity check (Phase 7d): verified `path_exists`, `delete`, and offline-remove tests fail under targeted mutation.

## Known Limitations / Intentionally Deferred
- **Owner scoping not enforced (codex P1).** Entries register with
  `owner_user_id=NULL` and `GET /api/v2/workspaces` does not filter by owner.
  This is deferred by design: the **v2 routers enforce no authentication today**
  (no auth middleware/dependency on any `/api/v2/*` route — the documented
  "v2 router auth gap"), so there is no caller identity to scope to. This matches
  the issue's explicit open question and CodeRabbit's Design Choice 1. The schema
  (nullable owner FK) and repo (`list_all(owner_user_id=...)`, `get_by_id`) are
  already multi-tenant-ready; wiring the owner filter + ownership checks on
  `DELETE` is a one-line change once v2 auth lands. **Until then, do not deploy
  the v2 API multi-tenant** — same caveat as every other unauthenticated v2
  endpoint (tasks, blockers, costs, …).
- **Local-only recents are not shown in the online list (codex P2, round 3).**
  The online list is server-authoritative. Appending browser-only recents would
  resurrect entries another device deregistered (the local mirror can't tell
  "never registered" from "deleted elsewhere"). Local-only projects remain
  reachable via the "Open Project" path input, which auto-registers them on open;
  the offline fallback still shows full localStorage history.
- **No pagination** on the list endpoint — out of scope; recents are inherently small.

## Implementation Notes
- Adapts CodeRabbit's plan, which referenced `codeframe/persistence/` and a
  `memory_repository.py` upsert example. Those no longer exist — `persistence/`
  was renamed to `platform_store/` (commit eb760ab) and there is no
  `memory_repository`. Retargeted to `platform_store/` and followed the
  `api_key_repository.py` + `BaseRepository` patterns.

Closes #601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side workspace registry with metadata (name, tech stack, created/last-opened)
  * API endpoints to list and deregister workspaces; UI shows stale/missing entries
  * Client hook + SWR integration syncing server list with a localStorage offline fallback; selection now bumps recency and triggers refresh

* **Tests**
  * End-to-end and unit tests added for registry backend, API, hook, and UI selector behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankbria/codeframe/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->