### PR TITLE
feat(auth): enforce authentication across the v2 API (#336)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,9 +99,11 @@ AUTH_SECRET=CHANGE-ME-IN-PRODUCTION
 # JWT token lifetime in seconds (default: 7 days)
 # JWT_LIFETIME_SECONDS=604800
 
-# Enable authentication requirement (default: false for migration)
-# Set to true in production to enforce authentication
-# AUTH_REQUIRED=false
+# Enforce authentication across the v2 API (default: ON / secure by default).
+# Every /api/v2/* route requires a JWT Bearer token or an X-API-Key.
+# Truthy: 1/true/yes/on  Falsy: 0/false/no/off (case-insensitive).
+# Set to "false" only for local development to disable auth.
+# CODEFRAME_AUTH_REQUIRED=true
 
 # ============================================================================
 # GitHub Integration (Optional - for PR creation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ Issue **import + traceability** (#565) is **complete**: `POST /api/v2/integratio
 
 **Phase 3.5C is complete** — `CaptureGlitchModal` form (description/markdown, source, scope, gate obligations, severity, expiry) reachable from the PROOF9 page and the persistent sidebar "Capture Glitch" button. REQ detail view (`/proof/[req_id]`) ships markdown description rendering, `ProofScope` metadata display, obligations table with `Latest Run` column, sortable/filterable evidence history, and empty-state CTA. Backend: `ScopeOut` model on `RequirementResponse`. Issues #568, #569.
 
+**v2 API auth enforcement (#336) is complete** — all 22 v2 REST routers require auth (`require_auth`: JWT Bearer or `X-API-Key`) via router-level dependencies in `server.py`; env-gated `CODEFRAME_AUTH_REQUIRED` (default **ON**; set `false` for local dev — read at request time). `?token=<JWT>` query auth works **only** on the two SSE routes (allowlist `_QUERY_TOKEN_PATHS` in `codeframe/auth/dependencies.py`); WS routers keep their own `?token=` auth. `/auth/register` admits only the bootstrap first user (403 after; seeded `!DISABLED!` admin excluded; in-process lock closes the TOCTOU window). Web UI: `/login` page (sign-in + create-first-account), axios Bearer interceptor from localStorage `auth_token`, loop-safe 401→`/login` redirect, SSE hooks append the token, sidebar logout; `/auth/*` proxied in `next.config.js`. Backend tests run auth-off via root `tests/conftest.py` `setdefault`; `tests/ui/test_v2_auth_enforcement.py` opts back in.
+
 Next, in order:
 - **4A**: PR status tracking + PROOF9 merge gate
 - **4B**: Post-merge glitch capture loop

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -10,6 +10,7 @@ JWT tokens get full permissions for backward compatibility.
 
 import logging
 import os
+import re
 from typing import Callable, Dict, Optional, Any
 
 from fastapi import Depends, HTTPException, Request, Security, status
@@ -34,6 +35,22 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 # Truthy/falsy values for CODEFRAME_AUTH_REQUIRED (case-insensitive).
 _AUTH_FALSY = {"0", "false", "no", "off"}
 
+# Routes allowed to authenticate via a ?token=<JWT> query parameter. Browser
+# EventSource (SSE) cannot send an Authorization header, so these streaming
+# routes accept the token in the URL — the same trade-off the WebSocket
+# routes already make. Keep this list tight: query-string credentials can
+# leak via proxy/access logs and browser history, so the fallback must NOT
+# apply to the rest of the API (codex review P2, issue #336).
+_QUERY_TOKEN_PATHS = (
+    re.compile(r"^/api/v2/tasks/[^/]+/stream$"),  # task event stream (SSE)
+    re.compile(r"^/api/v2/prd/stress-test$"),  # PRD stress-test stream (SSE)
+)
+
+
+def _query_token_allowed(path: str) -> bool:
+    """Whether this request path may authenticate via ?token= (SSE only)."""
+    return any(pattern.match(path) for pattern in _QUERY_TOKEN_PATHS)
+
 
 def auth_required() -> bool:
     """Whether authentication is enforced, read from the environment.
@@ -56,10 +73,11 @@ async def get_current_user(
 ) -> User:
     """Get currently authenticated user.
 
-    Requires a valid JWT, supplied either as an ``Authorization: Bearer``
-    header or, when no header is present, as a ``?token=<JWT>`` query
-    parameter (the latter enables browser EventSource / SSE, which cannot
-    send headers, and mirrors the WebSocket auth pattern).
+    Requires a valid JWT, supplied as an ``Authorization: Bearer`` header.
+    On the allowlisted SSE routes only (``_QUERY_TOKEN_PATHS``), a
+    ``?token=<JWT>`` query parameter is accepted when no header is present
+    (browser EventSource cannot send headers; mirrors the WebSocket
+    auth pattern).
 
     Args:
         request: FastAPI request object
@@ -71,14 +89,14 @@ async def get_current_user(
     Raises:
         HTTPException: 401 if authentication not provided or invalid
     """
-    # Resolve the bearer token from the Authorization header, falling back to
-    # a ``?token=<JWT>`` query parameter when no header is present. The query
-    # fallback enables browser EventSource (SSE), which cannot send headers,
-    # and mirrors the existing WebSocket auth pattern.
+    # Resolve the bearer token from the Authorization header. Only the
+    # allowlisted SSE routes may fall back to a ?token= query parameter
+    # (EventSource cannot send headers); everywhere else query-string
+    # credentials are rejected to keep them out of logs/history.
     token: Optional[str] = None
     if credentials and getattr(credentials, "credentials", None):
         token = credentials.credentials
-    elif request is not None:
+    elif request is not None and _query_token_allowed(request.url.path):
         token = request.query_params.get("token")
 
     if not token:

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -9,6 +9,7 @@ JWT tokens get full permissions for backward compatibility.
 """
 
 import logging
+import os
 from typing import Callable, Dict, Optional, Any
 
 from fastapi import Depends, HTTPException, Request, Security, status
@@ -30,6 +31,24 @@ logger = logging.getLogger(__name__)
 security = HTTPBearer(auto_error=False)
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
+# Truthy/falsy values for CODEFRAME_AUTH_REQUIRED (case-insensitive).
+_AUTH_FALSY = {"0", "false", "no", "off"}
+
+
+def auth_required() -> bool:
+    """Whether authentication is enforced, read from the environment.
+
+    Controlled by ``CODEFRAME_AUTH_REQUIRED`` (default ON / secure by default).
+    Read at request time so tests can monkeypatch the value per call.
+
+    Falsy values (case-insensitive): ``0``, ``false``, ``no``, ``off``.
+    Anything else (including unset) is treated as enabled.
+    """
+    value = os.getenv("CODEFRAME_AUTH_REQUIRED")
+    if value is None:
+        return True
+    return value.strip().lower() not in _AUTH_FALSY
+
 
 async def get_current_user(
     request: Request,
@@ -37,12 +56,14 @@ async def get_current_user(
 ) -> User:
     """Get currently authenticated user.
 
-    Authentication is always required. All requests must include a valid
-    JWT Bearer token in the Authorization header.
+    Requires a valid JWT, supplied either as an ``Authorization: Bearer``
+    header or, when no header is present, as a ``?token=<JWT>`` query
+    parameter (the latter enables browser EventSource / SSE, which cannot
+    send headers, and mirrors the WebSocket auth pattern).
 
     Args:
         request: FastAPI request object
-        credentials: Bearer token from Authorization header
+        credentials: Bearer token from Authorization header (optional)
 
     Returns:
         Authenticated user
@@ -50,8 +71,17 @@ async def get_current_user(
     Raises:
         HTTPException: 401 if authentication not provided or invalid
     """
-    # Authentication is always required
-    if not credentials or not credentials.credentials:
+    # Resolve the bearer token from the Authorization header, falling back to
+    # a ``?token=<JWT>`` query parameter when no header is present. The query
+    # fallback enables browser EventSource (SSE), which cannot send headers,
+    # and mirrors the existing WebSocket auth pattern.
+    token: Optional[str] = None
+    if credentials and getattr(credentials, "credentials", None):
+        token = credentials.credentials
+    elif request is not None:
+        token = request.query_params.get("token")
+
+    if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Not authenticated",
@@ -76,7 +106,7 @@ async def get_current_user(
         # auth.manager to ensure consistency with the JWTStrategy configuration.
         try:
             payload = pyjwt.decode(
-                credentials.credentials,
+                token,
                 SECRET,
                 algorithms=[JWT_ALGORITHM],
                 audience=JWT_AUDIENCE,
@@ -260,6 +290,15 @@ async def require_auth(
             # JWT users get all scopes for backward compatibility
             "scopes": [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN],
             "user": jwt_user,
+        }
+
+    # Auth disabled (local opt-out): return a synthetic local-admin principal
+    # instead of raising. Real credentials above always take precedence.
+    if not auth_required():
+        return {
+            "type": "disabled",
+            "user_id": None,
+            "scopes": [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN],
         }
 
     # No authentication provided

--- a/codeframe/auth/router.py
+++ b/codeframe/auth/router.py
@@ -1,4 +1,6 @@
 """Auth router configuration."""
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, select
 
@@ -16,8 +18,16 @@ router = APIRouter()
 # ._ensure_default_admin_user.
 _DISABLED_PASSWORD = "!DISABLED!"
 
+# Serializes the bootstrap registration check-then-create window. The count
+# check (here) and the user INSERT (fastapi-users route handler) run in
+# separate transactions, so without the lock two concurrent first-time
+# registrations could both pass the zero-users check (TOCTOU). The yield
+# dependency holds the lock until the response completes, covering creation.
+# In-process only — multi-worker deployments retain a narrow race.
+_register_lock = asyncio.Lock()
 
-async def allow_registration() -> None:
+
+async def allow_registration():
     """Gate registration to bootstrap-first-user only (issue #336).
 
     Registration is permitted only while no *real* (login-capable) account
@@ -25,20 +35,24 @@ async def allow_registration() -> None:
     password placeholder; that account cannot log in and does not count.
     Once the first real user registers, this raises 403.
     """
-    async_session_maker = get_async_session_maker()
-    async with async_session_maker() as session:
-        result = await session.execute(
-            select(func.count())
-            .select_from(User)
-            .where(User.hashed_password != _DISABLED_PASSWORD)
-        )
-        real_user_count = result.scalar_one()
+    async with _register_lock:
+        async_session_maker = get_async_session_maker()
+        async with async_session_maker() as session:
+            result = await session.execute(
+                select(func.count())
+                .select_from(User)
+                .where(User.hashed_password != _DISABLED_PASSWORD)
+            )
+            real_user_count = result.scalar_one()
 
-    if real_user_count > 0:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Registration is closed: an account already exists.",
-        )
+        if real_user_count > 0:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Registration is closed: an account already exists.",
+            )
+
+        # Hold the lock until the registration request finishes.
+        yield
 
 
 # Authentication routes (login, logout) - JWT endpoints at /auth/jwt/*

--- a/codeframe/auth/router.py
+++ b/codeframe/auth/router.py
@@ -1,11 +1,45 @@
 """Auth router configuration."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
 
 from codeframe.auth.schemas import UserCreate, UserRead, UserUpdate
-from codeframe.auth.manager import auth_backend, fastapi_users
+from codeframe.auth.manager import auth_backend, fastapi_users, get_async_session_maker
+from codeframe.auth.models import User
 from codeframe.auth.api_key_router import router as api_key_router
 
 router = APIRouter()
+
+
+# Placeholder password for the seeded bootstrap admin (id=1). It cannot match
+# any bcrypt hash, so that account can never log in. It is therefore NOT a real
+# account and does not close the registration window. See SchemaManager
+# ._ensure_default_admin_user.
+_DISABLED_PASSWORD = "!DISABLED!"
+
+
+async def allow_registration() -> None:
+    """Gate registration to bootstrap-first-user only (issue #336).
+
+    Registration is permitted only while no *real* (login-capable) account
+    exists. The database always seeds a default admin (id=1) with a disabled
+    password placeholder; that account cannot log in and does not count.
+    Once the first real user registers, this raises 403.
+    """
+    async_session_maker = get_async_session_maker()
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(func.count())
+            .select_from(User)
+            .where(User.hashed_password != _DISABLED_PASSWORD)
+        )
+        real_user_count = result.scalar_one()
+
+    if real_user_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Registration is closed: an account already exists.",
+        )
+
 
 # Authentication routes (login, logout) - JWT endpoints at /auth/jwt/*
 router.include_router(
@@ -14,11 +48,12 @@ router.include_router(
     tags=["auth"],
 )
 
-# Registration route at /auth/register
+# Registration route at /auth/register (bootstrap-first-user only)
 router.include_router(
     fastapi_users.get_register_router(UserRead, UserCreate),
     prefix="/auth",
     tags=["auth"],
+    dependencies=[Depends(allow_registration)],
 )
 
 # User management routes (get me, update me) at /users/*

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -153,8 +153,13 @@ async def lifespan(app: FastAPI):
     db.initialize()
     app.state.db = db
 
-    # Log that authentication is now always required
-    logger.info("🔒 Authentication: ENABLED (always required)")
+    # Log the effective auth mode (#336: env-gated, secure by default)
+    from codeframe.auth.dependencies import auth_required
+
+    if auth_required():
+        logger.info("🔒 Authentication: ENABLED (default; set CODEFRAME_AUTH_REQUIRED=false to disable locally)")
+    else:
+        logger.warning("🔓 Authentication: DISABLED via CODEFRAME_AUTH_REQUIRED — do not expose this server publicly")
 
     # Initialize rate limiting
     rate_limit_config = get_rate_limit_config()
@@ -284,10 +289,16 @@ The CodeFRAME API enables you to:
 
 ## Authentication
 
-All endpoints require authentication. The API supports two authentication methods:
+All `/api/v2/*` endpoints require authentication by default (disable for local
+development with `CODEFRAME_AUTH_REQUIRED=false`). Public: `/`, `/health`, docs,
+and the `/auth/*` login/register endpoints. Two authentication methods:
 
 1. **API Key** - Include `X-API-Key` header with your API key
 2. **Session Token** - Use JWT token from login endpoint in `Authorization: Bearer <token>` header
+
+SSE streaming endpoints additionally accept the JWT as a `?token=` query
+parameter (browser EventSource cannot send headers); this applies to the
+streaming routes only.
 
 ## Rate Limiting
 

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -10,7 +10,7 @@ from enum import Enum
 from pathlib import Path
 
 # Third-party imports
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
@@ -45,6 +45,7 @@ from codeframe.ui.routers import (
     workspace_v2,
 )
 from codeframe.auth import router as auth_router
+from codeframe.auth.dependencies import require_auth
 from codeframe.platform_store.database import Database
 from codeframe.lib.rate_limiter import (
     get_rate_limiter,
@@ -457,7 +458,7 @@ async def health_check():
 # ============================================================================
 
 
-@app.post("/test/broadcast")
+@app.post("/test/broadcast", dependencies=[Depends(require_auth)])
 async def test_broadcast(message: dict, project_id: int = None):
     """Trigger a WebSocket broadcast for testing purposes.
 
@@ -486,30 +487,39 @@ async def test_broadcast(message: dict, project_id: int = None):
 app.include_router(auth_router.router)
 
 # v2 API routers - all delegate to codeframe.core modules
-app.include_router(batches_v2.router)       # /api/v2/batches
-app.include_router(blockers_v2.router)      # /api/v2/blockers
-app.include_router(checkpoints_v2.router)   # /api/v2/checkpoints
-app.include_router(costs_v2.router)         # /api/v2/costs
-app.include_router(diagnose_v2.router)      # /api/v2/tasks/{id}/diagnose
-app.include_router(discovery_v2.router)     # /api/v2/discovery
-app.include_router(environment_v2.router)   # /api/v2/env
-app.include_router(events_v2.router)        # /api/v2/events
-app.include_router(gates_v2.router)         # /api/v2/gates
-app.include_router(git_v2.router)           # /api/v2/git
-app.include_router(github_integrations_v2.router)  # /api/v2/integrations/github
-app.include_router(interactive_sessions_v2.router)  # /api/v2/sessions
-app.include_router(session_chat_ws.router)          # /ws/sessions/{id}/chat
-app.include_router(terminal_ws.router)              # /ws/sessions/{id}/terminal
-app.include_router(pr_v2.router)            # /api/v2/pr
-app.include_router(prd_v2.router)           # /api/v2/prd
-app.include_router(proof_v2.router)         # /api/v2/proof
-app.include_router(review_v2.router)        # /api/v2/review
-app.include_router(schedule_v2.router)      # /api/v2/schedule
-app.include_router(settings_v2.router)      # /api/v2/settings
-app.include_router(streaming_v2.router)     # /api/v2/tasks/{id}/stream (SSE)
-app.include_router(tasks_v2.router)         # /api/v2/tasks
-app.include_router(templates_v2.router)     # /api/v2/templates
-app.include_router(workspace_v2.router)     # /api/v2/workspaces
+#
+# Auth enforcement (issue #336): every v2 REST router is mounted with a
+# blanket ``require_auth`` dependency. With CODEFRAME_AUTH_REQUIRED disabled
+# (local opt-out) require_auth returns a synthetic principal instead of
+# raising, so behavior is unchanged for local/dev use. The two WebSocket
+# routers (session_chat_ws, terminal_ws) are intentionally excluded — they
+# perform their own ?token= JWT auth and cannot use an HTTP 401 dependency.
+# The auth_router (login/register) stays public.
+_AUTH = [Depends(require_auth)]
+app.include_router(batches_v2.router, dependencies=_AUTH)       # /api/v2/batches
+app.include_router(blockers_v2.router, dependencies=_AUTH)      # /api/v2/blockers
+app.include_router(checkpoints_v2.router, dependencies=_AUTH)   # /api/v2/checkpoints
+app.include_router(costs_v2.router, dependencies=_AUTH)         # /api/v2/costs
+app.include_router(diagnose_v2.router, dependencies=_AUTH)      # /api/v2/tasks/{id}/diagnose
+app.include_router(discovery_v2.router, dependencies=_AUTH)     # /api/v2/discovery
+app.include_router(environment_v2.router, dependencies=_AUTH)   # /api/v2/env
+app.include_router(events_v2.router, dependencies=_AUTH)        # /api/v2/events
+app.include_router(gates_v2.router, dependencies=_AUTH)         # /api/v2/gates
+app.include_router(git_v2.router, dependencies=_AUTH)           # /api/v2/git
+app.include_router(github_integrations_v2.router, dependencies=_AUTH)  # /api/v2/integrations/github
+app.include_router(interactive_sessions_v2.router, dependencies=_AUTH)  # /api/v2/sessions
+app.include_router(session_chat_ws.router)          # /ws/sessions/{id}/chat (WS: own auth)
+app.include_router(terminal_ws.router)              # /ws/sessions/{id}/terminal (WS: own auth)
+app.include_router(pr_v2.router, dependencies=_AUTH)            # /api/v2/pr
+app.include_router(prd_v2.router, dependencies=_AUTH)           # /api/v2/prd
+app.include_router(proof_v2.router, dependencies=_AUTH)         # /api/v2/proof
+app.include_router(review_v2.router, dependencies=_AUTH)        # /api/v2/review
+app.include_router(schedule_v2.router, dependencies=_AUTH)      # /api/v2/schedule
+app.include_router(settings_v2.router, dependencies=_AUTH)      # /api/v2/settings
+app.include_router(streaming_v2.router, dependencies=_AUTH)     # /api/v2/tasks/{id}/stream (SSE)
+app.include_router(tasks_v2.router, dependencies=_AUTH)         # /api/v2/tasks
+app.include_router(templates_v2.router, dependencies=_AUTH)     # /api/v2/templates
+app.include_router(workspace_v2.router, dependencies=_AUTH)     # /api/v2/workspaces
 
 
 # ============================================================================

--- a/tests/auth/test_auth_mode.py
+++ b/tests/auth/test_auth_mode.py
@@ -1,0 +1,69 @@
+"""Tests for env-gated auth mode (issue #336).
+
+Auth is controlled by CODEFRAME_AUTH_REQUIRED:
+- default ON ("true")
+- read at request time (os.getenv per call) so tests can monkeypatch
+- truthy: "1/true/yes/on" (case-insensitive); falsy: "0/false/no/off"
+- when disabled, require_auth returns a synthetic auth dict instead of raising
+"""
+
+import pytest
+
+from codeframe.auth.dependencies import auth_required, require_auth
+from codeframe.auth.api_keys import SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN
+
+pytestmark = pytest.mark.v2
+
+
+class TestAuthRequiredHelper:
+    def test_default_is_on(self, monkeypatch):
+        monkeypatch.delenv("CODEFRAME_AUTH_REQUIRED", raising=False)
+        assert auth_required() is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", "ON"])
+    def test_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", value)
+        assert auth_required() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "FALSE", "No", "off", "OFF"])
+    def test_falsy_values(self, monkeypatch, value):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", value)
+        assert auth_required() is False
+
+    def test_unknown_value_defaults_to_on(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "maybe")
+        assert auth_required() is True
+
+    def test_read_at_request_time(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        assert auth_required() is False
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        assert auth_required() is True
+
+
+class TestRequireAuthBypass:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_synthetic_dict(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        result = await require_auth(api_key_auth=None, jwt_user=None)
+        assert result["type"] == "disabled"
+        assert result["user_id"] is None
+        assert result["scopes"] == [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN]
+
+    @pytest.mark.asyncio
+    async def test_enabled_no_creds_raises_401(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            await require_auth(api_key_auth=None, jwt_user=None)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_disabled_still_prefers_api_key(self, monkeypatch):
+        """If real credentials are present, they win even when auth disabled."""
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        api_key_auth = {"type": "api_key", "user_id": 7, "scopes": [SCOPE_READ]}
+        result = await require_auth(api_key_auth=api_key_auth, jwt_user=None)
+        assert result["type"] == "api_key"
+        assert result["user_id"] == 7

--- a/tests/auth/test_query_param_token.py
+++ b/tests/auth/test_query_param_token.py
@@ -1,8 +1,11 @@
 """Tests for ?token=<JWT> query-param fallback in get_current_user (issue #336).
 
-Browser EventSource (SSE) cannot send an Authorization header, so when no
-Bearer credentials are present, get_current_user falls back to a ``token``
-query parameter validated through the same JWT path.
+Browser EventSource (SSE) cannot send an Authorization header, so on the
+ALLOWLISTED SSE routes only (``_QUERY_TOKEN_PATHS``), get_current_user falls
+back to a ``token`` query parameter validated through the same JWT path.
+Everywhere else, query-string credentials are rejected (codex review P2):
+URLs land in proxy/access logs and browser history, so the fallback must not
+become an API-wide authentication mechanism.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -18,6 +21,11 @@ from codeframe.platform_store.database import Database
 
 pytestmark = pytest.mark.v2
 
+# An allowlisted SSE path (matches _QUERY_TOKEN_PATHS in auth.dependencies).
+SSE_PATH = "/api/v2/tasks/abc/stream"
+# A path NOT on the allowlist — query tokens must be rejected here.
+PLAIN_PATH = "/whoami"
+
 
 def _make_token(user_id: int = 1, secret: str = SECRET) -> str:
     payload = {
@@ -30,7 +38,8 @@ def _make_token(user_id: int = 1, secret: str = SECRET) -> str:
 
 @pytest.fixture
 def app_with_user(tmp_path, monkeypatch):
-    """App with a single protected route and a real test user in the DB."""
+    """App with protected routes (one SSE-allowlisted, one plain) and a real
+    test user in the DB."""
     db_path = tmp_path / "state.db"
     monkeypatch.setenv("DATABASE_PATH", str(db_path))
     reset_auth_engine()
@@ -51,8 +60,13 @@ def app_with_user(tmp_path, monkeypatch):
 
     app = FastAPI()
 
-    @app.get("/whoami")
+    @app.get(PLAIN_PATH)
     async def whoami(user=Depends(get_current_user)):
+        return {"id": user.id}
+
+    # Mounted at the real SSE path so the allowlist matches.
+    @app.get("/api/v2/tasks/{task_id}/stream")
+    async def fake_stream(task_id: str, user=Depends(get_current_user)):
         return {"id": user.id}
 
     @app.get("/maybe")
@@ -64,28 +78,45 @@ def app_with_user(tmp_path, monkeypatch):
     reset_auth_engine()
 
 
-class TestQueryParamToken:
-    def test_valid_query_token_authenticates(self, app_with_user):
+class TestQueryParamTokenOnSSERoutes:
+    def test_valid_query_token_authenticates_on_sse_path(self, app_with_user):
         client = TestClient(app_with_user)
         token = _make_token(1)
-        resp = client.get(f"/whoami?token={token}")
+        resp = client.get(f"{SSE_PATH}?token={token}")
         assert resp.status_code == 200
         assert resp.json()["id"] == 1
 
-    def test_missing_token_unauthorized(self, app_with_user):
+    def test_missing_token_unauthorized_on_sse_path(self, app_with_user):
         client = TestClient(app_with_user)
-        resp = client.get("/whoami")
+        resp = client.get(SSE_PATH)
         assert resp.status_code == 401
 
-    def test_invalid_query_token_unauthorized(self, app_with_user):
+    def test_invalid_query_token_unauthorized_on_sse_path(self, app_with_user):
         client = TestClient(app_with_user)
-        resp = client.get("/whoami?token=not-a-jwt")
+        resp = client.get(f"{SSE_PATH}?token=not-a-jwt")
         assert resp.status_code == 401
 
-    def test_header_still_works(self, app_with_user):
+    def test_header_still_works_on_sse_path(self, app_with_user):
         client = TestClient(app_with_user)
         token = _make_token(1)
-        resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+        resp = client.get(SSE_PATH, headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        assert resp.json()["id"] == 1
+
+
+class TestQueryParamTokenRejectedElsewhere:
+    def test_query_token_rejected_on_plain_route(self, app_with_user):
+        """A valid JWT in the query string must NOT authenticate non-SSE
+        routes — query credentials are SSE-only (codex review P2)."""
+        client = TestClient(app_with_user)
+        token = _make_token(1)
+        resp = client.get(f"{PLAIN_PATH}?token={token}")
+        assert resp.status_code == 401
+
+    def test_header_works_on_plain_route(self, app_with_user):
+        client = TestClient(app_with_user)
+        token = _make_token(1)
+        resp = client.get(PLAIN_PATH, headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         assert resp.json()["id"] == 1
 
@@ -96,9 +127,10 @@ class TestQueryParamToken:
         assert resp.status_code == 200
         assert resp.json()["id"] is None
 
-    def test_optional_authenticates_via_query_token(self, app_with_user):
+    def test_optional_ignores_query_token_on_plain_route(self, app_with_user):
+        """Even a valid query token yields anonymous on non-SSE routes."""
         client = TestClient(app_with_user)
         token = _make_token(1)
         resp = client.get(f"/maybe?token={token}")
         assert resp.status_code == 200
-        assert resp.json()["id"] == 1
+        assert resp.json()["id"] is None

--- a/tests/auth/test_query_param_token.py
+++ b/tests/auth/test_query_param_token.py
@@ -1,0 +1,104 @@
+"""Tests for ?token=<JWT> query-param fallback in get_current_user (issue #336).
+
+Browser EventSource (SSE) cannot send an Authorization header, so when no
+Bearer credentials are present, get_current_user falls back to a ``token``
+query parameter validated through the same JWT path.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+import pytest
+from fastapi import FastAPI, Depends, Request
+from fastapi.testclient import TestClient
+
+from codeframe.auth.dependencies import get_current_user, get_current_user_optional
+from codeframe.auth.manager import SECRET, JWT_ALGORITHM, reset_auth_engine
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+def _make_token(user_id: int = 1, secret: str = SECRET) -> str:
+    payload = {
+        "sub": str(user_id),
+        "aud": ["fastapi-users:auth"],
+        "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+    }
+    return pyjwt.encode(payload, secret, algorithm=JWT_ALGORITHM)
+
+
+@pytest.fixture
+def app_with_user(tmp_path, monkeypatch):
+    """App with a single protected route and a real test user in the DB."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
+    reset_auth_engine()
+
+    db = Database(db_path)
+    db.initialize()
+    db.conn.execute(
+        """
+        INSERT OR REPLACE INTO users (
+            id, email, name, hashed_password,
+            is_active, is_superuser, is_verified, email_verified
+        )
+        VALUES (1, 'test@example.com', 'Test User', '!DISABLED!', 1, 0, 1, 1)
+        """
+    )
+    db.conn.commit()
+    db.close()
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(user=Depends(get_current_user)):
+        return {"id": user.id}
+
+    @app.get("/maybe")
+    async def maybe(request: Request):
+        user = await get_current_user_optional(request)
+        return {"id": user.id if user else None}
+
+    yield app
+    reset_auth_engine()
+
+
+class TestQueryParamToken:
+    def test_valid_query_token_authenticates(self, app_with_user):
+        client = TestClient(app_with_user)
+        token = _make_token(1)
+        resp = client.get(f"/whoami?token={token}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == 1
+
+    def test_missing_token_unauthorized(self, app_with_user):
+        client = TestClient(app_with_user)
+        resp = client.get("/whoami")
+        assert resp.status_code == 401
+
+    def test_invalid_query_token_unauthorized(self, app_with_user):
+        client = TestClient(app_with_user)
+        resp = client.get("/whoami?token=not-a-jwt")
+        assert resp.status_code == 401
+
+    def test_header_still_works(self, app_with_user):
+        client = TestClient(app_with_user)
+        token = _make_token(1)
+        resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        assert resp.json()["id"] == 1
+
+    def test_optional_does_not_raise_on_invalid_query_token(self, app_with_user):
+        """get_current_user_optional must keep swallowing failures."""
+        client = TestClient(app_with_user)
+        resp = client.get("/maybe?token=not-a-jwt")
+        assert resp.status_code == 200
+        assert resp.json()["id"] is None
+
+    def test_optional_authenticates_via_query_token(self, app_with_user):
+        client = TestClient(app_with_user)
+        token = _make_token(1)
+        resp = client.get(f"/maybe?token={token}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == 1

--- a/tests/auth/test_registration_bootstrap.py
+++ b/tests/auth/test_registration_bootstrap.py
@@ -1,0 +1,72 @@
+"""Registration bootstrap gating (issue #336).
+
+/auth/register is allowed only while ZERO users exist. Once any user exists,
+it returns 403. Implemented via a dependency on the register router include.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.auth import router as auth_router
+from codeframe.auth.manager import reset_auth_engine
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def auth_client(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
+    reset_auth_engine()
+
+    db = Database(db_path)
+    db.initialize()
+    db.close()
+
+    app = FastAPI()
+    app.include_router(auth_router.router)
+    client = TestClient(app, raise_server_exceptions=False)
+    client.db_path = db_path
+    yield client
+    reset_auth_engine()
+
+
+def _add_real_user(db_path, user_id=2):
+    """Insert a real (login-capable) user — a non-disabled password hash."""
+    db = Database(db_path)
+    db.initialize()
+    db.conn.execute(
+        """
+        INSERT OR REPLACE INTO users (
+            id, email, name, hashed_password,
+            is_active, is_superuser, is_verified, email_verified
+        )
+        VALUES (?, 'existing@example.com', 'Existing',
+                '$2b$12$abcdefghijklmnopqrstuv', 1, 0, 1, 1)
+        """,
+        (user_id,),
+    )
+    db.conn.commit()
+    db.close()
+
+
+class TestRegistrationBootstrap:
+    def test_register_allowed_when_only_seeded_admin(self, auth_client):
+        """The seeded disabled-password admin must not close registration."""
+        resp = auth_client.post(
+            "/auth/register",
+            json={"email": "first@example.com", "password": "secret123"},
+        )
+        # Bootstrap allowed: registration proceeds (not gated with 403).
+        assert resp.status_code != 403, resp.text
+        assert resp.status_code in (200, 201), resp.text
+
+    def test_register_forbidden_once_a_real_user_exists(self, auth_client):
+        _add_real_user(auth_client.db_path)
+        resp = auth_client.post(
+            "/auth/register",
+            json={"email": "second@example.com", "password": "secret123"},
+        )
+        assert resp.status_code == 403, resp.text

--- a/tests/auth/test_registration_bootstrap.py
+++ b/tests/auth/test_registration_bootstrap.py
@@ -70,3 +70,36 @@ class TestRegistrationBootstrap:
             json={"email": "second@example.com", "password": "secret123"},
         )
         assert resp.status_code == 403, resp.text
+
+    def test_concurrent_first_registrations_admit_exactly_one(self, auth_client):
+        """TOCTOU guard: two simultaneous first-time registrations must not
+        both slip through the zero-users check (codex review P2). The yield
+        dependency holds an in-process lock until user creation completes, so
+        exactly one succeeds and the other gets 403."""
+        import anyio
+        import httpx
+
+        app = auth_client.app
+        statuses = []
+
+        async def _register(client, email):
+            resp = await client.post(
+                "/auth/register",
+                json={"email": email, "password": "secret123"},
+            )
+            statuses.append(resp.status_code)
+
+        async def _run():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(_register, client, "racer-a@example.com")
+                    tg.start_soon(_register, client, "racer-b@example.com")
+
+        anyio.run(_run)
+
+        assert sorted(statuses) == [201, 403] or sorted(statuses) == [200, 403], (
+            f"expected exactly one success and one 403, got {statuses}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,14 @@ import pytest
 # environment override win.
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
+# Run the existing TestClient suites with auth disabled (issue #336). Auth is
+# secure-by-default (CODEFRAME_AUTH_REQUIRED defaults ON), but the legacy suites
+# call v2 routes without credentials. Setting this BEFORE the app is imported
+# opts them out. The dedicated enforcement tests (tests/ui/test_v2_auth_
+# enforcement.py) explicitly monkeypatch it back to "true". ``setdefault`` lets
+# an explicit environment override win.
+os.environ.setdefault("CODEFRAME_AUTH_REQUIRED", "false")
+
 # All v1 legacy tests have been removed; nothing to ignore at the root.
 collect_ignore: list[str] = []
 

--- a/tests/ui/test_v2_auth_enforcement.py
+++ b/tests/ui/test_v2_auth_enforcement.py
@@ -35,7 +35,11 @@ V2_GET_ENDPOINTS = [
     ("pr", "/api/v2/pr/status"),
     ("prd", "/api/v2/prd"),
     ("proof", "/api/v2/proof/requirements"),
+    ("review", "/api/v2/review/diff"),
     ("schedule", "/api/v2/schedule"),
+    # streaming_v2 holds SSE utilities only; the SSE route itself is mounted
+    # under the tasks prefix — assert the auth dependency fires on it too.
+    ("streaming-sse", "/api/v2/tasks/abc/stream"),
     ("settings", "/api/v2/settings"),
     ("tasks", "/api/v2/tasks"),
     ("templates", "/api/v2/templates"),
@@ -74,6 +78,37 @@ def test_valid_jwt_not_401(auth_app, router_id, path):
     assert resp.status_code != 401, (
         f"{router_id} {path} returned 401 with a valid JWT"
     )
+
+
+def test_valid_api_key_not_401(auth_app, monkeypatch, tmp_path):
+    """End-to-end X-API-Key path: a real key stored in the platform store
+    must get past the router-level require_auth dependency."""
+    from codeframe.auth.api_keys import generate_api_key
+    from codeframe.platform_store.database import Database
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
+
+    db = Database(db_path)
+    db.initialize()
+    full_key, key_hash, prefix = generate_api_key()
+    db.api_keys.create(
+        user_id=1,
+        name="enforcement-test",
+        key_hash=key_hash,
+        prefix=prefix,
+        scopes=["read", "write", "admin"],
+    )
+    db.close()
+
+    # No lifespan (no `with`): get_api_key_auth falls back to DATABASE_PATH.
+    client = TestClient(auth_app, raise_server_exceptions=False)
+    resp = client.get("/api/v2/templates", headers={"X-API-Key": full_key})
+    assert resp.status_code != 401, resp.text
+
+    # And a bogus key must NOT pass.
+    resp = client.get("/api/v2/templates", headers={"X-API-Key": "cf_live_" + "0" * 32})
+    assert resp.status_code == 401
 
 
 def test_test_broadcast_requires_auth(auth_app):

--- a/tests/ui/test_v2_auth_enforcement.py
+++ b/tests/ui/test_v2_auth_enforcement.py
@@ -11,6 +11,8 @@ import importlib
 import pytest
 from fastapi.testclient import TestClient
 
+from codeframe.auth.manager import reset_auth_engine
+from codeframe.platform_store.database import Database
 from tests.conftest import create_test_jwt_token
 
 pytestmark = pytest.mark.v2
@@ -48,16 +50,41 @@ V2_GET_ENDPOINTS = [
 
 
 @pytest.fixture
-def auth_app(monkeypatch):
-    """Import the real server app with auth enforcement enabled."""
+def auth_app(tmp_path, monkeypatch):
+    """Import the real server app with auth enforcement enabled.
+
+    Provisions a dedicated initialized database with a test user (id=1) so
+    the JWT lookup path works in any environment — never rely on a dev
+    machine's ambient DATABASE_PATH (this fixture originally did, and passed
+    locally while failing in CI with "no such table: users").
+    """
+    db_path = tmp_path / "state.db"
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
     monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    reset_auth_engine()
+
+    db = Database(db_path)
+    db.initialize()
+    db.conn.execute(
+        """
+        INSERT OR REPLACE INTO users (
+            id, email, name, hashed_password,
+            is_active, is_superuser, is_verified, email_verified
+        )
+        VALUES (1, 'test@example.com', 'Test User', '!DISABLED!', 1, 0, 1, 1)
+        """
+    )
+    db.conn.commit()
+    db.close()
+
     # server module is import-time; the app object already exists. The
     # require_auth dependency reads the env at request time, so a freshly
     # constructed TestClient over the existing app honors the monkeypatch.
     from codeframe.ui import server
 
     importlib.reload(server)
-    return server.app
+    yield server.app
+    reset_auth_engine()
 
 
 @pytest.mark.parametrize("router_id,path", V2_GET_ENDPOINTS)

--- a/tests/ui/test_v2_auth_enforcement.py
+++ b/tests/ui/test_v2_auth_enforcement.py
@@ -1,0 +1,109 @@
+"""Central auth enforcement across the v2 API (issue #336).
+
+With CODEFRAME_AUTH_REQUIRED=true, every v2 REST router must reject
+unauthenticated requests with 401 (a 404/422 would mean the dependency did
+NOT fire). A valid JWT (header) must get past auth (not 401). Public
+endpoints (/, /health, docs, /auth/register) stay reachable.
+"""
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.conftest import create_test_jwt_token
+
+pytestmark = pytest.mark.v2
+
+
+# One representative GET endpoint per mounted v2 REST router. Cheap paths;
+# the goal is to confirm the router-level require_auth dependency fires.
+# (router id, GET path)
+V2_GET_ENDPOINTS = [
+    ("batches", "/api/v2/batches"),
+    ("blockers", "/api/v2/blockers"),
+    ("checkpoints", "/api/v2/checkpoints"),
+    ("costs", "/api/v2/costs/summary"),
+    ("diagnose", "/api/v2/tasks/abc/diagnose"),
+    ("discovery", "/api/v2/discovery/status"),
+    ("environment", "/api/v2/env/check"),
+    ("events", "/api/v2/events"),
+    ("gates", "/api/v2/gates"),
+    ("git", "/api/v2/git/status"),
+    ("github_integrations", "/api/v2/integrations/github/status"),
+    ("interactive_sessions", "/api/v2/sessions"),
+    ("pr", "/api/v2/pr/status"),
+    ("prd", "/api/v2/prd"),
+    ("proof", "/api/v2/proof/requirements"),
+    ("schedule", "/api/v2/schedule"),
+    ("settings", "/api/v2/settings"),
+    ("tasks", "/api/v2/tasks"),
+    ("templates", "/api/v2/templates"),
+    ("workspace", "/api/v2/workspaces"),
+]
+
+
+@pytest.fixture
+def auth_app(monkeypatch):
+    """Import the real server app with auth enforcement enabled."""
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    # server module is import-time; the app object already exists. The
+    # require_auth dependency reads the env at request time, so a freshly
+    # constructed TestClient over the existing app honors the monkeypatch.
+    from codeframe.ui import server
+
+    importlib.reload(server)
+    return server.app
+
+
+@pytest.mark.parametrize("router_id,path", V2_GET_ENDPOINTS)
+def test_unauthenticated_returns_401(auth_app, router_id, path):
+    client = TestClient(auth_app, raise_server_exceptions=False)
+    resp = client.get(path)
+    assert resp.status_code == 401, (
+        f"{router_id} {path} returned {resp.status_code}, expected 401 "
+        f"(auth dependency did not fire)"
+    )
+
+
+@pytest.mark.parametrize("router_id,path", V2_GET_ENDPOINTS)
+def test_valid_jwt_not_401(auth_app, router_id, path):
+    client = TestClient(auth_app, raise_server_exceptions=False)
+    token = create_test_jwt_token(user_id=1)
+    resp = client.get(path, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code != 401, (
+        f"{router_id} {path} returned 401 with a valid JWT"
+    )
+
+
+def test_test_broadcast_requires_auth(auth_app):
+    client = TestClient(auth_app, raise_server_exceptions=False)
+    resp = client.post("/test/broadcast", json={"message": {"x": 1}})
+    assert resp.status_code == 401
+
+
+class TestPublicEndpointsStayOpen:
+    def test_root(self, auth_app):
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        assert client.get("/").status_code == 200
+
+    def test_health(self, auth_app):
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        assert client.get("/health").status_code == 200
+
+    def test_docs(self, auth_app):
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        assert client.get("/docs").status_code == 200
+
+    def test_openapi(self, auth_app):
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        assert client.get("/openapi.json").status_code == 200
+
+    def test_register_not_401(self, auth_app):
+        """The register endpoint must remain reachable (not blanket-401'd)."""
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        resp = client.post(
+            "/auth/register",
+            json={"email": "x@example.com", "password": "secret123"},
+        )
+        assert resp.status_code != 401

--- a/web-ui/__mocks__/@hugeicons/react.js
+++ b/web-ui/__mocks__/@hugeicons/react.js
@@ -80,4 +80,9 @@ module.exports = {
   Notification02Icon: createIconMock('Notification02Icon'),
   // GitHub issue import (issue #564)
   GithubIcon: createIconMock('GithubIcon'),
+  // Auth / login (issue #336)
+  Login01Icon: createIconMock('Login01Icon'),
+  Logout01Icon: createIconMock('Logout01Icon'),
+  LockIcon: createIconMock('LockIcon'),
+  Mail01Icon: createIconMock('Mail01Icon'),
 };

--- a/web-ui/next.config.js
+++ b/web-ui/next.config.js
@@ -7,6 +7,13 @@ const nextConfig = {
           source: '/api/:path*',
           destination: 'http://localhost:8000/api/:path*',
         },
+        // Auth endpoints (/auth/jwt/login, /auth/register) live outside the
+        // /api prefix on the FastAPI server; proxy them too so the login flow
+        // works with the default empty NEXT_PUBLIC_API_URL (#336).
+        {
+          source: '/auth/:path*',
+          destination: 'http://localhost:8000/auth/:path*',
+        },
       ],
     };
   },

--- a/web-ui/src/__tests__/app/login.test.tsx
+++ b/web-ui/src/__tests__/app/login.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the /login page (issue #336):
+ * - renders email + password form and a sign-in button;
+ * - submits credentials via auth.login then redirects to /;
+ * - surfaces a friendly error when login fails;
+ * - the "create the first account" toggle reveals the register flow, which
+ *   calls register() then auto-logs-in and redirects.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import LoginPage from '@/app/login/page';
+
+const pushMock = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: jest.fn() }),
+}));
+
+const loginMock = jest.fn();
+const registerMock = jest.fn();
+jest.mock('@/lib/auth', () => ({
+  login: (...args: unknown[]) => loginMock(...args),
+  register: (...args: unknown[]) => registerMock(...args),
+}));
+
+beforeEach(() => {
+  pushMock.mockReset();
+  loginMock.mockReset();
+  registerMock.mockReset();
+});
+
+describe('LoginPage', () => {
+  it('renders the email and password fields and a sign-in button', () => {
+    render(<LoginPage />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('submits credentials and redirects to / on success', async () => {
+    loginMock.mockResolvedValueOnce('jwt-abc');
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pw123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith('user@example.com', 'pw123');
+    });
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('shows an error message when login fails', async () => {
+    loginMock.mockRejectedValueOnce(new Error('Invalid email or password.'));
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'bad' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('register flow: toggles, registers, auto-logs-in, and redirects', async () => {
+    registerMock.mockResolvedValueOnce(undefined);
+    loginMock.mockResolvedValueOnce('jwt-new');
+    render(<LoginPage />);
+
+    // Reveal the register flow.
+    fireEvent.click(screen.getByRole('button', { name: /create the first account/i }));
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'first@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pw123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledWith('first@example.com', 'pw123');
+    });
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith('first@example.com', 'pw123');
+    });
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/web-ui/src/__tests__/components/layout/AppLayout.test.tsx
+++ b/web-ui/src/__tests__/components/layout/AppLayout.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * AppLayout must render the login page bare — without the sidebar shell or
+ * pipeline progress bar (issue #336). On every other route it renders the
+ * full shell.
+ */
+import { render, screen } from '@testing-library/react';
+import { AppLayout } from '@/components/layout/AppLayout';
+
+let mockPathname = '/tasks';
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+jest.mock('@/components/layout/AppSidebar', () => ({
+  AppSidebar: () => <aside data-testid="app-sidebar" />,
+}));
+jest.mock('@/components/layout/PipelineProgressBar', () => ({
+  PipelineProgressBar: () => <div data-testid="pipeline-bar" />,
+}));
+
+describe('AppLayout', () => {
+  it('renders the sidebar shell on a normal route', () => {
+    mockPathname = '/tasks';
+    render(
+      <AppLayout>
+        <div data-testid="child">content</div>
+      </AppLayout>
+    );
+    expect(screen.getByTestId('app-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('pipeline-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('renders bare (no sidebar/pipeline bar) on /login', () => {
+    mockPathname = '/login';
+    render(
+      <AppLayout>
+        <div data-testid="child">login</div>
+      </AppLayout>
+    );
+    expect(screen.queryByTestId('app-sidebar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pipeline-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/__tests__/components/layout/AppSidebar.test.tsx
+++ b/web-ui/src/__tests__/components/layout/AppSidebar.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * AppSidebar must expose a Sign out control in its footer that calls
+ * auth.logout() (issue #336). The sidebar only renders when a workspace is
+ * selected, so we stub workspace storage to return a path.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppSidebar } from '@/components/layout/AppSidebar';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/tasks',
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/lib/workspace-storage', () => ({
+  getSelectedWorkspacePath: () => '/tmp/ws',
+}));
+
+// Avoid real network from SWR fetchers.
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: () => ({ data: undefined }),
+}));
+
+jest.mock('@/components/layout/NotificationCenter', () => ({
+  NotificationCenter: () => <div data-testid="notification-center" />,
+}));
+
+const logoutMock = jest.fn();
+jest.mock('@/lib/auth', () => ({
+  logout: () => logoutMock(),
+}));
+
+beforeEach(() => {
+  logoutMock.mockReset();
+});
+
+describe('AppSidebar logout control', () => {
+  it('renders a Sign out button that calls logout()', () => {
+    render(<AppSidebar />);
+    const button = screen.getByRole('button', { name: /sign out/i });
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web-ui/src/__tests__/hooks/useStressTestStream.test.ts
+++ b/web-ui/src/__tests__/hooks/useStressTestStream.test.ts
@@ -44,6 +44,7 @@ class MockEventSource {
 beforeEach(() => {
   MockEventSource.instances = [];
   (global as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+  localStorage.clear();
 });
 
 const WORKSPACE = '/tmp/test-workspace';
@@ -68,6 +69,23 @@ describe('useStressTestStream', () => {
     expect(MockEventSource.latest().url).toContain(
       `workspace_path=${encodeURIComponent(WORKSPACE)}`
     );
+  });
+
+  it('appends the auth token as a query param when authenticated (#336)', () => {
+    localStorage.setItem('auth_token', 'jwt-sse');
+    const { result } = renderHook(() => useStressTestStream(WORKSPACE));
+
+    act(() => result.current.start());
+
+    expect(MockEventSource.latest().url).toContain('token=jwt-sse');
+  });
+
+  it('omits the token param when not authenticated', () => {
+    const { result } = renderHook(() => useStressTestStream(WORKSPACE));
+
+    act(() => result.current.start());
+
+    expect(MockEventSource.latest().url).not.toContain('token=');
   });
 
   it('accumulates human-readable lines from progress events', () => {

--- a/web-ui/src/__tests__/hooks/useTaskStream.test.ts
+++ b/web-ui/src/__tests__/hooks/useTaskStream.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Covers the auth-token query param wiring for the task execution SSE stream
+ * (issue #336). EventSource cannot send an Authorization header, so the JWT
+ * must ride along as `?token=`.
+ */
+import { renderHook } from '@testing-library/react';
+import { useTaskStream } from '@/hooks/useTaskStream';
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+  close() {
+    this.readyState = MockEventSource.CLOSED;
+  }
+  static latest(): MockEventSource {
+    return MockEventSource.instances[MockEventSource.instances.length - 1];
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  (global as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+  localStorage.clear();
+});
+
+const WORKSPACE = '/tmp/ws';
+const TASK = 'task-1';
+
+describe('useTaskStream auth token (#336)', () => {
+  it('appends ?token= when authenticated', () => {
+    localStorage.setItem('auth_token', 'jwt-task');
+    renderHook(() => useTaskStream({ taskId: TASK, workspacePath: WORKSPACE }));
+    expect(MockEventSource.latest().url).toContain('token=jwt-task');
+    expect(MockEventSource.latest().url).toContain('/api/v2/tasks/task-1/stream');
+  });
+
+  it('omits the token param when not authenticated', () => {
+    renderHook(() => useTaskStream({ taskId: TASK, workspacePath: WORKSPACE }));
+    expect(MockEventSource.latest().url).not.toContain('token=');
+  });
+
+  it('does not open a connection when taskId is null', () => {
+    renderHook(() => useTaskStream({ taskId: null, workspacePath: WORKSPACE }));
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+});

--- a/web-ui/src/__tests__/lib/api.auth.test.ts
+++ b/web-ui/src/__tests__/lib/api.auth.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the auth behavior of the shared axios client (issue #336):
+ * - request interceptor attaches `Authorization: Bearer <token>` when present;
+ * - response interceptor on 401 clears the token and redirects to /login,
+ *   except when already on /login (and the existing error normalization stays
+ *   intact).
+ *
+ * We exercise the interceptors directly off the exported axios instance so we
+ * don't need a live server.
+ */
+import type { InternalAxiosRequestConfig, AxiosError } from 'axios';
+import { AxiosHeaders } from 'axios';
+
+import api from '@/lib/api';
+import { setToken, getToken } from '@/lib/auth';
+
+// Pull the registered handlers off the axios instance interceptor stacks.
+function getRequestHandler() {
+  // @ts-expect-error - axios keeps handlers on a private `.handlers` array
+  const handlers = api.interceptors.request.handlers as Array<{
+    fulfilled: (c: InternalAxiosRequestConfig) => InternalAxiosRequestConfig;
+  }>;
+  return handlers.find((h) => h && h.fulfilled)!.fulfilled;
+}
+
+function getResponseRejectHandler() {
+  // @ts-expect-error - private handlers array
+  const handlers = api.interceptors.response.handlers as Array<{
+    rejected: (e: AxiosError) => Promise<never>;
+  }>;
+  return handlers.find((h) => h && h.rejected)!.rejected;
+}
+
+describe('api request interceptor — Authorization header', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('attaches Bearer token when a token is stored', () => {
+    setToken('jwt-123');
+    const handler = getRequestHandler();
+    const config = handler({
+      headers: new AxiosHeaders(),
+    } as InternalAxiosRequestConfig);
+    expect(config.headers.Authorization).toBe('Bearer jwt-123');
+  });
+
+  it('does not attach Authorization when no token is stored', () => {
+    const handler = getRequestHandler();
+    const config = handler({
+      headers: new AxiosHeaders(),
+    } as InternalAxiosRequestConfig);
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+});
+
+describe('api response interceptor — 401 handling', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    localStorage.clear();
+    // Replace window.location with a writable stub so we can observe href set.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, href: '', pathname: '/tasks' },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('clears token and redirects to /login on 401', async () => {
+    setToken('jwt-123');
+    const handler = getResponseRejectHandler();
+
+    await expect(
+      handler({
+        message: 'Unauthorized',
+        response: { status: 401, data: { detail: 'Unauthorized' } },
+      } as AxiosError)
+    ).rejects.toMatchObject({ status_code: 401 });
+
+    expect(getToken()).toBeNull();
+    expect(window.location.href).toBe('/login');
+  });
+
+  it('does NOT redirect when already on /login', async () => {
+    (window.location as Location & { pathname: string }).pathname = '/login';
+    setToken('jwt-123');
+    const handler = getResponseRejectHandler();
+
+    await expect(
+      handler({
+        message: 'Unauthorized',
+        response: { status: 401, data: { detail: 'bad' } },
+      } as AxiosError)
+    ).rejects.toBeDefined();
+
+    expect(window.location.href).toBe('');
+  });
+
+  it('preserves error normalization for non-401 errors', async () => {
+    const handler = getResponseRejectHandler();
+    await expect(
+      handler({
+        message: 'Server error',
+        response: { status: 500, data: { detail: 'Boom' } },
+      } as AxiosError)
+    ).rejects.toMatchObject({ detail: 'Boom', status_code: 500 });
+    expect(window.location.href).toBe('');
+  });
+});

--- a/web-ui/src/__tests__/lib/auth.test.ts
+++ b/web-ui/src/__tests__/lib/auth.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the frontend auth library (issue #336).
+ *
+ * Covers token storage (localStorage key `auth_token`, SSR-safe),
+ * login (form-encoded POST /auth/jwt/login), register (bootstrap-first-user),
+ * logout (clear + redirect), the `withTokenParam` SSE helper, and friendly
+ * error normalization for bad credentials / closed registration.
+ */
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+import {
+  getToken,
+  setToken,
+  clearToken,
+  login,
+  register,
+  logout,
+  withTokenParam,
+} from '@/lib/auth';
+
+describe('auth token storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('setToken stores under the `auth_token` key and getToken reads it', () => {
+    setToken('jwt-abc');
+    expect(localStorage.getItem('auth_token')).toBe('jwt-abc');
+    expect(getToken()).toBe('jwt-abc');
+  });
+
+  it('getToken returns null when no token stored', () => {
+    expect(getToken()).toBeNull();
+  });
+
+  it('clearToken removes the token', () => {
+    setToken('jwt-abc');
+    clearToken();
+    expect(getToken()).toBeNull();
+  });
+});
+
+describe('login', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('POSTs form-encoded credentials and stores the returned token', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { access_token: 'jwt-login', token_type: 'bearer' },
+    });
+
+    const token = await login('user@example.com', 'pw123');
+
+    expect(token).toBe('jwt-login');
+    expect(getToken()).toBe('jwt-login');
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, body, config] = mockedAxios.post.mock.calls[0];
+    expect(url).toContain('/auth/jwt/login');
+    // Body must be form-encoded (URLSearchParams) with username/password.
+    const bodyStr = body instanceof URLSearchParams ? body.toString() : String(body);
+    expect(bodyStr).toContain('username=user%40example.com');
+    expect(bodyStr).toContain('password=pw123');
+    expect(config?.headers?.['Content-Type']).toBe(
+      'application/x-www-form-urlencoded'
+    );
+  });
+
+  it('throws a friendly message on bad credentials (400)', async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      response: { status: 400, data: { detail: 'LOGIN_BAD_CREDENTIALS' } },
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true) as unknown as typeof axios.isAxiosError;
+
+    await expect(login('user@example.com', 'wrong')).rejects.toThrow(
+      /invalid email or password/i
+    );
+  });
+});
+
+describe('register', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('POSTs JSON to /auth/register', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { id: '1', email: 'first@example.com' },
+    });
+
+    await register('first@example.com', 'pw123');
+
+    const [url, body] = mockedAxios.post.mock.calls[0];
+    expect(url).toContain('/auth/register');
+    expect(body).toEqual({ email: 'first@example.com', password: 'pw123' });
+  });
+
+  it('throws "registration is closed" on 403', async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      response: { status: 403, data: { detail: 'forbidden' } },
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true) as unknown as typeof axios.isAxiosError;
+
+    await expect(register('second@example.com', 'pw')).rejects.toThrow(
+      /registration is closed/i
+    );
+  });
+});
+
+describe('logout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('clears the token', () => {
+    setToken('jwt-abc');
+    logout();
+    expect(getToken()).toBeNull();
+  });
+});
+
+describe('withTokenParam', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns the URL unchanged when no token is stored', () => {
+    expect(withTokenParam('http://x/api/v2/stream')).toBe(
+      'http://x/api/v2/stream'
+    );
+  });
+
+  it('appends token with `?` when URL has no query string', () => {
+    setToken('jwt-xyz');
+    expect(withTokenParam('http://x/api/v2/stream')).toBe(
+      'http://x/api/v2/stream?token=jwt-xyz'
+    );
+  });
+
+  it('appends token with `&` when URL already has a query string', () => {
+    setToken('jwt-xyz');
+    expect(withTokenParam('http://x/api/v2/stream?workspace_path=%2Ftmp')).toBe(
+      'http://x/api/v2/stream?workspace_path=%2Ftmp&token=jwt-xyz'
+    );
+  });
+
+  it('URL-encodes the token value', () => {
+    setToken('a b/c');
+    expect(withTokenParam('http://x/s')).toBe('http://x/s?token=a%20b%2Fc');
+  });
+});

--- a/web-ui/src/__tests__/lib/auth.test.ts
+++ b/web-ui/src/__tests__/lib/auth.test.ts
@@ -63,9 +63,13 @@ describe('login', () => {
     const [url, body, config] = mockedAxios.post.mock.calls[0];
     expect(url).toContain('/auth/jwt/login');
     // Body must be form-encoded (URLSearchParams) with username/password.
-    const bodyStr = body instanceof URLSearchParams ? body.toString() : String(body);
-    expect(bodyStr).toContain('username=user%40example.com');
-    expect(bodyStr).toContain('password=pw123');
+    // Parse rather than substring-match so the assertion doesn't embed a
+    // "password=..." literal (GitGuardian generic-password false positive).
+    const params = new URLSearchParams(
+      body instanceof URLSearchParams ? body.toString() : String(body)
+    );
+    expect(params.get('username')).toBe('user@example.com');
+    expect(params.get('password')).toBe('pw123');
     expect(config?.headers?.['Content-Type']).toBe(
       'application/x-www-form-urlencoded'
     );

--- a/web-ui/src/app/login/page.tsx
+++ b/web-ui/src/app/login/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Login01Icon, Mail01Icon, LockIcon, Loading03Icon } from '@hugeicons/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card';
+import { login, register } from '@/lib/auth';
+
+type Mode = 'login' | 'register';
+
+/**
+ * Authentication page (issue #336). Renders bare — no sidebar — because
+ * `AppLayout` short-circuits the shell on the `/login` route.
+ *
+ * Two modes:
+ * - login: email + password → JWT, redirect to `/`.
+ * - register: bootstrap-first-user; on success auto-logs-in, then redirects.
+ */
+export default function LoginPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<Mode>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isRegister = mode === 'register';
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      if (isRegister) {
+        await register(email, password);
+        // First account created — log in immediately for a seamless handoff.
+        await login(email, password);
+      } else {
+        await login(email, password);
+      }
+      router.push('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function toggleMode() {
+    setMode((prev) => (prev === 'login' ? 'register' : 'login'));
+    setError(null);
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="space-y-1.5">
+          <div className="flex items-center gap-2">
+            <Login01Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+            <CardTitle>{isRegister ? 'Create your account' : 'Sign in'}</CardTitle>
+          </div>
+          <CardDescription>
+            {isRegister
+              ? 'Set up the first CodeFRAME account to get started.'
+              : 'Sign in to access your CodeFRAME workspace.'}
+          </CardDescription>
+        </CardHeader>
+
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {error && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {error}
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <label
+                htmlFor="email"
+                className="flex items-center gap-1.5 text-sm font-medium text-foreground"
+              >
+                <Mail01Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                Email
+              </label>
+              <Input
+                id="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                disabled={submitting}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                htmlFor="password"
+                className="flex items-center gap-1.5 text-sm font-medium text-foreground"
+              >
+                <LockIcon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                Password
+              </label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete={isRegister ? 'new-password' : 'current-password'}
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                disabled={submitting}
+              />
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex flex-col gap-3">
+            <Button type="submit" className="w-full" disabled={submitting}>
+              {submitting && (
+                <Loading03Icon className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              )}
+              {isRegister ? 'Create account' : 'Sign in'}
+            </Button>
+            <button
+              type="button"
+              onClick={toggleMode}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {isRegister
+                ? 'Already have an account? Sign in'
+                : 'First time here? Create the first account'}
+            </button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/web-ui/src/components/layout/AppLayout.tsx
+++ b/web-ui/src/components/layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
 import { AppSidebar } from './AppSidebar';
 import { PipelineProgressBar } from './PipelineProgressBar';
 
@@ -8,12 +9,22 @@ interface AppLayoutProps {
   children: ReactNode;
 }
 
+// Routes that render bare (no sidebar / pipeline bar) — e.g. the login page,
+// which is shown when the user is unauthenticated (issue #336).
+const BARE_ROUTES = new Set(['/login']);
+
 /**
  * Client-side layout shell that renders the persistent sidebar
  * alongside the main content area. The sidebar auto-hides when
- * no workspace is selected.
+ * no workspace is selected. The login page renders bare.
  */
 export function AppLayout({ children }: AppLayoutProps) {
+  const pathname = usePathname();
+
+  if (pathname && BARE_ROUTES.has(pathname)) {
+    return <>{children}</>;
+  }
+
   return (
     <div className="flex min-h-screen">
       <AppSidebar />

--- a/web-ui/src/components/layout/AppSidebar.tsx
+++ b/web-ui/src/components/layout/AppSidebar.tsx
@@ -16,8 +16,10 @@ import {
   Add01Icon,
   Settings01Icon,
   ChartLineData01Icon,
+  Logout01Icon,
 } from '@hugeicons/react';
 import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
+import { logout } from '@/lib/auth';
 import { blockersApi, sessionsApi } from '@/lib/api';
 import { CaptureGlitchModal } from '@/components/proof';
 import { NotificationCenter } from './NotificationCenter';
@@ -158,6 +160,15 @@ export function AppSidebar() {
         >
           <Add01Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
           <span className="hidden lg:inline" aria-hidden="true">Capture Glitch</span>
+        </button>
+        <button
+          type="button"
+          aria-label="Sign out"
+          onClick={() => logout()}
+          className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground lg:px-3"
+        >
+          <Logout01Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+          <span className="hidden lg:inline" aria-hidden="true">Sign out</span>
         </button>
       </div>
 

--- a/web-ui/src/hooks/useStressTestStream.ts
+++ b/web-ui/src/hooks/useStressTestStream.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import { useEventSource } from './useEventSource';
+import { withTokenParam } from '@/lib/auth';
 import type { StressTestEvent, StressTestAmbiguity } from '@/types';
 
 // ── Hook state ────────────────────────────────────────────────────────────
@@ -65,7 +66,9 @@ export function useStressTestStream(
   const sseBase = process.env.NEXT_PUBLIC_SSE_URL || 'http://localhost:8000';
   const url =
     active && workspacePath
-      ? `${sseBase}/api/v2/prd/stress-test?workspace_path=${encodeURIComponent(workspacePath)}&run=${runId}`
+      ? withTokenParam(
+          `${sseBase}/api/v2/prd/stress-test?workspace_path=${encodeURIComponent(workspacePath)}&run=${runId}`
+        )
       : null;
 
   const handleMessage = useCallback((data: string) => {

--- a/web-ui/src/hooks/useTaskStream.ts
+++ b/web-ui/src/hooks/useTaskStream.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import { useEventSource } from './useEventSource';
+import { withTokenParam } from '@/lib/auth';
 
 // ── Event types matching backend ExecutionEvent models ──────────────────
 
@@ -116,7 +117,9 @@ export function useTaskStream({
   const sseBase = process.env.NEXT_PUBLIC_SSE_URL || 'http://localhost:8000';
   const url =
     taskId && workspacePath
-      ? `${sseBase}/api/v2/tasks/${taskId}/stream?workspace_path=${encodeURIComponent(workspacePath)}`
+      ? withTokenParam(
+          `${sseBase}/api/v2/tasks/${taskId}/stream?workspace_path=${encodeURIComponent(workspacePath)}`
+        )
       : null;
 
   const handleMessage = useCallback(

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -6,6 +6,7 @@
  * and passes it with every request.
  */
 import axios, { AxiosInstance, AxiosError } from 'axios';
+import { getToken, clearToken } from './auth';
 import type {
   WorkspaceResponse,
   WorkspaceExistsResponse,
@@ -127,10 +128,29 @@ const createApiClient = (): AxiosInstance => {
     withCredentials: true,
   });
 
+  // Attach the JWT bearer token to every request when authenticated (#336).
+  client.interceptors.request.use((config) => {
+    const token = getToken();
+    if (token) {
+      config.headers.set('Authorization', `Bearer ${token}`);
+    }
+    return config;
+  });
+
   // Add response interceptor for error handling
   client.interceptors.response.use(
     (response) => response,
     (error: AxiosError<{ detail?: FastApiErrorDetail }>) => {
+      // On 401 (auth enabled, token missing/expired/invalid): drop the stale
+      // token and bounce to the login page — unless we're already there, to
+      // avoid a redirect loop on a failed login request (#336).
+      if (error.response?.status === 401 && typeof window !== 'undefined') {
+        clearToken();
+        if (window.location.pathname !== '/login') {
+          window.location.href = '/login';
+        }
+      }
+
       // Transform error for consistent handling
       const apiError: ApiError = {
         detail: normalizeErrorDetail(error.response?.data?.detail, error.message),

--- a/web-ui/src/lib/auth.ts
+++ b/web-ui/src/lib/auth.ts
@@ -1,0 +1,133 @@
+/**
+ * Frontend authentication library (issue #336).
+ *
+ * Owns the JWT lifecycle for the web UI:
+ * - Token storage under the `auth_token` localStorage key (the convention
+ *   already used by the WebSocket hooks — see `useAgentChat.ts`).
+ * - `login()` against fastapi-users' form-encoded `/auth/jwt/login`.
+ * - `register()` for the bootstrap-first-user flow (`/auth/register`).
+ * - `logout()` clears the token and redirects to `/login`.
+ * - `withTokenParam()` appends `?token=<jwt>` to SSE/EventSource URLs, which
+ *   cannot send an Authorization header.
+ *
+ * Error messages are normalized to friendly, user-facing strings.
+ */
+import axios from 'axios';
+
+const TOKEN_KEY = 'auth_token';
+
+// Login/register hit the API origin directly. Mirror the axios client base URL.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
+
+// ── Token storage (SSR-safe) ────────────────────────────────────────────
+
+export function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+// ── Auth flows ──────────────────────────────────────────────────────────
+
+interface LoginResponse {
+  access_token: string;
+  token_type: string;
+}
+
+/**
+ * Authenticate with email + password against fastapi-users' JWT login.
+ * The endpoint expects a form-encoded body (`username` / `password`), not JSON.
+ * On success the token is stored and returned.
+ */
+export async function login(email: string, password: string): Promise<string> {
+  const body = new URLSearchParams();
+  body.set('username', email);
+  body.set('password', password);
+
+  try {
+    const response = await axios.post<LoginResponse>(
+      `${API_BASE}/auth/jwt/login`,
+      body,
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      }
+    );
+    const token = response.data.access_token;
+    setToken(token);
+    return token;
+  } catch (error) {
+    throw normalizeAuthError(error, 'login');
+  }
+}
+
+/**
+ * Register the first account (bootstrap-first-user). The backend returns 403
+ * once any user exists, so this is only reachable on a fresh install.
+ */
+export async function register(email: string, password: string): Promise<void> {
+  try {
+    await axios.post(`${API_BASE}/auth/register`, { email, password });
+  } catch (error) {
+    throw normalizeAuthError(error, 'register');
+  }
+}
+
+/**
+ * Clear the stored token and send the user back to the login page.
+ * Safe to call from anywhere (guards `window`).
+ */
+export function logout(): void {
+  clearToken();
+  if (typeof window !== 'undefined') {
+    window.location.href = '/login';
+  }
+}
+
+// ── SSE helper ──────────────────────────────────────────────────────────
+
+/**
+ * Append the JWT as a `?token=` query param so EventSource (which cannot set
+ * an Authorization header) can authenticate. Handles URLs that already carry
+ * a query string. Returns the URL unchanged when no token is stored.
+ */
+export function withTokenParam(url: string): string {
+  const token = getToken();
+  if (!token) return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}token=${encodeURIComponent(token)}`;
+}
+
+// ── Error normalization ─────────────────────────────────────────────────
+
+function normalizeAuthError(error: unknown, flow: 'login' | 'register'): Error {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    if (flow === 'login' && status === 400) {
+      return new Error('Invalid email or password.');
+    }
+    if (flow === 'register' && status === 403) {
+      return new Error(
+        'Registration is closed — an account already exists. Please sign in.'
+      );
+    }
+    if (flow === 'register' && status === 400) {
+      return new Error('An account with that email already exists.');
+    }
+    const detail = error.response?.data?.detail;
+    if (typeof detail === 'string') return new Error(detail);
+  }
+  return new Error(
+    flow === 'login'
+      ? 'Sign-in failed. Please try again.'
+      : 'Registration failed. Please try again.'
+  );
+}


### PR DESCRIPTION
## Summary
Implements #336: authentication enforcement across the v2 API — backend enforcement, SSE token auth, JWT login web UI, and test migration.

- **Backend**: `require_auth` (JWT Bearer **or** `X-API-Key`) mounted as a router-level dependency on all 22 v2 REST routers + `/test/broadcast`. Env-gated via `CODEFRAME_AUTH_REQUIRED` (**default ON**, read at request time); when disabled, a synthetic local-admin principal preserves current local behavior. Public: `/`, `/health`, OpenAPI docs, `/auth/*`.
- **SSE**: `?token=<JWT>` accepted **only** on the two EventSource routes (`/api/v2/tasks/{id}/stream`, `/api/v2/prd/stress-test`) via a strict path allowlist; rejected everywhere else. WS routers keep their existing `?token=` auth (untouched).
- **Registration**: `/auth/register` is bootstrap-first-user only — 403 once a real account exists (seeded `!DISABLED!` admin excluded); check-then-create serialized with an in-process lock (TOCTOU guard).
- **Web UI**: `/login` page (sign-in + first-account bootstrap), axios interceptor attaching `Authorization: Bearer` from the existing `auth_token` localStorage convention, loop-safe 401 → `/login` redirect, SSE hooks append the token, logout in sidebar; `/auth/*` added to the Next.js rewrite proxy.

## Acceptance Criteria
- [x] With auth enabled: every `/api/v2/*` route 401s without credentials; passes with valid JWT and with valid API key (parametrized over all 22 routers, end-to-end X-API-Key test)
- [x] SSE authenticates via `?token=` (EventSource-compatible); WS unchanged
- [x] `/`, `/health`, docs, `/auth/jwt/login`, `/auth/register` remain public; `/test/broadcast` now requires auth
- [x] Web UI login flow end-to-end; REST/SSE/WS all carry the token; 401 redirects to `/login`
- [x] Backend suite green (3602 passed; 26 failures are pre-existing on main — verified via stash baseline: 20 stale-v1 `/api/projects` + 6 environment-dependent e2e/lifecycle); ruff clean
- [x] web-ui: 88 suites / 1000+ tests green; `npm run build` green
- [x] CLI golden path unaffected (no server required)

## Test Plan
- [x] Unit tests written (TDD approach) — 119 new/updated auth + enforcement tests
- [x] All tests passing
- [x] Diff coverage 98% on changed lines (gate ≥85%)
- [x] Linting clean (ruff; web-ui lint errors are pre-existing in untouched files)
- [x] Internal code review (advisory) completed — 2 Major findings fixed (router matrix completeness, e2e API-key path)
- [x] Cross-family review pass: **codex** (2 rounds). Round 1: P1 (auth proxy gap) and P2 (registration TOCTOU) fixed. Round 2: P2 (global query-token surface) fixed via SSE allowlist; P1 (token in SSE URL) mitigated + documented below.
- [x] Test mutation sanity check completed — 7 mutations across backend/frontend, all detected by tests

## Known Limitations / Intentionally Deferred
- **No JWT refresh flow** — 7-day token (`JWT_LIFETIME_SECONDS`); users re-login on expiry.
- **JWT appears in SSE/WS URLs** (browser EventSource/WebSocket cannot send headers). Scope is limited to the 2 SSE routes + 2 WS routes; the pre-existing WS pattern is unchanged. Proper fix (short-lived single-purpose stream tokens) is deferred — follow-up candidate.
- **Registration race lock is in-process** — multi-worker deployments retain a narrow first-registration race window.
- **Auth on by default requires first-run account creation** for the web UI (`codeframe serve` → login page → "create first account"). CLI is unaffected. Local opt-out: `CODEFRAME_AUTH_REQUIRED=false`.
- Pre-existing web-ui lint errors (6) and the 26 pre-existing backend test failures are untouched — out of scope.

## Implementation Notes
- WS auth (issue workstream B) was already implemented on both WS routers; this PR only added the SSE side.
- `streaming_v2.py` holds SSE utilities; the actual SSE route lives under the tasks prefix and is covered by `tasks_v2` router auth.
- Frontend 401-driven redirect means no auth-status probe endpoint is needed: with auth disabled, no 401 ever fires and the login page is simply never visited.

Closes #336