### PR TITLE
feat: opt-in telemetry + crash reporting (#616)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,9 @@ cf env check|install|doctor
 
 # GitHub PR
 cf pr create|status|checks|merge
+
+# Telemetry (machine-wide, opt-in)
+cf config telemetry on|off|status
 ```
 
 Note: `codeframe serve` exists but Golden Path does not depend on it.
@@ -284,6 +287,11 @@ RATE_LIMIT_AI=20/minute
 REDIS_URL=redis://localhost:6379
 
 CODEFRAME_API_KEY_SECRET=<secret>     # API key hashing
+
+# Telemetry (default: off — must be explicitly opted in)
+CODEFRAME_TELEMETRY=on|off            # Force telemetry on or off; overrides ~/.codeframe/telemetry.json
+CODEFRAME_TELEMETRY_ENDPOINT=<url>    # Override collector URL (default: https://telemetry.codeframe.dev/v1/events)
+DO_NOT_TRACK=1                        # Standard convention; disables telemetry when set (and not 0/false)
 ```
 
 ---

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,93 @@
+# CodeFRAME Telemetry & Privacy
+
+Last updated: 2026-06-12
+
+CodeFRAME includes **opt-in** anonymous telemetry and crash reporting to help
+us find and fix bugs during the beta. It is **off by default** — nothing is
+ever sent unless you explicitly turn it on.
+
+## How consent works
+
+On your first interactive `cf` command you are asked once whether to enable
+telemetry (default **No**). Your answer is stored machine-wide in
+`~/.codeframe/telemetry.json` and you are never asked again.
+
+You can change your mind at any time:
+
+```bash
+cf config telemetry on        # opt in
+cf config telemetry off       # opt out
+cf config telemetry status    # see the effective state and why
+```
+
+Precedence, highest first:
+
+1. `CODEFRAME_TELEMETRY=on|off` environment variable — this is also how
+   non-interactive runs (CI, scripts) are controlled; they are never prompted
+   and default to off.
+2. `DO_NOT_TRACK` — if set (and not `0`/`false`), telemetry is disabled,
+   following the [console DNT convention](https://consoledonottrack.com/).
+3. The stored answer in `~/.codeframe/telemetry.json`.
+4. Default: **off**.
+
+## What is collected
+
+Only when telemetry is enabled, one small batch is sent per CLI invocation.
+
+**Usage events** contain exactly:
+
+| Field | Example | Notes |
+|---|---|---|
+| `command` | `"work start"` | Validated against the registered command list — your arguments, file names, and typos are never included |
+| `duration_ms` | `1234` | Wall-clock duration of the command |
+| `exit_code` / `success` | `0` / `true` | |
+| `version` | `"0.1.0"` | CodeFRAME version |
+| `os` | `"linux"` | Operating system family only |
+| `python` | `"3.12.4"` | Python version |
+| `anonymous_id` | random UUID | Generated locally; not derived from any hardware, account, or network identifier |
+| `timestamp` | ISO-8601 UTC | |
+
+**Crash reports** (same opt-in) contain the exception **class name** (e.g.
+`ValueError`) and stack-trace frames **only from inside the CodeFRAME
+package**, with paths relative to the package (e.g.
+`codeframe/core/tasks.py:42 in update_status`), plus the version/OS/Python
+fields above.
+
+## What is never collected
+
+- Project content: no source code, diffs, file names, or file paths
+- Prompts, PRDs, task descriptions, or any LLM inputs/outputs
+- Command arguments of any kind
+- **Exception messages** — they are deliberately dropped because they often
+  embed user file paths
+- Stack frames from your code, the standard library, or dependencies
+- Usernames, hostnames, IP-derived identifiers, environment variables, or
+  API keys
+
+You can audit the full client implementation in
+[`codeframe/core/telemetry.py`](codeframe/core/telemetry.py) and
+[`codeframe/cli/telemetry_runtime.py`](codeframe/cli/telemetry_runtime.py).
+
+## Where it goes
+
+Events are POSTed over HTTPS to the CodeFRAME beta collector
+(`https://telemetry.codeframe.dev/v1/events` by default). The collector is the
+~50-line FastAPI app in
+[`scripts/telemetry_collector.py`](scripts/telemetry_collector.py) — it
+appends events to a flat file; there is no third-party analytics service
+involved. You can point the client at your own instance with
+`CODEFRAME_TELEMETRY_ENDPOINT=<url>` (or `endpoint` in
+`~/.codeframe/telemetry.json`).
+
+Sends are fire-and-forget with a short timeout; a failed or slow send never
+affects your command.
+
+## Retention & deletion
+
+- Beta telemetry is retained for **90 days**, then deleted.
+- Data is used only in aggregate to prioritize fixes; it is never sold or
+  shared.
+- To have all events for your `anonymous_id` deleted, open a GitHub issue or
+  email the maintainer with the id shown by `cf config telemetry status`.
+- Deleting `~/.codeframe/telemetry.json` resets your anonymous id and your
+  consent answer (you'll be prompted again on the next interactive run).

--- a/README.md
+++ b/README.md
@@ -345,6 +345,15 @@ export RATE_LIMIT_DEFAULT=100/minute        # Default limit
 
 For server configuration, rate limiting options, and API key setup, see [docs/PHASE_2_DEVELOPER_GUIDE.md](docs/PHASE_2_DEVELOPER_GUIDE.md).
 
+### Privacy & telemetry
+
+CodeFRAME has **opt-in** (default off) anonymous telemetry and crash reporting
+to help us fix beta bugs — command name, duration, exit code, version, and OS
+only; never code, prompts, arguments, or file paths. Control it with
+`cf config telemetry on|off|status`, `CODEFRAME_TELEMETRY=on|off`, or
+`DO_NOT_TRACK=1`. See [PRIVACY.md](PRIVACY.md) for exactly what is collected,
+where it goes, and retention.
+
 ---
 
 ## Testing

--- a/codeframe/__main__.py
+++ b/codeframe/__main__.py
@@ -9,11 +9,11 @@ The help text will correctly show 'codeframe' as the command name.
 
 def main():
     """Run the CLI with proper program name."""
-    from codeframe.cli.app import app
+    from codeframe.cli.app import main as app_main
 
-    # Use Typer's prog_name to override the usage line
-    # This is more reliable than sys.argv[0] manipulation
-    app(prog_name="codeframe")
+    # The telemetry-aware wrapper invokes the app with prog_name="codeframe",
+    # so the usage line shows the right command name here too.
+    app_main()
 
 
 if __name__ == "__main__":

--- a/codeframe/cli/__main__.py
+++ b/codeframe/cli/__main__.py
@@ -9,11 +9,11 @@ The help text will correctly show 'codeframe' as the command name.
 
 def main():
     """Run the CLI with proper program name."""
-    from codeframe.cli.app import app
+    from codeframe.cli.app import main as app_main
 
-    # Use Typer's prog_name to override the usage line
-    # This is more reliable than sys.argv[0] manipulation
-    app(prog_name="codeframe")
+    # The telemetry-aware wrapper invokes the app with prog_name="codeframe",
+    # so the usage line shows the right command name here too.
+    app_main()
 
 
 if __name__ == "__main__":

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -5654,6 +5654,10 @@ app.add_typer(dashboard_app, name="dashboard")
 
 app.add_typer(import_app, name="import")
 
+from codeframe.cli.config_commands import config_app  # noqa: E402
+
+app.add_typer(config_app, name="config")
+
 
 # =============================================================================
 # Version command

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -5672,5 +5672,17 @@ def version() -> None:
     console.print(f"CodeFRAME version: [bold green]{__version__}[/bold green]")
 
 
+def main() -> None:
+    """Console-script entry point: telemetry-aware wrapper around the app.
+
+    Adds the one-time opt-in prompt, anonymous usage events, and crash
+    reporting (all default OFF — see PRIVACY.md) without changing the app's
+    behavior or exit codes.
+    """
+    from codeframe.cli.telemetry_runtime import run
+
+    run(app)
+
+
 if __name__ == "__main__":
-    app()
+    main()

--- a/codeframe/cli/config_commands.py
+++ b/codeframe/cli/config_commands.py
@@ -1,0 +1,70 @@
+"""`cf config` — machine-wide CodeFRAME configuration (issue #616)."""
+
+import os
+
+import typer
+from rich.console import Console
+
+from codeframe.core import telemetry as telemetry_core
+
+config_app = typer.Typer(
+    name="config",
+    help="Manage machine-wide CodeFRAME configuration",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+@config_app.command()
+def telemetry(
+    action: str = typer.Argument(..., help="on | off | status"),
+) -> None:
+    """Enable, disable, or inspect anonymous telemetry (default: off).
+
+    See PRIVACY.md for exactly what is collected. Env overrides:
+    CODEFRAME_TELEMETRY=on|off always wins; DO_NOT_TRACK disables.
+    """
+    action = action.strip().lower()
+    if action not in ("on", "off", "status"):
+        console.print(f"[red]Error:[/red] unknown action '{action}' (expected on|off|status)")
+        raise typer.Exit(1)
+
+    if action == "status":
+        _print_status()
+        return
+
+    config = telemetry_core.load_config()
+    config.enabled = action == "on"
+    config.prompted = True
+    telemetry_core.save_config(config)
+
+    if config.enabled:
+        console.print(
+            "[green]Telemetry enabled.[/green] Anonymous usage events and crash "
+            "reports will be sent — see PRIVACY.md for exactly what is collected."
+        )
+        console.print(f"Anonymous id: [dim]{config.anonymous_id}[/dim]")
+    else:
+        console.print("[yellow]Telemetry disabled.[/yellow] Nothing will be sent.")
+
+
+def _print_status() -> None:
+    config = telemetry_core.load_config()
+    effective = telemetry_core.is_enabled()
+    state = "[green]enabled[/green]" if effective else "[yellow]disabled[/yellow]"
+    console.print(f"Telemetry: {state}")
+
+    override = telemetry_core.env_override()
+    if override is not None:
+        console.print(
+            f"  (overridden by CODEFRAME_TELEMETRY={os.environ['CODEFRAME_TELEMETRY']})"
+        )
+    elif os.environ.get("DO_NOT_TRACK", "").strip().lower() not in ("", "0", "false"):
+        console.print("  (disabled by DO_NOT_TRACK)")
+
+    console.print(f"  Config file: {telemetry_core.config_path()}")
+    console.print(f"  Endpoint: {telemetry_core.resolve_endpoint()}")
+    if telemetry_core.config_path().exists():
+        console.print(f"  Anonymous id: {config.anonymous_id}")
+    console.print("  Details: PRIVACY.md  |  Change: cf config telemetry on|off")

--- a/codeframe/cli/config_commands.py
+++ b/codeframe/cli/config_commands.py
@@ -50,17 +50,26 @@ def telemetry(
 
 
 def _print_status() -> None:
+    # Resolve the effective state from this single config read (rather than
+    # is_enabled(), which re-reads) so the displayed state and anonymous id
+    # can't disagree if the file changes between two loads.
     config = telemetry_core.load_config()
-    effective = telemetry_core.is_enabled()
+    override = telemetry_core.env_override()
+    dnt_active = os.environ.get("DO_NOT_TRACK", "").strip().lower() not in ("", "0", "false")
+    if override is not None:
+        effective = override
+    elif dnt_active:
+        effective = False
+    else:
+        effective = config.enabled
     state = "[green]enabled[/green]" if effective else "[yellow]disabled[/yellow]"
     console.print(f"Telemetry: {state}")
 
-    override = telemetry_core.env_override()
     if override is not None:
         console.print(
             f"  (overridden by CODEFRAME_TELEMETRY={os.environ['CODEFRAME_TELEMETRY']})"
         )
-    elif os.environ.get("DO_NOT_TRACK", "").strip().lower() not in ("", "0", "false"):
+    elif dnt_active:
         console.print("  (disabled by DO_NOT_TRACK)")
 
     console.print(f"  Config file: {telemetry_core.config_path()}")

--- a/codeframe/cli/telemetry_runtime.py
+++ b/codeframe/cli/telemetry_runtime.py
@@ -1,0 +1,153 @@
+"""Telemetry-aware CLI entry wrapper (issue #616).
+
+Wraps the Typer app to provide: the one-time opt-in prompt, command timing,
+success/failure capture, and crash reporting. Telemetry can never change the
+CLI's behavior — every telemetry step is best-effort and silent on failure,
+and the wrapped app's exit code / exception always propagates unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from typing import Optional
+
+import click
+import typer
+import typer.main
+from rich.console import Console
+
+from codeframe.core import telemetry
+
+logger = logging.getLogger(__name__)
+
+console = Console()
+
+# Bounded wait for the fire-and-forget send at process exit. Worst case this
+# adds 1s to an opted-in command; opted-out commands are unaffected.
+_SEND_JOIN_SECONDS = 1.0
+
+
+def _is_interactive() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def resolve_command_name(cli_app: typer.Typer, args: list[str]) -> Optional[str]:
+    """Map argv tokens to a registered command path ("work batch run").
+
+    Only names that exist in the command tree are ever returned — arbitrary
+    user tokens (file paths, task ids, typos) can never leak into telemetry.
+    Returns None when no command token is present (bare ``cf`` / ``--help``),
+    and "unknown" when the first token matches nothing.
+    """
+    group = typer.main.get_command(cli_app)
+    path: list[str] = []
+    for token in args:
+        if token.startswith("-"):
+            continue
+        if not isinstance(group, click.Group):
+            break
+        command = group.commands.get(token)
+        if command is None:
+            break
+        path.append(token)
+        group = command
+    if path:
+        return " ".join(path)
+    has_positional = any(not t.startswith("-") for t in args)
+    return "unknown" if has_positional else None
+
+
+def maybe_prompt_first_run(args: list[str]) -> None:
+    """One-time opt-in prompt (default No). Skipped when non-interactive, when
+    an env override is active, when already prompted, and during ``cf config``."""
+    try:
+        if not args or args[0].startswith("-") or args[0] == "config":
+            return
+        if telemetry.env_override() is not None:
+            return
+        if os.environ.get("DO_NOT_TRACK", "").strip().lower() not in ("", "0", "false"):
+            return
+        if not _is_interactive():
+            return
+        config = telemetry.load_config()
+        if config.prompted:
+            return
+        console.print(
+            "\n[bold]Help improve CodeFRAME?[/bold] Share anonymous usage events and "
+            "crash reports (command name, duration, version, OS — never code, "
+            "prompts, or file paths). Details: PRIVACY.md. "
+            "Change anytime: [cyan]cf config telemetry on|off[/cyan]"
+        )
+        answer = typer.confirm("Enable anonymous telemetry?", default=False)
+        config.enabled = answer
+        config.prompted = True
+        telemetry.save_config(config)
+        console.print()
+    except (click.Abort, KeyboardInterrupt):
+        raise
+    except Exception:
+        logger.debug("Telemetry first-run prompt failed", exc_info=True)
+
+
+def _coerce_exit_code(code: object) -> int:
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    return 1
+
+
+def _dispatch(
+    command: Optional[str],
+    start: float,
+    exit_code: int,
+    crash: Optional[BaseException] = None,
+) -> None:
+    """Build and send events for this invocation. Never raises."""
+    try:
+        if command is None or not telemetry.is_enabled():
+            return
+        config = telemetry.ensure_config()
+        duration_ms = int((time.monotonic() - start) * 1000)
+        events = [
+            telemetry.build_command_event(
+                command=command,
+                duration_ms=duration_ms,
+                exit_code=exit_code,
+                anonymous_id=config.anonymous_id,
+            )
+        ]
+        if crash is not None:
+            events.append(telemetry.build_crash_event(crash, config.anonymous_id))
+        thread = telemetry.send_events_background(events, telemetry.resolve_endpoint())
+        thread.join(_SEND_JOIN_SECONDS)
+    except Exception:
+        logger.debug("Telemetry dispatch failed", exc_info=True)
+
+
+def run(cli_app: typer.Typer) -> None:
+    """Run the Typer app with telemetry instrumentation around it."""
+    args = sys.argv[1:]
+    maybe_prompt_first_run(args)
+    command = resolve_command_name(cli_app, args)
+    start = time.monotonic()
+    try:
+        cli_app(prog_name="codeframe")
+    except SystemExit as e:
+        _dispatch(command, start, _coerce_exit_code(e.code))
+        raise
+    except (KeyboardInterrupt, click.Abort):
+        _dispatch(command, start, 130)
+        raise
+    except BaseException as e:
+        # Unhandled crash: record it, then let it propagate so Typer's
+        # excepthook still prints the traceback and the exit code is unchanged.
+        _dispatch(command, start, 1, crash=e)
+        raise
+    else:
+        # Click standalone mode normally exits via SystemExit; cover the
+        # non-standalone path for completeness.
+        _dispatch(command, start, 0)

--- a/codeframe/core/telemetry.py
+++ b/codeframe/core/telemetry.py
@@ -1,0 +1,232 @@
+"""Opt-in anonymous telemetry + crash reporting (issue #616).
+
+Headless core module — no FastAPI/UI imports. The CLI layer decides *when* to
+record; this module owns consent resolution, payload construction, and
+transport.
+
+Privacy guarantees (see PRIVACY.md):
+- Default OFF; nothing is ever sent unless the user opts in.
+- Resolution order: ``CODEFRAME_TELEMETRY`` env var > ``DO_NOT_TRACK`` >
+  ``~/.codeframe/telemetry.json`` > default off.
+- Events carry only: command name (validated against the registered command
+  tree by the caller), duration, exit code, version, OS, Python version, and a
+  random anonymous id. Never args, paths, prompts, or project content.
+- Crash reports carry the exception class and traceback frames *inside the
+  codeframe package only* (paths relativized); exception messages are omitted
+  because they frequently embed user file paths.
+- Sends are fire-and-forget with a short timeout; failures are always silent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import threading
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = "https://telemetry.codeframe.dev/v1/events"
+CONFIG_FILENAME = "telemetry.json"
+SCHEMA_VERSION = 1
+SEND_TIMEOUT_SECONDS = 3.0
+
+_TRUE_VALUES = {"on", "1", "true", "yes"}
+_FALSE_VALUES = {"off", "0", "false", "no"}
+
+
+@dataclass
+class TelemetryConfig:
+    """Machine-wide telemetry consent state, stored at ~/.codeframe/telemetry.json."""
+
+    enabled: bool = False
+    prompted: bool = False
+    anonymous_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    endpoint: Optional[str] = None
+
+
+def default_storage_dir() -> Path:
+    """Machine-wide config dir (same convention as CredentialManager)."""
+    return Path.home() / ".codeframe"
+
+
+def config_path(storage_dir: Optional[Path] = None) -> Path:
+    return (storage_dir or default_storage_dir()) / CONFIG_FILENAME
+
+
+def load_config(storage_dir: Optional[Path] = None) -> TelemetryConfig:
+    """Load config; a missing or corrupted file yields safe defaults (off)."""
+    path = config_path(storage_dir)
+    try:
+        data = json.loads(path.read_text())
+        return TelemetryConfig(
+            enabled=bool(data.get("enabled", False)),
+            prompted=bool(data.get("prompted", False)),
+            anonymous_id=str(data.get("anonymous_id") or uuid.uuid4()),
+            endpoint=data.get("endpoint") or None,
+        )
+    except FileNotFoundError:
+        return TelemetryConfig()
+    except (OSError, ValueError, TypeError):
+        logger.debug("Unreadable telemetry config at %s; using defaults", path)
+        return TelemetryConfig()
+
+
+def save_config(config: TelemetryConfig, storage_dir: Optional[Path] = None) -> None:
+    """Atomically persist config (unique temp file + os.replace)."""
+    import tempfile
+
+    path = config_path(storage_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "enabled": config.enabled,
+        "prompted": config.prompted,
+        "anonymous_id": config.anonymous_id,
+    }
+    if config.endpoint:
+        payload["endpoint"] = config.endpoint
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(payload, indent=2))
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def ensure_config(storage_dir: Optional[Path] = None) -> TelemetryConfig:
+    """Load config, persisting defaults on first call so the anonymous id is stable."""
+    config = load_config(storage_dir)
+    if not config_path(storage_dir).exists():
+        save_config(config, storage_dir)
+    return config
+
+
+def env_override() -> Optional[bool]:
+    """Explicit CODEFRAME_TELEMETRY=on|off override, or None if unset/unrecognized."""
+    value = os.environ.get("CODEFRAME_TELEMETRY", "").strip().lower()
+    if value in _TRUE_VALUES:
+        return True
+    if value in _FALSE_VALUES:
+        return False
+    return None
+
+
+def is_enabled(storage_dir: Optional[Path] = None) -> bool:
+    """Resolve consent: env var > DO_NOT_TRACK > config file > default off."""
+    override = env_override()
+    if override is not None:
+        return override
+    dnt = os.environ.get("DO_NOT_TRACK", "").strip().lower()
+    if dnt not in ("", "0", "false"):
+        return False
+    return load_config(storage_dir).enabled
+
+
+def resolve_endpoint(storage_dir: Optional[Path] = None) -> str:
+    """Resolve collector URL: env var > config file > built-in default."""
+    env_endpoint = os.environ.get("CODEFRAME_TELEMETRY_ENDPOINT", "").strip()
+    if env_endpoint:
+        return env_endpoint
+    return load_config(storage_dir).endpoint or DEFAULT_ENDPOINT
+
+
+def _base_event(event: str, anonymous_id: str) -> dict:
+    from codeframe import __version__
+
+    return {
+        "event": event,
+        "schema": SCHEMA_VERSION,
+        "anonymous_id": anonymous_id,
+        "version": __version__,
+        "os": platform.system().lower(),
+        "python": platform.python_version(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_command_event(
+    command: str, duration_ms: int, exit_code: int, anonymous_id: str
+) -> dict:
+    """Usage event: command name, duration, outcome — nothing else."""
+    payload = _base_event("command", anonymous_id)
+    payload.update(
+        {
+            "command": command,
+            "duration_ms": duration_ms,
+            "exit_code": exit_code,
+            "success": exit_code == 0,
+        }
+    )
+    return payload
+
+
+def _sanitize_frames(exc: BaseException) -> list[dict]:
+    """Keep only traceback frames inside the codeframe package, relativized.
+
+    Exception messages and out-of-package frames (user code, stdlib, deps) are
+    dropped entirely — they can embed user file paths.
+    """
+    package_root = Path(__file__).resolve().parent.parent  # .../codeframe
+    base = package_root.parent
+    frames = []
+    for frame in traceback.extract_tb(exc.__traceback__):
+        try:
+            relative = Path(frame.filename).resolve().relative_to(base)
+        except ValueError:
+            continue
+        if relative.parts and relative.parts[0] == package_root.name:
+            frames.append(
+                {"file": str(relative), "line": frame.lineno, "function": frame.name}
+            )
+    return frames
+
+
+def build_crash_event(exc: BaseException, anonymous_id: str) -> dict:
+    """Crash report: exception class + sanitized in-package frames only."""
+    payload = _base_event("crash", anonymous_id)
+    payload.update(
+        {"exception_type": type(exc).__name__, "frames": _sanitize_frames(exc)}
+    )
+    return payload
+
+
+def send_events(
+    events: list[dict],
+    endpoint: str,
+    timeout: float = SEND_TIMEOUT_SECONDS,
+    client: Optional[httpx.Client] = None,
+) -> bool:
+    """POST a batch of events. Never raises — telemetry must not break the CLI."""
+    try:
+        if client is not None:
+            response = client.post(endpoint, json={"events": events})
+        else:
+            with httpx.Client(timeout=timeout) as own_client:
+                response = own_client.post(endpoint, json={"events": events})
+        return 200 <= response.status_code < 300
+    except Exception:
+        logger.debug("Telemetry send to %s failed", endpoint, exc_info=True)
+        return False
+
+
+def send_events_background(events: list[dict], endpoint: str) -> threading.Thread:
+    """Fire-and-forget send on a daemon thread. Caller may join() with a bound."""
+    thread = threading.Thread(
+        target=send_events, args=(events, endpoint), daemon=True, name="telemetry-send"
+    )
+    thread.start()
+    return thread

--- a/docs/CLI_WIREFRAME.md
+++ b/docs/CLI_WIREFRAME.md
@@ -243,6 +243,37 @@ Each command:
 
 ---
 
+### `codeframe config telemetry <on|off|status>`
+**Purpose:** Enable, disable, or inspect machine-wide anonymous telemetry and crash reporting (default: off).
+
+**CLI module:**
+- `codeframe/cli/config_commands.py`
+
+**Core calls:**
+- `codeframe.core.telemetry.load_config() -> TelemetryConfig`
+- `codeframe.core.telemetry.save_config(config) -> None`
+- `codeframe.core.telemetry.env_override() -> bool | None` (for status display)
+
+**Options:**
+- `on`: Enable telemetry and persist consent.
+- `off`: Disable telemetry and persist consent.
+- `status`: Print current effective state (respects env overrides and `DO_NOT_TRACK`).
+
+**State writes:**
+- `~/.codeframe/telemetry.json` (machine-wide; not workspace-scoped)
+
+**Env overrides (resolution order):**
+- `CODEFRAME_TELEMETRY=on|off` — always wins
+- `DO_NOT_TRACK=1` — disables telemetry (standard convention)
+- `~/.codeframe/telemetry.json` — user preference
+- Default: off
+
+**Notes:**
+- The CLI wrapper (`codeframe/cli/telemetry_runtime.py`) shows a one-time opt-in prompt on the first interactive invocation. Users can skip or answer; the choice is persisted. The prompt is suppressed when `CODEFRAME_TELEMETRY` is set, when `DO_NOT_TRACK` is set, when non-interactive, and during `cf config` commands.
+- See `PRIVACY.md` for exactly what is and is not collected.
+
+---
+
 ## PRD: `codeframe prd ...`
 
 ### `codeframe prd generate` (Enhanced - Primary)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -275,6 +275,15 @@ codeframe checkpoint create "MVP complete"
 | `codeframe checkpoint create "name"` | Save state snapshot |
 | `codeframe checkpoint list` | List checkpoints |
 
+### Configuration Commands
+| Command | Description |
+|---------|-------------|
+| `cf config telemetry on` | Enable anonymous usage telemetry (opt-in) |
+| `cf config telemetry off` | Disable telemetry |
+| `cf config telemetry status` | Show current telemetry state and config path |
+
+> On first interactive use, CodeFRAME shows a one-time prompt asking whether to enable telemetry (default: No). You can also set `CODEFRAME_TELEMETRY=on|off` or `DO_NOT_TRACK=1` to skip the prompt. See [PRIVACY.md](../PRIVACY.md) for exactly what is collected.
+
 ---
 
 ## Execution Strategies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,8 @@ dev = [
 ]
 
 [project.scripts]
-codeframe = "codeframe.cli.app:app"
-cf = "codeframe.cli.app:app"  # Short alias for convenience
+codeframe = "codeframe.cli.app:main"
+cf = "codeframe.cli.app:main"  # Short alias for convenience
 
 [project.urls]
 Homepage = "https://github.com/frankbria/codeframe"

--- a/scripts/telemetry_collector.py
+++ b/scripts/telemetry_collector.py
@@ -39,9 +39,13 @@ def ingest(batch: EventBatch) -> dict:
         raise HTTPException(status_code=413, detail="batch too large")
     received_at = datetime.now(timezone.utc).isoformat()
     LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    # One write call per request so concurrent requests (uvicorn threadpool)
+    # can't interleave partial lines in the JSONL file.
+    lines = "".join(
+        json.dumps({**event, "received_at": received_at}) + "\n" for event in batch.events
+    )
     with LOG_PATH.open("a") as f:
-        for event in batch.events:
-            f.write(json.dumps({**event, "received_at": received_at}) + "\n")
+        f.write(lines)
     return {"accepted": len(batch.events)}
 
 

--- a/scripts/telemetry_collector.py
+++ b/scripts/telemetry_collector.py
@@ -1,0 +1,50 @@
+"""Minimal self-hostable telemetry collector for CodeFRAME beta (issue #616).
+
+Receives event batches from `cf` clients and appends them to a JSONL file —
+the cheapest backend that works for beta volume. No database, no auth, no
+dashboards; analyze with jq.
+
+Run:
+    TELEMETRY_LOG_PATH=/var/lib/codeframe/events.jsonl \
+        uvicorn telemetry_collector:app --host 0.0.0.0 --port 8400
+
+Point clients at it:
+    export CODEFRAME_TELEMETRY_ENDPOINT=https://your-host:8400/v1/events
+
+See PRIVACY.md at the repo root for what clients send and the retention policy.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+MAX_BATCH_SIZE = 100
+
+LOG_PATH = Path(os.environ.get("TELEMETRY_LOG_PATH", "./telemetry_events.jsonl"))
+
+app = FastAPI(title="CodeFRAME telemetry collector", docs_url=None, redoc_url=None)
+
+
+class EventBatch(BaseModel):
+    events: list[dict]
+
+
+@app.post("/v1/events", status_code=202)
+def ingest(batch: EventBatch) -> dict:
+    if len(batch.events) > MAX_BATCH_SIZE:
+        raise HTTPException(status_code=413, detail="batch too large")
+    received_at = datetime.now(timezone.utc).isoformat()
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("a") as f:
+        for event in batch.events:
+            f.write(json.dumps({**event, "received_at": received_at}) + "\n")
+    return {"accepted": len(batch.events)}
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"ok": True}

--- a/tests/cli/test_config_telemetry_cli.py
+++ b/tests/cli/test_config_telemetry_cli.py
@@ -1,0 +1,89 @@
+"""Tests for `cf config telemetry on|off|status` (issue #616)."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.app import app
+from codeframe.core import telemetry
+
+pytestmark = pytest.mark.v2
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Redirect ~ (and therefore ~/.codeframe) to a temp dir."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CODEFRAME_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    return tmp_path
+
+
+def _config_file(home):
+    return home / ".codeframe" / "telemetry.json"
+
+
+class TestTelemetryOn:
+    def test_enables_and_persists(self, home):
+        result = runner.invoke(app, ["config", "telemetry", "on"])
+        assert result.exit_code == 0
+        data = json.loads(_config_file(home).read_text())
+        assert data["enabled"] is True
+        assert data["prompted"] is True
+        assert "enabled" in result.output.lower()
+
+    def test_mentions_privacy_doc(self, home):
+        result = runner.invoke(app, ["config", "telemetry", "on"])
+        assert "PRIVACY.md" in result.output
+
+
+class TestTelemetryOff:
+    def test_disables_and_persists(self, home):
+        runner.invoke(app, ["config", "telemetry", "on"])
+        result = runner.invoke(app, ["config", "telemetry", "off"])
+        assert result.exit_code == 0
+        data = json.loads(_config_file(home).read_text())
+        assert data["enabled"] is False
+        assert data["prompted"] is True
+        assert "disabled" in result.output.lower()
+
+    def test_off_works_without_prior_config(self, home):
+        result = runner.invoke(app, ["config", "telemetry", "off"])
+        assert result.exit_code == 0
+        assert json.loads(_config_file(home).read_text())["enabled"] is False
+
+
+class TestTelemetryStatus:
+    def test_status_default_off(self, home):
+        result = runner.invoke(app, ["config", "telemetry", "status"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output.lower()
+
+    def test_status_when_on(self, home):
+        runner.invoke(app, ["config", "telemetry", "on"])
+        result = runner.invoke(app, ["config", "telemetry", "status"])
+        assert "enabled" in result.output.lower()
+
+    def test_status_shows_env_override(self, home, monkeypatch):
+        runner.invoke(app, ["config", "telemetry", "on"])
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "off")
+        result = runner.invoke(app, ["config", "telemetry", "status"])
+        assert "disabled" in result.output.lower()
+        assert "CODEFRAME_TELEMETRY" in result.output
+
+    def test_status_does_not_create_config(self, home):
+        runner.invoke(app, ["config", "telemetry", "status"])
+        assert not _config_file(home).exists()
+
+
+class TestValidation:
+    def test_unknown_action_fails(self, home):
+        result = runner.invoke(app, ["config", "telemetry", "sideways"])
+        assert result.exit_code != 0
+
+    def test_enabled_resolution_matches_core(self, home):
+        runner.invoke(app, ["config", "telemetry", "on"])
+        assert telemetry.is_enabled(home / ".codeframe") is True

--- a/tests/cli/test_config_telemetry_cli.py
+++ b/tests/cli/test_config_telemetry_cli.py
@@ -79,6 +79,20 @@ class TestTelemetryStatus:
         assert not _config_file(home).exists()
 
 
+class TestEndpointPreservation:
+    def test_custom_endpoint_survives_on_off(self, home):
+        """A hand-edited custom endpoint must survive consent changes."""
+        cfg = telemetry.load_config()
+        cfg.endpoint = "https://my-collector.example.com/v1/events"
+        telemetry.save_config(cfg)
+
+        runner.invoke(app, ["config", "telemetry", "on"])
+        runner.invoke(app, ["config", "telemetry", "off"])
+
+        data = json.loads(_config_file(home).read_text())
+        assert data["endpoint"] == "https://my-collector.example.com/v1/events"
+
+
 class TestValidation:
     def test_unknown_action_fails(self, home):
         result = runner.invoke(app, ["config", "telemetry", "sideways"])

--- a/tests/cli/test_telemetry_entry.py
+++ b/tests/cli/test_telemetry_entry.py
@@ -1,0 +1,215 @@
+"""Tests for the CLI telemetry entry wrapper (issue #616).
+
+Covers command-name resolution against the registered Typer tree, the one-time
+first-run prompt, and event dispatch on success / failure / crash.
+"""
+
+import json
+
+import pytest
+import typer
+
+from codeframe.cli import telemetry_runtime
+from codeframe.cli.app import app
+from codeframe.core import telemetry
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CODEFRAME_TELEMETRY", raising=False)
+    monkeypatch.delenv("CODEFRAME_TELEMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Capture dispatched events instead of hitting the network."""
+    captured = []
+
+    def fake_send_background(events, endpoint):
+        captured.append({"events": events, "endpoint": endpoint})
+
+        class _Thread:
+            daemon = True
+
+            def join(self, timeout=None):
+                return None
+
+        return _Thread()
+
+    monkeypatch.setattr(telemetry, "send_events_background", fake_send_background)
+    return captured
+
+
+class TestResolveCommandName:
+    def test_top_level_command(self):
+        assert telemetry_runtime.resolve_command_name(app, ["init", "/some/repo"]) == "init"
+
+    def test_nested_command(self):
+        assert (
+            telemetry_runtime.resolve_command_name(app, ["work", "start", "t1", "--execute"])
+            == "work start"
+        )
+
+    def test_deeply_nested_command(self):
+        assert (
+            telemetry_runtime.resolve_command_name(app, ["work", "batch", "run", "--all-ready"])
+            == "work batch run"
+        )
+
+    def test_no_args(self):
+        assert telemetry_runtime.resolve_command_name(app, []) is None
+
+    def test_only_options(self):
+        assert telemetry_runtime.resolve_command_name(app, ["--help"]) is None
+
+    def test_unknown_command_never_leaks_token(self):
+        """A typo'd (or arbitrary) first token must not appear in the result."""
+        name = telemetry_runtime.resolve_command_name(app, ["/home/user/secret.txt"])
+        assert name == "unknown"
+
+    def test_argument_after_command_not_appended(self):
+        """Positional args (task ids, file paths) are never part of the name."""
+        name = telemetry_runtime.resolve_command_name(app, ["prd", "add", "secret-plan.md"])
+        assert name == "prd add"
+        assert "secret" not in name
+
+
+class TestFirstRunPrompt:
+    def _interactive(self, monkeypatch, answer: bool):
+        monkeypatch.setattr(telemetry_runtime, "_is_interactive", lambda: True)
+        answers = {"called": 0}
+
+        def fake_confirm(text, default=False):
+            answers["called"] += 1
+            assert default is False  # opt-in: default must be No
+            return answer
+
+        monkeypatch.setattr(typer, "confirm", fake_confirm)
+        return answers
+
+    def test_prompts_once_and_persists_yes(self, home, monkeypatch):
+        answers = self._interactive(monkeypatch, answer=True)
+        telemetry_runtime.maybe_prompt_first_run(["status"])
+        assert answers["called"] == 1
+        data = json.loads((home / ".codeframe" / "telemetry.json").read_text())
+        assert data["enabled"] is True and data["prompted"] is True
+        # Second invocation: already prompted — no new prompt
+        telemetry_runtime.maybe_prompt_first_run(["status"])
+        assert answers["called"] == 1
+
+    def test_prompts_and_persists_no(self, home, monkeypatch):
+        self._interactive(monkeypatch, answer=False)
+        telemetry_runtime.maybe_prompt_first_run(["status"])
+        data = json.loads((home / ".codeframe" / "telemetry.json").read_text())
+        assert data["enabled"] is False and data["prompted"] is True
+
+    def test_skipped_when_not_interactive(self, home, monkeypatch):
+        monkeypatch.setattr(telemetry_runtime, "_is_interactive", lambda: False)
+        telemetry_runtime.maybe_prompt_first_run(["status"])
+        assert not (home / ".codeframe" / "telemetry.json").exists()
+
+    def test_skipped_when_env_override(self, home, monkeypatch):
+        self._interactive(monkeypatch, answer=True)
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "off")
+        telemetry_runtime.maybe_prompt_first_run(["status"])
+        assert not (home / ".codeframe" / "telemetry.json").exists()
+
+    def test_skipped_when_do_not_track(self, home, monkeypatch):
+        self._interactive(monkeypatch, answer=True)
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        telemetry_runtime.maybe_prompt_first_run(["status"])
+        assert not (home / ".codeframe" / "telemetry.json").exists()
+
+    def test_skipped_for_config_commands(self, home, monkeypatch):
+        answers = self._interactive(monkeypatch, answer=True)
+        telemetry_runtime.maybe_prompt_first_run(["config", "telemetry", "off"])
+        assert answers["called"] == 0
+
+    def test_skipped_for_bare_or_option_invocations(self, home, monkeypatch):
+        answers = self._interactive(monkeypatch, answer=True)
+        telemetry_runtime.maybe_prompt_first_run([])
+        telemetry_runtime.maybe_prompt_first_run(["--help"])
+        assert answers["called"] == 0
+
+
+def _tiny_app():
+    tiny = typer.Typer()
+
+    @tiny.command()
+    def ok():
+        pass
+
+    @tiny.command()
+    def fail():
+        raise typer.Exit(3)
+
+    @tiny.command()
+    def boom():
+        raise RuntimeError("kaboom /home/user/private.txt")
+
+    return tiny
+
+
+class TestRun:
+    def _run(self, monkeypatch, argv):
+        monkeypatch.setattr(telemetry_runtime, "_is_interactive", lambda: False)
+        monkeypatch.setattr("sys.argv", ["cf"] + argv)
+        tiny = _tiny_app()
+        with pytest.raises(SystemExit) as excinfo:
+            telemetry_runtime.run(tiny)
+        return excinfo.value.code
+
+    def test_success_event(self, home, sent, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "on")
+        code = self._run(monkeypatch, ["ok"])
+        assert code in (0, None)
+        assert len(sent) == 1
+        (event,) = sent[0]["events"]
+        assert event["event"] == "command"
+        assert event["command"] == "ok"
+        assert event["success"] is True
+        assert event["duration_ms"] >= 0
+
+    def test_failure_event_has_exit_code(self, home, sent, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "on")
+        code = self._run(monkeypatch, ["fail"])
+        assert code == 3
+        (event,) = sent[0]["events"]
+        assert event["success"] is False
+        assert event["exit_code"] == 3
+
+    def test_crash_sends_command_and_crash_events_and_reraises(
+        self, home, sent, monkeypatch
+    ):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "on")
+        monkeypatch.setattr(telemetry_runtime, "_is_interactive", lambda: False)
+        monkeypatch.setattr("sys.argv", ["cf", "boom"])
+        with pytest.raises(RuntimeError):
+            telemetry_runtime.run(_tiny_app())
+        events = sent[0]["events"]
+        kinds = {e["event"] for e in events}
+        assert kinds == {"command", "crash"}
+        crash = next(e for e in events if e["event"] == "crash")
+        assert crash["exception_type"] == "RuntimeError"
+        assert "private.txt" not in json.dumps(events)
+
+    def test_nothing_sent_when_disabled(self, home, sent, monkeypatch):
+        self._run(monkeypatch, ["ok"])  # default off
+        assert sent == []
+
+    def test_nothing_sent_when_do_not_track(self, home, sent, monkeypatch):
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        self._run(monkeypatch, ["ok"])
+        assert sent == []
+
+    def test_anonymous_id_is_stable_across_runs(self, home, sent, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "on")
+        self._run(monkeypatch, ["ok"])
+        self._run(monkeypatch, ["ok"])
+        ids = {batch["events"][0]["anonymous_id"] for batch in sent}
+        assert len(ids) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,12 @@ os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 # an explicit environment override win.
 os.environ.setdefault("CODEFRAME_AUTH_REQUIRED", "false")
 
+# Telemetry is opt-in (issue #616), but force it off for the whole suite so no
+# test — including subprocess-based lifecycle tests, which inherit the env —
+# can ever prompt or send events. The env var is the highest-precedence switch;
+# telemetry tests that exercise other switches delete it via monkeypatch.
+os.environ.setdefault("CODEFRAME_TELEMETRY", "off")
+
 # All v1 legacy tests have been removed; nothing to ignore at the root.
 collect_ignore: list[str] = []
 

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -185,13 +185,16 @@ class TestCrashEvent:
         assert "secret-user" not in json.dumps(event)
 
     def test_frames_only_include_codeframe_package(self):
-        """Frames outside the codeframe package (tests, stdlib) are dropped;
-        in-package frame paths are relative to the package parent."""
+        """Frames outside the codeframe package (tests, stdlib) are dropped.
+
+        The exception is raised from this test file, so every frame is
+        out-of-package and the sanitized list must be exactly empty — the
+        in-package (relative-path) case is covered by
+        test_in_package_frames_are_captured_relative.
+        """
         exc = self._raise_and_capture()
         event = telemetry.build_crash_event(exc, anonymous_id="abc")
-        for frame in event["frames"]:
-            assert frame["file"].startswith("codeframe/")
-            assert not frame["file"].startswith("/")
+        assert event["frames"] == []
 
     def test_in_package_frames_are_captured_relative(self, tmp_path):
         # Trigger a real exception inside the codeframe package: save_config's

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1,0 +1,245 @@
+"""Tests for codeframe.core.telemetry — opt-in anonymous telemetry (issue #616).
+
+Covers: config persistence, the enabled-resolution chain (env var > DO_NOT_TRACK
+> config file > default off), event payload contents (privacy guarantees), crash
+traceback sanitization, and silent network failure.
+"""
+
+import json
+import threading
+import uuid
+
+import httpx
+import pytest
+
+import codeframe
+from codeframe.core import telemetry
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def storage_dir(tmp_path):
+    """Isolated stand-in for ~/.codeframe."""
+    return tmp_path / ".codeframe"
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Remove all telemetry-related env vars (root conftest sets CODEFRAME_TELEMETRY=off)."""
+    monkeypatch.delenv("CODEFRAME_TELEMETRY", raising=False)
+    monkeypatch.delenv("CODEFRAME_TELEMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+
+class TestConfig:
+    def test_load_missing_file_returns_defaults(self, storage_dir):
+        cfg = telemetry.load_config(storage_dir)
+        assert cfg.enabled is False
+        assert cfg.prompted is False
+        # anonymous_id is a valid uuid4
+        assert uuid.UUID(cfg.anonymous_id).version == 4
+
+    def test_save_and_load_roundtrip(self, storage_dir):
+        cfg = telemetry.load_config(storage_dir)
+        cfg.enabled = True
+        cfg.prompted = True
+        telemetry.save_config(cfg, storage_dir)
+
+        loaded = telemetry.load_config(storage_dir)
+        assert loaded.enabled is True
+        assert loaded.prompted is True
+        assert loaded.anonymous_id == cfg.anonymous_id
+
+    def test_save_creates_dir_and_valid_json(self, storage_dir):
+        cfg = telemetry.load_config(storage_dir)
+        telemetry.save_config(cfg, storage_dir)
+        path = storage_dir / "telemetry.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["enabled"] is False
+
+    def test_corrupted_file_returns_defaults(self, storage_dir):
+        storage_dir.mkdir(parents=True)
+        (storage_dir / "telemetry.json").write_text("{not json!!")
+        cfg = telemetry.load_config(storage_dir)
+        assert cfg.enabled is False
+        assert cfg.prompted is False
+
+    def test_ensure_config_persists_on_first_call(self, storage_dir):
+        cfg = telemetry.ensure_config(storage_dir)
+        assert (storage_dir / "telemetry.json").exists()
+        again = telemetry.ensure_config(storage_dir)
+        assert again.anonymous_id == cfg.anonymous_id
+
+
+class TestIsEnabled:
+    def test_default_is_off(self, storage_dir, clean_env):
+        assert telemetry.is_enabled(storage_dir) is False
+
+    def test_config_file_on(self, storage_dir, clean_env):
+        cfg = telemetry.load_config(storage_dir)
+        cfg.enabled = True
+        telemetry.save_config(cfg, storage_dir)
+        assert telemetry.is_enabled(storage_dir) is True
+
+    @pytest.mark.parametrize("value", ["on", "1", "true", "ON", "True", "yes"])
+    def test_env_var_on_overrides_file_off(self, storage_dir, clean_env, monkeypatch, value):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", value)
+        assert telemetry.is_enabled(storage_dir) is True
+
+    @pytest.mark.parametrize("value", ["off", "0", "false", "OFF", "no"])
+    def test_env_var_off_overrides_file_on(self, storage_dir, clean_env, monkeypatch, value):
+        cfg = telemetry.load_config(storage_dir)
+        cfg.enabled = True
+        telemetry.save_config(cfg, storage_dir)
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", value)
+        assert telemetry.is_enabled(storage_dir) is False
+
+    def test_do_not_track_disables(self, storage_dir, clean_env, monkeypatch):
+        cfg = telemetry.load_config(storage_dir)
+        cfg.enabled = True
+        telemetry.save_config(cfg, storage_dir)
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        assert telemetry.is_enabled(storage_dir) is False
+
+    def test_explicit_env_on_beats_do_not_track(self, storage_dir, clean_env, monkeypatch):
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "on")
+        assert telemetry.is_enabled(storage_dir) is True
+
+    def test_unrecognized_env_value_falls_through_to_file(
+        self, storage_dir, clean_env, monkeypatch
+    ):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY", "banana")
+        assert telemetry.is_enabled(storage_dir) is False
+
+
+class TestEndpoint:
+    def test_default_endpoint(self, storage_dir, clean_env):
+        assert telemetry.resolve_endpoint(storage_dir) == telemetry.DEFAULT_ENDPOINT
+
+    def test_env_var_wins(self, storage_dir, clean_env, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_TELEMETRY_ENDPOINT", "http://localhost:9999/v1/events")
+        assert telemetry.resolve_endpoint(storage_dir) == "http://localhost:9999/v1/events"
+
+    def test_config_endpoint_beats_default(self, storage_dir, clean_env):
+        cfg = telemetry.load_config(storage_dir)
+        cfg.endpoint = "https://example.com/collect"
+        telemetry.save_config(cfg, storage_dir)
+        assert telemetry.resolve_endpoint(storage_dir) == "https://example.com/collect"
+
+
+class TestCommandEvent:
+    def test_payload_contents(self):
+        event = telemetry.build_command_event(
+            command="work start",
+            duration_ms=1234,
+            exit_code=0,
+            anonymous_id="abc-123",
+        )
+        assert event["event"] == "command"
+        assert event["command"] == "work start"
+        assert event["duration_ms"] == 1234
+        assert event["success"] is True
+        assert event["exit_code"] == 0
+        assert event["version"] == codeframe.__version__
+        assert event["anonymous_id"] == "abc-123"
+        assert "os" in event and "python" in event and "timestamp" in event
+
+    def test_nonzero_exit_is_failure(self):
+        event = telemetry.build_command_event(
+            command="init", duration_ms=5, exit_code=1, anonymous_id="x"
+        )
+        assert event["success"] is False
+        assert event["exit_code"] == 1
+
+    def test_no_forbidden_keys(self):
+        """Privacy: events never carry args, paths, or prompt content."""
+        event = telemetry.build_command_event(
+            command="prd add", duration_ms=10, exit_code=0, anonymous_id="x"
+        )
+        for forbidden in ("args", "argv", "cwd", "path", "prompt", "user", "hostname"):
+            assert forbidden not in event
+
+
+class TestCrashEvent:
+    def _raise_and_capture(self):
+        try:
+            raise ValueError("/home/secret-user/private-project/file.py exploded")
+        except ValueError as e:
+            return e
+
+    def test_crash_payload(self):
+        exc = self._raise_and_capture()
+        event = telemetry.build_crash_event(exc, anonymous_id="abc")
+        assert event["event"] == "crash"
+        assert event["exception_type"] == "ValueError"
+        assert event["version"] == codeframe.__version__
+        assert event["anonymous_id"] == "abc"
+
+    def test_crash_omits_exception_message(self):
+        """Exception messages often embed user file paths — never sent."""
+        exc = self._raise_and_capture()
+        event = telemetry.build_crash_event(exc, anonymous_id="abc")
+        assert "secret-user" not in json.dumps(event)
+
+    def test_frames_only_include_codeframe_package(self):
+        """Frames outside the codeframe package (tests, stdlib) are dropped;
+        in-package frame paths are relative to the package parent."""
+        exc = self._raise_and_capture()
+        event = telemetry.build_crash_event(exc, anonymous_id="abc")
+        for frame in event["frames"]:
+            assert frame["file"].startswith("codeframe/")
+            assert not frame["file"].startswith("/")
+
+    def test_in_package_frames_are_captured_relative(self, tmp_path):
+        # Trigger a real exception inside the codeframe package: save_config's
+        # mkdir fails because a path component is a regular file.
+        (tmp_path / "blocker").write_text("not a dir")
+        with pytest.raises(OSError) as excinfo:
+            telemetry.save_config(
+                telemetry.TelemetryConfig(), storage_dir=tmp_path / "blocker" / "sub"
+            )
+        event = telemetry.build_crash_event(excinfo.value, anonymous_id="abc")
+        assert any(
+            f["file"] == "codeframe/core/telemetry.py" for f in event["frames"]
+        )
+        for f in event["frames"]:
+            assert set(f) == {"file", "line", "function"}
+
+
+class TestSend:
+    def test_send_events_posts_json(self, clean_env):
+        received = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            received["url"] = str(request.url)
+            received["body"] = json.loads(request.content)
+            return httpx.Response(202)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        ok = telemetry.send_events(
+            [{"event": "command"}], "https://example.com/v1/events", client=client
+        )
+        assert ok is True
+        assert received["url"] == "https://example.com/v1/events"
+        assert received["body"] == {"events": [{"event": "command"}]}
+
+    def test_send_failure_is_silent(self, clean_env):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("refused")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        ok = telemetry.send_events([{"e": 1}], "https://example.com/x", client=client)
+        assert ok is False  # no exception raised
+
+    def test_send_events_background_returns_joinable_thread(self, clean_env, monkeypatch):
+        sent = threading.Event()
+        monkeypatch.setattr(
+            telemetry, "send_events", lambda *a, **kw: sent.set() or True
+        )
+        thread = telemetry.send_events_background([{"e": 1}], "https://example.com/x")
+        thread.join(2.0)
+        assert sent.is_set()
+        assert thread.daemon is True

--- a/tests/scripts/test_telemetry_collector.py
+++ b/tests/scripts/test_telemetry_collector.py
@@ -1,0 +1,65 @@
+"""Smoke tests for scripts/telemetry_collector.py — the minimal beta collector."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def collector(tmp_path, monkeypatch):
+    """Load the collector script with an isolated log path."""
+    log_path = tmp_path / "events.jsonl"
+    monkeypatch.setenv("TELEMETRY_LOG_PATH", str(log_path))
+    spec = importlib.util.spec_from_file_location(
+        "telemetry_collector", REPO_ROOT / "scripts" / "telemetry_collector.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return TestClient(module.app), log_path
+
+
+class TestCollector:
+    def test_accepts_batch_and_appends_jsonl(self, collector):
+        client, log_path = collector
+        events = [
+            {"event": "command", "command": "init", "exit_code": 0},
+            {"event": "crash", "exception_type": "ValueError"},
+        ]
+        response = client.post("/v1/events", json={"events": events})
+        assert response.status_code == 202
+        assert response.json() == {"accepted": 2}
+
+        lines = log_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["command"] == "init"
+        # Each stored line gets a server-side received_at stamp
+        assert "received_at" in json.loads(lines[0])
+
+    def test_appends_across_requests(self, collector):
+        client, log_path = collector
+        client.post("/v1/events", json={"events": [{"event": "command"}]})
+        client.post("/v1/events", json={"events": [{"event": "command"}]})
+        assert len(log_path.read_text().strip().splitlines()) == 2
+
+    def test_rejects_malformed_body(self, collector):
+        client, _ = collector
+        assert client.post("/v1/events", json={"nope": 1}).status_code == 422
+        assert client.post("/v1/events", json={"events": "not-a-list"}).status_code == 422
+
+    def test_rejects_oversized_batch(self, collector):
+        client, log_path = collector
+        events = [{"event": "command"}] * 101
+        response = client.post("/v1/events", json={"events": events})
+        assert response.status_code == 413
+        assert not log_path.exists()
+
+    def test_healthz(self, collector):
+        client, _ = collector
+        assert client.get("/healthz").status_code == 200


### PR DESCRIPTION
## Summary
Implements #616: Launch: opt-in telemetry + crash reporting.

- **`codeframe/core/telemetry.py`** (headless): consent state at `~/.codeframe/telemetry.json` (`enabled`/`prompted`/`anonymous_id`), resolution chain `CODEFRAME_TELEMETRY` env → `DO_NOT_TRACK` → config file → **default off**; command/crash event builders; fire-and-forget httpx sender that never raises.
- **`cf config telemetry on|off|status`** — new `cf config` Typer group; `status` shows effective state and which override produced it.
- **Entry wrapper** (`codeframe/cli/telemetry_runtime.py` + `main()` in `app.py`): one-time opt-in prompt (interactive TTY only, default **No**), command timing, exit-code capture, unhandled-exception crash capture. All three entry points (`cf`/`codeframe` console scripts, `python -m codeframe`, `python -m codeframe.cli`) route through it. Exit codes and exceptions propagate unchanged.
- **Privacy hardening**: command names are resolved against the registered Typer command tree, so raw argv (paths, ids, typos) can never leak; crash reports carry only in-package traceback frames with relativized paths and **omit exception messages**.
- **Minimal backend**: `scripts/telemetry_collector.py` — self-hostable ~50-line FastAPI JSONL appender (cheapest thing that works for beta volume).
- **PRIVACY.md** (repo root, linked from README): what is/isn't collected, consent precedence, endpoint, 90-day retention, deletion path.
- Suite hermeticity: root conftest sets `CODEFRAME_TELEMETRY=off` so tests never prompt or send.

## Acceptance Criteria
- [x] Opt-in only: one-time prompt on first run, default **off**; `cf config telemetry on|off`; honored everywhere including non-interactive runs (env var)
- [x] Anonymous usage events (command name, duration, success/failure, version, OS) — no project content, no prompts, no file paths
- [x] Crash reporting: unhandled-exception reports with stack trace + version, gated behind the same opt-in
- [x] PRIVACY.md documenting exactly what is collected, where it goes, and retention
- [x] Backend minimal: self-hostable JSONL collector

## Test Plan
- [x] Unit tests written first (TDD) — 70 new tests across core/CLI/collector
- [x] Full v2 suite passing (`pytest tests/ --ignore=tests/e2e -m v2` exit 0) + ruff + mypy (191 files) clean
- [x] Diff coverage 91% on changed lines (≥85% gate)
- [x] Internal code review (advisory) completed — no Critical/Major defects
- [x] Cross-family review pass: **codex** — one P2 finding (`python -m codeframe` bypassed wrapper) fixed in a0ea9da
- [x] Test mutation sanity check: 5 mutations (default-on, message leak, argv leak, re-prompt, send-when-disabled) — all killed by tests

## Known Limitations / Intentionally Deferred
- **Handled failures carry no stack trace**: commands that catch their own exceptions and `raise typer.Exit(1)` (the common CodeFRAME pattern) produce a failed *command* event but no crash event — crash reports are for unhandled exceptions only, per the issue contract.
- **Collector is unauthenticated and unthrottled beyond a 100-event batch cap** — acceptable for beta volume per the issue ("cheapest thing that works"); add auth/rate limiting before any public scale-up.
- **Up to 1s added exit latency on opted-in commands** when the collector is slow/unreachable (bounded daemon-thread join); opted-out runs are unaffected.
- **`telemetry.codeframe.dev` default endpoint is not yet provisioned** — until it is deployed, opted-in sends fail silently (by design); self-hosters use `CODEFRAME_TELEMETRY_ENDPOINT`.
- Installed environments need a reinstall/`uv sync` for the console-script change (`:app` → `:main`) to take effect.

## Implementation Notes
- Plan was self-authored (issue had no implementation plan comment) and approved interactively before implementation.
- `DO_NOT_TRACK` is honored as an extra off-switch (console DNT convention) — explicit `CODEFRAME_TELEMETRY=on` still wins as the more specific signal.

Closes #616