### PR TITLE
docs: launch-prep — SECURITY.md, licensing clarity, beta issue templates (#617, #618)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Report something that is broken or behaving incorrectly in CodeFRAME.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the
+        details below so we can reproduce and fix it quickly.
+
+        **Security issue?** Do not file it here — use [private vulnerability
+        reporting](https://github.com/frankbria/codeframe/security) instead. See
+        [SECURITY.md](https://github.com/frankbria/codeframe/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+      placeholder: "Running `cf work start` exits with ... but I expected ..."
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: CodeFRAME version
+      description: "Output of `cf --version` (or the commit hash if running from source)."
+      placeholder: "e.g. 0.x.y or commit 670c910"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows (WSL)
+        - Windows (native)
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Execution engine
+      description: Which agent engine were you using when the bug occurred?
+      options:
+        - built-in (ReAct)
+        - claude-code
+        - codex
+        - opencode
+        - kilocode
+        - "N/A — not running an agent"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands or actions, in order, that trigger the bug.
+      placeholder: |
+        1. cf init ...
+        2. cf tasks generate
+        3. cf work start <id> --execute
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any error output or stack traces. This is automatically formatted as code, so no backticks needed. Do not paste API keys or secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💡 Feature request or idea
+    url: https://github.com/frankbria/codeframe/discussions/categories/ideas
+    about: During the beta, feature requests live in Discussions → Ideas so we can shape them together before they become issues.
+  - name: 🙋 Questions & help
+    url: https://github.com/frankbria/codeframe/discussions/categories/q-a
+    about: Ask how to do something, share setup problems, or get unstuck in Discussions → Q&A.
+  - name: 🛠️ Show & Tell
+    url: https://github.com/frankbria/codeframe/discussions/categories/show-and-tell
+    about: Show what you built with CodeFRAME.
+  - name: 👋 Coming from ralph?
+    url: https://github.com/frankbria/codeframe/discussions/categories/coming-from-ralph
+    about: Migrating from ralph-claude-code? Start here for migration help and feature conversations.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/frankbria/codeframe/security/advisories/new
+    about: Privately report a security issue. Please do not open a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,40 @@
 
 Thank you for your interest in contributing to CodeFRAME!
 
+## Beta expectations
+
+CodeFRAME is in **public beta**. The product vision — Think → Build → Prove →
+Ship — is stable, but the surface area is still moving. Knowing what's settled
+and what isn't will save you time before you open a PR.
+
+**Stable enough to build on:**
+
+- The **Golden Path CLI** (`cf init/prd/tasks/work/proof/pr`) and its core
+  modules in `codeframe/core/`.
+- The **v2 REST API** and its authentication model.
+- The PROOF9 quality system and the agent/LLM adapter interfaces.
+
+**Still in flux (expect change):**
+
+- **Web UI** surfaces and components — pages are actively being added and
+  reworked; coordinate before large UI changes.
+- Anything behind a phase that is "in progress" in
+  [`docs/PRODUCT_ROADMAP.md`](docs/PRODUCT_ROADMAP.md).
+- Database schemas and on-disk `.codeframe/` formats may change between betas.
+
+**How to propose a change:** open a thread in
+[**Discussions → Ideas**](https://github.com/frankbria/codeframe/discussions/categories/ideas)
+*before* writing code for anything non-trivial. During the beta, feature
+requests are routed to Discussions (not the issue tracker) so we can shape them
+together; the issue tracker is reserved for confirmed bugs and accepted work.
+Bug reports go through the [bug report
+template](https://github.com/frankbria/codeframe/issues/new/choose). Security
+issues follow [SECURITY.md](SECURITY.md) — never a public issue or PR.
+
+Every change must support the Think → Build → Prove → Ship pipeline. If it
+doesn't, it likely won't be merged regardless of quality — see
+[`CLAUDE.md`](CLAUDE.md) and [`docs/VISION.md`](docs/VISION.md).
+
 ## Development Setup
 
 ```bash
@@ -134,4 +168,5 @@ See `codeframe/tasks/test_runner.py` for test runner configuration.
 
 ## Questions?
 
-Open an issue or start a discussion on GitHub.
+Ask in [Discussions → Q&A](https://github.com/frankbria/codeframe/discussions/categories/q-a).
+For licensing or commercial questions, see [LICENSING.md](LICENSING.md).

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,78 @@
+# Licensing
+
+CodeFRAME is released under the [GNU Affero General Public License v3.0
+(AGPL-3.0)](LICENSE). This page explains, in plain language, what that means for
+you — and what to do if the AGPL doesn't fit your situation.
+
+> This is a practical summary, not legal advice. The [LICENSE](LICENSE) file is
+> the binding text. When in doubt, consult a lawyer.
+
+## Why AGPL-3.0
+
+CodeFRAME is **open core**: the project is fully open source, and we intend to
+keep the core that way. The AGPL is a deliberate choice. It guarantees that
+CodeFRAME — and improvements to it — stay open, including when the software is
+offered to others as a network service. This protects the community from a
+closed fork being run as a competing hosted product without giving anything
+back.
+
+## What it means for you
+
+### Individuals and teams using CodeFRAME
+
+You can **use, run, modify, and self-host** CodeFRAME for any purpose, including
+commercial work, at no cost. If you run it for yourself or your team and don't
+distribute it or offer it to outside users as a service, the AGPL asks nothing
+further of you. Use it freely.
+
+### Companies using it internally
+
+The same applies to internal company use. Running CodeFRAME on your own
+infrastructure to deliver software for your own organization is fine and creates
+no source-disclosure obligation, even if you modify it — as long as those
+modified versions are not conveyed to outside parties or exposed to outside
+users over a network.
+
+### Companies offering it to others (the AGPL trigger)
+
+The AGPL's defining clause is **Section 13**: if you run a modified version of
+CodeFRAME and let users interact with it **over a network** (for example, a
+hosted SaaS built on or embedding CodeFRAME), you must offer those users the
+**complete corresponding source code** of your modified version, under the
+AGPL. The same applies if you distribute CodeFRAME or a derivative work: the
+recipient gets the source under the AGPL.
+
+In short:
+
+| Your situation                                              | AGPL obligation                                  |
+| ----------------------------------------------------------- | ------------------------------------------------ |
+| Run it for yourself / your team, unmodified or modified     | None beyond keeping the notices                  |
+| Internal company use, not exposed to outside users          | None beyond keeping the notices                  |
+| Offer it (or a derivative) to outside users over a network  | Publish your complete source under AGPL-3.0      |
+| Distribute it or embed it in software you ship              | Recipients get source under AGPL-3.0             |
+
+## Commercial licensing and hosted offering (planned)
+
+If the AGPL's network-source-disclosure requirement doesn't work for your
+business — for example, you want to **embed CodeFRAME in a closed-source
+product** or offer a hosted service **without** publishing your modifications —
+we plan to offer:
+
+- **Commercial / OEM licenses** that release you from the AGPL's copyleft
+  obligations for embedding and redistribution.
+- A **hosted CodeFRAME** offering for teams that would rather not self-host.
+
+Pricing and terms are still being finalized, but the path exists. If you have a
+commercial need, **tell us now** — early conversations shape what we build.
+
+## Get in touch
+
+- **Commercial licensing / OEM / hosted interest:** start a thread in the
+  [**Commercial & Licensing** discussion](https://github.com/frankbria/codeframe/discussions)
+  (look for the pinned *Early access & commercial interest* post) so we can
+  follow up. This is the capture point for launch — even before pricing is
+  published.
+- **Design partners & early access:** the same pinned discussion is where we
+  collect early-access signups. Reply there to be included.
+
+We read every one.

--- a/README.md
+++ b/README.md
@@ -395,11 +395,24 @@ cd web-ui && npm run build             # Production build verification
 
 Code standards: PEP 8, `ruff` for linting, type hints required, 85%+ test coverage.
 
+During the beta, feature ideas go to [Discussions -> Ideas](https://github.com/frankbria/codeframe/discussions/categories/ideas) before code. See [CONTRIBUTING.md](CONTRIBUTING.md) for what's stable, what isn't, and how to propose changes.
+
+---
+
+## Security, licensing & support
+
+CodeFRAME is in **public beta**.
+
+- **Security:** found a vulnerability? Report it privately via [GitHub private vulnerability reporting](https://github.com/frankbria/codeframe/security/advisories/new) -- never a public issue. See [SECURITY.md](SECURITY.md) for scope and response expectations.
+- **Licensing:** CodeFRAME is [AGPL-3.0](LICENSE), an open-core stance. [LICENSING.md](LICENSING.md) explains what that means for individuals, internal company use, and embedding -- and how to reach us about **commercial licensing or a hosted offering** (both planned).
+- **Early access / design partners:** we're capturing early-access interest in a pinned [Discussion](https://github.com/frankbria/codeframe/discussions). Reply there to be included.
+- **Help & community:** [Discussions -> Q&A](https://github.com/frankbria/codeframe/discussions/categories/q-a) for questions, [Ideas](https://github.com/frankbria/codeframe/discussions/categories/ideas) for feature requests, and [bug reports](https://github.com/frankbria/codeframe/issues/new/choose) for confirmed bugs.
+
 ---
 
 ## License
 
-[AGPL-3.0](LICENSE) -- Free to use, modify, and distribute. Derivative works and network services must release source code under the same license.
+[AGPL-3.0](LICENSE) -- Free to use, modify, and distribute. Derivative works and network services must release source code under the same license. See [LICENSING.md](LICENSING.md) for a plain-language explanation and commercial options.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy
+
+CodeFRAME is in public beta. We take security seriously and appreciate reports
+that help us protect users before and during launch.
+
+## Supported versions
+
+During the beta, only the latest release on the `main` branch receives security
+fixes. Pin to a tagged release for stability, but report against the most recent
+version when you can — older betas are not patched individually.
+
+| Version            | Supported          |
+| ------------------ | ------------------ |
+| `main` (latest)    | :white_check_mark: |
+| Older beta builds  | :x:                |
+
+## Reporting a vulnerability
+
+**Do not open a public issue, discussion, or pull request for security
+problems.** Public disclosure before a fix is available puts every user at risk.
+
+Report privately through GitHub's private vulnerability reporting:
+
+1. Go to the [**Security** tab](https://github.com/frankbria/codeframe/security)
+   of this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the advisory form with as much detail as you can (see below).
+
+This opens a private channel visible only to the maintainers. If you cannot use
+GitHub's private reporting for any reason, open a regular issue titled
+**"Security — request a private channel"** with **no technical details** and a
+maintainer will follow up privately.
+
+### What to include
+
+- A description of the vulnerability and its impact.
+- The CodeFRAME version or commit, your OS, and the execution engine in use
+  (`claude-code`, `codex`, `opencode`, or the built-in ReAct agent).
+- Step-by-step reproduction, including any configuration, environment variables,
+  or sample input required.
+- Proof-of-concept code or screenshots where applicable.
+
+### Response expectations
+
+- **Acknowledgement within 3 business days** of your report.
+- A first assessment (severity, whether we can reproduce it, and likely next
+  steps) **within 7 business days**.
+- Regular updates at least every 7 days until the issue is resolved.
+- We will coordinate a disclosure timeline with you and credit you in the
+  advisory unless you ask us not to.
+
+## Scope
+
+In scope: the CodeFRAME CLI, core orchestration, the FastAPI server, the web UI,
+and the LLM/agent adapters in this repository.
+
+Out of scope: vulnerabilities in upstream coding agents (Claude Code, Codex,
+OpenCode, Kilocode) or third-party LLM providers — please report those to their
+respective maintainers. Issues that require a user to run an untrusted PRD,
+task, or repository are expected behavior for an agent that executes code on
+your behalf; sandbox-escape findings, however, are in scope.
+
+## Handling secrets
+
+Never include API keys, tokens, or other credentials in a report. CodeFRAME
+stores provider keys via the machine-wide credential manager and never returns
+them in API responses; if you believe a key is being leaked, say so without
+pasting the key itself.


### PR DESCRIPTION
Launch-prep documentation for the public beta. Combines #617 (security + support channels + issue templates) and #618 (licensing clarity + early-access capture) since they share `README.md` and both depend on Discussions.

## What's in the diff
| File | Purpose |
|---|---|
| `SECURITY.md` | Private vulnerability reporting path, response expectations (3-day ack / 7-day assessment), beta supported-versions, scope, secret-handling note |
| `LICENSING.md` | Plain-language AGPL-3.0 for individuals / internal company use / embedding; commercial + hosted offering planned; contact route |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Bug form: version, OS, **engine** (claude-code/codex/opencode/kilocode/built-in), repro, logs |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues; routes feature ideas → Discussions/Ideas, plus Q&A, Show & Tell, Coming from ralph, and security → private advisories |
| `CONTRIBUTING.md` | "Beta expectations" — what's stable (Golden Path/CLI/v2 API/PROOF9) vs in flux (web UI), propose changes via Discussions |
| `README.md` | New "Security, licensing & support" section linking all of the above + early-access |

## Repo settings already applied (out of band, via gh API)
- ✅ **Private vulnerability reporting** enabled (`private_vulnerability_reporting.enabled = true`)
- ✅ **Discussions** enabled (`has_discussions = true`) — default categories created: Q&A, Ideas, Show and tell

## Manual follow-ups before announcing (no clean API — maintainer action)
GitHub provides no API to create Discussion categories or pin Discussions, so these are by hand:

- [ ] Create the **"Coming from ralph"** Discussion category. Name it exactly `Coming from ralph` so it auto-slugs to `coming-from-ralph`, matching the link in `config.yml` and the ralph announcement routing.
- [ ] Create and **pin** an **"Early access & commercial interest"** Discussion (Announcements or General). This is the contact path referenced by `LICENSING.md` and the README early-access link — it must exist before any announcement traffic arrives (#618 acceptance criterion).

Until those two are done, the `config.yml` "Coming from ralph" link and the README "pinned Discussion" link will 404. Everything else is live.

## Acceptance criteria
**#617**
- [x] SECURITY.md with private reporting path + response-expectation statement (private vuln reporting enabled)
- [x] Discussions enabled; Q&A / Ideas / Show & Tell exist; "Coming from ralph" = manual checklist above
- [x] Issue templates: bug report (version, OS, engine, repro) + feature request routed to Discussions/Ideas
- [x] CONTRIBUTING.md refreshed with beta expectations

**#618**
- [x] LICENSING.md: AGPL explained for individuals/internal/embedding; commercial + hosted planned; contact path
- [x] Early-access capture path defined (pinned Discussion) — creation/pinning is the manual checklist above
- [x] README links both

## Verification
- All issue-template YAML parses; bug form contains version/os/engine/repro fields (asserted).
- All internal doc links resolve to existing files.
- `uv run ruff check .` passes (no Python touched).
- Repo settings re-queried after applying: both confirmed on.

## Decisions
- **No public email**: per maintainer choice, security uses GitHub private reporting only; commercial/early-access routes to the pinned Discussion. No personal address exposed.

Closes #617
Closes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security policy for vulnerability reporting procedures
  * Clarified AGPL-3.0 licensing terms and commercial/hosted offering details
  * Enhanced contribution guidelines with beta stability expectations and GitHub Discussions routing

* **Chores**
  * Configured issue templates to streamline bug reporting and user support workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->