### PR TITLE
docs: add codeframe.sh contact aliases to launch docs

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -67,12 +67,12 @@ commercial need, **tell us now** — early conversations shape what we build.
 
 ## Get in touch
 
-- **Commercial licensing / OEM / hosted interest:** start a thread in the
-  [**Commercial & Licensing** discussion](https://github.com/frankbria/codeframe/discussions)
-  (look for the pinned *Early access & commercial interest* post) so we can
-  follow up. This is the capture point for launch — even before pricing is
-  published.
-- **Design partners & early access:** the same pinned discussion is where we
-  collect early-access signups. Reply there to be included.
+- **Commercial licensing / OEM / hosted interest:** email
+  **licensing@codeframe.sh**, or start a thread in the pinned *Early access &
+  commercial interest* [discussion](https://github.com/frankbria/codeframe/discussions)
+  if you'd rather do it in the open. This is the capture point for launch —
+  even before pricing is published.
+- **Design partners & early access:** email **hello@codeframe.sh** or reply to
+  the same pinned discussion to be included.
 
 We read every one.

--- a/README.md
+++ b/README.md
@@ -403,9 +403,9 @@ During the beta, feature ideas go to [Discussions -> Ideas](https://github.com/f
 
 CodeFRAME is in **public beta**.
 
-- **Security:** found a vulnerability? Report it privately via [GitHub private vulnerability reporting](https://github.com/frankbria/codeframe/security/advisories/new) -- never a public issue. See [SECURITY.md](SECURITY.md) for scope and response expectations.
-- **Licensing:** CodeFRAME is [AGPL-3.0](LICENSE), an open-core stance. [LICENSING.md](LICENSING.md) explains what that means for individuals, internal company use, and embedding -- and how to reach us about **commercial licensing or a hosted offering** (both planned).
-- **Early access / design partners:** we're capturing early-access interest in a pinned [Discussion](https://github.com/frankbria/codeframe/discussions). Reply there to be included.
+- **Security:** found a vulnerability? Report it privately via [GitHub private vulnerability reporting](https://github.com/frankbria/codeframe/security/advisories/new) (or `security@codeframe.sh`) -- never a public issue. See [SECURITY.md](SECURITY.md) for scope and response expectations.
+- **Licensing:** CodeFRAME is [AGPL-3.0](LICENSE), an open-core stance. [LICENSING.md](LICENSING.md) explains what that means for individuals, internal company use, and embedding -- and how to reach us about **commercial licensing or a hosted offering** (both planned). Commercial inquiries: `licensing@codeframe.sh`.
+- **Early access / design partners:** email `hello@codeframe.sh` or reply to the pinned [Discussion](https://github.com/frankbria/codeframe/discussions) to be included.
 - **Help & community:** [Discussions -> Q&A](https://github.com/frankbria/codeframe/discussions/categories/q-a) for questions, [Ideas](https://github.com/frankbria/codeframe/discussions/categories/ideas) for feature requests, and [bug reports](https://github.com/frankbria/codeframe/issues/new/choose) for confirmed bugs.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,9 @@ Report privately through GitHub's private vulnerability reporting:
 3. Fill in the advisory form with as much detail as you can (see below).
 
 This opens a private channel visible only to the maintainers. If you cannot use
-GitHub's private reporting for any reason, open a regular issue titled
-**"Security — request a private channel"** with **no technical details** and a
-maintainer will follow up privately.
+GitHub's private reporting for any reason, email **security@codeframe.sh** and a
+maintainer will follow up privately. GitHub private reporting is preferred — it
+keeps the full disclosure in one secure place.
 
 ### What to include
 


### PR DESCRIPTION
Follow-up to #622. Now that `codeframe.sh` mail forwarding is live, wires direct contact aliases into the launch docs so commercial and early-access leads aren't forced to negotiate in a public Discussion thread.

## Changes
- **SECURITY.md** — `security@codeframe.sh` as the non-GitHub fallback. GitHub private vulnerability reporting stays the **preferred** path (single secure place for full disclosure).
- **LICENSING.md** — `licensing@codeframe.sh` (commercial / OEM / hosted) and `hello@codeframe.sh` (design partners / early access). The pinned *Early access & commercial interest* Discussion is kept as the open-in-public alternative.
- **README.md** — same aliases surfaced in the "Security, licensing & support" section.

All three aliases forward to the maintainer's inbox.

## Not changed
- Security reporting **channel** is unchanged — GitHub private reporting remains primary; email is only a fallback.
- No website link added yet (no landing page at codeframe.sh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated licensing documentation with explicit email contacts for commercial licensing, OEM inquiries, and hosted deployment options
  * Added direct email contact for design partner and early access program requests
  * Enhanced security vulnerability reporting with an alternative email channel when GitHub private reporting is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->