### PR TITLE
feat: v0.9.1 — silence CLI AUTH_SECRET warning, add cf --version, trademark policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-13
+
+### Added
+- `cf --version` / `cf -V` prints the installed version. (Note: with `uv tool install`, check the version via `uv tool list` or `cf --version` — the package is isolated, so a system Python's `importlib.metadata` will not see it.)
+- `TRADEMARKS.md` — trademark policy clarifying that the AGPL covers the code, while the CodeFRAME name and logo are reserved trademarks (a fork may use the code but must rename).
+
+### Fixed
+- The default-`AUTH_SECRET` warning no longer prints on every `cf` command. It was emitted at import time and leaked onto the CLI (which never uses auth); the check now lives only in server startup validation, which still warns in self-hosted mode and fails hard in hosted mode.
+
+### Changed
+- README marks the CodeFRAME™ trademark and links the new policy; `LICENSING.md` notes the code/brand boundary.
+
 ## [0.9.0] - 2026-06-12
 
 First public beta and the first release published to PyPI as
@@ -28,5 +40,6 @@ name claim is being pursued in parallel. The CLI entry point remains `cf`.
 - Version bumped from a placeholder `0.1.0` to an honest beta `0.9.0`; development status classifier moved to `4 - Beta`.
 - README installation section now leads with `uv tool install` instead of git-clone; status badge updated to **beta** with a stability statement.
 
-[Unreleased]: https://github.com/frankbria/codeframe/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/frankbria/codeframe/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/frankbria/codeframe/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/frankbria/codeframe/releases/tag/v0.9.0

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -7,6 +7,11 @@ you — and what to do if the AGPL doesn't fit your situation.
 > This is a practical summary, not legal advice. The [LICENSE](LICENSE) file is
 > the binding text. When in doubt, consult a lawyer.
 
+> **Code vs. brand.** AGPL-3.0 licenses the **code**. It does **not** grant any
+> right to the **CodeFRAME™ name or logo**, which are trademarks covered
+> separately — see [TRADEMARKS.md](TRADEMARKS.md). You can fork the code under
+> the AGPL, but a fork must use a different name.
+
 ## Why AGPL-3.0
 
 CodeFRAME is **open core**: the project is fully open source, and we intend to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![CodeFRAME Header](./codeframe_github_header_1600x500.png)
 
-# CodeFRAME
+# CodeFRAME™
 
 ![Status](https://img.shields.io/badge/status-beta-orange)
 [![PyPI](https://img.shields.io/pypi/v/codeframe-ai)](https://pypi.org/project/codeframe-ai/)
@@ -428,6 +428,7 @@ CodeFRAME is in **public beta**.
 
 - **Security:** found a vulnerability? Report it privately via [GitHub private vulnerability reporting](https://github.com/frankbria/codeframe/security/advisories/new) (or `security@codeframe.sh`) -- never a public issue. See [SECURITY.md](SECURITY.md) for scope and response expectations.
 - **Licensing:** CodeFRAME is [AGPL-3.0](LICENSE), an open-core stance. [LICENSING.md](LICENSING.md) explains what that means for individuals, internal company use, and embedding -- and how to reach us about **commercial licensing or a hosted offering** (both planned). Commercial inquiries: `licensing@codeframe.sh`.
+- **Trademark:** the code is AGPL-3.0, but the **CodeFRAME name and logo are trademarks** and are *not* covered by the code license. See [TRADEMARKS.md](TRADEMARKS.md) before using the name for a fork or product.
 - **Early access / design partners:** email `hello@codeframe.sh` or reply to the pinned [Discussion](https://github.com/frankbria/codeframe/discussions) to be included.
 - **Help & community:** [Discussions -> Q&A](https://github.com/frankbria/codeframe/discussions/categories/q-a) for questions, [Ideas](https://github.com/frankbria/codeframe/discussions/categories/ideas) for feature requests, and [bug reports](https://github.com/frankbria/codeframe/issues/new/choose) for confirmed bugs.
 
@@ -437,8 +438,12 @@ CodeFRAME is in **public beta**.
 
 [AGPL-3.0](LICENSE) -- Free to use, modify, and distribute. Derivative works and network services must release source code under the same license. See [LICENSING.md](LICENSING.md) for a plain-language explanation and commercial options.
 
+The code is AGPL-3.0; the **CodeFRAME™ name and logo are trademarks** of Noatak Enterprises, LLC, dba Bria Strategy Group, and are not licensed under the AGPL -- see [TRADEMARKS.md](TRADEMARKS.md).
+
 ---
 
 **Built by [Frank Bria](https://x.com/FrankBria18044)**
 
 [Issues](https://github.com/frankbria/codeframe/issues) | [Discussions](https://github.com/frankbria/codeframe/discussions) | [Documentation](https://github.com/frankbria/codeframe/tree/main/docs)
+
+_CodeFRAME™ is a trademark of Noatak Enterprises, LLC, dba Bria Strategy Group. All rights reserved._

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,64 @@
+# CodeFRAME Trademark Policy
+
+> This policy explains how you may and may not use the CodeFRAME name and logo.
+> It is intentionally conservative and is **not legal advice**; it may be revised
+> as the trademark application progresses.
+
+## Ownership
+
+**CodeFRAME™** and the CodeFRAME logo are trademarks of **Noatak Enterprises,
+LLC, dba Bria Strategy Group** ("the owner"). A U.S. trademark application for
+the CodeFRAME mark is pending. All rights are reserved.
+
+The ™ symbol is used because the mark is not yet federally registered; it will
+be updated to ® if and when registration issues.
+
+## The code license does not grant trademark rights
+
+CodeFRAME's source code is licensed under [AGPL-3.0](LICENSE) (see
+[LICENSING.md](LICENSING.md)). **That license covers copyright in the code only.
+It does not grant any right to use the CodeFRAME name or logo.** This is the
+standard position for open-source licenses, which deliberately exclude
+trademarks.
+
+In other words: you are free to use, modify, and redistribute the *code* under
+the AGPL — but the *name and logo* are not part of that grant.
+
+## What you may do (no permission needed)
+
+- **Refer to CodeFRAME truthfully** ("nominative use") — e.g., "compatible with
+  CodeFRAME", "a plugin for CodeFRAME", "built on CodeFRAME" — provided you do
+  not imply that the owner endorses, sponsors, or is affiliated with your
+  project.
+- **State that your fork is derived from CodeFRAME**, as long as the fork is
+  clearly named something else (see below).
+- Use the name in **blog posts, talks, tutorials, and reviews** that discuss the
+  software.
+
+## What requires written permission
+
+- Using **"CodeFRAME" (or a confusingly similar name) as the name of your own**
+  product, service, company, fork, or distribution.
+- Using the **CodeFRAME logo** other than to refer to the unmodified project.
+- Any use that **suggests affiliation, sponsorship, or endorsement** by the
+  owner, or that could confuse users about the source of the software.
+- Use on **merchandise** or in **domain names**, social handles, or app-store
+  listings.
+
+If you maintain a fork, please give it a distinct name and may say, for example,
+"based on CodeFRAME" — but do not call the fork itself "CodeFRAME".
+
+## Using the mark correctly
+
+- Write it as **CodeFRAME** and include the ™ symbol on first or most prominent
+  use: **CodeFRAME™**.
+- Use it as an adjective modifying a noun ("the CodeFRAME platform"), not as a
+  verb or a generic noun.
+- `codeframe-ai` (the PyPI package) and `cf` (the command) are technical
+  identifiers, not the brand.
+
+## Requesting permission
+
+For any use that requires permission, or if you are unsure, contact
+**licensing@codeframe.sh** describing the intended use. We are generally happy to
+allow community uses that don't create confusion.

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -27,12 +27,11 @@ JWT_ALGORITHM = "HS256"
 JWT_AUDIENCE = ["fastapi-users:auth"]
 JWT_LIFETIME_SECONDS = int(os.getenv("JWT_LIFETIME_SECONDS", "604800"))  # 7 days
 
-# Warn if using default secret (but allow for development)
-if SECRET == DEFAULT_SECRET:
-    logger.warning(
-        "⚠️  AUTH_SECRET not set - using default value. "
-        "DO NOT USE IN PRODUCTION! Set AUTH_SECRET environment variable."
-    )
+# NOTE: The default-secret warning is intentionally NOT emitted at import time.
+# Importing this module must stay silent so it never leaks onto the CLI (the
+# Golden Path never uses auth). The check that matters runs when the server
+# actually starts — see codeframe/ui/server.py:_validate_security_config(),
+# which warns in self-hosted mode and fails hard in hosted mode.
 
 # Create async SQLAlchemy engine for auth
 # Uses aiosqlite driver for async SQLite access

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -54,6 +54,36 @@ app = typer.Typer(
 console = Console()
 
 
+def _get_version() -> str:
+    """Resolve the installed CodeFRAME version, falling back gracefully."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("codeframe-ai")
+    except PackageNotFoundError:  # running from an uninstalled source tree
+        return "0.0.0+unknown"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"codeframe {_get_version()}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _root(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-V",
+        help="Show the CodeFRAME version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """CodeFRAME: Autonomous coding agent orchestration (v2 CLI)."""
+
+
 # =============================================================================
 # Root-level commands (per GOLDEN_PATH.md)
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeframe-ai"
-version = "0.9.0"
+version = "0.9.1"
 description = "A project delivery system that orchestrates frontier coding agents: Think, Build, Prove, Ship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/auth/test_import_is_quiet.py
+++ b/tests/auth/test_import_is_quiet.py
@@ -1,0 +1,54 @@
+"""Regression: importing auth must not warn, and the CLI must stay quiet.
+
+The default-AUTH_SECRET warning used to fire at *import* time in
+``codeframe.auth.manager``. Because Python's last-resort logging handler prints
+WARNING records to stderr, that leaked onto every ``cf`` command (the Golden
+Path never uses auth). The warning now lives only in the server's startup
+validation. These tests pin that behavior.
+"""
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+def test_importing_auth_manager_emits_no_warning():
+    """A fresh interpreter importing auth.manager prints nothing to stderr."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import codeframe.auth.manager"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "AUTH_SECRET" not in result.stderr
+    assert "DO NOT USE IN PRODUCTION" not in result.stderr
+
+
+def test_server_validation_still_raises_in_hosted_mode(monkeypatch):
+    """The check that matters did not disappear — hosted + default secret fails."""
+    import codeframe.auth.manager as manager
+    from codeframe.ui.server import _validate_security_config
+
+    monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+    monkeypatch.setattr(manager, "SECRET", manager.DEFAULT_SECRET)
+
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        _validate_security_config()
+
+
+def test_server_validation_warns_but_allows_in_self_hosted_mode(monkeypatch, caplog):
+    """Self-hosted + default secret is allowed, with a warning at startup."""
+    import logging
+
+    import codeframe.auth.manager as manager
+    from codeframe.ui.server import _validate_security_config
+
+    monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+    monkeypatch.setattr(manager, "SECRET", manager.DEFAULT_SECRET)
+
+    with caplog.at_level(logging.WARNING):
+        _validate_security_config()  # must not raise
+
+    assert any("default AUTH_SECRET" in r.message for r in caplog.records)

--- a/tests/cli/test_version_flag.py
+++ b/tests/cli/test_version_flag.py
@@ -1,0 +1,20 @@
+"""`cf --version` / `cf -V` print the version and exit cleanly."""
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.app import app
+
+pytestmark = pytest.mark.v2
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize("flag", ["--version", "-V"])
+def test_version_flag_prints_version_and_exits(flag):
+    result = runner.invoke(app, [flag])
+    assert result.exit_code == 0
+    assert "codeframe" in result.stdout
+    # A semver-ish token must be present (e.g. 0.9.1 or 0.0.0+unknown).
+    assert re.search(r"\d+\.\d+\.\d+", result.stdout)

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "codeframe-ai"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bundles the follow-ups that surfaced after the v0.9.0 publish into a single v0.9.1. **Refs #613** (does not close it — PyPI go-live for 0.9.1 is the tag push).

## Fixes
**The `AUTH_SECRET not set` warning on every `cf` command.** It was a module-level side effect in `codeframe/auth/manager.py` that ran at *import*; Python's last-resort logging handler then printed it to stderr, so it leaked onto the CLI even though the Golden Path never uses auth. Removed the import-time warning. The check that matters is untouched: `ui/server.py:_validate_security_config()` (called at startup) still **warns in self-hosted mode and raises in hosted mode**. Covered by a new regression test (fresh-interpreter import is silent; hosted-mode still raises; self-hosted still warns).

## Added
- **`cf --version` / `cf -V`** — resolves the installed version from package metadata via a root Typer callback. This also fixes the verification confusion: with `uv tool install`, the package is isolated, so a *system* Python's `importlib.metadata.version('codeframe-ai')` raises `PackageNotFoundError` (expected, not a bug). Use `cf --version` or `uv tool list`.
- **`TRADEMARKS.md`** — trademark policy. The AGPL covers the **code**; the **CodeFRAME™ name and logo** are trademarks of **Noatak Enterprises, LLC, dba Bria Strategy Group**, reserved separately. Permits nominative use ("works with CodeFRAME"); requires permission to name a fork/product "CodeFRAME". Uses ™ (mark is pending, not yet registered — ® would be improper now). Conservative language, **flagged for your attorney's review**.

## Changed
- README: ™ on the header and a footer trademark notice; a "Trademark" bullet + cross-link. `LICENSING.md`: a code-vs-brand callout linking the policy.
- Version `0.9.0 → 0.9.1`; `CHANGELOG.md` updated.

## Verification
- New tests: `tests/auth/test_import_is_quiet.py`, `tests/cli/test_version_flag.py` — pass.
- Full `tests/cli/` + `tests/auth/`: **494 passed, 9 skipped** (serve stubs) — the new root callback doesn't disturb existing commands.
- `uv build` → `0.9.1`; `cf --version` → `codeframe 0.9.1`; wheel still complete (24 packages); `cf --help` shows **zero** AUTH_SECRET lines.
- `ruff check` clean.

## After merge (you)
Tag `v0.9.1` to publish: `git tag -a v0.9.1 -m "CodeFRAME 0.9.1" && git push origin v0.9.1` → the release workflow builds, publishes to PyPI (trusted publishing is already set up), and cuts the GitHub Release. ™ → ® swap is a future change once registration issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--version` / `-V` CLI flag to display installed version
  * Introduced CodeFRAME™ trademark policy documentation

* **Bug Fixes**
  * Resolved default `AUTH_SECRET` warnings appearing in CLI output

* **Documentation**
  * Added trademark usage guidelines and licensing clarifications
  * Updated README and licensing documents with trademark attribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->