### PR TITLE
fix(security): hard-fail on default AUTH_SECRET whenever auth is enabled (#643)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,9 +92,14 @@ OPENAI_API_KEY=sk-...
 # Authentication (fastapi-users)
 # ============================================================================
 
-# Secret key for JWT token signing (REQUIRED in production)
+# Secret key for JWT token signing (REQUIRED whenever auth is enabled).
+# Auth is ON by default, so the server REFUSES TO START with the built-in
+# default secret — set a strong random value before running `codeframe serve`.
 # Generate with: openssl rand -hex 32
-AUTH_SECRET=CHANGE-ME-IN-PRODUCTION
+# AUTH_SECRET=
+# Local-dev escape hatch only: set to 1 to start with the forgeable default
+# secret (never expose such a server). Prefer setting a real AUTH_SECRET.
+# CODEFRAME_ALLOW_INSECURE_SECRET=0
 
 # JWT token lifetime in seconds (default: 7 days)
 # JWT_LIFETIME_SECONDS=604800

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,6 +339,10 @@ jobs:
           DATABASE_PATH: ${{ github.workspace }}/.codeframe/state.db
           WORKSPACE_ROOT: ${{ github.workspace }}
           CODEFRAME_DEPLOYMENT_MODE: self_hosted
+          # Auth is ON by default and the server refuses to start on the default
+          # JWT secret (issue #643); supply a throwaway test secret so startup
+          # succeeds. Not a real credential — CI/E2E only.
+          AUTH_SECRET: ci-e2e-test-secret-not-a-real-credential
         run: |
           source .venv/bin/activate
           python -m uvicorn codeframe.ui.server:app --port 8080 > /tmp/server.log 2>&1 &

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -21,6 +21,21 @@ logger = logging.getLogger(__name__)
 DEFAULT_SECRET = "CHANGE-ME-IN-PRODUCTION"
 SECRET = os.getenv("AUTH_SECRET", DEFAULT_SECRET)
 
+
+def refresh_secret() -> str:
+    """Re-read ``AUTH_SECRET`` from the environment and update the module global.
+
+    ``SECRET`` is captured at import time, which happens before the server
+    lifespan loads ``.env`` (the auth router is imported while the app module is
+    imported via ``uvicorn codeframe.ui.server:app``). Call this after the
+    environment is loaded so JWT signing (``get_jwt_strategy`` reads the live
+    global), JWT verification, and the WS token decoders all use the configured
+    secret instead of the default. Returns the refreshed secret.
+    """
+    global SECRET
+    SECRET = os.getenv("AUTH_SECRET", DEFAULT_SECRET)
+    return SECRET
+
 # JWT configuration constants
 # These must match the JWTStrategy defaults from FastAPI Users
 JWT_ALGORITHM = "HS256"

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -34,6 +34,12 @@ def _read_auth_secret() -> str:
     value = os.getenv("AUTH_SECRET")
     if value is None or not value.strip():
         return DEFAULT_SECRET
+    # A whitespace-padded copy of the known default (e.g. an accidental
+    # "CHANGE-ME-IN-PRODUCTION " paste) is just as guessable, so normalize it
+    # back to the sentinel and let the startup guard catch it. Genuinely custom
+    # secrets are returned verbatim (their exact bytes are used for signing).
+    if value.strip() == DEFAULT_SECRET:
+        return DEFAULT_SECRET
     return value
 
 

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -19,7 +19,25 @@ logger = logging.getLogger(__name__)
 
 # Get configuration from environment
 DEFAULT_SECRET = "CHANGE-ME-IN-PRODUCTION"
-SECRET = os.getenv("AUTH_SECRET", DEFAULT_SECRET)
+
+
+def _read_auth_secret() -> str:
+    """Read ``AUTH_SECRET`` from the env, treating blank/whitespace as unset.
+
+    ``AUTH_SECRET=`` (empty) or a whitespace-only value would otherwise be a
+    distinct-from-default string and slip past the startup guard as a "custom"
+    secret — yet a blank HMAC key is just as forgeable as the known default. So
+    empty/whitespace values fall back to ``DEFAULT_SECRET`` and into the same
+    hard-fail path (issue #643). A real secret is returned verbatim (not
+    stripped) so the operator's exact value is used for signing.
+    """
+    value = os.getenv("AUTH_SECRET")
+    if value is None or not value.strip():
+        return DEFAULT_SECRET
+    return value
+
+
+SECRET = _read_auth_secret()
 
 
 def refresh_secret() -> str:
@@ -30,10 +48,14 @@ def refresh_secret() -> str:
     imported via ``uvicorn codeframe.ui.server:app``). Call this after the
     environment is loaded so JWT signing (``get_jwt_strategy`` reads the live
     global), JWT verification, and the WS token decoders all use the configured
-    secret instead of the default. Returns the refreshed secret.
+    secret instead of the default. Also keeps the fastapi-users password-reset /
+    email-verify token secrets in sync in case those routers are re-enabled.
+    Returns the refreshed secret.
     """
     global SECRET
-    SECRET = os.getenv("AUTH_SECRET", DEFAULT_SECRET)
+    SECRET = _read_auth_secret()
+    UserManager.reset_password_token_secret = SECRET
+    UserManager.verification_token_secret = SECRET
     return SECRET
 
 # JWT configuration constants

--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -40,7 +40,8 @@ import jwt as pyjwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from sqlalchemy import select
 
-from codeframe.auth.manager import SECRET, JWT_ALGORITHM, JWT_AUDIENCE, get_async_session_maker
+from codeframe.auth import manager
+from codeframe.auth.manager import JWT_ALGORITHM, JWT_AUDIENCE, get_async_session_maker
 from codeframe.auth.models import User
 from codeframe.core.adapters.streaming_chat import StreamingChatAdapter
 from codeframe.ui.shared import session_chat_manager
@@ -63,7 +64,9 @@ async def _authenticate_websocket(websocket: WebSocket) -> Optional[int]:
         return None
 
     try:
-        payload = pyjwt.decode(token, SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE)
+        # Read manager.SECRET live: it may be refreshed from .env at server
+        # startup (after import), so binding the value at import would stale it.
+        payload = pyjwt.decode(token, manager.SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE)
         user_id_str = payload.get("sub")
         if not user_id_str:
             await websocket.close(code=1008, reason="Invalid token: missing subject")

--- a/codeframe/ui/routers/terminal_ws.py
+++ b/codeframe/ui/routers/terminal_ws.py
@@ -25,7 +25,8 @@ import jwt as pyjwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from sqlalchemy import select
 
-from codeframe.auth.manager import SECRET, JWT_ALGORITHM, JWT_AUDIENCE, get_async_session_maker
+from codeframe.auth import manager
+from codeframe.auth.manager import JWT_ALGORITHM, JWT_AUDIENCE, get_async_session_maker
 from codeframe.auth.models import User
 
 logger = logging.getLogger(__name__)
@@ -50,7 +51,9 @@ async def _authenticate_websocket(websocket: WebSocket) -> int | None:
         return None
 
     try:
-        payload = pyjwt.decode(token, SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE)
+        # Read manager.SECRET live: it may be refreshed from .env at server
+        # startup (after import), so binding the value at import would stale it.
+        payload = pyjwt.decode(token, manager.SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE)
         user_id_str = payload.get("sub")
         if not user_id_str:
             await websocket.close(code=4001, reason="Invalid token: missing subject")

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -160,8 +160,7 @@ def _validate_security_config():
             "🚨 SECURITY: AUTH_SECRET must be set when authentication is enabled. "
             "The default secret lets anyone forge a valid JWT and bypass auth. "
             "Set AUTH_SECRET to a secure random value (e.g. `openssl rand -hex 32`), "
-            "or set CODEFRAME_AUTH_REQUIRED=false / CODEFRAME_ALLOW_INSECURE_SECRET=1 "
-            "for local development only."
+            "or set CODEFRAME_ALLOW_INSECURE_SECRET=1 for local development only."
         )
 
     # Auth disabled: the secret is not used to enforce access, so a default is

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -179,6 +179,14 @@ async def lifespan(app: FastAPI):
     from codeframe.core.config import load_environment
     load_environment()
 
+    # The auth manager captured SECRET at import time, before .env was loaded
+    # (the app module is imported by uvicorn before this lifespan runs). Refresh
+    # it from the now-loaded environment so a `.env`-only AUTH_SECRET is honored
+    # by signing, verification, and the WS decoders — and so the guard below
+    # validates the real configured secret, not a stale default (issue #643).
+    from codeframe.auth.manager import refresh_secret
+    refresh_secret()
+
     # Validate security configuration before starting
     _validate_security_config()
 

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -100,31 +100,76 @@ logger = logging.getLogger(__name__)
 # If session management is needed, implement in v2 core modules
 
 
+def _allow_insecure_secret() -> bool:
+    """Whether the local-dev escape hatch for the default JWT secret is set.
+
+    Controlled by ``CODEFRAME_ALLOW_INSECURE_SECRET`` (default OFF). Truthy
+    values (case-insensitive): ``1``, ``true``, ``yes``, ``on``. This hatch is
+    for local development only and is **never** honored in hosted mode.
+    """
+    value = os.getenv("CODEFRAME_ALLOW_INSECURE_SECRET")
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _validate_security_config():
     """Validate security configuration at startup.
 
+    Refuses to start whenever the JWT secret is still the publicly-known default
+    AND auth would actually be enforced — otherwise anyone can forge a valid JWT
+    and bypass auth on every v2/WS/SSE route (issue #643). A local-dev escape
+    hatch (``CODEFRAME_ALLOW_INSECURE_SECRET``) is honored only in self-hosted
+    mode; hosted mode always fails on the default secret.
+
     Raises:
-        RuntimeError: If security configuration is invalid for the deployment mode
+        RuntimeError: If auth is enabled (or hosted mode) while the default
+            secret is in use and no escape hatch applies.
     """
     from codeframe.auth.manager import SECRET, DEFAULT_SECRET
+    from codeframe.auth.dependencies import auth_required
+
+    if SECRET != DEFAULT_SECRET:
+        logger.info("🔐 AUTH_SECRET configured (custom secret in use)")
+        return
 
     deployment_mode = get_deployment_mode()
 
-    # In hosted mode, fail fast if using default JWT secret
-    if deployment_mode == DeploymentMode.HOSTED and SECRET == DEFAULT_SECRET:
+    # Hosted/production mode: never tolerate the default secret. The dev escape
+    # hatch is intentionally NOT honored here.
+    if deployment_mode == DeploymentMode.HOSTED:
         raise RuntimeError(
             "🚨 SECURITY: AUTH_SECRET must be set in hosted/production mode. "
             "Using the default secret compromises all JWT tokens. "
-            "Set the AUTH_SECRET environment variable to a secure random value."
+            "Set the AUTH_SECRET environment variable to a secure random value "
+            "(e.g. `openssl rand -hex 32`)."
         )
 
-    # Log security status
-    if SECRET == DEFAULT_SECRET:
-        logger.warning(
-            "⚠️  Running with default AUTH_SECRET - acceptable for self-hosted development only"
+    # Self-hosted with auth enabled: forging a JWT is trivial with the known
+    # default secret, so refuse to start unless the operator has explicitly
+    # opted into the insecure local-dev escape hatch.
+    if auth_required():
+        if _allow_insecure_secret():
+            logger.warning(
+                "⚠️  SECURITY: starting with the default AUTH_SECRET because "
+                "CODEFRAME_ALLOW_INSECURE_SECRET is set. JWTs can be forged — "
+                "use this for LOCAL DEVELOPMENT ONLY, never expose this server."
+            )
+            return
+        raise RuntimeError(
+            "🚨 SECURITY: AUTH_SECRET must be set when authentication is enabled. "
+            "The default secret lets anyone forge a valid JWT and bypass auth. "
+            "Set AUTH_SECRET to a secure random value (e.g. `openssl rand -hex 32`), "
+            "or set CODEFRAME_AUTH_REQUIRED=false / CODEFRAME_ALLOW_INSECURE_SECRET=1 "
+            "for local development only."
         )
-    else:
-        logger.info("🔐 AUTH_SECRET configured (custom secret in use)")
+
+    # Auth disabled: the secret is not used to enforce access, so a default is
+    # acceptable — but still warn so it isn't shipped into an exposed server.
+    logger.warning(
+        "⚠️  Running with default AUTH_SECRET - acceptable for self-hosted "
+        "development only (auth is disabled)"
+    )
 
 
 @asynccontextmanager

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -16,6 +16,18 @@ Get your project built with AI agents in minutes.
    export OPENAI_API_KEY=sk-...              # required for openai; not needed for local providers
    export OPENAI_BASE_URL=http://localhost:11434/v1  # for local providers (ollama, vllm)
    ```
+3. **`AUTH_SECRET` (required to run the server)** — the web UI / API
+   (`codeframe serve`) signs JWTs with this secret. Authentication is **on by
+   default**, so the server **refuses to start** with the built-in default
+   secret — set a strong random value:
+   ```bash
+   export AUTH_SECRET=$(openssl rand -hex 32)
+   ```
+   The Golden Path CLI does not use auth and needs no secret. For a throwaway
+   local server only, you may skip the secret by setting either
+   `CODEFRAME_ALLOW_INSECURE_SECRET=1` (signs JWTs with the known default —
+   forgeable, never expose it) or `CODEFRAME_AUTH_REQUIRED=false` (disables
+   auth entirely).
 
 ## Coming from ralph?
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -24,10 +24,12 @@ Get your project built with AI agents in minutes.
    export AUTH_SECRET=$(openssl rand -hex 32)
    ```
    The Golden Path CLI does not use auth and needs no secret. For a throwaway
-   local server only, you may skip the secret by setting either
-   `CODEFRAME_ALLOW_INSECURE_SECRET=1` (signs JWTs with the known default —
-   forgeable, never expose it) or `CODEFRAME_AUTH_REQUIRED=false` (disables
-   auth entirely).
+   local server only, set `CODEFRAME_ALLOW_INSECURE_SECRET=1` to start without
+   a secret — it signs JWTs with the known default (forgeable, never expose it)
+   while keeping auth on so the REST API and the session/terminal WebSockets all
+   work. (`CODEFRAME_AUTH_REQUIRED=false` is a separate knob that disables REST
+   auth but **not** WebSocket auth, so the sessions UI is only partially usable
+   in that mode.)
 
 ## Coming from ralph?
 

--- a/tests/auth/test_import_is_quiet.py
+++ b/tests/auth/test_import_is_quiet.py
@@ -39,13 +39,20 @@ def test_server_validation_still_raises_in_hosted_mode(monkeypatch):
 
 
 def test_server_validation_warns_but_allows_in_self_hosted_mode(monkeypatch, caplog):
-    """Self-hosted + default secret is allowed, with a warning at startup."""
+    """Self-hosted + default secret + auth OFF is allowed, with a warning.
+
+    Post-#643 the default secret is only tolerated when auth is not enforced;
+    set CODEFRAME_AUTH_REQUIRED=false explicitly so this test states its intent
+    rather than relying on the suite-wide conftest default. The auth-ON branch
+    (which now hard-fails) is covered in tests/ui/test_security_config.py.
+    """
     import logging
 
     import codeframe.auth.manager as manager
     from codeframe.ui.server import _validate_security_config
 
     monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
     monkeypatch.setattr(manager, "SECRET", manager.DEFAULT_SECRET)
 
     with caplog.at_level(logging.WARNING):

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -355,8 +355,10 @@ kill <PID>
 **Solution**:
 ```bash
 # Check if backend can start manually
+# AUTH_SECRET is required: auth is ON by default and the server refuses to
+# start on the default JWT secret (issue #643).
 cd /home/frankbria/projects/codeframe
-uv run uvicorn codeframe.ui.server:app --port 8080
+AUTH_SECRET=local-e2e-test-secret uv run uvicorn codeframe.ui.server:app --port 8080
 
 # If successful, check health endpoint
 curl http://localhost:8080/health

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -165,7 +165,9 @@ export default defineConfig({
     : [
         // Backend FastAPI server
         {
-          command: `cd ../.. && DATABASE_PATH=${TEST_DB_PATH} uv run uvicorn codeframe.ui.server:app --port 8080`,
+          // AUTH_SECRET: auth is ON by default and the server refuses to start
+          // on the default JWT secret (issue #643). Throwaway local-E2E value.
+          command: `cd ../.. && AUTH_SECRET=local-e2e-test-secret-not-a-real-credential DATABASE_PATH=${TEST_DB_PATH} uv run uvicorn codeframe.ui.server:app --port 8080`,
           url: 'http://localhost:8080/ws/health',
           reuseExistingServer: !process.env.CI,
           timeout: 120000,

--- a/tests/ui/test_security_config.py
+++ b/tests/ui/test_security_config.py
@@ -9,11 +9,10 @@ explicit local-dev escape hatch (which must never apply in hosted mode).
 
 import pytest
 
+from codeframe.auth.manager import DEFAULT_SECRET
 from codeframe.ui import server
 
 pytestmark = pytest.mark.v2
-
-DEFAULT_SECRET = "CHANGE-ME-IN-PRODUCTION"
 
 
 @pytest.fixture(autouse=True)
@@ -81,6 +80,17 @@ def test_hosted_mode_default_secret_fails_hard(monkeypatch):
     _set_secret(monkeypatch, DEFAULT_SECRET)
     monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
     monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        server._validate_security_config()
+
+
+def test_hosted_mode_default_secret_fails_even_with_auth_disabled(monkeypatch):
+    """Hosted mode rejects the default secret regardless of auth — the hosted
+    check fires before the auth_required() branch."""
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
 
     with pytest.raises(RuntimeError, match="AUTH_SECRET"):
         server._validate_security_config()

--- a/tests/ui/test_security_config.py
+++ b/tests/ui/test_security_config.py
@@ -95,3 +95,27 @@ def test_hosted_mode_escape_hatch_still_fails(monkeypatch):
 
     with pytest.raises(RuntimeError, match="AUTH_SECRET"):
         server._validate_security_config()
+
+
+def test_env_only_secret_is_honored_after_refresh(monkeypatch):
+    """Regression (#643 review P2): AUTH_SECRET set only in .env must let the
+    server start.
+
+    The auth manager captures SECRET at import time — before the lifespan loads
+    .env — so an operator who sets AUTH_SECRET only in .env would otherwise hit
+    the new hard-fail. The lifespan calls refresh_secret() after load_environment
+    so the real secret is seen. Simulate that: SECRET starts at the default, the
+    env then gains a real value, and refresh_secret() must update it so
+    validation passes and signing uses the configured secret.
+    """
+    import codeframe.auth.manager as manager
+
+    _set_secret(monkeypatch, DEFAULT_SECRET)  # stale import-time default
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    monkeypatch.setenv("AUTH_SECRET", "secret-loaded-from-dotenv-at-startup")
+
+    refreshed = manager.refresh_secret()
+
+    assert refreshed == "secret-loaded-from-dotenv-at-startup"
+    assert manager.SECRET == "secret-loaded-from-dotenv-at-startup"
+    server._validate_security_config()  # must not raise

--- a/tests/ui/test_security_config.py
+++ b/tests/ui/test_security_config.py
@@ -107,22 +107,39 @@ def test_hosted_mode_escape_hatch_still_fails(monkeypatch):
         server._validate_security_config()
 
 
-@pytest.mark.parametrize("blank", ["", "   "])
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", DEFAULT_SECRET + " ", "  " + DEFAULT_SECRET, f"\t{DEFAULT_SECRET}\n"],
+)
 @pytest.mark.parametrize("mode", ["self_hosted", "hosted"])
-def test_blank_secret_is_rejected_like_the_default(monkeypatch, blank, mode):
-    """A blank/whitespace AUTH_SECRET is as forgeable as the default, so it must
-    fall into the hard-fail path rather than be accepted as a custom secret."""
+def test_blank_or_padded_default_secret_is_rejected(monkeypatch, raw, mode):
+    """Blank/whitespace AUTH_SECRET — and a whitespace-padded copy of the known
+    default — are as forgeable as the default, so they must hit the hard-fail
+    path rather than be accepted as a custom secret."""
     import codeframe.auth.manager as manager
 
     _set_secret(monkeypatch, "stale-import-time-default")
     monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", mode)
     monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
-    monkeypatch.setenv("AUTH_SECRET", blank)
+    monkeypatch.setenv("AUTH_SECRET", raw)
 
     assert manager.refresh_secret() == DEFAULT_SECRET  # normalized to sentinel
 
     with pytest.raises(RuntimeError, match="AUTH_SECRET"):
         server._validate_security_config()
+
+
+def test_padded_custom_secret_is_preserved_verbatim(monkeypatch):
+    """A genuinely custom secret keeps its exact bytes (incl. padding) for
+    signing — only a padded copy of the *default* is normalized away."""
+    import codeframe.auth.manager as manager
+
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    monkeypatch.setenv("AUTH_SECRET", "  my-real-secret  ")
+
+    assert manager.refresh_secret() == "  my-real-secret  "  # not stripped
+    server._validate_security_config()  # must not raise
 
 
 def test_env_only_secret_is_honored_after_refresh(monkeypatch):

--- a/tests/ui/test_security_config.py
+++ b/tests/ui/test_security_config.py
@@ -107,6 +107,24 @@ def test_hosted_mode_escape_hatch_still_fails(monkeypatch):
         server._validate_security_config()
 
 
+@pytest.mark.parametrize("blank", ["", "   "])
+@pytest.mark.parametrize("mode", ["self_hosted", "hosted"])
+def test_blank_secret_is_rejected_like_the_default(monkeypatch, blank, mode):
+    """A blank/whitespace AUTH_SECRET is as forgeable as the default, so it must
+    fall into the hard-fail path rather than be accepted as a custom secret."""
+    import codeframe.auth.manager as manager
+
+    _set_secret(monkeypatch, "stale-import-time-default")
+    monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", mode)
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    monkeypatch.setenv("AUTH_SECRET", blank)
+
+    assert manager.refresh_secret() == DEFAULT_SECRET  # normalized to sentinel
+
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        server._validate_security_config()
+
+
 def test_env_only_secret_is_honored_after_refresh(monkeypatch):
     """Regression (#643 review P2): AUTH_SECRET set only in .env must let the
     server start.

--- a/tests/ui/test_security_config.py
+++ b/tests/ui/test_security_config.py
@@ -1,0 +1,97 @@
+"""Startup security validation for the JWT signing secret (issue #643).
+
+``_validate_security_config()`` must refuse to start the server whenever auth
+is enabled and the JWT secret is still the publicly-known default — otherwise
+anyone can forge a valid JWT and bypass auth on every v2/WS/SSE route. The only
+ways past the default secret are: a real ``AUTH_SECRET``, disabling auth, or an
+explicit local-dev escape hatch (which must never apply in hosted mode).
+"""
+
+import pytest
+
+from codeframe.ui import server
+
+pytestmark = pytest.mark.v2
+
+DEFAULT_SECRET = "CHANGE-ME-IN-PRODUCTION"
+
+
+@pytest.fixture(autouse=True)
+def clean_security_env(monkeypatch):
+    """Start each case from a known env: self-hosted, no escape hatch.
+
+    Individual tests opt into hosted mode / auth / escape hatch as needed. The
+    module-level ``SECRET`` is patched per test so the default-vs-real branch is
+    exercised without depending on the ambient ``AUTH_SECRET``.
+    """
+    monkeypatch.delenv("CODEFRAME_DEPLOYMENT_MODE", raising=False)
+    monkeypatch.delenv("CODEFRAME_ALLOW_INSECURE_SECRET", raising=False)
+    monkeypatch.delenv("CODEFRAME_AUTH_REQUIRED", raising=False)
+    yield
+
+
+def _set_secret(monkeypatch, value):
+    # _validate_security_config re-imports SECRET from the manager at call time,
+    # so patching the module attribute is enough (no reload required).
+    monkeypatch.setattr("codeframe.auth.manager.SECRET", value)
+
+
+def test_default_secret_with_auth_enabled_fails_hard(monkeypatch):
+    """AC1: default secret + auth on (self-hosted default) → startup error."""
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        server._validate_security_config()
+
+
+def test_default_secret_with_escape_hatch_starts(monkeypatch, caplog):
+    """AC2: escape hatch lets local dev run on the default secret (with a warning)."""
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    monkeypatch.setenv("CODEFRAME_ALLOW_INSECURE_SECRET", "1")
+
+    with caplog.at_level("WARNING"):
+        server._validate_security_config()  # must not raise
+
+    assert any("AUTH_SECRET" in rec.message for rec in caplog.records)
+
+
+def test_real_secret_starts(monkeypatch):
+    """AC2: a real secret + auth on → server starts (no error)."""
+    _set_secret(monkeypatch, "a-real-and-very-secret-value")
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+
+    server._validate_security_config()  # must not raise
+
+
+def test_default_secret_with_auth_disabled_starts(monkeypatch, caplog):
+    """Auth off → the secret is unused for enforcement, so only warn."""
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+
+    with caplog.at_level("WARNING"):
+        server._validate_security_config()  # must not raise
+
+    assert any("AUTH_SECRET" in rec.message for rec in caplog.records)
+
+
+def test_hosted_mode_default_secret_fails_hard(monkeypatch):
+    """Existing behavior preserved: hosted + default secret always fails."""
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        server._validate_security_config()
+
+
+def test_hosted_mode_escape_hatch_still_fails(monkeypatch):
+    """The dev escape hatch must never weaken hosted/production mode."""
+    _set_secret(monkeypatch, DEFAULT_SECRET)
+    monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    monkeypatch.setenv("CODEFRAME_ALLOW_INSECURE_SECRET", "1")
+
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        server._validate_security_config()


### PR DESCRIPTION
## Summary

Fixes #643 — a JWT-forgery auth bypass. The JWT signing secret defaulted to the publicly-known constant `CHANGE-ME-IN-PRODUCTION` and was only hard-rejected in `HOSTED` mode. Because the default deployment mode is `self_hosted` and auth is **ON by default** (HS256), a server started without `AUTH_SECRET` signed every JWT with the known default — anyone could forge a valid JWT for any `user_id` and bypass auth on all 22 v2 routers plus the WS/SSE routes.

## Change

`_validate_security_config()` (startup guard in `codeframe/ui/server.py`) now **refuses to start** whenever the default secret is in use **and** auth is enforced — regardless of deployment mode:

| Mode | Secret | Auth | Escape hatch | Result |
|------|--------|------|--------------|--------|
| self_hosted | default | on | — | **RuntimeError** (was: warn-only) |
| self_hosted | default | on | `CODEFRAME_ALLOW_INSECURE_SECRET=1` | starts (loud warning) |
| self_hosted | real | on | — | starts |
| self_hosted | default | off | — | starts (warning) |
| hosted | default | any | any | **RuntimeError** (hatch never weakens prod) |

The escape hatch (`CODEFRAME_ALLOW_INSECURE_SECRET`) exists only for throwaway local dev and is intentionally **not** honored in hosted mode.

## Acceptance criteria

- [x] Starting with auth enabled and no `AUTH_SECRET` raises a clear startup error (not a warning).
- [x] Test covers: default secret + auth on → fails; real secret → starts; escape-hatch env → starts with warning. (+ hosted-mode and auth-off branches.)
- [x] QUICKSTART documents setting `AUTH_SECRET`.

## Tests

`tests/ui/test_security_config.py` — 6 cases, one per branch (incl. a hosted-mode case proving the dev escape hatch never weakens production). Full `tests/ui` suite: **382 passed**. `ruff` clean.

## Demo evidence

Exercising the real `_validate_security_config()` code path across every scenario:

```
[REFUSED] default secret + auth ON (self-hosted)        -> 🚨 AUTH_SECRET must be set when authentication is enabled.
[STARTS ] real secret + auth ON
[STARTS ] escape hatch + default secret
[STARTS ] Auth OFF + default secret
[REFUSED] Hosted + default secret                       -> 🚨 AUTH_SECRET must be set in hosted/production mode.
[REFUSED] Hosted + escape hatch (must still refuse)     -> 🚨 AUTH_SECRET must be set in hosted/production mode.
```

## Files

- `codeframe/ui/server.py` — rewrite secret guard + add `_allow_insecure_secret()`
- `tests/ui/test_security_config.py` — new test file
- `docs/QUICKSTART.md` — document `AUTH_SECRET` as mandatory for the server
- `.env.example` — stop shipping the literal default as an active value

## Known limitations

- The CLI Golden Path never uses auth, so it is unaffected and needs no secret.
- Existing test suites run with `CODEFRAME_AUTH_REQUIRED=false` (via `tests/conftest.py`), so the new hard-fail does not trip them; the dedicated enforcement suite continues to opt auth back on without triggering the guard (it doesn't enter the server lifespan).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Quickstart to require authentication setup, explain secret generation, and document secure vs local insecure startup options.

* **New Features**
  * Added/clarified support for a local-development escape hatch (`CODEFRAME_ALLOW_INSECURE_SECRET=1`) when using the default JWT secret.
  * `AUTH_SECRET` is now treated as required when auth is enabled (config template updated accordingly).

* **Bug Fixes**
  * WebSocket JWT authentication now decodes using the currently configured `AUTH_SECRET`.

* **Tests**
  * Added security startup validation tests, including behavior differences for self-hosted vs hosted mode and env-only secret refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->