### PR TITLE
fix(security): warn when in-memory rate limiting is per-worker (#678)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,13 @@ RATE_LIMIT_ENABLED=true
 RATE_LIMIT_DEFAULT=100/minute
 RATE_LIMIT_AUTH=10/minute
 RATE_LIMIT_AI=20/minute
+RATE_LIMIT_STORAGE=memory             # memory (default) or redis
 REDIS_URL=redis://localhost:6379
+# Multi-worker deployments (uvicorn/gunicorn with --workers > 1): set
+# RATE_LIMIT_STORAGE=redis (+ REDIS_URL) for shared, cross-worker counters.
+# With the default in-memory storage each worker keeps its OWN counters, so the
+# effective limit — including auth brute-force protection — multiplies by the
+# worker count. The server logs a WARNING at startup when this is detected.
 
 CODEFRAME_API_KEY_SECRET=<secret>     # API key hashing
 

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -171,6 +171,53 @@ def _validate_security_config():
     )
 
 
+def _detect_worker_count() -> int:
+    """Best-effort detection of the configured uvicorn/gunicorn worker count.
+
+    Reads ``WEB_CONCURRENCY`` (honored by both uvicorn and gunicorn) and
+    ``UVICORN_WORKERS`` (uvicorn's env-var form of ``--workers``) and returns the
+    largest valid value found, or ``1`` when neither is set or parseable.
+
+    Worker count cannot be observed directly from inside a worker process, so
+    this is a best-effort signal for the startup warning below. A bare
+    ``uvicorn --workers N`` on the command line (no env var) is not detected.
+    """
+    count = 1
+    for var in ("WEB_CONCURRENCY", "UVICORN_WORKERS"):
+        raw = os.getenv(var)
+        if not raw or not raw.strip():
+            continue
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            continue
+        if value > count:
+            count = value
+    return count
+
+
+def _per_worker_rate_limit_warning(
+    *, enabled: bool, storage: str, worker_count: int
+) -> str | None:
+    """Return a startup warning when in-memory rate limiting is per-worker.
+
+    With in-memory storage each worker process keeps its own rate-limit
+    counters, so the effective limit multiplies by the worker count — silently
+    weakening brute-force protection on the auth endpoints (issue #678). Returns
+    ``None`` when the configuration is safe (rate limiting disabled,
+    redis-backed, or a single worker).
+    """
+    if not enabled or storage != "memory" or worker_count <= 1:
+        return None
+    return (
+        f"⚠️  Rate limiting uses in-memory storage with {worker_count} workers: "
+        f"counters are per-worker, so limits (including auth brute-force "
+        f"protection) are effectively multiplied by ~{worker_count}x. "
+        f"Set RATE_LIMIT_STORAGE=redis (with REDIS_URL) for shared, "
+        f"cross-worker rate limiting."
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifespan - startup and shutdown."""
@@ -224,6 +271,16 @@ async def lifespan(app: FastAPI):
                 f"(storage={rate_limit_config.storage}, "
                 f"standard={rate_limit_config.standard_limit})"
             )
+        # Warn when in-memory counters are split across multiple workers, which
+        # multiplies the effective limit and weakens auth brute-force protection
+        # (issue #678). Silent for single-worker and Redis-backed deployments.
+        per_worker_warning = _per_worker_rate_limit_warning(
+            enabled=rate_limit_config.enabled,
+            storage=rate_limit_config.storage,
+            worker_count=_detect_worker_count(),
+        )
+        if per_worker_warning:
+            logger.warning(per_worker_warning)
     else:
         logger.info("🚦 Rate limiting: DISABLED")
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -298,6 +298,21 @@ codeframe checkpoint create "MVP complete"
 
 > On first interactive use, CodeFRAME shows a one-time prompt asking whether to enable telemetry (default: No). You can also set `CODEFRAME_TELEMETRY=on|off` or `DO_NOT_TRACK=1` to skip the prompt. See [PRIVACY.md](../PRIVACY.md) for exactly what is collected.
 
+### Rate limiting in production
+
+The API server (`cf serve`) rate-limits requests, including auth brute-force
+protection. The storage backend is selected by `RATE_LIMIT_STORAGE` (default
+`memory`).
+
+> ⚠️ **Multi-worker deployments require Redis.** With the default in-memory
+> storage, each worker process keeps its **own** rate-limit counters, so running
+> with more than one worker (e.g. `uvicorn --workers 4`) multiplies the effective
+> limit by the worker count and silently weakens auth brute-force protection. For
+> any multi-worker deployment, set `RATE_LIMIT_STORAGE=redis` and `REDIS_URL` for
+> shared, cross-worker buckets. The server logs a `WARNING` at startup when it
+> detects in-memory storage with multiple workers (via the `WEB_CONCURRENCY` /
+> `UVICORN_WORKERS` env vars).
+
 ---
 
 ## Execution Strategies

--- a/tests/ui/test_rate_limit_worker_warning.py
+++ b/tests/ui/test_rate_limit_worker_warning.py
@@ -1,0 +1,100 @@
+"""Per-worker in-memory rate-limit startup warning (issue #678).
+
+In-memory rate limiting keeps separate counters in each worker process, so the
+effective limit multiplies by the worker count — silently weakening auth
+brute-force protection (the limits added in #644). The server must surface this
+at startup: a WARNING when rate limiting is enabled, storage is in-memory, and
+more than one worker is configured. Single-worker and Redis-backed deployments
+must stay silent and unchanged.
+"""
+
+import pytest
+
+from codeframe.ui import server
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture(autouse=True)
+def clean_worker_env(monkeypatch):
+    """Each case starts with no worker-count env vars set."""
+    monkeypatch.delenv("WEB_CONCURRENCY", raising=False)
+    monkeypatch.delenv("UVICORN_WORKERS", raising=False)
+    yield
+
+
+# --- _detect_worker_count -------------------------------------------------
+
+
+def test_worker_count_defaults_to_one_when_unset():
+    assert server._detect_worker_count() == 1
+
+
+def test_worker_count_reads_web_concurrency(monkeypatch):
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+    assert server._detect_worker_count() == 4
+
+
+def test_worker_count_reads_uvicorn_workers(monkeypatch):
+    monkeypatch.setenv("UVICORN_WORKERS", "2")
+    assert server._detect_worker_count() == 2
+
+
+def test_worker_count_takes_the_max_of_both(monkeypatch):
+    monkeypatch.setenv("WEB_CONCURRENCY", "2")
+    monkeypatch.setenv("UVICORN_WORKERS", "8")
+    assert server._detect_worker_count() == 8
+
+
+def test_worker_count_ignores_unparseable_values(monkeypatch):
+    monkeypatch.setenv("WEB_CONCURRENCY", "not-a-number")
+    assert server._detect_worker_count() == 1
+
+
+def test_worker_count_ignores_blank_and_whitespace(monkeypatch):
+    monkeypatch.setenv("WEB_CONCURRENCY", "   ")
+    assert server._detect_worker_count() == 1
+
+
+def test_worker_count_handles_padded_integer(monkeypatch):
+    monkeypatch.setenv("WEB_CONCURRENCY", " 3 ")
+    assert server._detect_worker_count() == 3
+
+
+# --- _per_worker_rate_limit_warning --------------------------------------
+
+
+def test_warning_fires_for_memory_multi_worker():
+    msg = server._per_worker_rate_limit_warning(
+        enabled=True, storage="memory", worker_count=4
+    )
+    assert msg is not None
+    assert "redis" in msg.lower()
+    assert "4" in msg
+
+
+def test_no_warning_for_redis_storage():
+    assert (
+        server._per_worker_rate_limit_warning(
+            enabled=True, storage="redis", worker_count=4
+        )
+        is None
+    )
+
+
+def test_no_warning_for_single_worker():
+    assert (
+        server._per_worker_rate_limit_warning(
+            enabled=True, storage="memory", worker_count=1
+        )
+        is None
+    )
+
+
+def test_no_warning_when_rate_limiting_disabled():
+    assert (
+        server._per_worker_rate_limit_warning(
+            enabled=False, storage="memory", worker_count=4
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

Closes #678.

In-memory rate limiting keeps **separate counters per worker process**, so the effective limit — including the auth brute-force protection added in #644 (`/auth/jwt/login`, `/auth/register`) — multiplies by the worker count in multi-worker deployments (e.g. `uvicorn --workers 4` turns `10/minute` into an effective ~40/minute). This was previously undocumented and produced no startup signal.

This is a **documentation + operational-safety** change. The mitigation (`RATE_LIMIT_STORAGE=redis` + `REDIS_URL`) already existed in `rate_limiter.py`; it was just undiscoverable.

## Changes

- **Startup WARNING** (`codeframe/ui/server.py`, in the `lifespan()` rate-limit init): logs a clear `WARNING` when rate limiting is **enabled**, storage is **in-memory**, and **>1 worker** is configured. Worker count is detected best-effort from `WEB_CONCURRENCY` / `UVICORN_WORKERS`. Two small testable helpers added: `_detect_worker_count()` and the pure `_per_worker_rate_limit_warning(...)`.
- **Docs**: `docs/QUICKSTART.md` gains a "Rate limiting in production" note; the `CLAUDE.md` rate-limit env block documents `RATE_LIMIT_STORAGE` and the multi-worker → Redis requirement.

## Acceptance criteria

- [x] Deployment docs state the Redis-for-multi-worker requirement for effective (auth) rate limiting.
- [x] Server logs a WARNING at startup when rate limiting is enabled + in-memory storage + workers > 1.
- [x] No behavior change to single-worker or Redis-backed deployments.

## Tests

New `tests/ui/test_rate_limit_worker_warning.py` (11 cases): worker-count detection (env unset/`WEB_CONCURRENCY`/`UVICORN_WORKERS`/max-of-both/unparseable/blank/padded) and the warning decision matrix (memory+multi → fires; redis / single-worker / disabled → silent). Full rate-limit + security suites pass (64 tests), lint clean.

## Known limitation

Worker count is detected from the `WEB_CONCURRENCY` / `UVICORN_WORKERS` env vars — the only signal observable from inside a worker process. A bare `uvicorn --workers N` on the command line (no env var set) is **not** detected, so the warning won't fire in that specific case. This matches how the issue frames it as a best-effort operational signal.