### PR TITLE
ci(frontend): add npm run build + re-enable frontend lint (#646)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,20 @@ jobs:
       - name: Run mypy (type checking)
         run: uv run mypy codeframe/
 
-      # Note: Frontend linting disabled - web-ui is legacy during v2 CLI-first refactor
-      # Re-enable when web-ui package.json is restored
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'web-ui/package-lock.json'
+
+      - name: Install frontend dependencies
+        working-directory: web-ui
+        run: npm ci
+
+      - name: Run frontend lint (eslint)
+        working-directory: web-ui
+        run: npm run lint
 
   # ============================================
   # Static Analysis - Check for Hardcoded URLs
@@ -264,6 +276,10 @@ jobs:
       - name: Install dependencies
         working-directory: web-ui
         run: npm ci
+
+      - name: Build (fail PR on TypeScript/build break)
+        working-directory: web-ui
+        run: npm run build
 
       - name: Run Jest tests with coverage
         working-directory: web-ui

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,6 +279,8 @@ jobs:
 
       - name: Build (fail PR on TypeScript/build break)
         working-directory: web-ui
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
         run: npm run build
 
       - name: Run Jest tests with coverage

--- a/web-ui/__tests__/app/proof/req_id/page.test.tsx
+++ b/web-ui/__tests__/app/proof/req_id/page.test.tsx
@@ -66,8 +66,6 @@ const waivedReq = {
   },
 };
 
-const mockEvidenceResponse = [];
-
 describe('ProofDetailPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/web-ui/src/__tests__/components/proof/ProofDetailPage.test.tsx
+++ b/web-ui/src/__tests__/components/proof/ProofDetailPage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import useSWR from 'swr';
 import ProofDetailPage from '@/app/proof/[req_id]/page';
 import * as storage from '@/lib/workspace-storage';
-import type { ProofEvidence, ProofRequirement, ProofEvidenceSortCol, SortDir } from '@/types';
+import type { ProofEvidence, ProofRequirement } from '@/types';
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 

--- a/web-ui/src/__tests__/components/tasks/GitHubIssueImportModal.test.tsx
+++ b/web-ui/src/__tests__/components/tasks/GitHubIssueImportModal.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import useSWR from 'swr';
 
 import { GitHubIssueImportModal } from '@/components/tasks/GitHubIssueImportModal';
-import { integrationsApi } from '@/lib/api';
 import type { GitHubIssue, GitHubIssuesResponse } from '@/types';
 
 jest.mock('swr');

--- a/web-ui/src/components/proof/CaptureGlitchModal.tsx
+++ b/web-ui/src/components/proof/CaptureGlitchModal.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { Cancel01Icon } from '@hugeicons/react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import {


### PR DESCRIPTION
## Summary

Closes #646. Two CI safety-net gaps for the actively-developed web UI:

1. **`frontend-tests` never ran `npm run build`** — a TypeScript/build break passed PR CI and only failed at deploy time.
2. **Frontend lint was disabled** in `code-quality` with a "legacy" comment contradicting CLAUDE.md (web UI is actively developed).

## Changes

- **`frontend-tests`**: add a `npm run build` step (fails the PR on a build break).
- **`code-quality`**: re-enable frontend lint — adds Node setup + `npm ci` + `npm run lint` so lint fast-fails alongside ruff/mypy (placement confirmed per issue text).
- **Cleared 6 eslint errors** (issue named 5; found one extra unused var):
  - `CaptureGlitchModal.tsx` — removed dead `Input` import (shipped code)
  - `ProofDetailPage.test.tsx` — removed unused `ProofEvidenceSortCol`, `SortDir`
  - `GitHubIssueImportModal.test.tsx` — removed unused `within`, `integrationsApi`
  - `page.test.tsx` — removed unused `mockEvidenceResponse` (**extra error not named in issue**)

## Verification

- `npm run lint` → 0 errors (exit 0)
- `npm run build` → exit 0
- `npx jest` on the 3 edited test files → 51 passed
- `test-summary` `needs` still includes `frontend-tests` (unchanged)
- Workflow YAML parses

## Acceptance criteria

- [x] `frontend-tests` runs `npm run build` and fails the PR on a build break
- [x] Frontend lint runs in CI and is green
- [x] `frontend-tests` remains wired into `test-summary`

## Known limitations

7 `react-hooks/exhaustive-deps` **warnings** remain in pre-existing components. ESLint exits 0 on warnings (no `--max-warnings`), so lint is green. Resolving them is behavioral and out of scope for this CI-hardening issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled frontend linting checks in the continuous integration workflow
  * Added a production build verification step before running the Jest/coverage test suite
* **Chores**
  * Cleaned up test files by removing unused fixtures/constants and unused type/imports
  * Updated test imports to reduce unnecessary dependencies while keeping existing mock behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->