### PR TITLE
fix(web-ui): AlertDialog session end, unified no-workspace UI, dead-code removal (#653)

### DIFF
--- a/web-ui/__tests__/components/sessions/SessionCard.test.tsx
+++ b/web-ui/__tests__/components/sessions/SessionCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SessionCard } from '@/components/sessions/SessionCard';
 import type { Session } from '@/types';
@@ -101,21 +101,30 @@ describe('SessionCard', () => {
     expect(screen.queryByRole('button', { name: /end/i })).not.toBeInTheDocument();
   });
 
-  it('calls onEnd when End button is clicked and confirmed', async () => {
+  it('opens a confirmation dialog before ending (does not call onEnd immediately)', async () => {
     const user = userEvent.setup();
-    window.confirm = jest.fn().mockReturnValue(true);
     renderCard({ state: 'active' });
     await user.click(screen.getByRole('button', { name: /end/i }));
-    expect(window.confirm).toHaveBeenCalled();
+    // Dialog is open; onEnd must not fire until the user confirms.
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(defaultHandlers.onEnd).not.toHaveBeenCalled();
+  });
+
+  it('calls onEnd when the End action is confirmed in the dialog', async () => {
+    const user = userEvent.setup();
+    renderCard({ state: 'active' });
+    await user.click(screen.getByRole('button', { name: /end/i }));
+    const dialog = screen.getByRole('alertdialog');
+    await user.click(within(dialog).getByRole('button', { name: /end session/i }));
     expect(defaultHandlers.onEnd).toHaveBeenCalledWith('aaaaaaaa-bbbb-cccc-dddd-eeeeeeee1234');
   });
 
-  it('does not call onEnd when confirm is cancelled', async () => {
+  it('does not call onEnd when the dialog is cancelled', async () => {
     const user = userEvent.setup();
-    window.confirm = jest.fn().mockReturnValue(false);
     renderCard({ state: 'active' });
     await user.click(screen.getByRole('button', { name: /end/i }));
-    expect(window.confirm).toHaveBeenCalled();
+    const dialog = screen.getByRole('alertdialog');
+    await user.click(within(dialog).getByRole('button', { name: /^keep$/i }));
     expect(defaultHandlers.onEnd).not.toHaveBeenCalled();
   });
 

--- a/web-ui/src/__tests__/hooks/useWorkspaceSelection.test.ts
+++ b/web-ui/src/__tests__/hooks/useWorkspaceSelection.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
+import { workspaceApi } from '@/lib/api';
+import {
+  getSelectedWorkspacePath,
+  setSelectedWorkspacePath,
+  clearSelectedWorkspacePath,
+} from '@/lib/workspace-storage';
+import { mutate as globalMutate } from 'swr';
+import type { WorkspaceResponse } from '@/types';
+
+jest.mock('swr', () => ({ mutate: jest.fn() }));
+jest.mock('@/hooks/useWorkspaces', () => ({ WORKSPACES_SWR_KEY: 'workspaces' }));
+jest.mock('@/lib/workspace-storage', () => ({
+  getSelectedWorkspacePath: jest.fn(),
+  setSelectedWorkspacePath: jest.fn(),
+  clearSelectedWorkspacePath: jest.fn(),
+}));
+jest.mock('@/lib/api', () => ({
+  workspaceApi: {
+    checkExists: jest.fn(),
+    getByPath: jest.fn(),
+    init: jest.fn(),
+  },
+}));
+
+const mockedApi = workspaceApi as jest.Mocked<typeof workspaceApi>;
+const mockedGet = getSelectedWorkspacePath as jest.Mock;
+
+function makeWorkspace(overrides: Partial<WorkspaceResponse> = {}): WorkspaceResponse {
+  return {
+    id: 'ws-1',
+    repo_path: '/p/new',
+    name: 'new',
+    tech_stack: 'Python',
+    ...overrides,
+  } as WorkspaceResponse;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGet.mockReturnValue(null);
+  mockedApi.getByPath.mockResolvedValue(makeWorkspace());
+});
+
+describe('useWorkspaceSelection', () => {
+  it('hydrates the path from localStorage on mount and flags ready', async () => {
+    mockedGet.mockReturnValue('/p/stored');
+    const { result } = renderHook(() => useWorkspaceSelection());
+
+    await waitFor(() => expect(result.current.workspaceReady).toBe(true));
+    expect(result.current.workspacePath).toBe('/p/stored');
+  });
+
+  it('selects an existing workspace without calling init or onInitialized', async () => {
+    mockedApi.checkExists.mockResolvedValue({ exists: true } as never);
+    const onInitialized = jest.fn();
+    const { result } = renderHook(() => useWorkspaceSelection());
+
+    await act(async () => {
+      await result.current.selectWorkspace('/p/exists', { onInitialized });
+    });
+
+    expect(mockedApi.init).not.toHaveBeenCalled();
+    expect(onInitialized).not.toHaveBeenCalled();
+    expect(setSelectedWorkspacePath).toHaveBeenCalledWith('/p/exists');
+    expect(globalMutate).toHaveBeenCalledWith('workspaces');
+    expect(result.current.workspacePath).toBe('/p/exists');
+    expect(result.current.isSelecting).toBe(false);
+  });
+
+  it('initializes a new workspace and fires onInitialized with the result', async () => {
+    mockedApi.checkExists.mockResolvedValue({ exists: false } as never);
+    const initialized = makeWorkspace({ tech_stack: 'TypeScript' });
+    mockedApi.init.mockResolvedValue(initialized);
+    const onInitialized = jest.fn();
+    const { result } = renderHook(() => useWorkspaceSelection());
+
+    await act(async () => {
+      await result.current.selectWorkspace('/p/new', { onInitialized });
+    });
+
+    expect(mockedApi.init).toHaveBeenCalledWith('/p/new', { detect: true });
+    expect(onInitialized).toHaveBeenCalledWith(initialized);
+    expect(result.current.workspacePath).toBe('/p/new');
+  });
+
+  it('captures a selection error and stops selecting on API failure', async () => {
+    mockedApi.checkExists.mockRejectedValue({ detail: 'boom' });
+    const { result } = renderHook(() => useWorkspaceSelection());
+
+    await act(async () => {
+      await result.current.selectWorkspace('/p/bad');
+    });
+
+    expect(result.current.selectionError).toBe('boom');
+    expect(result.current.isSelecting).toBe(false);
+    expect(result.current.workspacePath).toBeNull();
+  });
+
+  it('clearWorkspace resets the path, persists the clear, and drops a stale error', async () => {
+    mockedApi.checkExists.mockRejectedValue({ detail: 'boom' });
+    const { result } = renderHook(() => useWorkspaceSelection());
+
+    await act(async () => {
+      await result.current.selectWorkspace('/p/bad');
+    });
+    expect(result.current.selectionError).toBe('boom');
+
+    act(() => {
+      result.current.clearWorkspace();
+    });
+
+    expect(clearSelectedWorkspacePath).toHaveBeenCalled();
+    expect(result.current.workspacePath).toBeNull();
+    expect(result.current.selectionError).toBeNull();
+  });
+});

--- a/web-ui/src/app/costs/page.tsx
+++ b/web-ui/src/app/costs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import useSWR from 'swr';
 import {
   MoneyBag02Icon,
@@ -12,11 +12,8 @@ import { SpendBarChart } from '@/components/costs/SpendBarChart';
 import { TopTasksTable } from '@/components/costs/TopTasksTable';
 import { AgentCostBars } from '@/components/costs/AgentCostBars';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
-import { costsApi, workspaceApi } from '@/lib/api';
-import {
-  getSelectedWorkspacePath,
-  setSelectedWorkspacePath,
-} from '@/lib/workspace-storage';
+import { costsApi } from '@/lib/api';
+import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import type {
   CostSummaryResponse,
   TaskCostsResponse,
@@ -40,14 +37,13 @@ function formatCurrency(value: number, fractionDigits = 4): string {
 }
 
 export default function CostsPage() {
-  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
+  const {
+    workspacePath,
+    isSelecting,
+    selectionError,
+    selectWorkspace,
+  } = useWorkspaceSelection();
   const [days, setDays] = useState<number>(30);
-  const [isSelecting, setIsSelecting] = useState(false);
-  const [selectionError, setSelectionError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setWorkspacePath(getSelectedWorkspacePath());
-  }, []);
 
   const { data, error, isLoading } = useSWR<CostSummaryResponse, ApiError>(
     workspacePath ? ['/api/v2/costs/summary', workspacePath, days] : null,
@@ -67,28 +63,10 @@ export default function CostsPage() {
     { refreshInterval: 60000 }
   );
 
-  const handleSelectWorkspace = async (path: string) => {
-    setIsSelecting(true);
-    setSelectionError(null);
-    try {
-      const exists = await workspaceApi.checkExists(path);
-      if (!exists.exists) {
-        await workspaceApi.init(path, { detect: true });
-      }
-      setSelectedWorkspacePath(path);
-      setWorkspacePath(path);
-    } catch (err) {
-      const apiError = err as ApiError;
-      setSelectionError(apiError.detail || 'Failed to open project');
-    } finally {
-      setIsSelecting(false);
-    }
-  };
-
   if (!workspacePath) {
     return (
       <WorkspaceSelector
-        onSelectWorkspace={handleSelectWorkspace}
+        onSelectWorkspace={selectWorkspace}
         isLoading={isSelecting}
         error={selectionError}
       />

--- a/web-ui/src/app/execution/page.tsx
+++ b/web-ui/src/app/execution/page.tsx
@@ -4,9 +4,10 @@ import { Suspense, useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Loading03Icon } from '@hugeicons/react';
-import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
 import { tasksApi } from '@/lib/api';
 import { BatchExecutionMonitor } from '@/components/execution/BatchExecutionMonitor';
+import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
+import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 
 /**
  * Execution landing page wrapper.
@@ -43,15 +44,14 @@ function ExecutionLandingContent() {
   const batchId = searchParams.get('batch');
   const taskIdParam = searchParams.get('task');
 
-  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
-  const [workspaceReady, setWorkspaceReady] = useState(false);
+  const {
+    workspacePath,
+    workspaceReady,
+    isSelecting,
+    selectionError,
+    selectWorkspace,
+  } = useWorkspaceSelection();
   const [resolving, setResolving] = useState(true);
-
-  // Hydrate workspace path
-  useEffect(() => {
-    setWorkspacePath(getSelectedWorkspacePath());
-    setWorkspaceReady(true);
-  }, []);
 
   // Request browser notification permission once on first visit
   useEffect(() => {
@@ -97,19 +97,11 @@ function ExecutionLandingContent() {
 
   if (!workspacePath) {
     return (
-      <main className="min-h-screen bg-background">
-        <div className="mx-auto max-w-5xl px-4 py-8">
-          <div className="rounded-lg border bg-muted/50 p-6 text-center">
-            <p className="text-muted-foreground">
-              No workspace selected.{' '}
-              <Link href="/" className="text-primary hover:underline">
-                Select a workspace
-              </Link>{' '}
-              first.
-            </p>
-          </div>
-        </div>
-      </main>
+      <WorkspaceSelector
+        onSelectWorkspace={selectWorkspace}
+        isLoading={isSelecting}
+        error={selectionError}
+      />
     );
   }
 

--- a/web-ui/src/app/page.tsx
+++ b/web-ui/src/app/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import useSWR, { mutate as globalMutate } from 'swr';
-import { WORKSPACES_SWR_KEY } from '@/hooks/useWorkspaces';
+import { useState } from 'react';
+import useSWR from 'swr';
 import {
   WorkspaceHeader,
   WorkspaceStatsCards,
@@ -14,11 +13,7 @@ import { ProofStatusWidget } from '@/components/proof';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
 import { workspaceApi, tasksApi, eventsApi } from '@/lib/api';
 import { TechStackConfirmDialog } from '@/components/workspace/TechStackConfirmDialog';
-import {
-  getSelectedWorkspacePath,
-  setSelectedWorkspacePath,
-  clearSelectedWorkspacePath,
-} from '@/lib/workspace-storage';
+import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import type {
   WorkspaceResponse,
   TaskListResponse,
@@ -96,21 +91,19 @@ function mapEventToActivity(event: EventResponse): ActivityItem {
 
 export default function WorkspacePage() {
   // Track the selected workspace path
-  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
-  const [isSelectingWorkspace, setIsSelectingWorkspace] = useState(false);
-  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const {
+    workspacePath,
+    isSelecting: isSelectingWorkspace,
+    selectionError,
+    selectWorkspace,
+    clearWorkspace,
+  } = useWorkspaceSelection();
 
   // Tech stack confirmation dialog state
   const [techStackDialog, setTechStackDialog] = useState<{
     open: boolean;
     detectedStack: string | null;
   }>({ open: false, detectedStack: null });
-
-  // Load workspace path from localStorage on mount
-  useEffect(() => {
-    const stored = getSelectedWorkspacePath();
-    setWorkspacePath(stored);
-  }, []);
 
   // Fetch workspace data (only if we have a path)
   const {
@@ -141,44 +134,17 @@ export default function WorkspacePage() {
   // Map events to activity items
   const activities: ActivityItem[] = (eventsData?.events || []).map(mapEventToActivity);
 
-  // Handle workspace selection/initialization
-  const handleSelectWorkspace = async (path: string) => {
-    setIsSelectingWorkspace(true);
-    setSelectionError(null);
-
-    try {
-      // First check if workspace exists
-      const exists = await workspaceApi.checkExists(path);
-
-      if (exists.exists) {
-        // Workspace exists, just select it. Touch /current so the server bumps
-        // recency and tracks it — fire-and-forget so a transient error on this
-        // best-effort call can't block opening an accessible workspace.
-        void workspaceApi.getByPath(path).catch(() => {});
-        setSelectedWorkspacePath(path);
-        setWorkspacePath(path);
-      } else {
-        // Initialize new workspace and show tech stack confirmation
-        const initialized = await workspaceApi.init(path, { detect: true });
-        setSelectedWorkspacePath(path);
-        setWorkspacePath(path);
-        setTechStackDialog({ open: true, detectedStack: initialized.tech_stack });
-      }
-      // Keep the server-backed workspace list fresh (localStorage dual-write
-      // already happened via setSelectedWorkspacePath → addToRecentWorkspaces).
-      void globalMutate(WORKSPACES_SWR_KEY);
-    } catch (error) {
-      const apiError = error as ApiError;
-      setSelectionError(apiError.detail || 'Failed to open project');
-    } finally {
-      setIsSelectingWorkspace(false);
-    }
-  };
+  // Handle workspace selection/initialization. A newly initialized workspace
+  // opens the tech-stack confirmation dialog via the hook's onInitialized hook.
+  const handleSelectWorkspace = (path: string) =>
+    selectWorkspace(path, {
+      onInitialized: (initialized) =>
+        setTechStackDialog({ open: true, detectedStack: initialized.tech_stack }),
+    });
 
   // Handle switching to a different workspace
   const handleSwitchWorkspace = () => {
-    clearSelectedWorkspacePath();
-    setWorkspacePath(null);
+    clearWorkspace();
   };
 
   // Show workspace selector if no path selected

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -16,7 +16,8 @@ import { ProofStatusBadge, WaiveDialog, GateRunPanel, GateRunBanner, RunHistoryP
 import { proofApi } from '@/lib/api';
 import { useProofRun } from '@/hooks/useProofRun';
 import { useNotificationContext } from '@/contexts/NotificationContext';
-import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
+import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
+import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import type { ProofRequirement, ProofRequirementListResponse, ProofReqStatus, ProofSeverity, ProofRunDetail } from '@/types';
 
 // ── Sort / filter types ────────────────────────────────────────────────────
@@ -101,8 +102,13 @@ function sortAriaAttribute(col: SortCol, activeCol: SortCol, activeDir: SortDir)
 // ── Main page ──────────────────────────────────────────────────────────────
 
 function ProofPageContent() {
-  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
-  const [workspaceReady, setWorkspaceReady] = useState(false);
+  const {
+    workspacePath,
+    workspaceReady,
+    isSelecting,
+    selectionError,
+    selectWorkspace,
+  } = useWorkspaceSelection();
   const [waivedReq, setWaivedReq] = useState<ProofRequirement | null>(null);
   const [captureOpen, setCaptureOpen] = useState(false);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
@@ -146,11 +152,6 @@ function ProofPageContent() {
 
   const searchParams = useSearchParams();
   const gateFilter = searchParams.get('gate')?.toLowerCase() ?? null;
-
-  useEffect(() => {
-    setWorkspacePath(getSelectedWorkspacePath());
-    setWorkspaceReady(true);
-  }, []);
 
   const { data, error, isLoading, mutate } = useSWR<ProofRequirementListResponse>(
     workspacePath ? `/api/v2/proof/requirements?path=${workspacePath}` : null,
@@ -201,16 +202,11 @@ function ProofPageContent() {
 
   if (!workspacePath) {
     return (
-      <main className="min-h-screen bg-background">
-        <div className="mx-auto max-w-7xl px-4 py-8">
-          <div className="rounded-lg border bg-muted/50 p-6 text-center">
-            <p className="text-muted-foreground">
-              No workspace selected. Return to{' '}
-              <Link href="/" className="text-primary hover:underline">Workspace</Link> and select a project.
-            </p>
-          </div>
-        </div>
-      </main>
+      <WorkspaceSelector
+        onSelectWorkspace={selectWorkspace}
+        isLoading={isSelecting}
+        error={selectionError}
+      />
     );
   }
 

--- a/web-ui/src/app/review/page.tsx
+++ b/web-ui/src/app/review/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import Link from 'next/link';
 import useSWR from 'swr';
-import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
 import { reviewApi, gatesApi, gitApi, prApi, tasksApi } from '@/lib/api';
+import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
+import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import { parseDiff, getFilePath } from '@/lib/diffParser';
 import type {
   DiffStatsResponse,
@@ -25,8 +25,13 @@ import { PRStatusPanel } from '@/components/review/PRStatusPanel';
 import { PRHistoryPanel } from '@/components/review/PRHistoryPanel';
 
 export default function ReviewPage() {
-  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
-  const [workspaceReady, setWorkspaceReady] = useState(false);
+  const {
+    workspacePath,
+    workspaceReady,
+    isSelecting,
+    selectionError,
+    selectWorkspace,
+  } = useWorkspaceSelection();
 
   // Core state
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -50,11 +55,6 @@ export default function ReviewPage() {
 
   // Feedback
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
-
-  useEffect(() => {
-    setWorkspacePath(getSelectedWorkspacePath());
-    setWorkspaceReady(true);
-  }, []);
 
   // Fetch diff data
   const {
@@ -230,19 +230,11 @@ export default function ReviewPage() {
   // No workspace
   if (!workspacePath) {
     return (
-      <main className="min-h-screen bg-background">
-        <div className="mx-auto max-w-7xl px-4 py-8">
-          <div className="rounded-lg border bg-muted/50 p-6 text-center">
-            <p className="text-muted-foreground">
-              No workspace selected. Return to{' '}
-              <Link href="/" className="text-primary hover:underline">
-                Workspace
-              </Link>{' '}
-              and select a project.
-            </p>
-          </div>
-        </div>
-      </main>
+      <WorkspaceSelector
+        onSelectWorkspace={selectWorkspace}
+        isLoading={isSelecting}
+        error={selectionError}
+      />
     );
   }
 

--- a/web-ui/src/app/settings/page.tsx
+++ b/web-ui/src/app/settings/page.tsx
@@ -155,7 +155,7 @@ export default function SettingsPage() {
                   saving={saving}
                 />
               ) : (
-                <ComingSoon />
+                <p className="text-sm text-muted-foreground">Loading…</p>
               )}
             </section>
           </TabsContent>
@@ -210,10 +210,6 @@ export default function SettingsPage() {
       </div>
     </main>
   );
-}
-
-function ComingSoon() {
-  return <p className="text-sm text-muted-foreground">Coming soon</p>;
 }
 
 function NoWorkspaceMessage() {

--- a/web-ui/src/components/prd/StressTestModal.tsx
+++ b/web-ui/src/components/prd/StressTestModal.tsx
@@ -72,7 +72,7 @@ export function StressTestModal({
     }
   }, [lines]);
 
-  const ambiguities = result?.ambiguities ?? [];
+  const ambiguities = useMemo(() => result?.ambiguities ?? [], [result]);
   const hasResults = status === 'complete' && ambiguities.length > 0;
 
   const answeredCount = useMemo(

--- a/web-ui/src/components/sessions/SessionCard.tsx
+++ b/web-ui/src/components/sessions/SessionCard.tsx
@@ -5,6 +5,17 @@ import { formatDistanceToNow } from 'date-fns';
 import { Cancel01Icon } from '@hugeicons/react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import type { Session } from '@/types';
 
 interface SessionCardProps {
@@ -17,12 +28,6 @@ export function SessionCard({ session, onEnd }: SessionCardProps) {
   const workspaceName = session.workspace_path.split('/').pop() || session.workspace_path;
   const isActive = session.state === 'active';
   const relativeTime = formatDistanceToNow(new Date(session.created_at), { addSuffix: true });
-
-  const handleEnd = () => {
-    if (window.confirm('End this session? This will stop the active agent.')) {
-      onEnd(session.id);
-    }
-  };
 
   return (
     <Card className="transition-colors hover:border-primary/50">
@@ -54,15 +59,32 @@ export function SessionCard({ session, onEnd }: SessionCardProps) {
             </Link>
           </Button>
           {isActive && (
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-7 gap-1 px-2 text-xs text-destructive"
-              onClick={handleEnd}
-            >
-              <Cancel01Icon className="h-3.5 w-3.5" />
-              End
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 gap-1 px-2 text-xs text-destructive"
+                >
+                  <Cancel01Icon className="h-3.5 w-3.5" />
+                  End
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>End this session?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will stop the active agent for this session.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => onEnd(session.id)}>
+                    End Session
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           )}
         </div>
       </CardContent>

--- a/web-ui/src/components/tasks/GitHubIssueImportModal.tsx
+++ b/web-ui/src/components/tasks/GitHubIssueImportModal.tsx
@@ -91,7 +91,7 @@ export function GitHubIssueImportModal({
       })
   );
 
-  const issues = data?.issues ?? [];
+  const issues = useMemo(() => data?.issues ?? [], [data]);
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
 

--- a/web-ui/src/hooks/useWorkspaceSelection.ts
+++ b/web-ui/src/hooks/useWorkspaceSelection.ts
@@ -23,8 +23,6 @@ interface SelectWorkspaceOptions {
 export interface UseWorkspaceSelectionResult {
   /** The selected workspace path, or null when none is selected. */
   workspacePath: string | null;
-  /** Imperatively set the path (e.g. after the home tech-stack flow). */
-  setWorkspacePath: (path: string | null) => void;
   /**
    * True once the path has been hydrated from localStorage on mount. Pages
    * gate their no-workspace UI on this to avoid an SSR/client hydration
@@ -99,11 +97,13 @@ export function useWorkspaceSelection(): UseWorkspaceSelectionResult {
   const clearWorkspace = useCallback(() => {
     clearSelectedWorkspacePath();
     setWorkspacePath(null);
+    // Drop any prior selection error so the selector doesn't re-render with a
+    // stale message after the user returns to it.
+    setSelectionError(null);
   }, []);
 
   return {
     workspacePath,
-    setWorkspacePath,
     workspaceReady,
     isSelecting,
     selectionError,

--- a/web-ui/src/hooks/useWorkspaceSelection.ts
+++ b/web-ui/src/hooks/useWorkspaceSelection.ts
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { mutate as globalMutate } from 'swr';
+import { WORKSPACES_SWR_KEY } from '@/hooks/useWorkspaces';
+import { workspaceApi } from '@/lib/api';
+import {
+  getSelectedWorkspacePath,
+  setSelectedWorkspacePath,
+  clearSelectedWorkspacePath,
+} from '@/lib/workspace-storage';
+import type { ApiError, WorkspaceResponse } from '@/types';
+
+interface SelectWorkspaceOptions {
+  /**
+   * Called after a *new* workspace is initialized (the path did not exist yet).
+   * Lets a page react to the freshly created workspace — e.g. the home page
+   * opens its tech-stack confirmation dialog.
+   */
+  onInitialized?: (workspace: WorkspaceResponse) => void;
+}
+
+export interface UseWorkspaceSelectionResult {
+  /** The selected workspace path, or null when none is selected. */
+  workspacePath: string | null;
+  /** Imperatively set the path (e.g. after the home tech-stack flow). */
+  setWorkspacePath: (path: string | null) => void;
+  /**
+   * True once the path has been hydrated from localStorage on mount. Pages
+   * gate their no-workspace UI on this to avoid an SSR/client hydration
+   * mismatch (localStorage is client-only).
+   */
+  workspaceReady: boolean;
+  /** True while {@link selectWorkspace} is resolving. */
+  isSelecting: boolean;
+  /** Last selection error message, or null. */
+  selectionError: string | null;
+  /** Validate/initialize a workspace path, persist it, and select it. */
+  selectWorkspace: (path: string, opts?: SelectWorkspaceOptions) => Promise<void>;
+  /** Clear the current selection (returns the user to the selector). */
+  clearWorkspace: () => void;
+}
+
+/**
+ * Shared workspace-selection state for pages that require a workspace.
+ *
+ * Centralizes the "no workspace selected" flow so every page renders the same
+ * {@link WorkspaceSelector} instead of bespoke link cards. Mirrors the original
+ * per-page handlers: check existence, init with tech-stack detection when new,
+ * persist to localStorage, and keep the server-backed workspace list fresh.
+ */
+export function useWorkspaceSelection(): UseWorkspaceSelectionResult {
+  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
+  const [workspaceReady, setWorkspaceReady] = useState(false);
+  const [isSelecting, setIsSelecting] = useState(false);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+
+  // Hydrate from localStorage on mount (client-only).
+  useEffect(() => {
+    setWorkspacePath(getSelectedWorkspacePath());
+    setWorkspaceReady(true);
+  }, []);
+
+  const selectWorkspace = useCallback(
+    async (path: string, opts?: SelectWorkspaceOptions) => {
+      setIsSelecting(true);
+      setSelectionError(null);
+
+      try {
+        const exists = await workspaceApi.checkExists(path);
+
+        if (exists.exists) {
+          // Touch /current so the server bumps recency — fire-and-forget so a
+          // transient error on this best-effort call can't block opening an
+          // accessible workspace.
+          void workspaceApi.getByPath(path).catch(() => {});
+          setSelectedWorkspacePath(path);
+          setWorkspacePath(path);
+        } else {
+          const initialized = await workspaceApi.init(path, { detect: true });
+          setSelectedWorkspacePath(path);
+          setWorkspacePath(path);
+          opts?.onInitialized?.(initialized);
+        }
+
+        // Keep the server-backed workspace list fresh (localStorage dual-write
+        // already happened via setSelectedWorkspacePath).
+        void globalMutate(WORKSPACES_SWR_KEY);
+      } catch (error) {
+        const apiError = error as ApiError;
+        setSelectionError(apiError.detail || 'Failed to open project');
+      } finally {
+        setIsSelecting(false);
+      }
+    },
+    []
+  );
+
+  const clearWorkspace = useCallback(() => {
+    clearSelectedWorkspacePath();
+    setWorkspacePath(null);
+  }, []);
+
+  return {
+    workspacePath,
+    setWorkspacePath,
+    workspaceReady,
+    isSelecting,
+    selectionError,
+    selectWorkspace,
+    clearWorkspace,
+  };
+}


### PR DESCRIPTION
Closes #653 — Phase 6.7.3 frontend polish (P3, post-beta; none of these block beta).

## What changed
1. **AlertDialog for session end** — `SessionCard` no longer uses the native `window.confirm`; it now uses the project's `AlertDialog` (same pattern as `BatchExecutionMonitor` stop/cancel). The "End" button is the dialog trigger; **End Session** confirms, **Keep** dismisses.
2. **Unified no-workspace UI** — `/`, `/costs`, `/proof`, `/review`, `/execution` previously split between the full `WorkspaceSelector` (home/costs) and three slightly-divergent "Return to Workspace" link cards. All five now render `WorkspaceSelector` via a new shared **`useWorkspaceSelection`** hook that centralizes path hydration, existence-check/init-with-detect, localStorage persistence, and the workspace-list refresh. Home keeps its tech-stack confirmation flow via the hook's `onInitialized` callback.
3. **Dead `ComingSoon` removed** — the unreachable `: <ComingSoon />` fallback in `settings/page.tsx` (and its helper) is gone; the agent tab falls back to a neutral `Loading…` while `draft` is null.
4. **Memo dep churn fixed** — `StressTestModal` (`ambiguities`) and `GitHubIssueImportModal` (`issues`) wrapped their fresh-array-literals in `useMemo`, clearing 4 `react-hooks/exhaustive-deps` warnings.

Net effect on the touched pages is a code reduction (−175/+239 with the new 113-line hook).

## Acceptance criteria — verification (outcome evidence)
- ✅ **Session end uses AlertDialog** — new behavioral tests: clicking *End* opens `role="alertdialog"` and does **not** call `onEnd`; confirming calls `onEnd(session.id)`; *Keep* does not. (`SessionCard.test.tsx`, 17 passed). `window.confirm` removed (0 occurrences).
- ✅ **Consistent no-workspace UI** — all 5 pages render `WorkspaceSelector`; `CostsPage` "shows the workspace selector when no workspace is set" passes; 0 remaining bespoke link cards.
- ✅ **Dead `ComingSoon` branch removed** — 0 occurrences in `src/`; SettingsPage suite passes.
- ✅ **(Fix list) memo deps stabilized** — 0 `exhaustive-deps` warnings on the two modals (was 4).

## Test/quality gates
- `npm test` → **90 suites / 1015 tests passing**
- `npm run build` → **success** (TypeScript clean in app code)
- `npx eslint .` → **0 errors** (only 3 pre-existing, unrelated warnings remain)
- Cross-family review (`codex review --base main`) → **no actionable regressions**

## Known limitations
- `/proof`, `/review`, `/execution` now offer **inline** workspace selection (previously a link back to `/`). This is the intended unification (matches `/` and `/costs`, and the existing `CostsPage` test that blesses `WorkspaceSelector` as the no-workspace UI).
- No live screenshots captured: the four behaviors are covered by behavioral tests asserting the actual outcomes (dialog gating, selector render, absence of dead code, lint deltas).