### PR TITLE
fix(auth): honor CODEFRAME_AUTH_REQUIRED in WebSocket auth (#676)

### DIFF
--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -11,9 +11,9 @@ JWT tokens get full permissions for backward compatibility.
 import logging
 import os
 import re
-from typing import Callable, Dict, Optional, Any
+from typing import Callable, Dict, Optional, Any, Tuple
 
-from fastapi import Depends, HTTPException, Request, Security, status
+from fastapi import Depends, HTTPException, Request, Security, WebSocket, status
 from fastapi.security import APIKeyHeader, HTTPBearer, HTTPAuthorizationCredentials
 
 from codeframe.auth.models import User
@@ -325,6 +325,89 @@ async def require_auth(
         detail="Authentication required",
         headers={"WWW-Authenticate": "Bearer, ApiKey"},
     )
+
+
+async def authenticate_websocket(
+    websocket: WebSocket,
+    *,
+    close_code: int,
+) -> Tuple[bool, Optional[int]]:
+    """Authenticate a WebSocket connection, honoring the no-auth opt-out.
+
+    This is the single source of truth for WebSocket auth so the terminal and
+    session-chat sockets cannot drift from the REST behavior of ``require_auth()``:
+
+    - When auth is disabled (``CODEFRAME_AUTH_REQUIRED`` falsy), returns
+      ``(True, None)`` without requiring a token — the same synthetic local
+      principal (``user_id=None``) REST admits in no-auth mode.
+    - Otherwise validates the ``?token=<JWT>`` query parameter (decode → subject
+      → active DB user). On success returns ``(True, user_id)``. On any failure
+      the socket is closed with ``close_code`` and ``(False, None)`` is returned.
+
+    Args:
+        websocket: The incoming WebSocket connection (not yet accepted).
+        close_code: Close code to use when rejecting (callers pass their existing
+            code, e.g. ``4001`` for terminal, ``1008`` for session chat).
+
+    Returns:
+        ``(authenticated, user_id)``. ``user_id`` is ``None`` both in no-auth
+        mode and on failure — callers gate on the boolean, not on ``user_id``.
+    """
+    # Single source of truth for the no-auth opt-out — shared with require_auth().
+    if not auth_required():
+        return True, None
+
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=close_code, reason="Authentication required: missing token")
+        return False, None
+
+    import jwt as pyjwt
+    from sqlalchemy import select
+
+    from codeframe.auth import manager
+    from codeframe.auth.manager import (
+        JWT_ALGORITHM,
+        JWT_AUDIENCE,
+        get_async_session_maker,
+    )
+
+    try:
+        # Read manager.SECRET live: it may be refreshed from .env at server
+        # startup (after import), so binding the value at import would stale it.
+        payload = pyjwt.decode(
+            token, manager.SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE
+        )
+        user_id_str = payload.get("sub")
+        if not user_id_str:
+            await websocket.close(code=close_code, reason="Invalid token: missing subject")
+            return False, None
+        user_id = int(user_id_str)
+    except pyjwt.ExpiredSignatureError:
+        await websocket.close(code=close_code, reason="Token expired")
+        return False, None
+    except (pyjwt.InvalidTokenError, ValueError) as exc:
+        logger.debug("WebSocket JWT decode error: %s", exc)
+        await websocket.close(code=close_code, reason="Invalid authentication token")
+        return False, None
+
+    try:
+        async_session_maker = get_async_session_maker()
+        async with async_session_maker() as session:
+            result = await session.execute(select(User).where(User.id == user_id))
+            user = result.scalar_one_or_none()
+            if user is None:
+                await websocket.close(code=close_code, reason="User not found")
+                return False, None
+            if not user.is_active:
+                await websocket.close(code=close_code, reason="User is inactive")
+                return False, None
+    except Exception as exc:
+        logger.error("WebSocket user lookup error: %s", exc)
+        await websocket.close(code=close_code, reason="Authentication failed")
+        return False, None
+
+    return True, user_id
 
 
 def require_scope(required_scope: str) -> Callable:

--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -34,15 +34,11 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
-import jwt as pyjwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from sqlalchemy import select
 
-from codeframe.auth import manager
-from codeframe.auth.manager import JWT_ALGORITHM, JWT_AUDIENCE, get_async_session_maker
-from codeframe.auth.models import User
+from codeframe.auth.dependencies import authenticate_websocket
 from codeframe.core.adapters.streaming_chat import StreamingChatAdapter
 from codeframe.ui.shared import session_chat_manager
 
@@ -56,47 +52,13 @@ router = APIRouter(tags=["websocket"])
 # ---------------------------------------------------------------------------
 
 
-async def _authenticate_websocket(websocket: WebSocket) -> Optional[int]:
-    """Validate JWT from query param. Returns user_id or closes with 1008."""
-    token = websocket.query_params.get("token")
-    if not token:
-        await websocket.close(code=1008, reason="Authentication required: missing token")
-        return None
+async def _authenticate_websocket(websocket: WebSocket) -> Tuple[bool, Optional[int]]:
+    """Authenticate the session-chat WebSocket via the shared helper.
 
-    try:
-        # Read manager.SECRET live: it may be refreshed from .env at server
-        # startup (after import), so binding the value at import would stale it.
-        payload = pyjwt.decode(token, manager.SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE)
-        user_id_str = payload.get("sub")
-        if not user_id_str:
-            await websocket.close(code=1008, reason="Invalid token: missing subject")
-            return None
-        user_id = int(user_id_str)
-    except pyjwt.ExpiredSignatureError:
-        await websocket.close(code=1008, reason="Token expired")
-        return None
-    except (pyjwt.InvalidTokenError, ValueError) as exc:
-        logger.debug("WebSocket JWT decode error: %s", exc)
-        await websocket.close(code=1008, reason="Invalid authentication token")
-        return None
-
-    try:
-        async_session_maker = get_async_session_maker()
-        async with async_session_maker() as session:
-            result = await session.execute(select(User).where(User.id == user_id))
-            user = result.scalar_one_or_none()
-            if user is None:
-                await websocket.close(code=1008, reason="User not found")
-                return None
-            if not user.is_active:
-                await websocket.close(code=1008, reason="User is inactive")
-                return None
-    except Exception as exc:
-        logger.error("WebSocket user lookup error: %s", exc)
-        await websocket.close(code=1008, reason="Authentication failed")
-        return None
-
-    return user_id
+    Returns ``(authenticated, user_id)``; closes the socket with ``1008`` on
+    failure. ``user_id`` is ``None`` in no-auth mode — matching REST.
+    """
+    return await authenticate_websocket(websocket, close_code=1008)
 
 
 async def _run_streaming_adapter(
@@ -146,8 +108,8 @@ async def _run_streaming_adapter(
 async def session_chat_ws(session_id: str, websocket: WebSocket) -> None:
     """Bidirectional WebSocket for streaming agent chat on an interactive session."""
     # --- Auth ---
-    user_id = await _authenticate_websocket(websocket)
-    if user_id is None:
+    authenticated, _user_id = await _authenticate_websocket(websocket)
+    if not authenticated:
         return
 
     # --- Session validation ---

--- a/codeframe/ui/routers/terminal_ws.py
+++ b/codeframe/ui/routers/terminal_ws.py
@@ -20,22 +20,20 @@ import json
 import logging
 import os
 import shutil
+from typing import Optional, Tuple
 
-import jwt as pyjwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from sqlalchemy import select
 
-from codeframe.auth import manager
-from codeframe.auth.manager import JWT_ALGORITHM, JWT_AUDIENCE, get_async_session_maker
-from codeframe.auth.models import User
+from codeframe.auth.dependencies import authenticate_websocket
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["websocket"])
 
-# Per-user concurrent terminal connection counter (in-process; resets on restart)
+# Per-user concurrent terminal connection counter (in-process; resets on restart).
+# Key is the user_id, or None in no-auth mode (all local terminals share a bucket).
 _MAX_TERMINALS_PER_USER = 3
-_user_terminal_counts: dict[int, int] = {}
+_user_terminal_counts: dict[Optional[int], int] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -43,47 +41,13 @@ _user_terminal_counts: dict[int, int] = {}
 # ---------------------------------------------------------------------------
 
 
-async def _authenticate_websocket(websocket: WebSocket) -> int | None:
-    """Validate JWT from query param. Returns user_id or closes the socket."""
-    token = websocket.query_params.get("token")
-    if not token:
-        await websocket.close(code=4001, reason="Authentication required: missing token")
-        return None
+async def _authenticate_websocket(websocket: WebSocket) -> Tuple[bool, Optional[int]]:
+    """Authenticate the terminal WebSocket via the shared helper.
 
-    try:
-        # Read manager.SECRET live: it may be refreshed from .env at server
-        # startup (after import), so binding the value at import would stale it.
-        payload = pyjwt.decode(token, manager.SECRET, algorithms=[JWT_ALGORITHM], audience=JWT_AUDIENCE)
-        user_id_str = payload.get("sub")
-        if not user_id_str:
-            await websocket.close(code=4001, reason="Invalid token: missing subject")
-            return None
-        user_id = int(user_id_str)
-    except pyjwt.ExpiredSignatureError:
-        await websocket.close(code=4001, reason="Token expired")
-        return None
-    except (pyjwt.InvalidTokenError, ValueError) as exc:
-        logger.debug("Terminal WS JWT decode error: %s", exc)
-        await websocket.close(code=4001, reason="Invalid authentication token")
-        return None
-
-    try:
-        async_session_maker = get_async_session_maker()
-        async with async_session_maker() as session:
-            result = await session.execute(select(User).where(User.id == user_id))
-            user = result.scalar_one_or_none()
-            if user is None:
-                await websocket.close(code=4001, reason="User not found")
-                return None
-            if not user.is_active:
-                await websocket.close(code=4001, reason="User is inactive")
-                return None
-    except Exception as exc:
-        logger.error("Terminal WS user lookup error: %s", exc)
-        await websocket.close(code=4001, reason="Authentication failed")
-        return None
-
-    return user_id
+    Returns ``(authenticated, user_id)``; closes the socket with ``4001`` on
+    failure. ``user_id`` is ``None`` in no-auth mode — matching REST.
+    """
+    return await authenticate_websocket(websocket, close_code=4001)
 
 
 # ---------------------------------------------------------------------------
@@ -95,8 +59,8 @@ async def _authenticate_websocket(websocket: WebSocket) -> int | None:
 async def session_terminal_ws(session_id: str, websocket: WebSocket) -> None:
     """Bidirectional WebSocket that shells bash in the session's workspace."""
     # --- Auth ---
-    user_id = await _authenticate_websocket(websocket)
-    if user_id is None:
+    authenticated, user_id = await _authenticate_websocket(websocket)
+    if not authenticated:
         return
 
     # --- Session lookup ---
@@ -111,8 +75,10 @@ async def session_terminal_ws(session_id: str, websocket: WebSocket) -> None:
         return
 
     # --- Ownership check ---
+    # Skipped in no-auth mode (user_id is None): there is no identity to enforce,
+    # matching REST behavior under CODEFRAME_AUTH_REQUIRED=false.
     session_user_id = session.get("user_id")
-    if session_user_id is not None and int(session_user_id) != user_id:
+    if user_id is not None and session_user_id is not None and int(session_user_id) != user_id:
         await websocket.close(code=4003, reason="Forbidden: session belongs to another user")
         return
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -27,9 +27,10 @@ Get your project built with AI agents in minutes.
    local server only, set `CODEFRAME_ALLOW_INSECURE_SECRET=1` to start without
    a secret — it signs JWTs with the known default (forgeable, never expose it)
    while keeping auth on so the REST API and the session/terminal WebSockets all
-   work. (`CODEFRAME_AUTH_REQUIRED=false` is a separate knob that disables REST
-   auth but **not** WebSocket auth, so the sessions UI is only partially usable
-   in that mode.)
+   work. (`CODEFRAME_AUTH_REQUIRED=false` is a separate knob that disables auth
+   entirely for local dev — both the REST API and the session/terminal
+   WebSockets then accept unauthenticated connections, so the sessions UI is
+   fully usable in that mode.)
 
 ## Coming from ralph?
 

--- a/tests/api/test_session_chat_ws.py
+++ b/tests/api/test_session_chat_ws.py
@@ -47,14 +47,16 @@ def _ws_url(session_id: str, token: str) -> str:
 class TestSessionChatWSAuth:
     """WebSocket endpoint rejects unauthenticated and invalid connections."""
 
-    def test_rejects_missing_token(self, api_client: TestClient):
+    def test_rejects_missing_token(self, api_client: TestClient, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         session_id = _create_session(api_client)
         with pytest.raises(WebSocketDisconnect) as exc_info:
             with api_client.websocket_connect(f"/ws/sessions/{session_id}/chat") as ws:
                 ws.receive_json()
         assert exc_info.value.code == 1008
 
-    def test_rejects_invalid_token(self, api_client: TestClient):
+    def test_rejects_invalid_token(self, api_client: TestClient, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         session_id = _create_session(api_client)
         with pytest.raises(WebSocketDisconnect) as exc_info:
             with api_client.websocket_connect(
@@ -63,7 +65,8 @@ class TestSessionChatWSAuth:
                 ws.receive_json()
         assert exc_info.value.code == 1008
 
-    def test_rejects_expired_token(self, api_client: TestClient):
+    def test_rejects_expired_token(self, api_client: TestClient, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         from datetime import datetime, timedelta, timezone
         from codeframe.auth.manager import SECRET
         import jwt as pyjwt
@@ -82,6 +85,15 @@ class TestSessionChatWSAuth:
             ) as ws:
                 ws.receive_json()
         assert exc_info.value.code == 1008
+
+    def test_no_auth_mode_connects_without_token(self, api_client: TestClient, monkeypatch):
+        """With CODEFRAME_AUTH_REQUIRED=false, the chat WS connects with no token (matches REST)."""
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        session_id = _create_session(api_client)
+        with api_client.websocket_connect(f"/ws/sessions/{session_id}/chat") as ws:
+            ws.send_json({"type": "ping"})
+            data = ws.receive_json()
+            assert data["type"] == "pong"
 
     def test_accepts_valid_token(self, api_client: TestClient):
         """A valid JWT connects successfully (responds to ping)."""

--- a/tests/auth/test_websocket_auth.py
+++ b/tests/auth/test_websocket_auth.py
@@ -1,0 +1,75 @@
+"""Tests for the shared WebSocket auth helper (issue #676).
+
+`authenticate_websocket()` is the single source of truth that lets terminal and
+session-chat WebSockets honor `CODEFRAME_AUTH_REQUIRED` the same way `require_auth()`
+does for REST:
+- auth disabled -> (True, None) without requiring a token (synthetic local principal)
+- auth enabled  -> validate the ?token= JWT, or close the socket with the given code
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from codeframe.auth.dependencies import authenticate_websocket
+
+pytestmark = pytest.mark.v2
+
+
+def _make_ws(token: str | None = None):
+    """Minimal WebSocket double with query_params and an awaitable close()."""
+    ws = MagicMock()
+    ws.query_params = {} if token is None else {"token": token}
+    ws.close = AsyncMock()
+    return ws
+
+
+class TestNoAuthMode:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_local_principal_without_token(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        ws = _make_ws(token=None)
+
+        ok, user_id = await authenticate_websocket(ws, close_code=4001)
+
+        assert ok is True
+        assert user_id is None
+        ws.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disabled_ignores_provided_token(self, monkeypatch):
+        """A stale/garbage token must not break the connection in no-auth mode."""
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        ws = _make_ws(token="not-a-jwt")
+
+        ok, user_id = await authenticate_websocket(ws, close_code=1008)
+
+        assert ok is True
+        assert user_id is None
+        ws.close.assert_not_awaited()
+
+
+class TestAuthEnabled:
+    @pytest.mark.asyncio
+    async def test_enabled_missing_token_closes(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        ws = _make_ws(token=None)
+
+        ok, user_id = await authenticate_websocket(ws, close_code=4001)
+
+        assert ok is False
+        assert user_id is None
+        ws.close.assert_awaited_once()
+        assert ws.close.await_args.kwargs["code"] == 4001
+
+    @pytest.mark.asyncio
+    async def test_enabled_invalid_token_closes_with_given_code(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        ws = _make_ws(token="not-a-jwt")
+
+        ok, user_id = await authenticate_websocket(ws, close_code=1008)
+
+        assert ok is False
+        assert user_id is None
+        ws.close.assert_awaited_once()
+        assert ws.close.await_args.kwargs["code"] == 1008

--- a/tests/ui/test_terminal_ws.py
+++ b/tests/ui/test_terminal_ws.py
@@ -39,7 +39,8 @@ def _make_app(session_data: dict | None = None, user_data=None):
 
 
 class TestTerminalWsAuth:
-    def test_missing_token_closes_4001(self):
+    def test_missing_token_closes_4001(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         app = _make_app()
         client = TestClient(app)
         with pytest.raises(Exception):
@@ -47,7 +48,8 @@ class TestTerminalWsAuth:
             with client.websocket_connect("/ws/sessions/s1/terminal"):
                 pass
 
-    def test_invalid_token_closes_4001(self):
+    def test_invalid_token_closes_4001(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         app = _make_app()
         client = TestClient(app)
         with pytest.raises(Exception):
@@ -62,7 +64,7 @@ class TestTerminalWsAuth:
         # Patch auth to succeed and return user_id=1
         with patch(
             "codeframe.ui.routers.terminal_ws._authenticate_websocket",
-            new=AsyncMock(return_value=1),
+            new=AsyncMock(return_value=(True, 1)),
         ):
             with pytest.raises(Exception):
                 with client.websocket_connect("/ws/sessions/missing/terminal?token=x"):
@@ -75,7 +77,7 @@ class TestTerminalWsAuth:
 
         with patch(
             "codeframe.ui.routers.terminal_ws._authenticate_websocket",
-            new=AsyncMock(return_value=1),
+            new=AsyncMock(return_value=(True, 1)),
         ):
             with pytest.raises(Exception):
                 with client.websocket_connect("/ws/sessions/s1/terminal?token=x"):
@@ -90,7 +92,7 @@ class TestTerminalWsAuth:
 
         with patch(
             "codeframe.ui.routers.terminal_ws._authenticate_websocket",
-            new=AsyncMock(return_value=1),
+            new=AsyncMock(return_value=(True, 1)),
         ):
             with pytest.raises(Exception):
                 with client.websocket_connect("/ws/sessions/s1/terminal?token=x"):
@@ -127,7 +129,7 @@ class TestTerminalWsRelay:
         with (
             patch(
                 "codeframe.ui.routers.terminal_ws._authenticate_websocket",
-                new=AsyncMock(return_value=1),
+                new=AsyncMock(return_value=(True, 1)),
             ),
             patch(
                 "asyncio.create_subprocess_exec",
@@ -139,6 +141,30 @@ class TestTerminalWsRelay:
                 # Connection was accepted; we can receive bytes
                 # (mock stdout.read returns b"$ " then b"" to end relay)
                 pass  # Just verify it connected without error
+
+    def test_no_auth_mode_connects_without_token(self, monkeypatch):
+        """With CODEFRAME_AUTH_REQUIRED=false, the terminal WS connects with no token."""
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        # Session has a user_id, but in no-auth mode (user_id=None) ownership is skipped.
+        app = _make_app(
+            session_data={"state": "active", "workspace_path": "/tmp", "user_id": 999}
+        )
+
+        mock_proc = MagicMock()
+        mock_proc.stdin = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"$ ")
+        mock_proc.terminate = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=mock_proc),
+        ):
+            client = TestClient(app)
+            # No ?token= and no auth patch — real auth helper must admit it.
+            with client.websocket_connect("/ws/sessions/s1/terminal") as ws:
+                pass  # Connected without error → no-auth path works
 
     def test_resize_message_does_not_crash(self):
         """Sending a resize JSON message should be silently ignored."""
@@ -157,7 +183,7 @@ class TestTerminalWsRelay:
         with (
             patch(
                 "codeframe.ui.routers.terminal_ws._authenticate_websocket",
-                new=AsyncMock(return_value=1),
+                new=AsyncMock(return_value=(True, 1)),
             ),
             patch(
                 "asyncio.create_subprocess_exec",


### PR DESCRIPTION
## Summary

Fixes #676. `CODEFRAME_AUTH_REQUIRED=false` (the documented local no-auth opt-out) disabled REST auth but the **terminal** and **session-chat** WebSockets still demanded a `?token=` JWT and closed the connection — so the sessions UI and embedded terminal were unusable in no-auth mode. The two WS auth helpers also duplicated the JWT-validation logic, which is how they drifted from REST in the first place.

## Approach (issue's preferred option 1)

Collapse both near-identical WS auth helpers into a single shared `authenticate_websocket()` in `codeframe/auth/dependencies.py` that consults `auth_required()` **first** — the same source of truth `require_auth()` uses for REST:

- **No-auth mode** → returns `(True, None)` without requiring a token, mirroring REST's synthetic local principal (`user_id=None`).
- **Auth enabled** → validates the `?token=` JWT exactly as before (decode → subject → active DB user) and closes with the caller's existing code (`4001` terminal / `1008` chat) on any failure.

The per-router `_authenticate_websocket` wrappers remain (now thin delegates) and just pass their close code. Downstream, the terminal ownership check is skipped when `user_id is None`, and the per-user terminal counter buckets no-auth terminals together.

## Acceptance criteria

- [x] **WS connects without a token in no-auth mode**, matching REST — terminal + chat.
- [x] **REST and WS share a single source of truth** for the no-auth decision (`auth_required()`); duplicated JWT logic removed.
- [x] **Tests**: WS connects in no-auth mode, and both sockets still reject missing/invalid/expired tokens when auth is enabled.

## Testing

- `tests/auth/test_websocket_auth.py` (new): shared-helper unit tests — no-auth pass-through `(True, None)`, auth-on missing/invalid token closes with the caller's code.
- `tests/ui/test_terminal_ws.py`: added no-auth connect test; existing auth-rejection tests pinned to `CODEFRAME_AUTH_REQUIRED=true`; mock contract updated to `(ok, user_id)`.
- `tests/api/test_session_chat_ws.py`: added no-auth connect test; rejection tests pinned to auth-on.
- Full `tests/auth/`, `test_v2_auth_enforcement.py`, `test_security_config.py` green; ruff clean.

Cross-family review: `codex review --base main` found no introduced bugs.

## Known limitations

- No-auth mode is local-dev only (unchanged scope). In no-auth mode the terminal per-user cap (3) is shared across all local terminals (single `None` bucket), and session ownership is not enforced — symmetric with REST, which has no identity to enforce when auth is disabled.
- Frontend WS hooks still append the token when one is present; harmless in no-auth mode (the token is ignored).
