### PR TITLE
fix(ci): run full non-e2e suite, drop -m v2 blind spot (#669)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,12 +236,12 @@ jobs:
           uv pip install -e .
           echo "✅ Package installed in editable mode"
 
-      - name: Run pytest (v2 suite) with coverage
-        timeout-minutes: 15
+      - name: Run pytest (full non-e2e suite) with coverage
+        timeout-minutes: 20
         run: |
           uv run pytest tests/ \
             --ignore=tests/e2e \
-            -m v2 \
+            -m "not lifecycle" \
             -q \
             --tb=short \
             --cov=codeframe \
@@ -249,7 +249,8 @@ jobs:
             --cov-report=xml \
             --cov-report=html
           echo "Coverage measured for reporting purposes."
-          echo "Note: -m v2 covers v2 code paths only; legacy v1 modules are excluded."
+          echo "Note: gate runs every non-e2e test except 'lifecycle' (real-LLM,"
+          echo "      run locally via scripts/lifecycle before opening a PR)."
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,10 +152,10 @@ tests/
 
 ### Python / CLI
 ```bash
-uv run pytest                     # All tests
-uv run pytest -m v2               # v2 tests only
-uv run pytest tests/core/         # Core module tests
-uv run pytest tests/lifecycle/    # Lifecycle tests (no live API calls — uses MockProvider)
+uv run pytest                            # All tests
+uv run pytest --ignore=tests/e2e -m "not lifecycle"  # The CI gate (every non-e2e, non-real-LLM test)
+uv run pytest tests/core/                # Core module tests
+scripts/lifecycle --mode cli|api|web|all # Real-LLM lifecycle tests (run locally before a PR)
 uv run ruff check .
 
 # Web UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ tests/
 ### Python / CLI
 ```bash
 uv run pytest                            # All tests
-uv run pytest --ignore=tests/e2e -m "not lifecycle"  # The CI gate (every non-e2e, non-real-LLM test)
+uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"  # The CI gate (every non-e2e, non-real-LLM test)
 uv run pytest tests/core/                # Core module tests
 scripts/lifecycle --mode cli|api|web|all # Real-LLM lifecycle tests (run locally before a PR)
 uv run ruff check .

--- a/pytest.ini
+++ b/pytest.ini
@@ -45,6 +45,13 @@ markers =
     edge_case: marks edge case tests for boundary conditions and error handling
     lifecycle: full end-to-end lifecycle tests (real LLM calls — run via scripts/lifecycle)
 
+# CI gate (the backend job in .github/workflows/test.yml) runs the full non-e2e
+# suite EXCEPT real-LLM lifecycle tests:
+#   pytest tests/ --ignore=tests/e2e -m "not lifecycle"
+# The `v2` marker is no longer a CI gate (the v1->v2 refactor is done); it stays
+# registered for back-compat / ad-hoc selection. Don't rely on it to gate a
+# test — anything non-e2e and non-lifecycle runs in CI by default (#669).
+#
 # To run only unit tests (fast):
 #   pytest -m "not integration and not slow and not e2e"
 #
@@ -53,9 +60,6 @@ markers =
 #
 # To run all tests except slow ones:
 #   pytest -m "not slow"
-#
-# To run only v2 tests:
-#   pytest -m v2
 #
 # To run lifecycle tests (real LLM — use scripts/lifecycle instead):
 #   ANTHROPIC_API_KEY=sk-ant-... pytest -m lifecycle

--- a/tests/auth/test_query_param_token.py
+++ b/tests/auth/test_query_param_token.py
@@ -15,8 +15,9 @@ import pytest
 from fastapi import FastAPI, Depends, Request
 from fastapi.testclient import TestClient
 
+from codeframe.auth import manager
 from codeframe.auth.dependencies import get_current_user, get_current_user_optional
-from codeframe.auth.manager import SECRET, JWT_ALGORITHM, reset_auth_engine
+from codeframe.auth.manager import JWT_ALGORITHM, reset_auth_engine
 from codeframe.platform_store.database import Database
 
 pytestmark = pytest.mark.v2
@@ -27,7 +28,13 @@ SSE_PATH = "/api/v2/tasks/abc/stream"
 PLAIN_PATH = "/whoami"
 
 
-def _make_token(user_id: int = 1, secret: str = SECRET) -> str:
+def _make_token(user_id: int = 1, secret: str = None) -> str:
+    # Read manager.SECRET live, not at import. get_current_user verifies against
+    # the live global, and any test that starts the app via TestClient refreshes
+    # it from .env (lifespan -> refresh_secret). Binding at import would make
+    # these tokens unverifiable once that happens — an order-dependent flake.
+    if secret is None:
+        secret = manager.SECRET
     payload = {
         "sub": str(user_id),
         "aud": ["fastapi-users:auth"],


### PR DESCRIPTION
Closes #669.

## Problem
The backend CI gate ran `pytest tests/ --ignore=tests/e2e -m v2`, but the root
`tests/conftest.py` never auto-marks `v2`. So `-m v2` **silently deselected ~514
tests (~40% of files)** — they never gated a PR. The `v1→v2` refactor the filter
existed for is finished.

## What I did
**Categorized the 514 deselected tests** (`-m "not v2"`): **497 pass, 16 skip, 1
fails** — and that 1 is a real-LLM `lifecycle` test, excluded from CI by design.
=> **No dead tests remain** (the v1 `/api/projects` pair was already removed in
#667). The blind spot was ~500 legit tests that simply never ran in CI.

## Changes
- **CI** (`.github/workflows/test.yml`): `-m v2` → `-m "not lifecycle"`. Every
  non-e2e test now gates PRs; only real-LLM `lifecycle` tests are excluded (they
  need a key + cost money — run locally via `scripts/lifecycle` before the PR).
  `timeout-minutes` 15 → 20 for the ~500 extra tests under coverage.
- **`pytest.ini`**: document the two-tier gate. The `v2` marker is kept for
  back-compat but no longer gates — anything non-e2e/non-lifecycle runs by default,
  so the suite can't silently shrink again.
- **`tests/auth/test_query_param_token.py`**: sign JWTs with the **live**
  `manager.SECRET` instead of the import-time binding.

## Two-tier test strategy (explicit going forward)
- **CI (every PR):** `-m "not lifecycle"` — fast, no API key, environment-correctness.
- **Local pre-PR:** `scripts/lifecycle --mode cli|api|web|all` — the real-LLM
  end-to-end tests. Not skipped, just a separate tier.

## Why the test change was needed
Un-hiding the suite surfaced a real order-dependent flake. `test_query_param_token`
bound `SECRET` at import and signed tokens with it, but `get_current_user` verifies
against the live `manager.SECRET`. Any test that starts the app via `TestClient`
refreshes the secret from `.env` (lifespan → `refresh_secret`), making import-bound
tokens unverifiable → 3 happy-path tests 401. CI's backend job has no `.env`, so it
was a local-only landmine, but it's now fixed and deterministic.

## Verification
- Full non-e2e run (`-m "not lifecycle"`): **3830 passed, 11 skipped, 6 deselected
  (lifecycle only), 0 failed** in 8m06s (was 3333 gated / 514 blind).
- Leak repro (`adapters + health + query_param`): 3 failed → **44 passed** after the fix.
- `ruff check` clean.

## Acceptance criteria
- [x] Deselected tests categorized (dead vs legit); dead ones removed (0 remained).
- [x] Legit tests run in CI (filter relaxed to `not lifecycle`).
- [x] CI no longer silently excludes ~40% of files; selection is explicit and green.

## Known limitations
- `lifecycle` tests still don't run in CI by design (real LLM). They're covered by
  the local `scripts/lifecycle` tier, not this gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CI to run all non-e2e tests except real-LLM `lifecycle` tests.
  * Increased the pytest step timeout to 20 minutes.
  * Improved JWT query-param token generation to use the current shared secret at runtime.
* **Documentation**
  * Refreshed test command examples to match the new non-`lifecycle` CI selection behavior.
* **Chores**
  * Updated CI configuration guidance/comments to reflect the updated test selection strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->