### PR TITLE
fix(web-ui): resolve react-hooks/exhaustive-deps warnings (#682)

### DIFF
--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/web-ui/src/app/proof/[req_id]/page.tsx
+++ b/web-ui/src/app/proof/[req_id]/page.tsx
@@ -85,7 +85,7 @@ export default function ProofDetailPage() {
     setFilterGate(saved.gate);
     setFilterResult(saved.result);
     setSearch(saved.search);
-  }, []);
+  }, [reqId]);
 
   const { data: req, error: reqError, isLoading: reqLoading, mutate: mutateReq } =
     useSWR<ProofRequirement>(

--- a/web-ui/src/components/execution/BatchExecutionMonitor.tsx
+++ b/web-ui/src/components/execution/BatchExecutionMonitor.tsx
@@ -88,15 +88,16 @@ export function BatchExecutionMonitor({ batchId, workspacePath }: BatchExecution
   }, [batchId, workspacePath]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll every 5 seconds while batch is active
+  const batchStatus = batch?.status;
   useEffect(() => {
-    const isActive = batch && !['COMPLETED', 'FAILED', 'CANCELLED'].includes(batch.status);
+    const isActive = batchStatus && !['COMPLETED', 'FAILED', 'CANCELLED'].includes(batchStatus);
     if (isActive) {
       pollRef.current = setInterval(fetchBatch, 5000);
     }
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
     };
-  }, [batch?.status, fetchBatch]);
+  }, [batchStatus, fetchBatch]);
 
   // Note: batch.completed / blocker.created notifications are dispatched by the
   // cross-page background watcher in NotificationProvider (issue #652), so they

--- a/web-ui/src/components/prd/DiscoveryPanel.tsx
+++ b/web-ui/src/components/prd/DiscoveryPanel.tsx
@@ -48,6 +48,28 @@ export function DiscoveryPanel({
   const [error, setError] = useState<string | null>(null);
   const [pendingSession, setPendingSession] = useState<PendingSession | null>(null);
 
+  // ─── Start a brand-new session ─────────────────────────────────
+  // Declared before initSession so it can be a stable dependency of it.
+  const startNewSession = useCallback(async () => {
+    setError(null);
+    setPendingSession(null);
+    try {
+      const resp = await discoveryApi.start(workspacePath);
+      setSessionId(resp.session_id);
+      setState('discovering');
+      setMessages([
+        {
+          role: 'assistant',
+          content: questionText(resp.question),
+          timestamp: now(),
+        },
+      ]);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.detail || 'Failed to start discovery session');
+    }
+  }, [workspacePath]);
+
   // ─── Initialise: check for existing session before starting ────
   const initSession = useCallback(async () => {
     setIsThinking(true);
@@ -80,28 +102,7 @@ export function DiscoveryPanel({
     } finally {
       setIsThinking(false);
     }
-  }, [workspacePath]);
-
-  // ─── Start a brand-new session ─────────────────────────────────
-  const startNewSession = useCallback(async () => {
-    setError(null);
-    setPendingSession(null);
-    try {
-      const resp = await discoveryApi.start(workspacePath);
-      setSessionId(resp.session_id);
-      setState('discovering');
-      setMessages([
-        {
-          role: 'assistant',
-          content: questionText(resp.question),
-          timestamp: now(),
-        },
-      ]);
-    } catch (err) {
-      const apiErr = err as ApiError;
-      setError(apiErr.detail || 'Failed to start discovery session');
-    }
-  }, [workspacePath]);
+  }, [workspacePath, startNewSession]);
 
   // ─── Resume an existing session ────────────────────────────────
   const resumeSession = useCallback(() => {


### PR DESCRIPTION
Closes #682.

## What

Resolves the remaining `react-hooks/exhaustive-deps` warnings and enforces zero-warnings in CI lint.

**Scope note:** The issue listed 7 warnings. By the time this ran (after #658's eslint-10 + react-hooks plugin upgrade, which the issue explicitly sequenced before this work), only **3 remained** — the 4 `useMemo` warnings in `StressTestModal` / `GitHubIssueImportModal` were already cleared by that upgrade.

## Changes

| File | Fix |
|------|-----|
| `proof/[req_id]/page.tsx` | Add `reqId` to the mount effect deps (setters are stable; correctly reloads session filters if the route param changes) |
| `BatchExecutionMonitor.tsx` | Hoist `const batchStatus = batch?.status` and depend on it — preserves the original "re-run the poll only when status changes" intent |
| `DiscoveryPanel.tsx` | Reorder `startNewSession` before `initSession` (no back-dependency) and add it to `initSession`'s deps, avoiding a TDZ reference |
| `package.json` | `lint` now runs `eslint . --max-warnings 0` to prevent regressions (issue's optional acceptance criterion) |

All changes are behavior-preserving.

## Verification (outcome evidence)

- `npm run lint` → exit 0, **0 warnings** (was 3 before)
- `npm test` → **1020 passed** / 91 suites
- `npm run build` → succeeds

## Acceptance criteria

- [x] All remaining warnings resolved without regressions
- [x] `--max-warnings 0` enforced in the lint step

## Known limitations

None. The 2 deliberate `eslint-disable` lines for mount-only effects (`BatchExecutionMonitor` initial fetch, `DiscoveryPanel` auto-init) are pre-existing and intentionally left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter state restoration when switching between different requirement IDs, preventing stale filters from persisting.

* **Chores**
  * Strengthened code quality standards by enforcing stricter linting rules.
  * Improved internal polling and hook dependency management for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->