### PR TITLE
fix(security): block SSRF to internal/metadata hosts in webhook URLs (#656)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,15 @@ REDIS_URL=redis://localhost:6379
 
 CODEFRAME_API_KEY_SECRET=<secret>     # API key hashing
 
+# Outbound webhook SSRF guard (#656) — default OFF (block)
+CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1    # Allow webhook URLs whose host resolves to
+                                      # private/loopback/link-local/metadata IPs.
+                                      # Off by default: such hosts are rejected by
+                                      # the notifications save + test endpoints to
+                                      # prevent SSRF (e.g. 169.254.169.254 IMDS).
+                                      # Set for self-hosted ops with legit internal
+                                      # webhook targets (localhost, RFC1918).
+
 # Telemetry (default: off — must be explicitly opted in)
 CODEFRAME_TELEMETRY=on|off            # Force telemetry on or off; overrides ~/.codeframe/telemetry.json
 CODEFRAME_TELEMETRY_ENDPOINT=<url>    # Override collector URL (default: https://telemetry.codeframe.dev/v1/events)

--- a/codeframe/notifications/webhook.py
+++ b/codeframe/notifications/webhook.py
@@ -260,6 +260,10 @@ class WebhookNotificationService:
                     target_url,
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=self.timeout),
+                    # SSRF (#656): the URL host is validated before saving, but
+                    # a public target could 302 → 169.254.169.254 / localhost.
+                    # Webhook delivery never needs to follow redirects, so don't.
+                    allow_redirects=False,
                 ) as response:
                     ok = 200 <= response.status < 300
                     if not ok:

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -16,7 +16,10 @@ require a workspace. Env vars take precedence at read time. Notifications
 config is per-workspace and persisted under .codeframe/notifications_config.json.
 """
 
+import ipaddress
 import logging
+import os
+import socket
 
 from typing import Optional, cast
 
@@ -447,13 +450,84 @@ async def get_notification_settings(
 _ALLOWED_WEBHOOK_SCHEMES = frozenset({"http", "https"})
 
 
+def _allow_private_webhook_hosts() -> bool:
+    """Opt-out for the SSRF host check.
+
+    Off by default (block private/internal targets). Self-hosted operators who
+    legitimately point webhooks at ``localhost`` or an internal service set
+    ``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1`` — read at request time so it can be
+    toggled without a restart.
+    """
+    return os.getenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _assert_webhook_host_is_public(hostname: str) -> None:
+    """Reject webhook hosts that resolve to internal/metadata/private IPs.
+
+    Blocks the SSRF vector where an authenticated user points the webhook at
+    ``169.254.169.254`` (cloud IMDS), ``127.0.0.1``, or an RFC1918 address —
+    the ``/notifications/test`` endpoint fires the URL immediately and returns
+    the HTTP status, a blind-to-semi-blind SSRF primitive. IP literals are
+    checked directly; DNS names are resolved and every returned address is
+    checked. A host that cannot be resolved is allowed through — it isn't
+    reachable right now, and we don't want to block saving a not-yet-live URL.
+
+    ponytail: resolve-and-check, not a request-time pinned connector, so DNS
+    rebinding (public at save, private at fire) is out of scope. Upgrade path:
+    pin the resolved IP through a custom aiohttp connector in ``send_event``.
+    """
+    if _allow_private_webhook_hosts():
+        return
+
+    try:
+        candidates = [ipaddress.ip_address(hostname)]
+    except ValueError:
+        try:
+            candidates = [
+                ipaddress.ip_address(info[4][0])
+                for info in socket.getaddrinfo(
+                    hostname, None, proto=socket.IPPROTO_TCP
+                )
+            ]
+        except socket.gaierror:
+            return  # unresolvable now → not reachable now; don't block the save
+
+    for ip in candidates:
+        # ::ffff:169.254.169.254 — judge by the embedded IPv4 address.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=api_error(
+                    f"Webhook host resolves to a private/internal address "
+                    f"({ip}); refusing to avoid SSRF. Set "
+                    f"CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1 to allow internal targets.",
+                    ErrorCodes.VALIDATION_ERROR,
+                ),
+            )
+
+
 def _validate_webhook_url(url: Optional[str]) -> Optional[str]:
     """Normalize and validate a user-supplied webhook URL.
 
     Returns the trimmed URL on success, or ``None`` if empty. Raises
     ``HTTPException(400)`` for non-``http(s)`` schemes — without this guard,
     a user could enter ``file:///...`` or ``ftp://...`` and aiohttp would
-    happily attempt the request (SSRF on local resources).
+    happily attempt the request (SSRF on local resources) — and for hosts that
+    resolve to private/internal/metadata IPs (see ``_assert_webhook_host_is_public``).
     """
     from urllib.parse import urlparse
 
@@ -477,6 +551,8 @@ def _validate_webhook_url(url: Optional[str]) -> Optional[str]:
                 ErrorCodes.VALIDATION_ERROR,
             ),
         )
+    if parsed.hostname:
+        _assert_webhook_host_is_public(parsed.hostname)
     return trimmed
 
 
@@ -494,7 +570,8 @@ async def update_notification_settings(
     the saved URL. The URL is validated for ``http(s)`` scheme to avoid
     ``file://`` / ``ftp://`` SSRF on local resources.
     """
-    url = _validate_webhook_url(body.webhook_url)
+    # Off the event loop: _validate_webhook_url may do a blocking DNS lookup.
+    url = await run_in_threadpool(_validate_webhook_url, body.webhook_url)
     try:
         save_notifications_config(
             workspace,
@@ -553,7 +630,8 @@ async def test_notification_webhook(
     # We discard the return value: ``_validate_webhook_url`` raises
     # ``HTTPException(400)`` on a bad scheme/host, which is the side-effect
     # we want here. The trimmed URL it returns is already in ``url``.
-    _validate_webhook_url(url)
+    # Off the event loop — it may do a blocking DNS lookup.
+    await run_in_threadpool(_validate_webhook_url, url)
 
     svc = WebhookNotificationService(webhook_url=url, timeout=5)
     result = await svc.send_event(format_test_payload())

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -477,9 +477,10 @@ def _assert_webhook_host_is_public(hostname: str) -> None:
     checked. A host that cannot be resolved is allowed through — it isn't
     reachable right now, and we don't want to block saving a not-yet-live URL.
 
-    ponytail: resolve-and-check, not a request-time pinned connector, so DNS
-    rebinding (public at save, private at fire) is out of scope. Upgrade path:
-    pin the resolved IP through a custom aiohttp connector in ``send_event``.
+    Known limitation: resolve-and-check, not a request-time pinned connector,
+    so DNS rebinding (public at save, private at fire) is out of scope.
+    Upgrade path: pin the resolved IP through a custom aiohttp connector in
+    ``send_event``.
     """
     if _allow_private_webhook_hosts():
         return

--- a/tests/notifications/test_webhook_send_event.py
+++ b/tests/notifications/test_webhook_send_event.py
@@ -56,6 +56,17 @@ async def test_send_event_returns_not_ok_on_5xx():
 
 
 @pytest.mark.asyncio
+async def test_send_event_does_not_follow_redirects():
+    """SSRF (#656): redirects must not be followed — a public target could
+    302 → 169.254.169.254 / localhost and bypass the save-time host check."""
+    svc = WebhookNotificationService(webhook_url="https://example.com/hook", timeout=5)
+    session = _mock_post(200)
+    with patch("aiohttp.ClientSession", return_value=session):
+        await svc.send_event(format_test_payload())
+    assert session.post.call_args.kwargs["allow_redirects"] is False
+
+
+@pytest.mark.asyncio
 async def test_send_event_no_url_returns_error():
     svc = WebhookNotificationService(webhook_url=None, timeout=5)
     result = await svc.send_event({"event": "test"})

--- a/tests/ui/test_settings_notifications.py
+++ b/tests/ui/test_settings_notifications.py
@@ -136,10 +136,12 @@ class TestUpdateNotificationSettings:
         assert r.status_code == 200
 
     def test_accepts_http(self, client):
-        """Plain http is allowed for public endpoints."""
+        """Plain http is allowed for public endpoints. Uses a global IP literal
+        (no DNS lookup) so the test is hermetic — TEST-NET ranges count as
+        private under ipaddress, so a real routable global IP is used."""
         r = client.put(
             "/api/v2/settings/notifications",
-            json={"webhook_url": "http://example.com:9876/h", "webhook_enabled": True},
+            json={"webhook_url": "http://8.8.8.8:9876/h", "webhook_enabled": True},
         )
         assert r.status_code == 200
 
@@ -157,10 +159,31 @@ class TestUpdateNotificationSettings:
         assert r.status_code == 400
 
     def test_rejects_localhost(self, client):
-        """localhost resolves to a loopback address → blocked by default."""
+        """A DNS name resolving to loopback → blocked. getaddrinfo is mocked so
+        the test doesn't depend on how the CI image resolves ``localhost``
+        (some return ::1, some 127.0.0.1, hardened ones not at all)."""
+        with patch(
+            "codeframe.ui.routers.settings_v2.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("127.0.0.1", 0))],
+        ):
+            r = client.put(
+                "/api/v2/settings/notifications",
+                json={
+                    "webhook_url": "http://localhost:9876/h",
+                    "webhook_enabled": True,
+                },
+            )
+        assert r.status_code == 400
+
+    def test_rejects_ipv4_mapped_ipv6_metadata(self, client):
+        """::ffff:169.254.169.254 must be unwrapped to its IPv4 and rejected —
+        the trickiest case, easy to silently break in a refactor."""
         r = client.put(
             "/api/v2/settings/notifications",
-            json={"webhook_url": "http://localhost:9876/h", "webhook_enabled": True},
+            json={
+                "webhook_url": "http://[::ffff:169.254.169.254]/h",
+                "webhook_enabled": True,
+            },
         )
         assert r.status_code == 400
 
@@ -188,11 +211,12 @@ class TestUpdateNotificationSettings:
     def test_allows_private_host_when_opted_in(self, client, monkeypatch):
         """CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1 is the documented escape hatch."""
         monkeypatch.setenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "1")
-        r = client.put(
-            "/api/v2/settings/notifications",
-            json={"webhook_url": "http://127.0.0.1:8000/h", "webhook_enabled": True},
-        )
-        assert r.status_code == 200
+        for host in ("http://127.0.0.1:8000/h", "http://10.0.0.5/h"):
+            r = client.put(
+                "/api/v2/settings/notifications",
+                json={"webhook_url": host, "webhook_enabled": True},
+            )
+            assert r.status_code == 200, host
 
 
 class TestNotificationWebhookTest:

--- a/tests/ui/test_settings_notifications.py
+++ b/tests/ui/test_settings_notifications.py
@@ -136,10 +136,61 @@ class TestUpdateNotificationSettings:
         assert r.status_code == 200
 
     def test_accepts_http(self, client):
-        """Plain http is allowed for local testing / internal endpoints."""
+        """Plain http is allowed for public endpoints."""
+        r = client.put(
+            "/api/v2/settings/notifications",
+            json={"webhook_url": "http://example.com:9876/h", "webhook_enabled": True},
+        )
+        assert r.status_code == 200
+
+    # --- SSRF host validation (#656) ---------------------------------------
+
+    def test_rejects_metadata_ip(self, client):
+        """Cloud IMDS (169.254.169.254) must be rejected — the core SSRF target."""
+        r = client.put(
+            "/api/v2/settings/notifications",
+            json={
+                "webhook_url": "http://169.254.169.254/latest/meta-data/",
+                "webhook_enabled": True,
+            },
+        )
+        assert r.status_code == 400
+
+    def test_rejects_localhost(self, client):
+        """localhost resolves to a loopback address → blocked by default."""
         r = client.put(
             "/api/v2/settings/notifications",
             json={"webhook_url": "http://localhost:9876/h", "webhook_enabled": True},
+        )
+        assert r.status_code == 400
+
+    def test_rejects_loopback_ip(self, client):
+        r = client.put(
+            "/api/v2/settings/notifications",
+            json={"webhook_url": "http://127.0.0.1:8000/h", "webhook_enabled": True},
+        )
+        assert r.status_code == 400
+
+    def test_rejects_rfc1918_ip(self, client):
+        r = client.put(
+            "/api/v2/settings/notifications",
+            json={"webhook_url": "http://10.0.0.5/h", "webhook_enabled": True},
+        )
+        assert r.status_code == 400
+
+    def test_rejects_ipv6_loopback(self, client):
+        r = client.put(
+            "/api/v2/settings/notifications",
+            json={"webhook_url": "http://[::1]:8000/h", "webhook_enabled": True},
+        )
+        assert r.status_code == 400
+
+    def test_allows_private_host_when_opted_in(self, client, monkeypatch):
+        """CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1 is the documented escape hatch."""
+        monkeypatch.setenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "1")
+        r = client.put(
+            "/api/v2/settings/notifications",
+            json={"webhook_url": "http://127.0.0.1:8000/h", "webhook_enabled": True},
         )
         assert r.status_code == 200
 
@@ -214,6 +265,17 @@ class TestNotificationWebhookTest:
         path = workspace.state_dir / "notifications_config.json"
         path.write_text(
             '{"webhook_url": "file:///etc/passwd", "webhook_enabled": true}'
+        )
+        r = client.post("/api/v2/settings/notifications/test")
+        assert r.status_code == 400
+
+    def test_rejects_metadata_ip_at_test_time(self, client, workspace):
+        """SSRF (#656): a hand-edited config pointing at IMDS must be refused
+        by /test, not fired."""
+        path = workspace.state_dir / "notifications_config.json"
+        path.write_text(
+            '{"webhook_url": "http://169.254.169.254/latest/meta-data/", '
+            '"webhook_enabled": true}'
         )
         r = client.post("/api/v2/settings/notifications/test")
         assert r.status_code == 400


### PR DESCRIPTION
Closes #656.

## Problem
Outbound-webhook URL validation checked the **scheme** only. An authenticated user could set the webhook to `http://169.254.169.254/...` (cloud IMDS), `http://localhost:8000/...`, or any RFC1918 address — and `/notifications/test` fires it immediately and returns the HTTP status, giving a blind-to-semi-blind SSRF primitive against internal services and cloud metadata.

## Fix
- **Host validation** (`_validate_webhook_url`, `settings_v2.py`): after scheme/netloc checks, resolve the host and reject `is_private | is_loopback | is_link_local | is_reserved | is_multicast | is_unspecified` — IPv4, IPv6, and IPv4-mapped IPv6 (`::ffff:169.254.169.254`). IP literals are checked directly; DNS names are resolved and every returned address checked. Both the **save** (PUT) and **test** (POST) endpoints flow through this, so both are covered.
- **Opt-out**: `CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1` for self-hosted operators with legitimate internal targets (the issue's "unless explicitly opted in"). Off by default.
- **Redirect bypass closed**: `send_event` now sends `allow_redirects=False` — a public target can no longer `302 → 169.254.169.254`.
- **Event loop**: host resolution runs via `run_in_threadpool` so a slow resolver can't stall request handling.

## Acceptance criteria
- [x] Webhook URLs pointing at private/loopback/link-local/metadata hosts are rejected by both save and test endpoints.
- [x] Tests cover the metadata IP and localhost cases (plus loopback IP, RFC1918, IPv6 loopback, opt-in, redirect-not-followed, and test-time rejection).

## Tests
`tests/ui/test_settings_notifications.py` (save + test endpoints) and `tests/notifications/test_webhook_send_event.py` (no-redirect). 41 passing locally; `ruff` clean.

## Known limitation
Resolve-and-check at save/test time, not a request-time **pinned** connector — so DNS rebinding (host resolves public at save, private at fire) is out of scope. Redirect-blocking mitigates the most practical variant. Upgrade path noted in code: pin the resolved IP through a custom aiohttp connector in `send_event`.

## Review
Cross-family review via `codex review`; both findings (redirect bypass P1, blocking DNS P2) addressed in this PR.