### PR TITLE
fix(react_agent): persist tokens via workspace repo, not control-plane DB (#713)

### DIFF
--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -343,21 +343,29 @@ class ReactAgent:
     def _persist_token_usage(self, task_id: str) -> None:
         """Persist accumulated token records to the workspace database.
 
-        Uses MetricsTracker.record_token_usage_sync for synchronous writes.
+        Writes through a plain per-workspace TokenRepository (issue #713): the
+        control-plane Database.initialize() runs SchemaManager, which seeds
+        users/api_keys/sessions + an admin row into the domain DB. The
+        token_usage table itself is created by workspace._init_database (#712).
         Failures are logged but never propagated to the caller.
-        The database connection is always closed via try/finally.
+        The connection is always closed via try/finally.
         """
         if not self._token_records:
             return
 
-        db = None
+        conn = None
         try:
-            from codeframe.lib.metrics_tracker import MetricsTracker
-            from codeframe.platform_store.database import Database
+            import sqlite3
 
-            db = Database(str(self.workspace.db_path))
-            db.initialize()
-            tracker = MetricsTracker(db=db)
+            from codeframe.lib.metrics_tracker import MetricsTracker
+            from codeframe.platform_store.repositories.token_repository import (
+                TokenRepository,
+            )
+
+            conn = sqlite3.connect(str(self.workspace.db_path))
+            # TokenRepository exposes save_token_usage, the only method
+            # MetricsTracker needs; no control-plane schema is created.
+            tracker = MetricsTracker(db=TokenRepository(sync_conn=conn))
 
             # v1 tasks have integer PKs; v2 workspaces use UUID strings.
             # Pass the raw value — SQLite preserves the type, and downstream
@@ -386,9 +394,9 @@ class ReactAgent:
                 "Token usage persistence failed for task %s", task_id, exc_info=True,
             )
         finally:
-            if db is not None:
+            if conn is not None:
                 try:
-                    db.close()
+                    conn.close()
                 except Exception:
                     pass
 

--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import threading
 from pathlib import Path
 from datetime import datetime, timezone
@@ -355,8 +356,6 @@ class ReactAgent:
 
         conn = None
         try:
-            import sqlite3
-
             from codeframe.lib.metrics_tracker import MetricsTracker
             from codeframe.platform_store.repositories.token_repository import (
                 TokenRepository,

--- a/tests/core/test_react_agent_tokens.py
+++ b/tests/core/test_react_agent_tokens.py
@@ -341,8 +341,10 @@ class TestPersistDoesNotPolluteWorkspaceDb:
 
         # The record was written...
         assert row_count == 1
-        # ...and no control-plane/auth tables (nor the admin row they carry)
-        # were seeded into the per-workspace domain DB.
+        # ...and none of the control-plane/auth tables (nor the admin row they
+        # carry) were seeded into the per-workspace domain DB.
         assert "users" not in tables
+        assert "accounts" not in tables
         assert "api_keys" not in tables
         assert "sessions" not in tables
+        assert "audit_logs" not in tables

--- a/tests/core/test_react_agent_tokens.py
+++ b/tests/core/test_react_agent_tokens.py
@@ -294,3 +294,55 @@ class TestReactAgentTokenPersistenceFailure:
         # Token records should still be available in-memory
         records = agent.get_token_usage()
         assert len(records) == 1
+
+
+class TestPersistDoesNotPolluteWorkspaceDb:
+    """Issue #713 / P0.2: _persist_token_usage must write through the
+    per-workspace schema, NOT the control-plane Database (which seeds
+    users/api_keys/sessions + an admin row into the workspace DB)."""
+
+    def _real_workspace(self, tmp_path):
+        from codeframe.core.workspace import create_or_load_workspace
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        return create_or_load_workspace(repo)
+
+    def test_persists_token_usage_without_control_plane_tables(self, tmp_path):
+        import sqlite3
+
+        from codeframe.core.react_agent import ReactAgent
+
+        ws = self._real_workspace(tmp_path)
+        agent = ReactAgent(workspace=ws, llm_provider=MockProvider())
+        agent._token_records = [
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "model": "claude-sonnet-4-5",
+                "call_type": "task_execution",
+                "iteration": 1,
+            }
+        ]
+
+        agent._persist_token_usage("a1b2c3d4-uuid-task")
+
+        conn = sqlite3.connect(str(ws.db_path))
+        try:
+            row_count = conn.execute("SELECT COUNT(*) FROM token_usage").fetchone()[0]
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        finally:
+            conn.close()
+
+        # The record was written...
+        assert row_count == 1
+        # ...and no control-plane/auth tables (nor the admin row they carry)
+        # were seeded into the per-workspace domain DB.
+        assert "users" not in tables
+        assert "api_keys" not in tables
+        assert "sessions" not in tables


### PR DESCRIPTION
## What & why
`ReactAgent._persist_token_usage` persisted token records by constructing a control-plane `Database(workspace.db_path)` and calling `db.initialize()`, which runs `SchemaManager.create_schema()` — seeding `users`/`accounts`/`api_keys`/`sessions`/`audit_logs` tables **and an `admin@localhost` row** into every per-workspace `state.db`. That pollutes the domain DB with auth tables and was the mechanism that masked #712 (`initialize()` "succeeded" while never creating `token_usage`).

Fixes **#713 [P0.2]** (depends on #712, merged).

## Change
`core/react_agent.py._persist_token_usage`: persist through a plain `TokenRepository(sync_conn=sqlite3.connect(workspace.db_path))` instead of the control-plane `Database`. `MetricsTracker` only needs `save_token_usage`, which `TokenRepository` provides — so this reuses the existing INSERT **and** cost calculation with **zero** control-plane schema creation. The `token_usage` table itself is created by `workspace._init_database` (shipped in #712). Connection closed in `finally`; WARNING-on-failure (from #712) retained.

## Tests (TDD, RED→GREEN)
New `TestPersistDoesNotPolluteWorkspaceDb` in `test_react_agent_tokens.py`: builds a **real** workspace via `create_or_load_workspace`, runs `_persist_token_usage`, and asserts (a) the record lands in `token_usage`, and (b) `users`/`api_keys`/`sessions` are **absent** from the workspace DB. RED before the fix (tables present), GREEN after.

`104 passed` across react_agent + costs + token-schema suites. `ruff` clean, `mypy` clean (191 files, incl. the strict `metrics_tracker` module).

## Demo (both acceptance criteria)
```
AC1 — token_usage persisted through workspace schema:
   rows: [('a1b2c3d4-uuid-task', 1000, 500, 0.0105)]
AC2 — control-plane tables absent from workspace DB:
   users present=False | api_keys present=False | sessions present=False
   accounts present=False | audit_logs present=False
Result: PASS
```

## Acceptance criteria
- [x] Token usage persists through the per-workspace connection/schema, not the control-plane `Database`
- [x] A workspace DB after an agent run contains no `users`/`api_keys`/`sessions` tables and no admin row
