### PR TITLE
fix(auth): enforce API-key scopes on v2 routes (#717)

### DIFF
--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -454,6 +454,10 @@ def require_scope(required_scope: str) -> Callable:
     Returns:
         Dependency function that validates scope
     """
+    # Depends on require_auth directly (not require_method_scope): on admin
+    # routes both run, but FastAPI caches require_auth within a request, so
+    # there is exactly one authentication call — the method guard checks
+    # write and this checks admin against the same principal (#717).
     async def check_scope(auth: Dict[str, Any] = Depends(require_auth)) -> Dict[str, Any]:
         """Verify principal has required scope."""
         if not has_scope(auth, required_scope):

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -327,6 +327,31 @@ async def require_auth(
     )
 
 
+# HTTP methods that only read state — everything else mutates (#717).
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+async def require_method_scope(
+    request: Request,
+    auth: Dict[str, Any] = Depends(require_auth),
+) -> Dict[str, Any]:
+    """Router-level guard that enforces scope by HTTP method (issue #717).
+
+    Safe methods (GET/HEAD/OPTIONS) require the ``read`` scope; mutating
+    methods (POST/PUT/PATCH/DELETE) require ``write``. Admin-only routes layer
+    their own ``Depends(require_scope("admin"))`` on top. JWT principals and the
+    auth-disabled synthetic principal both carry all scopes, so this only
+    constrains scoped API keys — a read-only key can no longer mutate state.
+    """
+    required = SCOPE_READ if request.method.upper() in _SAFE_METHODS else SCOPE_WRITE
+    if not has_scope(auth, required):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Insufficient permissions: '{required}' scope required",
+        )
+    return auth
+
+
 async def authenticate_websocket(
     websocket: WebSocket,
     *,

--- a/codeframe/ui/routers/pr_v2.py
+++ b/codeframe/ui/routers/pr_v2.py
@@ -18,6 +18,8 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from codeframe.auth.api_keys import SCOPE_ADMIN
+from codeframe.auth.dependencies import require_scope
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_standard
 from codeframe.git.github_integration import GitHubIntegration, GitHubAPIError, PRDetails
@@ -599,7 +601,11 @@ async def create_pull_request(
         await client.close()
 
 
-@router.post("/{pr_number}/merge", response_model=MergeResponse)
+@router.post(
+    "/{pr_number}/merge",
+    response_model=MergeResponse,
+    dependencies=[Depends(require_scope(SCOPE_ADMIN))],  # merging to the repo is admin-only (#717)
+)
 @rate_limit_standard()
 async def merge_pull_request(
     request: Request,

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -27,6 +27,9 @@ from anthropic import Anthropic as _AnthropicClient
 from anthropic import AuthenticationError as _AnthropicAuthError
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.concurrency import run_in_threadpool
+
+from codeframe.auth.api_keys import SCOPE_ADMIN
+from codeframe.auth.dependencies import require_scope
 from openai import AuthenticationError as _OpenAIAuthError
 from openai import OpenAI as _OpenAIClient
 from pydantic import BaseModel, Field
@@ -235,7 +238,11 @@ async def list_key_status(
     return [_build_status(p, manager) for p in KEY_PROVIDERS]
 
 
-@router.put("/keys/{provider}", response_model=KeyStatusResponse)
+@router.put(
+    "/keys/{provider}",
+    response_model=KeyStatusResponse,
+    dependencies=[Depends(require_scope(SCOPE_ADMIN))],  # credential storage is admin-only (#717)
+)
 @rate_limit_standard()
 async def store_key(
     provider: str,
@@ -268,7 +275,11 @@ async def store_key(
     return _build_status(cast(KeyProvider, provider), manager)
 
 
-@router.delete("/keys/{provider}", status_code=204)
+@router.delete(
+    "/keys/{provider}",
+    status_code=204,
+    dependencies=[Depends(require_scope(SCOPE_ADMIN))],  # credential deletion is admin-only (#717)
+)
 @rate_limit_standard()
 async def delete_key(
     provider: str,

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -45,7 +45,7 @@ from codeframe.ui.routers import (
     workspace_v2,
 )
 from codeframe.auth import router as auth_router
-from codeframe.auth.dependencies import require_auth
+from codeframe.auth.dependencies import require_auth, require_method_scope
 from codeframe.platform_store.database import Database
 from codeframe.lib.rate_limiter import (
     get_rate_limiter,
@@ -742,13 +742,15 @@ app.include_router(auth_router.router)
 # v2 API routers - all delegate to codeframe.core modules
 #
 # Auth enforcement (issue #336): every v2 REST router is mounted with a
-# blanket ``require_auth`` dependency. With CODEFRAME_AUTH_REQUIRED disabled
-# (local opt-out) require_auth returns a synthetic principal instead of
-# raising, so behavior is unchanged for local/dev use. The two WebSocket
-# routers (session_chat_ws, terminal_ws) are intentionally excluded — they
-# perform their own ?token= JWT auth and cannot use an HTTP 401 dependency.
-# The auth_router (login/register) stays public.
-_AUTH = [Depends(require_auth)]
+# blanket scope-aware auth dependency. ``require_method_scope`` first resolves
+# ``require_auth`` (honoring CODEFRAME_AUTH_REQUIRED — disabled returns a
+# synthetic all-scopes principal, so local/dev/tests are unchanged), then
+# enforces scope by HTTP method (#717): safe methods need ``read``, mutating
+# methods need ``write``. Admin-only routes (credential storage, PR merge) add
+# their own ``Depends(require_scope("admin"))``. The two WebSocket routers
+# (session_chat_ws, terminal_ws) are intentionally excluded — they perform
+# their own ?token= JWT auth. The auth_router (login/register) stays public.
+_AUTH = [Depends(require_method_scope)]
 app.include_router(batches_v2.router, dependencies=_AUTH)       # /api/v2/batches
 app.include_router(blockers_v2.router, dependencies=_AUTH)      # /api/v2/blockers
 app.include_router(checkpoints_v2.router, dependencies=_AUTH)   # /api/v2/checkpoints

--- a/tests/ui/test_v2_scope_enforcement.py
+++ b/tests/ui/test_v2_scope_enforcement.py
@@ -116,3 +116,22 @@ class TestAdminScope:
             "/api/v2/pr/1/merge", headers=_hdr(keys["write"]), json={}
         )
         assert r.status_code == 403
+
+    def test_admin_key_allowed_on_pr_merge(self, scoped_app):
+        app, keys = scoped_app
+        r = TestClient(app).post(
+            "/api/v2/pr/1/merge", headers=_hdr(keys["admin"]), json={}
+        )
+        # admin passes the scope gate; may 400/404/422 on body/logic, never 403.
+        assert r.status_code != 403
+        assert r.status_code != 401
+
+
+class TestPatchIsMutating:
+    def test_read_key_forbidden_on_patch(self, scoped_app):
+        app, keys = scoped_app
+        # PATCH is not a safe method → needs write; a read key must 403.
+        r = TestClient(app).patch(
+            "/api/v2/tasks/abc", headers=_hdr(keys["read"]), json={}
+        )
+        assert r.status_code == 403

--- a/tests/ui/test_v2_scope_enforcement.py
+++ b/tests/ui/test_v2_scope_enforcement.py
@@ -1,0 +1,118 @@
+"""API-key scope enforcement across the v2 API (issue #717 / P0.6).
+
+Before this, every v2 router mounted a blanket ``require_auth`` that proved
+*authentication* only — a read-scoped key could POST/PUT/DELETE and even store
+credentials or merge PRs. Now:
+
+- safe methods (GET) need ``read``
+- mutating methods (POST/PUT/PATCH/DELETE) need ``write``
+- credential storage/deletion and PR-merge need ``admin``
+
+JWT principals and the auth-disabled synthetic principal carry all scopes, so
+this only constrains scoped API keys.
+"""
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from codeframe.auth.api_keys import SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN
+from codeframe.auth.manager import reset_auth_engine
+from codeframe.core.api_key_service import ApiKeyService
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def scoped_app(tmp_path, monkeypatch):
+    """Real server app with auth ON and three API keys (read/write/admin)."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    reset_auth_engine()
+
+    db = Database(db_path)
+    db.initialize()
+    db.conn.execute(
+        """
+        INSERT OR REPLACE INTO users (
+            id, email, name, hashed_password,
+            is_active, is_superuser, is_verified, email_verified
+        ) VALUES (1, 'test@example.com', 'Test', '!DISABLED!', 1, 0, 1, 1)
+        """
+    )
+    db.conn.commit()
+
+    svc = ApiKeyService(db)
+    keys = {
+        "read": svc.create_api_key(user_id=1, name="r", scopes=[SCOPE_READ]).key,
+        "write": svc.create_api_key(user_id=1, name="w", scopes=[SCOPE_READ, SCOPE_WRITE]).key,
+        "admin": svc.create_api_key(user_id=1, name="a", scopes=[SCOPE_ADMIN]).key,
+    }
+    db.close()
+
+    from codeframe.ui import server
+
+    importlib.reload(server)
+    yield server.app, keys
+    reset_auth_engine()
+
+
+def _hdr(key: str) -> dict:
+    return {"X-API-Key": key}
+
+
+class TestMethodScope:
+    def test_read_key_allowed_on_get(self, scoped_app):
+        app, keys = scoped_app
+        r = TestClient(app).get("/api/v2/settings", headers=_hdr(keys["read"]))
+        assert r.status_code != 403  # read scope satisfies a GET
+        assert r.status_code != 401
+
+    def test_read_key_forbidden_on_write(self, scoped_app):
+        app, keys = scoped_app
+        # PUT /api/v2/settings mutates → needs write; read key must 403 before
+        # any body validation (router-level dependency fires first).
+        r = TestClient(app).put("/api/v2/settings", headers=_hdr(keys["read"]), json={})
+        assert r.status_code == 403
+
+    def test_write_key_allowed_on_write(self, scoped_app):
+        app, keys = scoped_app
+        r = TestClient(app).put("/api/v2/settings", headers=_hdr(keys["write"]), json={})
+        assert r.status_code != 403  # write scope passes the method guard
+        assert r.status_code != 401
+
+
+class TestAdminScope:
+    def test_read_key_forbidden_on_credential_storage(self, scoped_app):
+        app, keys = scoped_app
+        r = TestClient(app).put(
+            "/api/v2/settings/keys/openai", headers=_hdr(keys["read"]), json={"value": "sk-x"}
+        )
+        assert r.status_code == 403
+
+    def test_write_key_forbidden_on_credential_storage(self, scoped_app):
+        app, keys = scoped_app
+        # write is not enough — credential storage is admin-only.
+        r = TestClient(app).put(
+            "/api/v2/settings/keys/openai", headers=_hdr(keys["write"]), json={"value": "sk-x"}
+        )
+        assert r.status_code == 403
+
+    def test_admin_key_allowed_on_credential_storage(self, scoped_app):
+        app, keys = scoped_app
+        r = TestClient(app).put(
+            "/api/v2/settings/keys/openai", headers=_hdr(keys["admin"]), json={"value": "sk-x"}
+        )
+        # admin passes the scope gate; may 400 on value format, but never 403.
+        assert r.status_code != 403
+        assert r.status_code != 401
+
+    def test_write_key_forbidden_on_pr_merge(self, scoped_app):
+        app, keys = scoped_app
+        r = TestClient(app).post(
+            "/api/v2/pr/1/merge", headers=_hdr(keys["write"]), json={}
+        )
+        assert r.status_code == 403


### PR DESCRIPTION
## What & why
`require_scope` was fully implemented but wired into **zero** routes: every v2 router mounted a blanket `require_auth`, which only proves *authentication*. A key created with `read` scope could POST/PUT/DELETE, **store/delete machine-wide credentials, and merge PRs** — a leaked "read-only" CI token was effectively an admin token.

Fixes **#717 [P0.6]**.

## Change (one chokepoint + two admin routes)
- **`auth/dependencies.py`**: new `require_method_scope` — resolves `require_auth`, then enforces scope by HTTP method: safe methods (GET/HEAD/OPTIONS) → `read`, mutating methods (POST/PUT/PATCH/DELETE) → `write`.
- **`ui/server.py`**: swap the blanket `_AUTH = [Depends(require_auth)]` → `[Depends(require_method_scope)]`, so all 22 routers are covered in one place (no per-endpoint edits).
- **admin-only routes** get an extra `Depends(require_scope("admin"))`: `settings` `PUT`/`DELETE /keys/{provider}` (credential storage/deletion) and `pr` `POST /{n}/merge`.

**No collateral impact:** JWT principals (web UI) and the auth-disabled synthetic principal both carry all scopes, so the web UI, local dev, and the auth-off test default are unchanged — only scoped API keys are constrained.

## Tests (`tests/ui/test_v2_scope_enforcement.py`)
Read/write/admin keys against real routes with auth ON: read→403 on write routes and credential storage; write→403 on credential storage + PR-merge; admin→passes; read→200 on GET.

`188 passed` across auth-enforcement + settings + pr + integration + scope suites (no regressions). `ruff` + `mypy` clean.

## Demo (live status codes)
```
route                                   read  write  admin
GET  /api/v2/settings (read)             200    200    200
PUT  /api/v2/settings (write)            403    422    422
PUT  /settings/keys/openai (admin)       403    403    400
POST /pr/1/merge (admin)                 403    403    400
```
(403 = blocked by scope; 4xx-non-403 = scope passed, hit body/logic validation.)

## Acceptance criteria
- [x] Mutating endpoints require `write`; credential-management and PR-merge require `admin`
- [x] A read-scoped API key gets 403 on a representative write route and on credential storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method-based access control for the API, so read-only requests and write requests now require different permission levels.
  * Tightened access to PR merging and machine-wide API key management, limiting these actions to admin users.

* **Tests**
  * Added coverage for permission checks across read, write, and admin actions to confirm the new access rules work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->