### PR TITLE
fix(security): enforce single-trust-domain; block shared credentials in hosted mode (#718)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,26 @@ respective maintainers. Issues that require a user to run an untrusted PRD,
 task, or repository are expected behavior for an agent that executes code on
 your behalf; sandbox-escape findings, however, are in scope.
 
+## Deployment trust model
+
+CodeFRAME has two deployment modes (`CODEFRAME_DEPLOYMENT_MODE`):
+
+- **`self_hosted` (default) — a single trust domain.** One operator or team runs
+  the instance and shares its **machine-wide** credential store (one LLM key set,
+  one GitHub PAT). Do **not** expose a self-hosted instance to mutually
+  distrusting users: any authenticated user can act within the configured
+  workspace(s), and credentials are shared by design. Multiple untrusting users
+  require separate instances (or hosted mode).
+- **`hosted` — multi-tenant.** `WORKSPACE_ROOT` is mandatory (the server fails
+  closed if unset) and each user is confined to `<WORKSPACE_ROOT>/<user_id>`, so
+  tenants cannot reach each other's workspaces. Because the credential store is
+  machine-wide and cannot yet be safely shared across tenants, the shared
+  credential and GitHub-PAT **mutation** endpoints (`PUT`/`DELETE
+  /api/v2/settings/keys/*`, `POST /connect`, `DELETE /disconnect`) are **disabled
+  (HTTP 403)** in hosted mode — provide provider keys via per-instance
+  environment variables instead. Per-user credential scoping is tracked as a
+  follow-up.
+
 ## Handling secrets
 
 Never include API keys, tokens, or other credentials in a report. CodeFRAME

--- a/codeframe/ui/dependencies.py
+++ b/codeframe/ui/dependencies.py
@@ -111,6 +111,8 @@ def forbid_shared_credentials_in_hosted_mode() -> None:
     per-instance environment variables instead. Per-user credential scoping is a
     tracked follow-up; until then hosted mode fails closed.
     """
+    # Deferred import: codeframe.ui.server imports from this module at module
+    # level, so importing it at the top would be circular.
     from codeframe.ui.server import is_hosted_mode
 
     if is_hosted_mode():

--- a/codeframe/ui/dependencies.py
+++ b/codeframe/ui/dependencies.py
@@ -99,6 +99,30 @@ def revalidate_workspace_path(workspace_path: str, user_id: Optional[int]) -> Op
         return None
 
 
+def forbid_shared_credentials_in_hosted_mode() -> None:
+    """Block shared machine-wide credential mutation in hosted mode (#718).
+
+    CodeFRAME's credential store (``CredentialManager``) is machine-wide — one
+    set of LLM keys and one GitHub PAT per host. That is fine for a *self-hosted*
+    deployment, which is a single trust domain (one operator/team). In *hosted*
+    (multi-tenant) mode it would let any tenant view (last-4), overwrite, or
+    delete another tenant's secrets, so credential storage/deletion and GitHub
+    connect/disconnect are disabled there — hosted tenants supply credentials via
+    per-instance environment variables instead. Per-user credential scoping is a
+    tracked follow-up; until then hosted mode fails closed.
+    """
+    from codeframe.ui.server import is_hosted_mode
+
+    if is_hosted_mode():
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Shared credential storage is disabled in hosted mode. Provide "
+                "credentials via environment variables per deployment (#718)."
+            ),
+        )
+
+
 def get_workspace_manager(request: Request) -> WorkspaceManager:
     """Get workspace manager from application state.
 

--- a/codeframe/ui/routers/github_integrations_v2.py
+++ b/codeframe/ui/routers/github_integrations_v2.py
@@ -44,7 +44,10 @@ from codeframe.core.github_integration_config import (
 from codeframe.core import tasks
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
-from codeframe.ui.dependencies import get_v2_workspace
+from codeframe.ui.dependencies import (
+    forbid_shared_credentials_in_hosted_mode,
+    get_v2_workspace,
+)
 from codeframe.ui.response_models import ErrorCodes, api_error
 
 logger = logging.getLogger(__name__)
@@ -171,7 +174,11 @@ async def get_status(
     )
 
 
-@router.post("/connect", response_model=ConnectResponse)
+@router.post(
+    "/connect",
+    response_model=ConnectResponse,
+    dependencies=[Depends(forbid_shared_credentials_in_hosted_mode)],  # shared PAT, not cross-tenant (#718)
+)
 @rate_limit_ai()
 async def connect(
     request: Request,
@@ -277,7 +284,11 @@ async def connect(
     )
 
 
-@router.delete("/disconnect", status_code=204)
+@router.delete(
+    "/disconnect",
+    status_code=204,
+    dependencies=[Depends(forbid_shared_credentials_in_hosted_mode)],  # shared PAT, not cross-tenant (#718)
+)
 @rate_limit_standard()
 async def disconnect(
     request: Request,

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -30,6 +30,7 @@ from fastapi.concurrency import run_in_threadpool
 
 from codeframe.auth.api_keys import SCOPE_ADMIN
 from codeframe.auth.dependencies import require_scope
+from codeframe.ui.dependencies import forbid_shared_credentials_in_hosted_mode
 from openai import AuthenticationError as _OpenAIAuthError
 from openai import OpenAI as _OpenAIClient
 from pydantic import BaseModel, Field
@@ -241,7 +242,10 @@ async def list_key_status(
 @router.put(
     "/keys/{provider}",
     response_model=KeyStatusResponse,
-    dependencies=[Depends(require_scope(SCOPE_ADMIN))],  # credential storage is admin-only (#717)
+    dependencies=[
+        Depends(require_scope(SCOPE_ADMIN)),  # credential storage is admin-only (#717)
+        Depends(forbid_shared_credentials_in_hosted_mode),  # not shareable across tenants (#718)
+    ],
 )
 @rate_limit_standard()
 async def store_key(
@@ -278,7 +282,10 @@ async def store_key(
 @router.delete(
     "/keys/{provider}",
     status_code=204,
-    dependencies=[Depends(require_scope(SCOPE_ADMIN))],  # credential deletion is admin-only (#717)
+    dependencies=[
+        Depends(require_scope(SCOPE_ADMIN)),  # credential deletion is admin-only (#717)
+        Depends(forbid_shared_credentials_in_hosted_mode),  # not shareable across tenants (#718)
+    ],
 )
 @rate_limit_standard()
 async def delete_key(

--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -157,8 +157,16 @@ def _get_registry(request: Request):
     return getattr(db, "workspace_registry", None)
 
 
-def _register_workspace(request: Request, workspace: Workspace) -> None:
-    """Best-effort upsert of a workspace into the server-side registry."""
+def _register_workspace(
+    request: Request, workspace: Workspace, owner_user_id: Optional[int] = None
+) -> None:
+    """Best-effort upsert of a workspace into the server-side registry.
+
+    ``owner_user_id`` is the authenticated principal's id (#718) — recorded for
+    defense-in-depth so the registry knows who owns each workspace. Owner-scoped
+    list/delete enforcement is #720; hosted-mode tenant isolation is path-based
+    (#655).
+    """
     registry = _get_registry(request)
     if registry is None:
         return
@@ -167,7 +175,7 @@ def _register_workspace(request: Request, workspace: Workspace) -> None:
             repo_path=str(workspace.repo_path),
             name=workspace.repo_path.name,
             tech_stack=workspace.tech_stack,
-            owner_user_id=None,  # Until auth is enforced on v2 routers.
+            owner_user_id=owner_user_id,
         )
     except Exception as e:  # noqa: BLE001 - tracking must never break the request
         logger.warning("Failed to register workspace in registry: %s", e)
@@ -292,7 +300,7 @@ async def init_workspace(
             workspace = ws.create_or_load_workspace(repo_path, tech_stack=tech_stack)
 
         # Register (or refresh) the workspace in the server-side registry (#601).
-        _register_workspace(request, workspace)
+        _register_workspace(request, workspace, auth.get("user_id"))
 
         return _workspace_to_response(workspace)
 
@@ -311,6 +319,7 @@ async def init_workspace(
 async def get_current_workspace(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> WorkspaceResponse:
     """Get information about the current workspace.
 
@@ -332,7 +341,7 @@ async def get_current_workspace(
             if entry is not None:
                 registry.update_last_opened(entry["id"])
             else:
-                _register_workspace(request, workspace)
+                _register_workspace(request, workspace, auth.get("user_id"))
         except Exception as e:  # noqa: BLE001 - tracking must never break the request
             logger.warning("Failed to track workspace access: %s", e)
 
@@ -345,6 +354,7 @@ async def update_current_workspace(
     request: Request,
     body: UpdateWorkspaceRequest,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> WorkspaceResponse:
     """Update the current workspace.
 
@@ -368,7 +378,7 @@ async def update_current_workspace(
         if body.tech_stack is not None:
             updated = ws.update_workspace_tech_stack(workspace.repo_path, body.tech_stack)
             # Keep the registry's cached metadata (tech_stack) in sync (#601).
-            _register_workspace(request, updated)
+            _register_workspace(request, updated, auth.get("user_id"))
 
         return _workspace_to_response(updated)
 

--- a/tests/ui/test_hosted_credential_block.py
+++ b/tests/ui/test_hosted_credential_block.py
@@ -52,12 +52,26 @@ class TestCredentialEndpointHostedBlock:
         r = self._client().delete("/api/v2/settings/keys/openai")
         assert r.status_code == 403
 
+    def test_github_connect_blocked_in_hosted_mode(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+        # The guard fires before workspace-allowlist resolution, so no
+        # WORKSPACE_ROOT setup is needed.
+        r = self._client().post(
+            "/api/v2/integrations/github/connect", json={"repo": "o/r", "pat": "ghp_x"}
+        )
+        assert r.status_code == 403
+
+    def test_github_disconnect_blocked_in_hosted_mode(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+        r = self._client().delete("/api/v2/integrations/github/disconnect")
+        assert r.status_code == 403
+
     def test_store_key_not_hosted_blocked_in_self_hosted(self, monkeypatch):
         monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
         r = self._client().put("/api/v2/settings/keys/openai", json={"value": "sk-x"})
-        # self-hosted: the hosted guard is a no-op; may 400 on value format, but
-        # never the hosted-mode 403.
-        assert not (r.status_code == 403 and "hosted mode" in r.json().get("detail", "").lower())
+        # self-hosted: the hosted guard is a no-op; the request passes it and hits
+        # value-format validation (400). It must never be the hosted-mode 403.
+        assert r.status_code != 403, f"unexpected hosted-mode 403 in self-hosted: {r.json()}"
 
 
 class TestOwnerPersistence:

--- a/tests/ui/test_hosted_credential_block.py
+++ b/tests/ui/test_hosted_credential_block.py
@@ -1,0 +1,82 @@
+"""Single-trust-domain enforcement (issue #718 / P0.7).
+
+CodeFRAME's credential store is machine-wide (one LLM key set + one GitHub PAT
+per host). That's fine for self-hosted (a single trust domain), but in hosted
+multi-tenant mode it would let any tenant view/overwrite/delete another's
+secrets. So credential + GitHub-PAT *mutation* endpoints fail closed in hosted
+mode; tenants supply credentials via per-instance env vars instead.
+
+Also verifies workspaces persist owner_user_id from the authenticated principal.
+"""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.v2
+
+
+class TestForbidGuard:
+    def test_raises_in_hosted_mode(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+        from codeframe.ui.dependencies import forbid_shared_credentials_in_hosted_mode
+
+        with pytest.raises(HTTPException) as exc:
+            forbid_shared_credentials_in_hosted_mode()
+        assert exc.value.status_code == 403
+
+    def test_noop_in_self_hosted(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+        from codeframe.ui.dependencies import forbid_shared_credentials_in_hosted_mode
+
+        assert forbid_shared_credentials_in_hosted_mode() is None  # no raise
+
+
+class TestCredentialEndpointHostedBlock:
+    """conftest defaults auth OFF → synthetic admin principal, so these isolate
+    the hosted-mode credential guard (not the scope/auth layer)."""
+
+    def _client(self):
+        from codeframe.ui import server
+
+        return TestClient(server.app)
+
+    def test_store_key_blocked_in_hosted_mode(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+        r = self._client().put("/api/v2/settings/keys/openai", json={"value": "sk-x"})
+        assert r.status_code == 403
+        assert "hosted mode" in r.json().get("detail", "").lower()
+
+    def test_delete_key_blocked_in_hosted_mode(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+        r = self._client().delete("/api/v2/settings/keys/openai")
+        assert r.status_code == 403
+
+    def test_store_key_not_hosted_blocked_in_self_hosted(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+        r = self._client().put("/api/v2/settings/keys/openai", json={"value": "sk-x"})
+        # self-hosted: the hosted guard is a no-op; may 400 on value format, but
+        # never the hosted-mode 403.
+        assert not (r.status_code == 403 and "hosted mode" in r.json().get("detail", "").lower())
+
+
+class TestOwnerPersistence:
+    def test_register_workspace_passes_owner_id(self, monkeypatch):
+        """_register_workspace forwards the authenticated user_id to the registry."""
+        from codeframe.ui.routers import workspace_v2
+
+        captured = {}
+
+        class _FakeRegistry:
+            def upsert(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(workspace_v2, "_get_registry", lambda request: _FakeRegistry())
+
+        class _WS:
+            from pathlib import Path as _P
+            repo_path = _P("/tmp/demo-repo")
+            tech_stack = "python"
+
+        workspace_v2._register_workspace(request=None, workspace=_WS(), owner_user_id=42)
+        assert captured["owner_user_id"] == 42


### PR DESCRIPTION
## What & why
CodeFRAME's credential store is **machine-wide** (one LLM key set + one GitHub PAT per host), and self-hosted mode had no workspace-owner check. In a multi-tenant deployment every user could view (last-4), overwrite, or delete another's secrets, and — with no `WORKSPACE_ROOT` — read/write another's workspace.

Fixes **#718 [P0.7]**. Approach: **enforce + document a single-trust-domain model** (the AC's sanctioned alternative to a full per-user credential rework; **confirmed with the maintainer**).

## Context — what already existed
Hosted-mode **workspace** isolation shipped in #655: `WORKSPACE_ROOT` is mandatory in hosted mode (fails closed if unset) and each user is confined to `<root>/<user_id>`. This PR closes the **credential** side + formalizes the model.

## Changes
- **`forbid_shared_credentials_in_hosted_mode()`** (`ui/dependencies.py`): credential + GitHub-PAT **mutation** endpoints fail closed (403) in hosted mode — `PUT`/`DELETE /api/v2/settings/keys/*`, `POST /connect`, `DELETE /disconnect`. GET status stays readable. Self-hosted (single trust domain) is unaffected.
- **owner_user_id persistence** (`workspace_v2.py`): `_register_workspace` now records `auth["user_id"]` (was hardcoded `None`). Defense-in-depth; owner-scoped list/delete **enforcement** is #720.
- **`SECURITY.md`**: documents the self-hosted single-trust-domain model and the hosted-mode credential block.

## Tests (`tests/ui/test_hosted_credential_block.py`)
Guard unit (hosted→raises, self-hosted→no-op); `PUT`/`DELETE /keys` → 403 in hosted, not-hosted-403 in self-hosted; `_register_workspace` forwards owner_user_id. `124 passed` across settings/github/workspace/registry/scope suites. `ruff` + `mypy` clean.

## Demo (auth-off to isolate the guard; a real hosted tenant is authenticated then hits the same 403)
```
mode          PUT keys  DELETE keys  GET keys
self_hosted        400          400       200   (allowed; 400 = value format)
hosted             403          403       200   (mutations blocked; read status allowed)
```

## Acceptance criteria
- [x] Deployments intended for >1 user require `WORKSPACE_ROOT` (fail closed in hosted mode) — shipped in #655, documented here
- [x] Workspaces persist `owner_user_id` from `auth["user_id"]` (owner-scoped enforcement is #720)
- [x] Single-trust-domain limitation enforced (hosted-mode credential 403) **and** documented (SECURITY.md); multi-tenant shared-credential path blocked

## Known limitation / follow-up
Per-user credential scoping (so hosted tenants can store their own keys through the API) is deferred to the follow-up issue below.
