### PR TITLE
fix(security): enforce workspace allowlist on GET /workspaces/exists (#719)

### DIFF
--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -494,11 +494,8 @@ async def check_workspace_exists(
     Returns:
         Whether workspace exists and path info
     """
-    # Enforce the workspace allowlist (#719): without this any authenticated
-    # user could probe arbitrary host paths for existence and get the fully
-    # resolved absolute path back. enforce_workspace_allowlist resolves the
-    # path and raises 403 for anything outside the permitted roots (so the
-    # resolved path is never echoed for out-of-allowlist inputs).
+    # Enforce the allowlist (#719): else this leaks existence + resolved paths
+    # for arbitrary host paths. Raises 403 (path not echoed) for out-of-root.
     path = enforce_workspace_allowlist(Path(repo_path), auth.get("user_id"))
     exists = ws.workspace_exists(path)
 

--- a/codeframe/ui/routers/workspace_v2.py
+++ b/codeframe/ui/routers/workspace_v2.py
@@ -482,22 +482,30 @@ async def update_workspace_config(
 async def check_workspace_exists(
     request: Request,
     repo_path: str = Query(..., description="Path to check for workspace"),
+    auth: dict = Depends(require_auth),
 ) -> dict:
     """Check if a workspace exists at a given path.
 
     Args:
         request: HTTP request for rate limiting
         repo_path: Path to check
+        auth: Authenticated principal (for the workspace allowlist)
 
     Returns:
         Whether workspace exists and path info
     """
-    path = Path(repo_path).resolve()
+    # Enforce the workspace allowlist (#719): without this any authenticated
+    # user could probe arbitrary host paths for existence and get the fully
+    # resolved absolute path back. enforce_workspace_allowlist resolves the
+    # path and raises 403 for anything outside the permitted roots (so the
+    # resolved path is never echoed for out-of-allowlist inputs).
+    path = enforce_workspace_allowlist(Path(repo_path), auth.get("user_id"))
+    exists = ws.workspace_exists(path)
 
     return {
-        "exists": ws.workspace_exists(path),
+        "exists": exists,
         "path": str(path),
-        "state_dir": str(path / ".codeframe") if ws.workspace_exists(path) else None,
+        "state_dir": str(path / ".codeframe") if exists else None,
     }
 
 

--- a/tests/ui/test_exists_allowlist.py
+++ b/tests/ui/test_exists_allowlist.py
@@ -51,6 +51,17 @@ class TestExistsAllowlist:
         )
         assert r.status_code == 403
 
+    def test_hosted_mode_rejects_probe(self, tmp_path, monkeypatch):
+        """Hosted mode confines each user to <root>/<user_id>; with auth off in
+        the test suite (user_id=None) any probe fails closed with 403."""
+        base = tmp_path / "roots"
+        (base / "proj").mkdir(parents=True)
+        create_or_load_workspace(base / "proj")
+        monkeypatch.setenv("WORKSPACE_ROOT", str(base))
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "hosted")
+        r = _client().get("/api/v2/workspaces/exists", params={"repo_path": str(base / "proj")})
+        assert r.status_code == 403
+
     def test_no_root_self_hosted_unchanged(self, tmp_path, monkeypatch):
         """Self-hosted default (no WORKSPACE_ROOT): still works (single trust domain)."""
         proj = tmp_path / "proj"

--- a/tests/ui/test_exists_allowlist.py
+++ b/tests/ui/test_exists_allowlist.py
@@ -1,0 +1,63 @@
+"""GET /api/v2/workspaces/exists must honor the workspace allowlist (#719 / P0.8).
+
+Previously it resolved a raw client path and returned existence + the resolved
+absolute path with no allowlist check — a filesystem-existence oracle and path
+leak for any authenticated user. With WORKSPACE_ROOT set, out-of-root probes
+must 403 and never echo the resolved path.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+def _client():
+    from codeframe.ui import server
+    return TestClient(server.app)
+
+
+class TestExistsAllowlist:
+    def test_out_of_root_probe_rejected(self, tmp_path, monkeypatch):
+        base = tmp_path / "roots"
+        base.mkdir()
+        monkeypatch.setenv("WORKSPACE_ROOT", str(base))
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+        r = _client().get("/api/v2/workspaces/exists", params={"repo_path": "/etc"})
+        assert r.status_code == 403
+        # The resolved absolute path must not be leaked.
+        assert "/etc" not in str(r.json())
+
+    def test_in_root_path_allowed(self, tmp_path, monkeypatch):
+        base = tmp_path / "roots"
+        proj = base / "proj"
+        proj.mkdir(parents=True)
+        create_or_load_workspace(proj)
+        monkeypatch.setenv("WORKSPACE_ROOT", str(base))
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+        r = _client().get("/api/v2/workspaces/exists", params={"repo_path": str(proj)})
+        assert r.status_code == 200
+        assert r.json()["exists"] is True
+
+    def test_traversal_escape_rejected(self, tmp_path, monkeypatch):
+        base = tmp_path / "roots"
+        base.mkdir()
+        monkeypatch.setenv("WORKSPACE_ROOT", str(base))
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+        r = _client().get(
+            "/api/v2/workspaces/exists", params={"repo_path": str(base / ".." / "escape")}
+        )
+        assert r.status_code == 403
+
+    def test_no_root_self_hosted_unchanged(self, tmp_path, monkeypatch):
+        """Self-hosted default (no WORKSPACE_ROOT): still works (single trust domain)."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        create_or_load_workspace(proj)
+        monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", "self_hosted")
+        r = _client().get("/api/v2/workspaces/exists", params={"repo_path": str(proj)})
+        assert r.status_code == 200
+        assert r.json()["exists"] is True


### PR DESCRIPTION
## What & why
`GET /api/v2/workspaces/exists` resolved a **raw client-supplied `repo_path`** and returned `{exists, path, state_dir}` with **no** `enforce_workspace_allowlist` call (unlike `init_workspace`). So any authenticated user — any tenant in hosted mode — could probe arbitrary host paths for existence and get the fully-resolved absolute path back. A filesystem-existence oracle + path disclosure.

Fixes **#719 [P0.8]**.

## Change
`check_workspace_exists` now takes `auth` and routes `repo_path` through `enforce_workspace_allowlist(Path(repo_path), auth["user_id"])` — the same guard `init_workspace` uses. Out-of-allowlist inputs raise 403 (so the resolved path is never echoed); in-root paths resolve and return normally. Self-hosted with no `WORKSPACE_ROOT` is unchanged (single trust domain).

## Tests (`tests/ui/test_exists_allowlist.py`)
Out-of-root probe → 403 (+ asserts the path is not leaked); traversal `..` escape → 403; in-root path → 200 `exists=true`; self-hosted no-root → unchanged. `35 passed` across workspace suites. `ruff` + `mypy` clean.

## Demo
```
in-root proj        -> 200  exists=True
out-of-root /etc    -> 403  blocked (no path leaked)
traversal ../escape -> 403  blocked
```

## Acceptance criteria
- [x] `check_workspace_exists` runs the path through `enforce_workspace_allowlist` (403 for out-of-root)
- [x] The fully-resolved absolute path is not echoed for out-of-allowlist inputs
