### PR TITLE
fix(cli): use click.Choice in cf proof capture (#723)

### DIFF
--- a/codeframe/cli/proof_commands.py
+++ b/codeframe/cli/proof_commands.py
@@ -8,6 +8,7 @@ from datetime import date
 from pathlib import Path
 from typing import Optional
 
+import click
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -75,12 +76,14 @@ def capture(
     if not severity:
         severity = typer.prompt(
             "Severity", default="medium",
-            type=typer.Choice(["critical", "high", "medium", "low"]),
+            # click.Choice — typer has no Choice; typer.prompt delegates to
+            # click.prompt, so this constrains the interactive input (#723).
+            type=click.Choice(["critical", "high", "medium", "low"]),
         )
     if not source:
         source = typer.prompt(
             "Source", default="qa",
-            type=typer.Choice(["production", "qa", "dogfooding", "monitoring", "user_report"]),
+            type=click.Choice(["production", "qa", "dogfooding", "monitoring", "user_report"]),
         )
 
     try:

--- a/tests/cli/test_proof_commands.py
+++ b/tests/cli/test_proof_commands.py
@@ -78,6 +78,26 @@ class TestCapture:
         assert req.title == "Login rejects valid credentials"
         assert req.status == ReqStatus.OPEN
 
+    def test_capture_interactive_prompts_do_not_crash(self, ws):
+        """#723: severity/source were prompted with the nonexistent typer.Choice,
+        so any interactive `cf proof capture` (no --severity/--source) raised
+        AttributeError. Drive the interactive branch via stdin and assert it
+        captures cleanly."""
+        workspace, workspace_path = ws
+        result = runner.invoke(
+            app,
+            [
+                "proof", "capture", "-w", str(workspace_path),
+                "--title", "T", "--description", "D", "--where", "src/x.py",
+            ],
+            input="high\nqa\n",  # severity Choice, then source Choice
+        )
+        assert result.exit_code == 0, result.output
+        assert "REQ-0001" in result.output
+        req = ledger.get_requirement(workspace, "REQ-0001")
+        assert req is not None
+        assert req.severity.value == "high"
+
     def test_capture_second_req_increments_id(self, ws_with_req):
         """A second capture should produce REQ-0002."""
         workspace, workspace_path = ws_with_req

--- a/tests/cli/test_proof_commands.py
+++ b/tests/cli/test_proof_commands.py
@@ -96,7 +96,9 @@ class TestCapture:
         assert "REQ-0001" in result.output
         req = ledger.get_requirement(workspace, "REQ-0001")
         assert req is not None
+        # Both repaired Choice prompts (severity + source) took effect.
         assert req.severity.value == "high"
+        assert req.source.value == "qa"
 
     def test_capture_second_req_increments_id(self, ws_with_req):
         """A second capture should produce REQ-0002."""


### PR DESCRIPTION
## What & why
The interactive `cf proof capture` path prompted for severity and source with `type=typer.Choice([...])` — but **typer has no `Choice`** (only `click.Choice`). So any `cf proof capture` run *without* `--severity/--source` raised `AttributeError` with an uncaught traceback, breaking the command's own documented interactive usage.

Fixes **#723 [P0.12]**.

## Change
`import click` and use `click.Choice` at both prompt sites. `typer.prompt` delegates to `click.prompt`, which accepts a `click.Choice` type, so the interactive input is now constrained correctly.

## Tests
`test_capture_interactive_prompts_do_not_crash` drives the interactive branch (title/description/where via flags, severity+source via stdin) and asserts a clean capture (exit 0, REQ-0001, severity persisted). This is the branch existing tests skipped (they always pass `--severity/--source`). `18 passed`. `ruff` + `mypy` clean.

## Demo
```
$ printf 'high\nqa\n' | cf proof capture --title "Login bug" --description "..." --where src/auth.py
  Obligations: unit, contract
  Generated test stubs: unit: 15 lines, contract: 9 lines
EXIT=0        # was: AttributeError traceback
```

## Acceptance criteria
- [x] Interactive `cf proof capture` prompts for severity/source without crashing (click.Choice)
- [x] A CLI test drives the interactive branch
