### PR TITLE
fix(proof): explicit UNVERIFIABLE state for gates without runners (#728)

### DIFF
--- a/codeframe/cli/proof_commands.py
+++ b/codeframe/cli/proof_commands.py
@@ -144,7 +144,7 @@ def run(
         codeframe proof run --gate unit
     """
     from codeframe.core.workspace import get_workspace
-    from codeframe.core.proof.models import Gate
+    from codeframe.core.proof.models import Gate, GateOutcome
     from codeframe.core.proof.runner import run_proof
 
     workspace_path = repo_path or Path.cwd()
@@ -178,21 +178,41 @@ def run(
     table.add_column("Gate", style="blue")
     table.add_column("Result", style="bold")
 
-    all_pass = True
+    _CELL = {
+        GateOutcome.PASSED: "[green]PASS[/green]",
+        GateOutcome.FAILED: "[red]FAIL[/red]",
+        GateOutcome.UNVERIFIABLE: "[yellow]UNVERIFIABLE[/yellow]",
+    }
+    any_failed = False
+    unverifiable_gates: set[str] = set()
     for req_id, gate_results in results.items():
-        for g, passed in gate_results:
-            status = "[green]PASS[/green]" if passed else "[red]FAIL[/red]"
-            if not passed:
-                all_pass = False
-            table.add_row(req_id, g.value, status)
+        for g, outcome in gate_results:
+            if outcome == GateOutcome.FAILED:
+                any_failed = True
+            elif outcome == GateOutcome.UNVERIFIABLE:
+                unverifiable_gates.add(g.value)
+            table.add_row(req_id, g.value, _CELL[outcome])
 
     console.print(table)
 
-    if all_pass:
-        console.print("\n[green]All obligations satisfied.[/green]")
-    else:
+    if unverifiable_gates:
+        gates = ", ".join(sorted(unverifiable_gates))
+        console.print(
+            f"\n[yellow]Could not verify {len(unverifiable_gates)} gate(s):[/yellow] "
+            f"{gates} — no automated runner. "
+            "Waive with 'cf proof waive <REQ> --reason \"...\"'."
+        )
+
+    if any_failed:
         console.print("\n[red]Some obligations failed.[/red] Fix issues and re-run.")
         raise typer.Exit(1)
+    elif unverifiable_gates:
+        console.print(
+            "\n[green]No obligations failed[/green] "
+            "[dim](some gates could not be verified).[/dim]"
+        )
+    else:
+        console.print("\n[green]All obligations satisfied.[/green]")
 
 
 @proof_app.command("list")
@@ -319,7 +339,13 @@ def show(
     if evidence_list:
         console.print(f"\n[bold]Evidence ({len(evidence_list)}):[/bold]")
         for ev in evidence_list[:10]:
-            status = "[green]PASS[/green]" if ev.satisfied else "[red]FAIL[/red]"
+            if ev.status == "unverifiable":
+                status = "[yellow]UNVERIFIABLE[/yellow]"
+            elif ev.satisfied:
+                status = "[green]PASS[/green]"
+            else:
+                # Legacy rows (status=None) fall back to the satisfied bool.
+                status = "[red]FAIL[/red]"
             console.print(f"  {ev.gate.value} {status} — {ev.artifact_path}")
 
 

--- a/codeframe/core/proof/evidence.py
+++ b/codeframe/core/proof/evidence.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from codeframe.core.proof import ledger
-from codeframe.core.proof.models import Evidence, Gate, Requirement
+from codeframe.core.proof.models import Evidence, Gate, GateOutcome, Requirement
 from codeframe.core.workspace import Workspace
 
 
@@ -28,18 +28,23 @@ def attach_evidence(
     req_id: str,
     gate: Gate,
     artifact_path: str,
-    satisfied: bool,
+    outcome: GateOutcome,
     run_id: str,
 ) -> Evidence:
-    """Create and persist an evidence record with artifact checksum."""
+    """Create and persist an evidence record with artifact checksum.
+
+    `satisfied` is True only when the gate PASSED; UNVERIFIABLE and FAILED both
+    record satisfied=False. The tri-state `outcome` is preserved in `status`.
+    """
     evidence = Evidence(
         req_id=req_id,
         gate=gate,
-        satisfied=satisfied,
+        satisfied=(outcome == GateOutcome.PASSED),
         artifact_path=artifact_path,
         artifact_checksum=_sha256(artifact_path),
         timestamp=datetime.now(timezone.utc),
         run_id=run_id,
+        status=outcome.value,
     )
     ledger.save_evidence(workspace, evidence)
     return evidence

--- a/codeframe/core/proof/ledger.py
+++ b/codeframe/core/proof/ledger.py
@@ -5,6 +5,7 @@ Tables live in the workspace's state.db alongside PRDs and tasks.
 """
 
 import json
+import sqlite3
 from datetime import date, datetime, timezone
 from typing import Optional
 
@@ -125,19 +126,35 @@ def _ensure_tables(workspace: Workspace) -> None:
     _migrate_evidence_status_column(workspace)
 
 
+# Workspaces already checked for the #728 status column this process —
+# skips the per-call PRAGMA once the migration is known to have run.
+_status_migrated_workspaces: set[str] = set()
+
+
 def _migrate_evidence_status_column(workspace: Workspace) -> None:
     """Add proof_evidence.status to pre-existing DBs that predate #728.
 
     The column is nullable; old rows read back status=None. No-op once present.
     """
+    if workspace.id in _status_migrated_workspaces:
+        return
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-    cursor.execute("PRAGMA table_info(proof_evidence)")
-    columns = {row[1] for row in cursor.fetchall()}
-    if columns and "status" not in columns:
-        cursor.execute("ALTER TABLE proof_evidence ADD COLUMN status TEXT")
-        conn.commit()
-    conn.close()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(proof_evidence)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if columns and "status" not in columns:
+            try:
+                cursor.execute("ALTER TABLE proof_evidence ADD COLUMN status TEXT")
+                conn.commit()
+            except sqlite3.OperationalError as exc:
+                # Concurrent first-run: another worker added the column
+                # between our check and the ALTER.
+                if "duplicate column" not in str(exc).lower():
+                    raise
+        _status_migrated_workspaces.add(workspace.id)
+    finally:
+        conn.close()
 
 
 # --- Serialization helpers ---

--- a/codeframe/core/proof/ledger.py
+++ b/codeframe/core/proof/ledger.py
@@ -67,6 +67,7 @@ def init_proof_tables(workspace: Workspace) -> None:
             timestamp TEXT NOT NULL,
             run_id TEXT NOT NULL,
             workspace_id TEXT NOT NULL,
+            status TEXT,
             FOREIGN KEY (req_id) REFERENCES proof_requirements(id)
         )
     """)
@@ -121,6 +122,22 @@ def _ensure_tables(workspace: Workspace) -> None:
     conn.close()
     if missing:
         init_proof_tables(workspace)
+    _migrate_evidence_status_column(workspace)
+
+
+def _migrate_evidence_status_column(workspace: Workspace) -> None:
+    """Add proof_evidence.status to pre-existing DBs that predate #728.
+
+    The column is nullable; old rows read back status=None. No-op once present.
+    """
+    conn = get_db_connection(workspace)
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA table_info(proof_evidence)")
+    columns = {row[1] for row in cursor.fetchall()}
+    if columns and "status" not in columns:
+        cursor.execute("ALTER TABLE proof_evidence ADD COLUMN status TEXT")
+        conn.commit()
+    conn.close()
 
 
 # --- Serialization helpers ---
@@ -315,12 +332,13 @@ def save_evidence(workspace: Workspace, evidence: Evidence) -> None:
     cursor.execute(
         """INSERT INTO proof_evidence
            (req_id, gate, satisfied, artifact_path, artifact_checksum,
-            timestamp, run_id, workspace_id)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            timestamp, run_id, workspace_id, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             evidence.req_id, evidence.gate.value, int(evidence.satisfied),
             evidence.artifact_path, evidence.artifact_checksum,
             evidence.timestamp.isoformat(), evidence.run_id, workspace.id,
+            evidence.status,
         ),
     )
     conn.commit()
@@ -334,7 +352,7 @@ def list_evidence(workspace: Workspace, req_id: str) -> list[Evidence]:
     cursor = conn.cursor()
     cursor.execute(
         """SELECT req_id, gate, satisfied, artifact_path, artifact_checksum,
-                  timestamp, run_id
+                  timestamp, run_id, status
            FROM proof_evidence WHERE req_id = ? AND workspace_id = ?
            ORDER BY timestamp DESC""",
         (req_id, workspace.id),
@@ -346,6 +364,7 @@ def list_evidence(workspace: Workspace, req_id: str) -> list[Evidence]:
             req_id=r[0], gate=Gate(r[1]), satisfied=bool(r[2]),
             artifact_path=r[3], artifact_checksum=r[4],
             timestamp=datetime.fromisoformat(r[5]), run_id=r[6],
+            status=r[7],
         )
         for r in rows
     ]
@@ -460,7 +479,7 @@ def get_run_evidence(workspace: Workspace, run_id: str) -> list[Evidence]:
     cursor = conn.cursor()
     cursor.execute(
         """SELECT req_id, gate, satisfied, artifact_path, artifact_checksum,
-                  timestamp, run_id
+                  timestamp, run_id, status
            FROM proof_evidence WHERE run_id = ? AND workspace_id = ?
            ORDER BY timestamp ASC""",
         (run_id, workspace.id),
@@ -472,6 +491,7 @@ def get_run_evidence(workspace: Workspace, run_id: str) -> list[Evidence]:
             req_id=r[0], gate=Gate(r[1]), satisfied=bool(r[2]),
             artifact_path=r[3], artifact_checksum=r[4],
             timestamp=datetime.fromisoformat(r[5]), run_id=r[6],
+            status=r[7],
         )
         for r in rows
     ]

--- a/codeframe/core/proof/models.py
+++ b/codeframe/core/proof/models.py
@@ -33,6 +33,19 @@ class Gate(str, Enum):
 PROOF9_GATE_ORDER: tuple[str, ...] = tuple(g.value for g in Gate)
 
 
+class GateOutcome(str, Enum):
+    """Outcome of running a single proof obligation's gate.
+
+    UNVERIFIABLE is distinct from FAILED: the gate has no automated runner
+    (e.g. e2e, visual, a11y, perf, demo, manual), so the obligation could not
+    be checked at all. It never satisfies a requirement and never fails a run.
+    """
+
+    PASSED = "passed"
+    FAILED = "failed"
+    UNVERIFIABLE = "unverifiable"
+
+
 class GlitchType(str, Enum):
     """Classification of the glitch that produced a requirement."""
 
@@ -88,7 +101,7 @@ class Obligation:
     """A single proof obligation attached to a requirement."""
 
     gate: Gate
-    status: str = "pending"  # pending, satisfied, failed
+    status: str = "pending"  # pending, satisfied, failed, unverifiable
 
 
 @dataclass
@@ -121,6 +134,7 @@ class Evidence:
     artifact_checksum: str
     timestamp: datetime
     run_id: str
+    status: Optional[str] = None  # passed, failed, unverifiable (None for legacy rows)
 
 
 @dataclass

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -16,6 +16,7 @@ from codeframe.core.proof.evidence import attach_evidence
 from codeframe.core.proof.models import (
     PROOF_CONFIG_FILENAME,
     Gate,
+    GateOutcome,
     ProofRun,
     ReqStatus,
 )
@@ -71,16 +72,27 @@ _GATE_TO_CORE: dict[Gate, str] = {
     Gate.SEC: "ruff",
 }
 
+# Map a gate outcome to the persisted obligation status string.
+_OUTCOME_TO_OBLIGATION_STATUS: dict[GateOutcome, str] = {
+    GateOutcome.PASSED: "satisfied",
+    GateOutcome.FAILED: "failed",
+    GateOutcome.UNVERIFIABLE: "unverifiable",
+}
 
-def _run_gate(workspace: Workspace, gate: Gate) -> tuple[bool, str]:
-    """Execute a single gate and return (passed, output).
 
-    Uses core/gates.py for gates that have direct tool support.
-    Returns (True, "") for gates without automated tooling yet.
+def _run_gate(workspace: Workspace, gate: Gate) -> tuple[GateOutcome, str]:
+    """Execute a single gate and return (outcome, output).
+
+    Uses core/gates.py for gates that have direct tool support. Gates without
+    an automated runner return UNVERIFIABLE — the obligation could not be
+    checked, which is distinct from running and failing.
     """
     core_gate_name = _GATE_TO_CORE.get(gate)
     if not core_gate_name:
-        return False, f"Gate {gate.value} has no automated runner — cannot verify"
+        return (
+            GateOutcome.UNVERIFIABLE,
+            f"Gate {gate.value} has no automated runner — cannot verify",
+        )
 
     try:
         from codeframe.core.gates import run as run_gates
@@ -88,10 +100,11 @@ def _run_gate(workspace: Workspace, gate: Gate) -> tuple[bool, str]:
         output_parts = [
             f"{check.name}: {check.status.value}" for check in result.checks
         ]
-        return result.passed, "\n".join(output_parts)
+        outcome = GateOutcome.PASSED if result.passed else GateOutcome.FAILED
+        return outcome, "\n".join(output_parts)
     except Exception as exc:
         logger.warning("Gate %s failed to run: %s", gate.value, exc)
-        return False, str(exc)
+        return GateOutcome.FAILED, str(exc)
 
 
 def run_proof(
@@ -100,7 +113,7 @@ def run_proof(
     full: bool = False,
     gate_filter: Optional[Gate] = None,
     run_id: Optional[str] = None,
-) -> dict[str, list[tuple[Gate, bool]]]:
+) -> dict[str, list[tuple[Gate, GateOutcome]]]:
     """Execute proof obligations and collect evidence.
 
     Args:
@@ -110,7 +123,7 @@ def run_proof(
         run_id: Unique run identifier (auto-generated if not provided)
 
     Returns:
-        Dict mapping req_id → list of (Gate, satisfied) tuples
+        Dict mapping req_id → list of (Gate, GateOutcome) tuples
     """
     if not run_id:
         run_id = str(uuid.uuid4())[:8]
@@ -157,7 +170,7 @@ def run_proof(
     if not full:
         changed_scope = get_changed_scope(workspace)
 
-    results: dict[str, list[tuple[Gate, bool]]] = {}
+    results: dict[str, list[tuple[Gate, GateOutcome]]] = {}
     artifact_dir = workspace.state_dir / "proof_artifacts"
     artifact_dir.mkdir(exist_ok=True)
 
@@ -168,7 +181,7 @@ def run_proof(
             if not intersects(req.scope, changed_scope):
                 continue
 
-        req_results: list[tuple[Gate, bool]] = []
+        req_results: list[tuple[Gate, GateOutcome]] = []
 
         for obl in req.obligations:
             # Apply gate filter
@@ -180,7 +193,7 @@ def run_proof(
                 continue
 
             # Run the gate
-            passed, output = _run_gate(workspace, obl.gate)
+            outcome, output = _run_gate(workspace, obl.gate)
 
             # Write artifact
             artifact_path = artifact_dir / f"{req.id}_{obl.gate.value}_{run_id}.txt"
@@ -189,25 +202,35 @@ def run_proof(
             # Attach evidence
             attach_evidence(
                 workspace, req.id, obl.gate,
-                str(artifact_path), passed, run_id,
+                str(artifact_path), outcome, run_id,
             )
 
             # Update obligation status
-            obl.status = "satisfied" if passed else "failed"
-            req_results.append((obl.gate, passed))
+            obl.status = _OUTCOME_TO_OBLIGATION_STATUS[outcome]
+            req_results.append((obl.gate, outcome))
 
         if req_results:
             results[req.id] = req_results
 
-            # Always persist obligation status updates
-            all_satisfied = all(passed for _, passed in req_results)
-            if all_satisfied and len(req_results) == len(req.obligations):
+            # Always persist obligation status updates. A requirement is only
+            # SATISFIED when every obligation PASSED and all obligations ran —
+            # an unverifiable obligation leaves it OPEN (and waivable).
+            all_passed = all(o == GateOutcome.PASSED for _, o in req_results)
+            if all_passed and len(req_results) == len(req.obligations):
                 req.status = ReqStatus.SATISFIED
             ledger.save_requirement(workspace, req)
 
     completed_at = datetime.now(timezone.utc)
     duration_ms = int((completed_at - started_at).total_seconds() * 1000)
-    executed = [passed for gate_results in results.values() for _, passed in gate_results]
+    # Only gates that actually ran (passed or failed) count toward the tally;
+    # unverifiable gates neither pass nor fail, so a run with only unverifiable
+    # outcomes passes.
+    executed = [
+        outcome == GateOutcome.PASSED
+        for gate_results in results.values()
+        for _, outcome in gate_results
+        if outcome != GateOutcome.UNVERIFIABLE
+    ]
     all_passed = all(executed) if executed else True
     if not all_passed and strictness == "warn":
         logger.warning(

--- a/codeframe/tui/app.py
+++ b/codeframe/tui/app.py
@@ -221,6 +221,7 @@ class DashboardApp(App):
         "satisfied": "✅",
         "failed": "❌",
         "pending": "⏳",
+        "unverifiable": "❓",
     }
 
     def _update_proof_panel(self, data: DashboardData) -> None:

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -37,6 +37,7 @@ from codeframe.core.proof.models import (
     PROOF9_GATE_ORDER,
     PROOF_CONFIG_FILENAME,
     Gate,
+    GateOutcome,
     ReqStatus,
     Severity,
     Source,
@@ -220,6 +221,7 @@ class EvidenceResponse(BaseModel):
     artifact_checksum: str
     timestamp: str
     run_id: str
+    status: Optional[str] = None
 
 
 class EvidenceWithContentResponse(EvidenceResponse):
@@ -411,9 +413,18 @@ async def run_proof_endpoint(
             gate_filter=body.gate,
             run_id=run_id,
         )
-        # Serialize: dict[req_id → list[tuple[Gate, bool]]] → JSON-safe
+        # Serialize: dict[req_id → list[tuple[Gate, GateOutcome]]] → JSON-safe.
+        # `satisfied` is kept for compatibility; `status` carries the tri-state
+        # outcome (passed / failed / unverifiable).
         serialized = {
-            req_id: [{"gate": gate.value, "satisfied": satisfied} for gate, satisfied in gate_results]
+            req_id: [
+                {
+                    "gate": gate.value,
+                    "satisfied": outcome == GateOutcome.PASSED,
+                    "status": outcome.value,
+                }
+                for gate, outcome in gate_results
+            ]
             for req_id, gate_results in results.items()
         }
 
@@ -426,11 +437,15 @@ async def run_proof_endpoint(
         if persisted_run is not None:
             passed = persisted_run.overall_passed
         else:
-            passed = all(
-                satisfied
+            # Mirror the runner rule: unverifiable outcomes neither pass nor
+            # fail, so a run with only unverifiable gates passes.
+            executed = [
+                outcome == GateOutcome.PASSED
                 for gate_results in results.values()
-                for _, satisfied in gate_results
-            )
+                for _, outcome in gate_results
+                if outcome != GateOutcome.UNVERIFIABLE
+            ]
+            passed = all(executed) if executed else True
         response = RunProofResponse(
             success=True,
             run_id=run_id,
@@ -602,6 +617,7 @@ async def get_run_evidence_endpoint(
                     req_id=req_id,
                     gate=gate_result["gate"],
                     satisfied=gate_result["satisfied"],
+                    status=gate_result.get("status"),
                     artifact_path="",
                     artifact_checksum="",
                     timestamp="",
@@ -628,6 +644,7 @@ async def get_run_evidence_endpoint(
             req_id=e.req_id,
             gate=e.gate.value,
             satisfied=e.satisfied,
+            status=e.status,
             artifact_path=e.artifact_path,
             artifact_checksum=e.artifact_checksum,
             timestamp=e.timestamp.isoformat(),
@@ -746,6 +763,7 @@ async def list_evidence_endpoint(
             req_id=e.req_id,
             gate=e.gate.value,
             satisfied=e.satisfied,
+            status=e.status,
             artifact_path=e.artifact_path,
             artifact_checksum=e.artifact_checksum,
             timestamp=e.timestamp.isoformat(),

--- a/tests/cli/test_proof_commands.py
+++ b/tests/cli/test_proof_commands.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 
 from codeframe.cli.app import app
 from codeframe.core.proof import ledger
-from codeframe.core.proof.models import ReqStatus
+from codeframe.core.proof.models import GateOutcome, ReqStatus
 from codeframe.core.workspace import create_or_load_workspace
 
 pytestmark = pytest.mark.v2
@@ -146,7 +146,7 @@ class TestRun:
     @patch("codeframe.core.proof.runner._run_gate")
     def test_run_with_passing_obligations(self, mock_run_gate, ws_with_req):
         """run --full with all gates passing should exit 0 and print PASS."""
-        mock_run_gate.return_value = (True, "All tests passed")
+        mock_run_gate.return_value = (GateOutcome.PASSED, "All tests passed")
         _, workspace_path = ws_with_req
 
         result = runner.invoke(app, ["proof", "run", "-w", str(workspace_path), "--full"])
@@ -158,11 +158,68 @@ class TestRun:
     @patch("codeframe.core.proof.runner._run_gate")
     def test_run_with_failing_obligations(self, mock_run_gate, ws_with_req):
         """run --full with any gate failing should exit 1 and print FAIL."""
-        mock_run_gate.return_value = (False, "assertion failed")
+        mock_run_gate.return_value = (GateOutcome.FAILED, "assertion failed")
         _, workspace_path = ws_with_req
 
         result = runner.invoke(app, ["proof", "run", "-w", str(workspace_path), "--full"])
 
+        assert result.exit_code == 1, result.output
+        assert "FAIL" in result.output
+
+    def test_run_unverifiable_only_prints_unverifiable_and_exits_zero(self, ws):
+        """A REQ whose only obligations are unrunnable gates (e2e/demo) should
+        print UNVERIFIABLE, exit 0, and tell the user the gates can be waived."""
+        workspace, workspace_path = ws
+        # "button click" classifies as UI_WIRING_BUG → obligations [E2E, DEMO],
+        # both without an automated runner → unverifiable.
+        result = runner.invoke(app, [
+            "proof", "capture", "-w", str(workspace_path),
+            "--title", "Button click does nothing",
+            "--description", "Submit button click handler never fires the callback",
+            "--where", "src/ui/form.tsx",
+            "--severity", "medium", "--source", "qa",
+        ])
+        assert result.exit_code == 0, result.output
+
+        result = runner.invoke(app, ["proof", "run", "-w", str(workspace_path), "--full"])
+        assert result.exit_code == 0, result.output
+        assert "UNVERIFIABLE" in result.output
+        assert "waive" in result.output.lower()
+        # The requirement stays open (unverifiable never satisfies).
+        req = ledger.get_requirement(workspace, "REQ-0001")
+        assert req.status == ReqStatus.OPEN
+
+    @patch("codeframe.core.proof.runner._run_gate")
+    def test_run_mixed_fail_and_unverifiable_exits_one(self, mock_run_gate, ws):
+        """A real FAIL alongside unverifiable gates still exits 1."""
+        from datetime import datetime, timezone
+
+        from codeframe.core.proof.models import (
+            Gate, GateOutcome, Obligation, Requirement, RequirementScope,
+            ReqStatus, Severity, Source,
+        )
+
+        workspace, workspace_path = ws
+        ledger.save_requirement(
+            workspace,
+            Requirement(
+                id="REQ-0001", title="Mixed", description="mixed gates",
+                severity=Severity.MEDIUM, source=Source.QA,
+                scope=RequirementScope(files=["x.py"]),
+                obligations=[Obligation(gate=Gate.UNIT), Obligation(gate=Gate.E2E)],
+                evidence_rules=[], status=ReqStatus.OPEN,
+                created_at=datetime.now(timezone.utc),
+            ),
+        )
+
+        def _outcome(_ws, gate):
+            if gate == Gate.UNIT:
+                return (GateOutcome.FAILED, "assertion failed")
+            return (GateOutcome.UNVERIFIABLE, "cannot verify")
+
+        mock_run_gate.side_effect = _outcome
+
+        result = runner.invoke(app, ["proof", "run", "-w", str(workspace_path), "--full"])
         assert result.exit_code == 1, result.output
         assert "FAIL" in result.output
 
@@ -318,7 +375,7 @@ class TestClosedLoop:
         assert "REQ-0001" in result.output
 
         # Step 2 — run with obligations failing
-        mock_run_gate.return_value = (False, "assertion failed")
+        mock_run_gate.return_value = (GateOutcome.FAILED, "assertion failed")
         result = runner.invoke(app, ["proof", "run", "-w", str(workspace_path), "--full"])
         assert result.exit_code == 1, result.output
         assert "FAIL" in result.output
@@ -330,7 +387,7 @@ class TestClosedLoop:
         assert "Open" in result.output
 
         # Step 4 — run with all obligations passing
-        mock_run_gate.return_value = (True, "all green")
+        mock_run_gate.return_value = (GateOutcome.PASSED, "all green")
         result = runner.invoke(app, ["proof", "run", "-w", str(workspace_path), "--full"])
         assert result.exit_code == 0, result.output
         assert "PASS" in result.output

--- a/tests/core/test_proof9.py
+++ b/tests/core/test_proof9.py
@@ -365,7 +365,7 @@ class TestScope:
 class TestEvidence:
     def test_attach_evidence(self, workspace, tmp_path):
         from codeframe.core.proof.evidence import attach_evidence
-        from codeframe.core.proof.models import Gate
+        from codeframe.core.proof.models import Gate, GateOutcome
         from codeframe.core.proof import ledger
 
         # Create artifact file
@@ -374,9 +374,10 @@ class TestEvidence:
 
         ev = attach_evidence(
             workspace, "REQ-0001", Gate.UNIT,
-            str(artifact), True, "run-1",
+            str(artifact), GateOutcome.PASSED, "run-1",
         )
         assert ev.satisfied is True
+        assert ev.status == "passed"
         assert ev.artifact_checksum != ""
         assert len(ev.artifact_checksum) == 64  # SHA-256
 
@@ -387,7 +388,7 @@ class TestEvidence:
     def test_check_obligation_satisfied(self, workspace, tmp_path):
         from codeframe.core.proof.evidence import attach_evidence, check_obligation_satisfied
         from codeframe.core.proof.models import (
-            Gate, Requirement, Severity, Source, RequirementScope, Obligation,
+            Gate, GateOutcome, Requirement, Severity, Source, RequirementScope, Obligation,
         )
 
         req = Requirement(
@@ -403,7 +404,7 @@ class TestEvidence:
         # Attach passing evidence
         artifact = tmp_path / "out.txt"
         artifact.write_text("passed")
-        attach_evidence(workspace, "REQ-0001", Gate.UNIT, str(artifact), True, "run-1")
+        attach_evidence(workspace, "REQ-0001", Gate.UNIT, str(artifact), GateOutcome.PASSED, "run-1")
 
         assert check_obligation_satisfied(workspace, req, Gate.UNIT) is True
 
@@ -501,7 +502,7 @@ class TestRunner:
     def test_run_proof_full(self, mock_run_gate, workspace):
         from codeframe.core.proof.runner import run_proof
         from codeframe.core.proof.capture import capture_requirement
-        from codeframe.core.proof.models import Severity, Source
+        from codeframe.core.proof.models import GateOutcome, Severity, Source
 
         # Capture a requirement first
         capture_requirement(
@@ -509,30 +510,30 @@ class TestRunner:
             where="src/calc.py", severity=Severity.MEDIUM, source=Source.QA,
         )
 
-        mock_run_gate.return_value = (True, "All tests passed")
+        mock_run_gate.return_value = (GateOutcome.PASSED, "All tests passed")
 
         results = run_proof(workspace, full=True)
         assert len(results) == 1
         req_id = list(results.keys())[0]
-        assert all(passed for _, passed in results[req_id])
+        assert all(o == GateOutcome.PASSED for _, o in results[req_id])
 
     @patch("codeframe.core.proof.runner._run_gate")
     def test_run_proof_with_failure(self, mock_run_gate, workspace):
         from codeframe.core.proof.runner import run_proof
         from codeframe.core.proof.capture import capture_requirement
-        from codeframe.core.proof.models import Severity, Source
+        from codeframe.core.proof.models import GateOutcome, Severity, Source
 
         capture_requirement(
             workspace, title="Test bug", description="Logic error",
             where="src/calc.py", severity=Severity.MEDIUM, source=Source.QA,
         )
 
-        mock_run_gate.return_value = (False, "Tests failed")
+        mock_run_gate.return_value = (GateOutcome.FAILED, "Tests failed")
 
         results = run_proof(workspace, full=True)
         assert len(results) == 1
         req_id = list(results.keys())[0]
-        assert not all(passed for _, passed in results[req_id])
+        assert not all(o == GateOutcome.PASSED for _, o in results[req_id])
 
 
 # --- CLI Tests ---
@@ -619,3 +620,127 @@ class TestCLI:
         result = runner.invoke(app, ["proof", "status", "-w", str(tmp_path)])
         assert result.exit_code == 0
         assert "1" in result.output  # 1 requirement
+
+
+# --- Evidence status (tri-state UNVERIFIABLE, #728) ---
+
+
+class TestEvidenceStatus:
+    def test_evidence_status_round_trip(self, workspace, tmp_path):
+        """Evidence.status persists and reads back through the ledger."""
+        from codeframe.core.proof.ledger import save_evidence, list_evidence
+        from codeframe.core.proof.models import Evidence, Gate
+
+        ev = Evidence(
+            req_id="REQ-0001", gate=Gate.E2E, satisfied=False,
+            artifact_path="/tmp/e2e.txt", artifact_checksum="abc",
+            timestamp=datetime.now(timezone.utc), run_id="run-1",
+            status="unverifiable",
+        )
+        save_evidence(workspace, ev)
+
+        loaded = list_evidence(workspace, "REQ-0001")
+        assert len(loaded) == 1
+        assert loaded[0].status == "unverifiable"
+        assert loaded[0].satisfied is False
+
+    def test_evidence_status_defaults_none(self, workspace, tmp_path):
+        """Evidence saved without an explicit status reads back status=None."""
+        from codeframe.core.proof.ledger import save_evidence, list_evidence
+        from codeframe.core.proof.models import Evidence, Gate
+
+        ev = Evidence(
+            req_id="REQ-0002", gate=Gate.UNIT, satisfied=True,
+            artifact_path="/tmp/unit.txt", artifact_checksum="def",
+            timestamp=datetime.now(timezone.utc), run_id="run-2",
+        )
+        save_evidence(workspace, ev)
+
+        loaded = list_evidence(workspace, "REQ-0002")
+        assert loaded[0].status is None
+
+    def test_legacy_db_without_status_column_migrates(self, tmp_path):
+        """A pre-existing proof_evidence table lacking the status column is
+        migrated (ALTER TABLE ADD COLUMN) and old rows read back status=None."""
+        from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+        from codeframe.core.proof.ledger import list_evidence, save_evidence
+        from codeframe.core.proof.models import Evidence, Gate
+
+        ws = create_or_load_workspace(tmp_path)
+
+        # Create the legacy schema (no status column) and insert a row directly.
+        conn = get_db_connection(ws)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE proof_evidence (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                req_id TEXT NOT NULL,
+                gate TEXT NOT NULL,
+                satisfied INTEGER NOT NULL,
+                artifact_path TEXT NOT NULL,
+                artifact_checksum TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                workspace_id TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """INSERT INTO proof_evidence
+               (req_id, gate, satisfied, artifact_path, artifact_checksum,
+                timestamp, run_id, workspace_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "REQ-0009", "unit", 1, "/tmp/old.txt", "old",
+                datetime.now(timezone.utc).isoformat(), "old-run", ws.id,
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        # Old row reads back with status=None despite the missing column.
+        loaded = list_evidence(ws, "REQ-0009")
+        assert len(loaded) == 1
+        assert loaded[0].status is None
+
+        # New writes with a status also work after migration.
+        save_evidence(
+            ws,
+            Evidence(
+                req_id="REQ-0009", gate=Gate.E2E, satisfied=False,
+                artifact_path="/tmp/new.txt", artifact_checksum="new",
+                timestamp=datetime.now(timezone.utc), run_id="new-run",
+                status="unverifiable",
+            ),
+        )
+        loaded = list_evidence(ws, "REQ-0009")
+        statuses = {e.status for e in loaded}
+        assert "unverifiable" in statuses
+        assert None in statuses
+
+    def test_check_obligation_not_satisfied_by_unverifiable(self, workspace, tmp_path):
+        """Unverifiable evidence must NOT satisfy an obligation."""
+        from codeframe.core.proof.evidence import (
+            attach_evidence, check_obligation_satisfied,
+        )
+        from codeframe.core.proof.models import (
+            Gate, GateOutcome, Requirement, Severity, Source,
+            RequirementScope, Obligation,
+        )
+
+        req = Requirement(
+            id="REQ-0003", title="Test", description="Test",
+            severity=Severity.MEDIUM, source=Source.QA,
+            scope=RequirementScope(), obligations=[Obligation(gate=Gate.E2E)],
+            evidence_rules=[],
+        )
+
+        artifact = tmp_path / "e2e.txt"
+        artifact.write_text("cannot verify")
+        attach_evidence(
+            workspace, "REQ-0003", Gate.E2E, str(artifact),
+            GateOutcome.UNVERIFIABLE, "run-1",
+        )
+
+        assert check_obligation_satisfied(workspace, req, Gate.E2E) is False

--- a/tests/core/test_proof_runner_config.py
+++ b/tests/core/test_proof_runner_config.py
@@ -19,6 +19,7 @@ from codeframe.core.proof.ledger import get_run, init_proof_tables, save_require
 from codeframe.core.proof.models import (
     PROOF_CONFIG_FILENAME,
     Gate,
+    GateOutcome,
     Obligation,
     Requirement,
     RequirementScope,
@@ -68,7 +69,7 @@ class TestRunnerEnabledGatesFilter:
         # Patch _run_gate so we can see which gates were invoked
         with patch(
             "codeframe.core.proof.runner._run_gate",
-            return_value=(True, ""),
+            return_value=(GateOutcome.PASSED, ""),
         ) as mock_gate:
             run_proof(workspace, full=True)
 
@@ -82,7 +83,7 @@ class TestRunnerEnabledGatesFilter:
 
         with patch(
             "codeframe.core.proof.runner._run_gate",
-            return_value=(True, ""),
+            return_value=(GateOutcome.PASSED, ""),
         ) as mock_gate:
             run_proof(workspace, full=True)
 
@@ -103,7 +104,7 @@ class TestEmptyEnabledGates:
 
         with caplog.at_level(logging.WARNING, logger="codeframe.core.proof.runner"), patch(
             "codeframe.core.proof.runner._run_gate",
-            return_value=(True, ""),
+            return_value=(GateOutcome.PASSED, ""),
         ) as mock_gate:
             run_proof(workspace, full=True, run_id="empty-gates")
 
@@ -131,7 +132,7 @@ class TestRunnerStrictness:
 
         with patch(
             "codeframe.core.proof.runner._run_gate",
-            return_value=(False, "boom"),
+            return_value=(GateOutcome.FAILED, "boom"),
         ):
             run_proof(workspace, full=True, run_id="strict-run")
 
@@ -149,7 +150,7 @@ class TestRunnerStrictness:
 
         with patch(
             "codeframe.core.proof.runner._run_gate",
-            return_value=(False, "boom"),
+            return_value=(GateOutcome.FAILED, "boom"),
         ):
             run_proof(workspace, full=True, run_id="warn-run")
 

--- a/tests/core/test_proof_runner_outcomes.py
+++ b/tests/core/test_proof_runner_outcomes.py
@@ -1,0 +1,214 @@
+"""Tests for the tri-state gate outcome model (issue #728).
+
+The 6 PROOF9 gates without an automated runner (e2e, visual, a11y, perf,
+demo, manual) must return an explicit UNVERIFIABLE outcome instead of a
+perpetual FAIL. UNVERIFIABLE:
+- never satisfies a requirement (it stays OPEN and waivable)
+- never fails a run (overall_passed excludes it)
+- is distinct from a gate that ran and failed
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from codeframe.core.proof.ledger import (
+    get_run,
+    init_proof_tables,
+    list_evidence,
+    save_requirement,
+)
+from codeframe.core.proof.models import (
+    PROOF_CONFIG_FILENAME,
+    Gate,
+    GateOutcome,
+    Obligation,
+    Requirement,
+    RequirementScope,
+    ReqStatus,
+    Severity,
+    Source,
+)
+from codeframe.core.proof.runner import _run_gate, run_proof
+from codeframe.core.workspace import Workspace, create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    ws = create_or_load_workspace(tmp_path)
+    init_proof_tables(ws)
+    return ws
+
+
+def _make_req(req_id: str, gates: list[Gate]) -> Requirement:
+    return Requirement(
+        id=req_id,
+        title=f"Test {req_id}",
+        description="test",
+        severity=Severity.MEDIUM,
+        source=Source.QA,
+        scope=RequirementScope(files=["x.py"]),
+        obligations=[Obligation(gate=g) for g in gates],
+        evidence_rules=[],
+        status=ReqStatus.OPEN,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class TestGateOutcomeEnum:
+    def test_values(self):
+        assert GateOutcome.PASSED == "passed"
+        assert GateOutcome.FAILED == "failed"
+        assert GateOutcome.UNVERIFIABLE == "unverifiable"
+
+    def test_str_enum(self):
+        assert GateOutcome.UNVERIFIABLE.value == "unverifiable"
+        assert isinstance(GateOutcome.PASSED, str)
+
+
+class TestRunGateOutcome:
+    """_run_gate returns (GateOutcome, str)."""
+
+    def test_unmapped_gate_is_unverifiable(self, workspace):
+        outcome, output = _run_gate(workspace, Gate.E2E)
+        assert outcome == GateOutcome.UNVERIFIABLE
+        assert "cannot verify" in output
+
+    def test_mapped_gate_passed(self, workspace):
+        from codeframe.core.gates import GateResult
+
+        fake = GateResult(passed=True, checks=[])
+        with patch("codeframe.core.gates.run", return_value=fake):
+            outcome, _ = _run_gate(workspace, Gate.UNIT)
+        assert outcome == GateOutcome.PASSED
+
+    def test_mapped_gate_failed(self, workspace):
+        from codeframe.core.gates import GateResult
+
+        fake = GateResult(passed=False, checks=[])
+        with patch("codeframe.core.gates.run", return_value=fake):
+            outcome, _ = _run_gate(workspace, Gate.UNIT)
+        assert outcome == GateOutcome.FAILED
+
+    def test_exception_path_is_failed(self, workspace):
+        with patch("codeframe.core.gates.run", side_effect=RuntimeError("boom")):
+            outcome, output = _run_gate(workspace, Gate.UNIT)
+        assert outcome == GateOutcome.FAILED
+        assert "boom" in output
+
+
+class TestUnverifiableRollup:
+    """Unverifiable obligations keep the requirement OPEN and do not fail runs."""
+
+    def test_unverifiable_keeps_req_open(self, workspace):
+        # UI_WIRING_BUG maps to [E2E, DEMO], both unmapped → unverifiable.
+        save_requirement(workspace, _make_req("REQ-U1", [Gate.E2E, Gate.DEMO]))
+
+        results = run_proof(workspace, full=True, run_id="unverif-run")
+
+        outcomes = [o for _, o in results["REQ-U1"]]
+        assert all(o == GateOutcome.UNVERIFIABLE for o in outcomes)
+
+        from codeframe.core.proof.ledger import get_requirement
+
+        req = get_requirement(workspace, "REQ-U1")
+        assert req.status == ReqStatus.OPEN
+
+    def test_unverifiable_only_run_passes(self, workspace):
+        save_requirement(workspace, _make_req("REQ-U2", [Gate.E2E]))
+
+        run_proof(workspace, full=True, run_id="unverif-only")
+
+        run = get_run(workspace, "unverif-only")
+        assert run is not None
+        assert run.overall_passed is True
+
+    def test_unverifiable_obligation_status_persisted(self, workspace):
+        save_requirement(workspace, _make_req("REQ-U3", [Gate.E2E]))
+        run_proof(workspace, full=True, run_id="unverif-status")
+
+        from codeframe.core.proof.ledger import get_requirement
+
+        req = get_requirement(workspace, "REQ-U3")
+        assert req.obligations[0].status == "unverifiable"
+
+    def test_unverifiable_evidence_not_satisfied(self, workspace):
+        save_requirement(workspace, _make_req("REQ-U4", [Gate.E2E]))
+        run_proof(workspace, full=True, run_id="unverif-ev")
+
+        evidence = list_evidence(workspace, "REQ-U4")
+        assert len(evidence) == 1
+        assert evidence[0].satisfied is False
+        assert evidence[0].status == "unverifiable"
+
+    def test_mixed_pass_and_unverifiable_stays_open(self, workspace):
+        # UNIT (mapped, passes) + E2E (unmapped, unverifiable).
+        save_requirement(workspace, _make_req("REQ-U5", [Gate.UNIT, Gate.E2E]))
+
+        with patch(
+            "codeframe.core.proof.runner._run_gate",
+            side_effect=lambda ws, gate: (
+                (GateOutcome.PASSED, "ok")
+                if gate == Gate.UNIT
+                else (GateOutcome.UNVERIFIABLE, "cannot verify")
+            ),
+        ):
+            run_proof(workspace, full=True, run_id="mixed-run")
+
+        from codeframe.core.proof.ledger import get_requirement
+
+        req = get_requirement(workspace, "REQ-U5")
+        # A partially-unverifiable requirement is not satisfied.
+        assert req.status == ReqStatus.OPEN
+        run = get_run(workspace, "mixed-run")
+        # But the run passes — nothing actually failed.
+        assert run.overall_passed is True
+
+
+class TestRealFailureStillFails:
+    """A gate that ran and failed still fails the run (unchanged semantics)."""
+
+    def test_real_failure_fails_strict(self, workspace):
+        save_requirement(workspace, _make_req("REQ-F1", [Gate.UNIT]))
+        (workspace.state_dir / PROOF_CONFIG_FILENAME).write_text(
+            json.dumps({"enabled_gates": ["unit"], "strictness": "strict"})
+        )
+        with patch(
+            "codeframe.core.proof.runner._run_gate",
+            return_value=(GateOutcome.FAILED, "boom"),
+        ):
+            run_proof(workspace, full=True, run_id="fail-strict")
+        run = get_run(workspace, "fail-strict")
+        assert run.overall_passed is False
+
+    def test_real_failure_warns(self, workspace):
+        save_requirement(workspace, _make_req("REQ-F2", [Gate.UNIT]))
+        (workspace.state_dir / PROOF_CONFIG_FILENAME).write_text(
+            json.dumps({"enabled_gates": ["unit"], "strictness": "warn"})
+        )
+        with patch(
+            "codeframe.core.proof.runner._run_gate",
+            return_value=(GateOutcome.FAILED, "boom"),
+        ):
+            run_proof(workspace, full=True, run_id="fail-warn")
+        run = get_run(workspace, "fail-warn")
+        assert run.overall_passed is True
+
+    def test_failure_plus_unverifiable_fails_strict(self, workspace):
+        save_requirement(workspace, _make_req("REQ-F3", [Gate.UNIT, Gate.E2E]))
+        with patch(
+            "codeframe.core.proof.runner._run_gate",
+            side_effect=lambda ws, gate: (
+                (GateOutcome.FAILED, "boom")
+                if gate == Gate.UNIT
+                else (GateOutcome.UNVERIFIABLE, "cannot verify")
+            ),
+        ):
+            run_proof(workspace, full=True, run_id="fail-plus-unverif")
+        run = get_run(workspace, "fail-plus-unverif")
+        assert run.overall_passed is False

--- a/tests/ui/test_proof_config.py
+++ b/tests/ui/test_proof_config.py
@@ -21,6 +21,7 @@ from fastapi.testclient import TestClient
 from codeframe.core.proof.ledger import save_requirement
 from codeframe.core.proof.models import (
     Gate,
+    GateOutcome,
     Obligation,
     Requirement,
     RequirementScope,
@@ -209,7 +210,7 @@ class TestRunCachePassedSemantics:
 
         with patch(
             "codeframe.core.proof.runner._run_gate",
-            return_value=(False, "boom"),
+            return_value=(GateOutcome.FAILED, "boom"),
         ):
             run_resp = test_client.post("/api/v2/proof/run", json={"full": True})
 

--- a/tests/ui/test_proof_v2.py
+++ b/tests/ui/test_proof_v2.py
@@ -320,6 +320,51 @@ class TestRunProof:
         data = response.json()
         assert isinstance(data["results"], dict)
 
+    def test_run_results_carry_status(self, test_client):
+        """Each gate result carries a tri-state status alongside satisfied."""
+        test_client.post(
+            "/api/v2/proof/requirements",
+            json={
+                "title": "Logic bug for status test",
+                "description": "Calculation returns the wrong value",
+                "where": "core/tasks.py",
+                "severity": "medium",
+                "source": "qa",
+            },
+        )
+        data = test_client.post("/api/v2/proof/run", json={"full": True}).json()
+        gate_results = [gr for reqs in data["results"].values() for gr in reqs]
+        assert gate_results, "expected at least one gate result"
+        for gr in gate_results:
+            assert "satisfied" in gr
+            assert "status" in gr
+            assert gr["status"] in ("passed", "failed", "unverifiable")
+
+    def test_unverifiable_only_run_passes(self, test_client):
+        """A run whose only obligations are unrunnable gates passes (not failed)."""
+        # "button click" → UI_WIRING_BUG → obligations [e2e, demo], both
+        # without an automated runner → unverifiable.
+        test_client.post(
+            "/api/v2/proof/requirements",
+            json={
+                "title": "Button click does nothing",
+                "description": "Submit button click handler never fires the callback",
+                "where": "web-ui/components/Form.tsx",
+                "severity": "medium",
+                "source": "qa",
+            },
+        )
+        post = test_client.post("/api/v2/proof/run", json={"full": True}).json()
+        run_id = post["run_id"]
+
+        gate_results = [gr for reqs in post["results"].values() for gr in reqs]
+        assert gate_results
+        assert all(gr["status"] == "unverifiable" for gr in gate_results)
+        assert all(gr["satisfied"] is False for gr in gate_results)
+
+        status = test_client.get(f"/api/v2/proof/runs/{run_id}").json()
+        assert status["passed"] is True
+
 
 # ============================================================================
 # GET /api/v2/proof/runs/{run_id} — poll run status
@@ -653,3 +698,22 @@ class TestGetRunEvidence:
         data = test_client.get(f"/api/v2/proof/runs/{run_id}/evidence").json()
         for ev in data["evidence"]:
             assert "artifact_text" in ev, "Evidence item missing artifact_text"
+
+    def test_run_evidence_carries_status(self, test_client):
+        """Unverifiable gates surface status='unverifiable' on run evidence."""
+        test_client.post(
+            "/api/v2/proof/requirements",
+            json={
+                "title": "Button click does nothing",
+                "description": "Submit button click handler never fires the callback",
+                "where": "web-ui/components/Form.tsx",
+                "severity": "medium",
+                "source": "qa",
+            },
+        )
+        run_id = test_client.post("/api/v2/proof/run", json={"full": True}).json()["run_id"]
+        data = test_client.get(f"/api/v2/proof/runs/{run_id}/evidence").json()
+        assert data["evidence"], "expected evidence records"
+        for ev in data["evidence"]:
+            assert "status" in ev
+            assert ev["status"] == "unverifiable"

--- a/web-ui/src/__tests__/components/proof/GateEvidencePanel.test.tsx
+++ b/web-ui/src/__tests__/components/proof/GateEvidencePanel.test.tsx
@@ -43,6 +43,23 @@ describe('GateEvidencePanel', () => {
     expect(screen.getByText('fail')).toBeInTheDocument();
   });
 
+  it('shows "cannot verify" pill for unverifiable evidence', () => {
+    render(<GateEvidencePanel evidence={[makeEvidence({ gate: 'e2e', satisfied: false, status: 'unverifiable' })]} />);
+    expect(screen.getByText('cannot verify')).toBeInTheDocument();
+    expect(screen.queryByText('fail')).not.toBeInTheDocument();
+  });
+
+  it('shows pass pill when status is passed', () => {
+    render(<GateEvidencePanel evidence={[makeEvidence({ satisfied: true, status: 'passed' })]} />);
+    expect(screen.getByText('pass')).toBeInTheDocument();
+  });
+
+  it('falls back to satisfied bool for legacy evidence without status', () => {
+    render(<GateEvidencePanel evidence={[makeEvidence({ satisfied: false, status: null })]} />);
+    expect(screen.getByText('fail')).toBeInTheDocument();
+    expect(screen.queryByText('cannot verify')).not.toBeInTheDocument();
+  });
+
   it('expands to show artifact text on click', () => {
     const ev = makeEvidence({ artifact_text: 'hello output' });
     render(<GateEvidencePanel evidence={[ev]} />);

--- a/web-ui/src/__tests__/components/proof/GateRunBanner.test.tsx
+++ b/web-ui/src/__tests__/components/proof/GateRunBanner.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { GateRunBanner } from '@/components/proof/GateRunBanner';
+
+describe('GateRunBanner', () => {
+  it('shows the green all-passed banner when passed and nothing unverifiable', () => {
+    render(<GateRunBanner passed message="done" onRetry={() => {}} />);
+    expect(screen.getByText('All gates passed')).toBeInTheDocument();
+  });
+
+  it('shows the red failed banner when not passed', () => {
+    render(<GateRunBanner passed={false} message="boom" onRetry={() => {}} />);
+    expect(screen.getByText('Some gates failed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('shows an amber "could not be verified" banner when passed but gates were unverifiable', () => {
+    render(<GateRunBanner passed message="done" unverifiableCount={2} onRetry={() => {}} />);
+    expect(screen.getByText(/could not be verified/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 gate/i)).toBeInTheDocument();
+    // Not treated as a failure.
+    expect(screen.queryByText('Some gates failed')).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/__tests__/components/proof/ProofDetailPage.test.tsx
+++ b/web-ui/src/__tests__/components/proof/ProofDetailPage.test.tsx
@@ -187,6 +187,25 @@ describe('ProofDetailPage — result filter', () => {
     expect(rows).toHaveLength(2);
     rows.forEach((r) => expect(r.querySelectorAll('td')[1].textContent?.trim()).toBe('fail'));
   });
+
+  it('unverifiable evidence renders "cannot verify" and is excluded from the fail filter', () => {
+    setup([
+      ...EVIDENCE,
+      { req_id: 'REQ-001', gate: 'e2e', satisfied: false, status: 'unverifiable', artifact_path: '/a/e2e.log', artifact_checksum: '', timestamp: '2026-01-05T10:00:00Z', run_id: 'run-005' },
+    ]);
+    // Rendered as its own tri-state, not as a red fail
+    expect(evidenceRows()[0].querySelectorAll('td')[1].textContent?.trim()).toBe('cannot verify');
+
+    fireEvent.change(screen.getByRole('combobox', { name: /result/i }), { target: { value: 'fail' } });
+    const failRows = evidenceRows();
+    expect(failRows).toHaveLength(2);
+    failRows.forEach((r) => expect(r.querySelectorAll('td')[1].textContent?.trim()).toBe('fail'));
+
+    fireEvent.change(screen.getByRole('combobox', { name: /result/i }), { target: { value: 'unverifiable' } });
+    const unvRows = evidenceRows();
+    expect(unvRows).toHaveLength(1);
+    expect(unvRows[0].querySelectorAll('td')[1].textContent?.trim()).toBe('cannot verify');
+  });
 });
 
 describe('ProofDetailPage — search filter', () => {

--- a/web-ui/src/__tests__/hooks/useProofRun.test.ts
+++ b/web-ui/src/__tests__/hooks/useProofRun.test.ts
@@ -185,6 +185,67 @@ describe('useProofRun', () => {
     expect(result.current.errorMessage).toBeTruthy();
   });
 
+  it('maps status:"unverifiable" entries to gate status "unverifiable" (not "failed")', async () => {
+    const startResponse = {
+      success: true,
+      run_id: 'unv-test',
+      results: {
+        'req-1': [
+          { gate: 'unit', satisfied: true, status: 'passed' as const },
+          { gate: 'e2e', satisfied: false, status: 'unverifiable' as const },
+        ],
+      },
+      message: 'done',
+    };
+    const getResponse = {
+      run_id: 'unv-test',
+      status: 'complete' as const,
+      results: {
+        'req-1': [
+          { gate: 'unit', satisfied: true, status: 'passed' as const },
+          { gate: 'e2e', satisfied: false, status: 'unverifiable' as const },
+        ],
+      },
+      // Backend owns the rule: unverifiable is not a real failure → passed=true.
+      passed: true,
+      message: 'done',
+    };
+    mockStartRun.mockResolvedValue(startResponse);
+    mockGetRun.mockResolvedValue(getResponse);
+
+    const { result } = renderHook(() => useProofRun());
+    act(() => { result.current.startRun(WORKSPACE); });
+    await waitFor(() => expect(result.current.runState).toBe('polling'));
+
+    await act(async () => { jest.advanceTimersByTime(2000); });
+    await waitFor(() => expect(result.current.runState).toBe('complete'));
+
+    const e2e = result.current.gateEntries.find((e) => e.gate === 'e2e');
+    expect(e2e?.status).toBe('unverifiable');
+    const unit = result.current.gateEntries.find((e) => e.gate === 'unit');
+    expect(unit?.status).toBe('passed');
+    // Unverifiable-only-vs-passing run still completes as passed.
+    expect(result.current.passed).toBe(true);
+  });
+
+  it('falls back to satisfied bool when legacy entries omit status', async () => {
+    // No `status` field → legacy cached run; map via satisfied boolean.
+    mockStartRun.mockResolvedValue(makeStartRunResponse(false));
+    mockGetRun.mockResolvedValue(makeGetRunResponse(false));
+
+    const { result } = renderHook(() => useProofRun());
+    act(() => { result.current.startRun(WORKSPACE); });
+    await waitFor(() => expect(result.current.runState).toBe('polling'));
+
+    await act(async () => { jest.advanceTimersByTime(2000); });
+    await waitFor(() => expect(result.current.runState).toBe('complete'));
+
+    const unit = result.current.gateEntries.find((e) => e.gate === 'unit');
+    expect(unit?.status).toBe('failed');
+    const sec = result.current.gateEntries.find((e) => e.gate === 'sec');
+    expect(sec?.status).toBe('passed');
+  });
+
   it('retry() resets state to idle', async () => {
     mockStartRun.mockRejectedValue(new Error('fail'));
 

--- a/web-ui/src/app/proof/[req_id]/page.tsx
+++ b/web-ui/src/app/proof/[req_id]/page.tsx
@@ -16,6 +16,23 @@ function sessionKey(reqId: string) {
   return `proof-evidence-filters:${reqId}`;
 }
 
+// Tri-state evidence result: 'unverifiable' is not a failure. Legacy rows
+// (status absent/null) fall back to the satisfied boolean.
+type EvidenceResult = 'pass' | 'fail' | 'unverifiable';
+
+function evidenceResult(ev: ProofEvidence): EvidenceResult {
+  if (ev.status === 'unverifiable') return 'unverifiable';
+  return ev.satisfied ? 'pass' : 'fail';
+}
+
+const RESULT_RANK: Record<EvidenceResult, number> = { fail: 0, unverifiable: 1, pass: 2 };
+
+const RESULT_CLASS: Record<EvidenceResult, string> = {
+  pass: 'text-green-600',
+  fail: 'text-red-600',
+  unverifiable: 'text-amber-600 dark:text-amber-400',
+};
+
 function loadSessionFilters(reqId: string): { gate: string; result: string; search: string } {
   if (typeof window === 'undefined') return { gate: '', result: '', search: '' };
   try {
@@ -140,8 +157,7 @@ export default function ProofDetailPage() {
     let rows = [...evidence];
 
     if (filterGate) rows = rows.filter((e) => e.gate === filterGate);
-    if (filterResult === 'pass') rows = rows.filter((e) => e.satisfied);
-    if (filterResult === 'fail') rows = rows.filter((e) => !e.satisfied);
+    if (filterResult) rows = rows.filter((e) => evidenceResult(e) === filterResult);
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(
@@ -155,7 +171,7 @@ export default function ProofDetailPage() {
       let cmp = 0;
       switch (sortCol) {
         case 'gate':      cmp = a.gate.localeCompare(b.gate); break;
-        case 'result':    cmp = Number(a.satisfied) - Number(b.satisfied); break;
+        case 'result':    cmp = RESULT_RANK[evidenceResult(a)] - RESULT_RANK[evidenceResult(b)]; break;
         case 'run_id':    cmp = a.run_id.localeCompare(b.run_id); break;
         case 'timestamp': cmp = a.timestamp.localeCompare(b.timestamp); break;
         case 'artifact':  cmp = (a.artifact_path ?? '').localeCompare(b.artifact_path ?? ''); break;
@@ -326,7 +342,9 @@ export default function ProofDetailPage() {
                       {req.obligations.map((ob, i) => {
                         const latestEv = latestRunByGate[ob.gate];
                         const effectiveStatus = latestEv
-                          ? latestEv.satisfied ? 'satisfied' : 'failed'
+                          ? latestEv.status === 'unverifiable'
+                            ? 'unverifiable'
+                            : latestEv.satisfied ? 'satisfied' : 'failed'
                           : ob.status;
                         return (
                           <tr key={i} className="border-b last:border-0">
@@ -337,6 +355,8 @@ export default function ProofDetailPage() {
                                   ? 'text-green-600'
                                   : effectiveStatus === 'failed'
                                   ? 'text-red-600'
+                                  : effectiveStatus === 'unverifiable'
+                                  ? 'text-amber-600 dark:text-amber-400'
                                   : 'text-muted-foreground'
                               }>
                                 {effectiveStatus}
@@ -348,7 +368,11 @@ export default function ProofDetailPage() {
                                   type="button"
                                   title="Filter evidence history to this run"
                                   onClick={() => focusRun(latestEv.run_id)}
-                                  className={`cursor-pointer underline-offset-2 hover:underline ${latestEv.satisfied ? 'text-green-600' : 'text-red-600'}`}
+                                  className={`cursor-pointer underline-offset-2 hover:underline ${
+                                    latestEv.status === 'unverifiable'
+                                      ? 'text-amber-600 dark:text-amber-400'
+                                      : latestEv.satisfied ? 'text-green-600' : 'text-red-600'
+                                  }`}
                                 >
                                   {latestEv.run_id}
                                 </button>
@@ -404,6 +428,7 @@ export default function ProofDetailPage() {
                       <option value="">All</option>
                       <option value="pass">Pass</option>
                       <option value="fail">Fail</option>
+                      <option value="unverifiable">Cannot verify</option>
                     </select>
                   </label>
 
@@ -483,8 +508,8 @@ export default function ProofDetailPage() {
                         >
                           <td className="px-4 py-2 font-mono text-xs">{ev.gate}</td>
                           <td className="px-4 py-2">
-                            <span className={ev.satisfied ? 'text-green-600' : 'text-red-600'}>
-                              {ev.satisfied ? 'pass' : 'fail'}
+                            <span className={RESULT_CLASS[evidenceResult(ev)]}>
+                              {evidenceResult(ev) === 'unverifiable' ? 'cannot verify' : evidenceResult(ev)}
                             </span>
                           </td>
                           <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{ev.run_id}</td>

--- a/web-ui/src/app/proof/[req_id]/page.tsx
+++ b/web-ui/src/app/proof/[req_id]/page.tsx
@@ -501,15 +501,17 @@ export default function ProofDetailPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredEvidence.map((ev) => (
+                      {filteredEvidence.map((ev) => {
+                        const result = evidenceResult(ev);
+                        return (
                         <tr
                           key={`${ev.req_id}:${ev.run_id}:${ev.timestamp}:${ev.gate}:${ev.artifact_path}`}
                           className="border-b last:border-0"
                         >
                           <td className="px-4 py-2 font-mono text-xs">{ev.gate}</td>
                           <td className="px-4 py-2">
-                            <span className={RESULT_CLASS[evidenceResult(ev)]}>
-                              {evidenceResult(ev) === 'unverifiable' ? 'cannot verify' : evidenceResult(ev)}
+                            <span className={RESULT_CLASS[result]}>
+                              {result === 'unverifiable' ? 'cannot verify' : result}
                             </span>
                           </td>
                           <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{ev.run_id}</td>
@@ -520,7 +522,8 @@ export default function ProofDetailPage() {
                             <span className="line-clamp-1">{ev.artifact_path || '—'}</span>
                           </td>
                         </tr>
-                      ))}
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -301,7 +301,12 @@ function ProofPageContent() {
               <GateRunPanel gateEntries={gateEntries} />
             )}
             {runState === 'complete' && passed !== null && (
-              <GateRunBanner passed={passed} message={runMessage ?? ''} onRetry={retry} />
+              <GateRunBanner
+                passed={passed}
+                message={runMessage ?? ''}
+                onRetry={retry}
+                unverifiableCount={gateEntries.filter((e) => e.status === 'unverifiable').length}
+              />
             )}
             {runState === 'error' && errorMessage && (
               <div
@@ -578,6 +583,14 @@ function ProofPageContent() {
                 <div>
                   <dt className="font-medium text-foreground">Gates / Obligations</dt>
                   <dd>Evidence rules — specific tests or checks that must pass to satisfy a requirement.</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-foreground">Gate Results</dt>
+                  <dd>
+                    A gate can <strong>pass</strong> (green), <strong>fail</strong> (red), or be{' '}
+                    <span className="text-amber-700 dark:text-amber-400">could not be verified</span> (amber) —
+                    the check couldn&apos;t run, so it never fails a run and stays waivable.
+                  </dd>
                 </div>
               </dl>
             </div>

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -588,7 +588,7 @@ function ProofPageContent() {
                   <dt className="font-medium text-foreground">Gate Results</dt>
                   <dd>
                     A gate can <strong>pass</strong> (green), <strong>fail</strong> (red), or be{' '}
-                    <span className="text-amber-700 dark:text-amber-400">could not be verified</span> (amber) —
+                    <span className="text-amber-700 dark:text-amber-400">unverifiable</span> (amber) —
                     the check couldn&apos;t run, so it never fails a run and stays waivable.
                   </dd>
                 </div>

--- a/web-ui/src/components/proof/GateEvidencePanel.tsx
+++ b/web-ui/src/components/proof/GateEvidencePanel.tsx
@@ -39,15 +39,21 @@ function GateEvidenceRow({ ev }: GateEvidenceRowProps) {
         className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-muted/30 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
       >
         <span className="font-mono text-xs text-muted-foreground w-16 shrink-0 capitalize">{ev.gate}</span>
-        <span
-          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-            ev.satisfied
-              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-              : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-          }`}
-        >
-          {ev.satisfied ? 'pass' : 'fail'}
-        </span>
+        {ev.status === 'unverifiable' ? (
+          <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+            cannot verify
+          </span>
+        ) : (
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+              ev.satisfied
+                ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+            }`}
+          >
+            {ev.satisfied ? 'pass' : 'fail'}
+          </span>
+        )}
         <span className="ml-auto text-xs text-muted-foreground">{expanded ? '▲' : '▼'}</span>
       </button>
 

--- a/web-ui/src/components/proof/GateRunBanner.tsx
+++ b/web-ui/src/components/proof/GateRunBanner.tsx
@@ -6,9 +6,27 @@ interface GateRunBannerProps {
   passed: boolean;
   message: string;
   onRetry: () => void;
+  /** Number of gates that could not be verified (waivable, not failures). */
+  unverifiableCount?: number;
 }
 
-export function GateRunBanner({ passed, message, onRetry }: GateRunBannerProps) {
+export function GateRunBanner({ passed, message, onRetry, unverifiableCount = 0 }: GateRunBannerProps) {
+  if (passed && unverifiableCount > 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mb-4 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-900/50 dark:bg-amber-900/10"
+      >
+        <span className="h-2.5 w-2.5 rounded-full bg-amber-400" aria-hidden="true" />
+        <p className="text-sm font-medium text-amber-900 dark:text-amber-300">
+          Gates passed — {unverifiableCount} gate{unverifiableCount === 1 ? '' : 's'} could not be verified
+        </p>
+        {message && <span className="text-xs text-amber-800/80 dark:text-amber-400/80 ml-1">{message}</span>}
+      </div>
+    );
+  }
+
   if (passed) {
     return (
       <div

--- a/web-ui/src/components/proof/GateRunPanel.tsx
+++ b/web-ui/src/components/proof/GateRunPanel.tsx
@@ -8,11 +8,12 @@ interface GateRunPanelProps {
 }
 
 // Map GateRunStatus to Badge variant names from the shared design system
-const STATUS_VARIANT: Record<GateRunStatus, 'backlog' | 'in-progress' | 'done' | 'failed'> = {
+const STATUS_VARIANT: Record<GateRunStatus, 'backlog' | 'in-progress' | 'done' | 'failed' | 'unverifiable'> = {
   pending: 'backlog',
   running: 'in-progress',
   passed: 'done',
   failed: 'failed',
+  unverifiable: 'unverifiable',
 };
 
 export function GateRunPanel({ gateEntries }: GateRunPanelProps) {

--- a/web-ui/src/components/ui/badge.tsx
+++ b/web-ui/src/components/ui/badge.tsx
@@ -18,7 +18,8 @@ const badgeVariants = cva(
         // Task status variants
         ready: 'border-transparent bg-blue-100 text-blue-900',
         'in-progress': 'border-transparent bg-amber-100 text-amber-900',
-        unverifiable: 'border-transparent bg-amber-100 text-amber-900',
+        // Distinct from in-progress amber so a running gate visibly flips
+        unverifiable: 'border-amber-300 bg-amber-50 text-amber-800',
         done: 'border-transparent bg-green-100 text-green-900',
         blocked: 'border-transparent bg-red-100 text-red-900',
         failed: 'border-transparent bg-red-200 text-red-900',

--- a/web-ui/src/components/ui/badge.tsx
+++ b/web-ui/src/components/ui/badge.tsx
@@ -18,6 +18,7 @@ const badgeVariants = cva(
         // Task status variants
         ready: 'border-transparent bg-blue-100 text-blue-900',
         'in-progress': 'border-transparent bg-amber-100 text-amber-900',
+        unverifiable: 'border-transparent bg-amber-100 text-amber-900',
         done: 'border-transparent bg-green-100 text-green-900',
         blocked: 'border-transparent bg-red-100 text-red-900',
         failed: 'border-transparent bg-red-200 text-red-900',

--- a/web-ui/src/hooks/useProofRun.ts
+++ b/web-ui/src/hooks/useProofRun.ts
@@ -94,7 +94,10 @@ export function useProofRun(): UseProofRunReturn {
                   .flat()
                   .map((item) => ({
                     gate: item.gate,
-                    status: item.satisfied ? ('passed' as GateRunStatus) : ('failed' as GateRunStatus),
+                    // Prefer the tri-state `status` field; fall back to the
+                    // `satisfied` boolean for legacy cached runs that omit it.
+                    status: (item.status ??
+                      (item.satisfied ? 'passed' : 'failed')) as GateRunStatus,
                   }))
               );
 

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -385,6 +385,8 @@ export interface ProofEvidence {
   req_id: string;
   gate: string;
   satisfied: boolean;
+  // Tri-state gate outcome. Absent/null on legacy rows → fall back to `satisfied`.
+  status?: 'passed' | 'failed' | 'unverifiable' | null;
   artifact_path: string;
   artifact_checksum: string;
   timestamp: string;
@@ -428,14 +430,14 @@ export interface RunProofRequest {
 export interface RunProofResponse {
   success: boolean;
   run_id: string;
-  results: Record<string, Array<{ gate: string; satisfied: boolean }>>;
+  results: Record<string, Array<{ gate: string; satisfied: boolean; status?: 'passed' | 'failed' | 'unverifiable' }>>;
   message: string;
 }
 
 export interface RunStatusResponse {
   run_id: string;
   status: 'running' | 'complete';
-  results: Record<string, Array<{ gate: string; satisfied: boolean }>>;
+  results: Record<string, Array<{ gate: string; satisfied: boolean; status?: 'passed' | 'failed' | 'unverifiable' }>>;
   passed: boolean;
   message: string;
 }
@@ -459,7 +461,7 @@ export interface ProofRunDetail extends ProofRunSummary {
 }
 
 // UI-only types for per-gate display in the Run Gates panel
-export type GateRunStatus = 'pending' | 'running' | 'passed' | 'failed';
+export type GateRunStatus = 'pending' | 'running' | 'passed' | 'failed' | 'unverifiable';
 
 export interface GateRunEntry {
   gate: string;


### PR DESCRIPTION
Closes #728.

## Problem
`_GATE_TO_CORE` only maps UNIT/CONTRACT→pytest and SEC→ruff; the other 6 gates (e2e, visual, a11y, perf, demo, manual) returned `(False, "no automated runner — cannot verify")`, so most captured glitches could never be SATISFIED and "cannot verify" was indistinguishable from "ran and failed".

## Approach
Per the issue's acceptance criteria "OR" clause: an explicit **UNVERIFIABLE** tri-state (CodeRabbit's plan, adapted), not 6 new runners.

- **Core**: new `GateOutcome` enum (`passed`/`failed`/`unverifiable`); `_run_gate` returns the tri-state (stale docstring fixed); `run_proof` maps obligation status three-way, keeps requirements **OPEN (waivable)** on unverifiable, and excludes unverifiable from `overall_passed` — a run never fails solely because a gate couldn't be verified.
- **Evidence/ledger**: `Evidence.status` persists the outcome. `proof_evidence` gains a nullable `status TEXT` column with a `PRAGMA table_info`-guarded `ALTER TABLE` migration (legacy rows read back `status=None`, all consumers fall back to the `satisfied` bool).
- **API** (`proof_v2`): run results carry `{gate, satisfied, status}` (`satisfied` kept for compat); `EvidenceResponse` gains optional `status`; `passed` aggregation mirrors the runner rule.
- **CLI**: yellow `UNVERIFIABLE` cell; unverifiable-only run **exits 0** with a summary naming the unverifiable gates and a `cf proof waive` hint; real FAILs still exit 1.
- **TUI**: distinct ❓ icon.
- **Web UI**: `'unverifiable'` added to `GateRunStatus`; amber badge variant; amber banner branch ("Gates passed — N gate(s) could not be verified"); amber "cannot verify" pills in evidence panels; `/proof/[req_id]` evidence history renders/filters/sorts the tri-state (incl. a new "Cannot verify" filter option); `gate.run.failed` notifications no longer fire for unverifiable gates; help section documents the amber state. `ProofReqStatus` (open/satisfied/waived) intentionally unchanged — this is a gate/obligation-level state.

## Acceptance criteria
- ✅ Unrunnable gates return an explicit UNVERIFIABLE/waivable state distinct from "ran and failed"
- ✅ `/proof` UI and run results distinguish "cannot verify" from "failed"
- ✅ Stale `_run_gate` docstring corrected

## Testing
- Backend: full CI-gate scope `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` → **3964 passed**; `ruff check .` clean. New `tests/core/test_proof_runner_outcomes.py` (+14) plus extensions in test_proof9 (+4), CLI (+2), proof_v2 (+3), incl. a legacy-DB column-migration test.
- Web UI: `npm test` → 95 suites / 1051+ tests green (new GateRunBanner suite, useProofRun tri-state cases, evidence-history filter regression test); `npm run build` compiles.
- Cross-family review: `codex review` — its one P2 (evidence history treating unverifiable as fail) fixed with a regression test.

## Known limitations
- PR-merge-gate semantics unchanged by design: `pr_v2` snapshots treat unverifiable as **not passed** (not proven ≠ proven); the raw status string flows into `gate_breakdown` for display.
- The 6 gates still have no real runners — that's future work (Playwright/axe/lighthouse wiring); this PR makes their state honest and waivable instead of falsely failing.
- CONTRACT still maps to pytest (same as UNIT); distinguishing it needs a contract-test corpus, out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proof runs and evidence now show a third result state: **Cannot verify / Unverifiable**.
  * The UI includes new icons, badges, filters, and banner messaging for unverifiable outcomes.

* **Bug Fixes**
  * Proof runs now distinguish true failures from unverifiable checks, improving overall run status accuracy.
  * Legacy evidence still displays correctly when the new status field is missing.

* **Documentation**
  * Updated in-app proof terminology to describe pass, fail, and cannot verify results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->