### PR TITLE
fix(proof): write generated test stubs to disk (#730)

### DIFF
--- a/codeframe/cli/proof_commands.py
+++ b/codeframe/cli/proof_commands.py
@@ -115,10 +115,13 @@ def capture(
     console.print(f"  Scope routes: {', '.join(req.scope.routes) or 'none'}")
 
     if stubs:
-        console.print("\n[bold]Generated test stubs:[/bold]")
-        for gate, content in stubs.items():
-            lines = len(content.splitlines())
-            console.print(f"  [cyan]{gate.value}[/cyan]: {lines} lines")
+        console.print("\n[bold]Test stubs written:[/bold]")
+        for gate, path in stubs.items():
+            try:
+                shown = path.relative_to(workspace.repo_path)
+            except ValueError:
+                shown = path
+            console.print(f"  [cyan]{gate.value}[/cyan]: {shown}")
 
 
 @proof_app.command("run")

--- a/codeframe/core/proof/capture.py
+++ b/codeframe/core/proof/capture.py
@@ -1,10 +1,11 @@
 """PROOF9 capture logic.
 
 Orchestrates the creation of a new requirement from a glitch report:
-classify → obligations → scope → save → generate stubs.
+classify → obligations → scope → save → generate stubs → write stubs to disk.
 """
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 from codeframe.core.proof import ledger
@@ -20,7 +21,7 @@ from codeframe.core.proof.obligations import (
     suggest_evidence_rules,
 )
 from codeframe.core.proof.scope import build_scope_from_capture
-from codeframe.core.proof.stubs import generate_stubs
+from codeframe.core.proof.stubs import generate_stubs, write_stub_files
 from codeframe.core.workspace import Workspace
 
 
@@ -34,10 +35,11 @@ def capture_requirement(
     source: Source,
     created_by: str = "human",
     source_issue: Optional[str] = None,
-) -> tuple[Requirement, dict[Gate, str]]:
+) -> tuple[Requirement, dict[Gate, Path]]:
     """Create a new requirement from a glitch report.
 
-    Returns the saved Requirement and a dict of Gate → stub content.
+    Returns the saved Requirement and a dict of Gate → written stub file path
+    (stubs are persisted under tests/proof/<req_id>/).
     """
     # 1. Classify the glitch
     glitch_type = classify_glitch(description)
@@ -73,7 +75,8 @@ def capture_requirement(
     # 6. Persist
     ledger.save_requirement(workspace, req)
 
-    # 7. Generate test stubs
+    # 7. Generate test stubs and write them to disk
     stubs = generate_stubs(req)
+    stub_paths = write_stub_files(workspace, req, stubs)
 
-    return req, stubs
+    return req, stub_paths

--- a/codeframe/core/proof/capture.py
+++ b/codeframe/core/proof/capture.py
@@ -72,11 +72,13 @@ def capture_requirement(
         glitch_type=glitch_type,
     )
 
-    # 6. Persist
-    ledger.save_requirement(workspace, req)
-
-    # 7. Generate test stubs and write them to disk
+    # 6. Generate test stubs and write them to disk BEFORE persisting the
+    # requirement: if the write fails, no REQ id is burned (next_req_id is
+    # MAX-based) and a retry reuses the same id + files (skip-if-exists).
     stubs = generate_stubs(req)
     stub_paths = write_stub_files(workspace, req, stubs)
+
+    # 7. Persist
+    ledger.save_requirement(workspace, req)
 
     return req, stub_paths

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -4,7 +4,20 @@ Generates skeleton test files for each proof gate obligation.
 Uses inline templates (no Jinja2 dependency for simplicity).
 """
 
+from pathlib import Path
+from typing import Optional
+
 from codeframe.core.proof.models import Gate, Requirement
+from codeframe.core.workspace import Workspace
+
+# Per-gate file extension for written stubs. Pytest gates default to .py;
+# E2E stubs are Playwright TypeScript, DEMO/MANUAL are markdown-ish scripts.
+_EXTENSIONS: dict[Gate, str] = {
+    Gate.E2E: ".ts",
+    Gate.DEMO: ".md",
+    Gate.MANUAL: ".md",
+}
+_DEFAULT_EXTENSION = ".py"
 
 _TEMPLATES: dict[Gate, str] = {
     Gate.UNIT: '''\
@@ -157,3 +170,29 @@ def generate_stubs(req: Requirement) -> dict[Gate, str]:
         result[obligation.gate] = content
 
     return result
+
+
+def write_stub_files(
+    workspace: Workspace,
+    req: Requirement,
+    stubs: dict[Gate, str],
+    out_dir: Optional[Path] = None,
+) -> dict[Gate, Path]:
+    """Write generated stub content to disk under tests/proof/<req_id>/.
+
+    Existing files are never overwritten (they may hold developer edits).
+    Returns a mapping of Gate → path for every stub file that now exists.
+    """
+    target = out_dir or workspace.repo_path / "tests" / "proof" / req.id
+    target.mkdir(parents=True, exist_ok=True)
+
+    slug = _slugify(req.title)
+    paths: dict[Gate, Path] = {}
+    for gate, content in stubs.items():
+        ext = _EXTENSIONS.get(gate, _DEFAULT_EXTENSION)
+        path = target / f"test_{slug}_{gate.value}{ext}"
+        if not path.exists():
+            path.write_text(content, encoding="utf-8")
+        paths[gate] = path
+
+    return paths

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -21,7 +21,11 @@ _DEFAULT_EXTENSION = ".py"
 
 _TEMPLATES: dict[Gate, str] = {
     Gate.UNIT: '''\
-"""Unit test for {req_id}: {title}"""
+"""Unit test for {req_id}: {title}
+
+Draft stub — rename this file to {filename}.py once implemented so pytest
+collects it (draft_* files are deliberately outside pytest discovery).
+"""
 import pytest
 
 
@@ -38,7 +42,11 @@ def test_unit_{slug}():
     assert False, "Not implemented yet — replace with real assertions"
 ''',
     Gate.CONTRACT: '''\
-"""Contract test for {req_id}: {title}"""
+"""Contract test for {req_id}: {title}
+
+Draft stub — rename this file to {filename}.py once implemented so pytest
+collects it (draft_* files are deliberately outside pytest discovery).
+"""
 import pytest
 
 
@@ -49,10 +57,10 @@ def test_contract_{slug}():
     assert False, "Not implemented yet — replace with real assertions"
 ''',
     Gate.E2E: '''\
-"""E2E test for {req_id}: {title}
-
-Run with: npx playwright test {filename}
-"""
+// E2E test for {req_id}: {title}
+//
+// Draft stub — rename to {filename}.spec.ts once implemented so Playwright
+// collects it, then run: npx playwright test {filename}.spec.ts
 import {{ test, expect }} from '@playwright/test';
 
 test('{title}', async ({{ page }}) => {{
@@ -64,7 +72,11 @@ test('{title}', async ({{ page }}) => {{
 }});
 ''',
     Gate.VISUAL: '''\
-"""Visual snapshot test for {req_id}: {title}"""
+"""Visual snapshot test for {req_id}: {title}
+
+Draft stub — rename this file to {filename}.py once implemented so pytest
+collects it (draft_* files are deliberately outside pytest discovery).
+"""
 import pytest
 
 
@@ -75,7 +87,11 @@ def test_visual_{slug}():
     assert False, "Not implemented yet — add snapshot comparison"
 ''',
     Gate.A11Y: '''\
-"""Accessibility test for {req_id}: {title}"""
+"""Accessibility test for {req_id}: {title}
+
+Draft stub — rename this file to {filename}.py once implemented so pytest
+collects it (draft_* files are deliberately outside pytest discovery).
+"""
 import pytest
 
 
@@ -86,7 +102,11 @@ def test_a11y_{slug}():
     assert False, "Not implemented yet — add a11y assertions"
 ''',
     Gate.PERF: '''\
-"""Performance test for {req_id}: {title}"""
+"""Performance test for {req_id}: {title}
+
+Draft stub — rename this file to {filename}.py once implemented so pytest
+collects it (draft_* files are deliberately outside pytest discovery).
+"""
 import pytest
 import time
 
@@ -99,7 +119,11 @@ def test_perf_{slug}():
     assert elapsed < 1.0, f"Took {{elapsed:.2f}}s — exceeds budget"
 ''',
     Gate.SEC: '''\
-"""Security check for {req_id}: {title}"""
+"""Security check for {req_id}: {title}
+
+Draft stub — rename this file to {filename}.py once implemented so pytest
+collects it (draft_* files are deliberately outside pytest discovery).
+"""
 import pytest
 
 
@@ -110,17 +134,16 @@ def test_sec_{slug}():
     assert False, "Not implemented yet — add security assertions"
 ''',
     Gate.DEMO: '''\
-"""Demo walkthrough for {req_id}: {title}
+# Demo walkthrough for {req_id}: {title}
 
-This is an automated demo script that proves the feature works.
-Run with: showboat exec {filename}
-"""
+An automated demo script that proves the feature works.
+Run with: showboat exec {filename}.md
 
-# Steps:
-# 1. TODO: Navigate to the feature
-# 2. TODO: Perform the action
-# 3. TODO: Capture screenshot/output as evidence
-# 4. TODO: Verify expected outcome
+## Steps
+1. TODO: Navigate to the feature
+2. TODO: Perform the action
+3. TODO: Capture screenshot/output as evidence
+4. TODO: Verify expected outcome
 ''',
     Gate.MANUAL: '''\
 # Manual Verification Checklist: {req_id}
@@ -180,6 +203,11 @@ def write_stub_files(
 ) -> dict[Gate, Path]:
     """Write generated stub content to disk under tests/proof/<req_id>/.
 
+    Pytest stubs get a ``draft_`` filename prefix so plain ``pytest`` never
+    collects their placeholder ``assert False`` bodies; the proof runner's
+    scoped ``-k test_id`` run then reports "named test missing" (FAILED) until
+    the developer implements the stub and renames it to ``test_*.py``.
+
     Existing files are never overwritten (they may hold developer edits).
     Returns a mapping of Gate → path for every stub file that now exists.
     """
@@ -190,7 +218,8 @@ def write_stub_files(
     paths: dict[Gate, Path] = {}
     for gate, content in stubs.items():
         ext = _EXTENSIONS.get(gate, _DEFAULT_EXTENSION)
-        path = target / f"test_{slug}_{gate.value}{ext}"
+        prefix = "draft_" if ext == ".py" else ""
+        path = target / f"{prefix}test_{slug}_{gate.value}{ext}"
         if not path.exists():
             path.write_text(content, encoding="utf-8")
         paths[gate] = path

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -4,11 +4,14 @@ Generates skeleton test files for each proof gate obligation.
 Uses inline templates (no Jinja2 dependency for simplicity).
 """
 
+import logging
 from pathlib import Path
 from typing import Optional
 
 from codeframe.core.proof.models import Gate, Requirement
 from codeframe.core.workspace import Workspace
+
+logger = logging.getLogger(__name__)
 
 # Per-gate file extension for written stubs. Pytest gates default to .py;
 # E2E stubs are Playwright TypeScript, DEMO/MANUAL are markdown-ish scripts.
@@ -60,7 +63,7 @@ def test_contract_{slug}():
 // E2E test for {req_id}: {title}
 //
 // Draft stub — rename to {filename}.spec.ts once implemented so Playwright
-// collects it, then run: npx playwright test {filename}.spec.ts
+// collects it, then run: npx playwright test tests/proof/{req_id}/{filename}.spec.ts
 import {{ test, expect }} from '@playwright/test';
 
 test('{title}', async ({{ page }}) => {{
@@ -137,7 +140,7 @@ def test_sec_{slug}():
 # Demo walkthrough for {req_id}: {title}
 
 An automated demo script that proves the feature works.
-Run with: showboat exec {filename}.md
+Run with: showboat exec tests/proof/{req_id}/{filename}.md
 
 ## Steps
 1. TODO: Navigate to the feature
@@ -220,7 +223,9 @@ def write_stub_files(
         ext = _EXTENSIONS.get(gate, _DEFAULT_EXTENSION)
         prefix = "draft_" if ext == ".py" else ""
         path = target / f"{prefix}test_{slug}_{gate.value}{ext}"
-        if not path.exists():
+        if path.exists():
+            logger.debug("stub already exists, not overwriting: %s", path)
+        else:
             path.write_text(content, encoding="utf-8")
         paths[gate] = path
 

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -164,9 +164,12 @@ class RequirementResponse(BaseModel):
 
 
 class CaptureRequirementResponse(RequirementResponse):
-    """Capture response adds stubs_count."""
+    """Capture response adds the written stub files."""
 
-    stubs_count: int = Field(description="Number of test stub files generated")
+    stubs_count: int = Field(description="Number of test stub files written")
+    stub_paths: list[str] = Field(
+        description="Repo-relative paths of the written test stub files"
+    )
 
 
 class RequirementListResponse(BaseModel):
@@ -314,8 +317,8 @@ async def capture_requirement_endpoint(
 ) -> CaptureRequirementResponse:
     """Capture a requirement from a glitch report.
 
-    Classifies the glitch, derives proof obligations, generates test stubs,
-    and persists the requirement to the ledger.
+    Classifies the glitch, derives proof obligations, writes test stubs to
+    disk under tests/proof/<req_id>/, and persists the requirement to the ledger.
     """
     try:
         req, stubs = capture_requirement(
@@ -329,7 +332,12 @@ async def capture_requirement_endpoint(
             source_issue=body.source_issue,
         )
         resp = _req_to_response(req)
-        return CaptureRequirementResponse(**resp.model_dump(), stubs_count=len(stubs))
+        stub_paths = sorted(
+            str(p.relative_to(workspace.repo_path)) for p in stubs.values()
+        )
+        return CaptureRequirementResponse(
+            **resp.model_dump(), stubs_count=len(stub_paths), stub_paths=stub_paths
+        )
     except Exception as e:
         logger.error("Failed to capture requirement: %s", e, exc_info=True)
         raise HTTPException(

--- a/tests/cli/test_proof_commands.py
+++ b/tests/cli/test_proof_commands.py
@@ -78,6 +78,23 @@ class TestCapture:
         assert req.title == "Login rejects valid credentials"
         assert req.status == ReqStatus.OPEN
 
+    def test_capture_writes_stub_files_and_prints_paths(self, ws):
+        """Stubs are written under tests/proof/<req_id>/ and paths printed (#730)."""
+        workspace, workspace_path = ws
+        result = runner.invoke(
+            app, ["proof", "capture", "-w", str(workspace_path)] + _CAPTURE_ARGS
+        )
+
+        assert result.exit_code == 0, result.output
+        stub_dir = workspace_path / "tests" / "proof" / "REQ-0001"
+        stub_files = list(stub_dir.iterdir())
+        assert stub_files, "no stub files written"
+        for f in stub_files:
+            assert "REQ-0001" in f.read_text(encoding="utf-8")
+            assert str(f.relative_to(workspace_path)) in result.output
+        # No false "line count" claims — output names real files
+        assert "lines" not in result.output
+
     def test_capture_interactive_prompts_do_not_crash(self, ws):
         """#723: severity/source were prompted with the nonexistent typer.Choice,
         so any interactive `cf proof capture` (no --severity/--source) raised

--- a/tests/core/test_proof9.py
+++ b/tests/core/test_proof9.py
@@ -449,6 +449,61 @@ class TestStubs:
         assert Gate.UNIT in stubs
         assert Gate.E2E in stubs
 
+    def _req(self, gates):
+        from codeframe.core.proof.models import (
+            Requirement, Severity, Source, RequirementScope, Obligation,
+        )
+        return Requirement(
+            id="REQ-0001", title="Login rejects empty password",
+            description="Empty passwords should fail validation",
+            severity=Severity.HIGH, source=Source.QA,
+            scope=RequirementScope(),
+            obligations=[Obligation(gate=g) for g in gates],
+            evidence_rules=[],
+        )
+
+    def test_write_stub_files_creates_files(self, workspace):
+        from codeframe.core.proof.stubs import generate_stubs, write_stub_files
+        from codeframe.core.proof.models import Gate
+
+        req = self._req([Gate.UNIT, Gate.E2E, Gate.MANUAL])
+        stubs = generate_stubs(req)
+        paths = write_stub_files(workspace, req, stubs)
+
+        stub_dir = workspace.repo_path / "tests" / "proof" / req.id
+        assert set(paths) == {Gate.UNIT, Gate.E2E, Gate.MANUAL}
+        for gate, path in paths.items():
+            assert path.parent == stub_dir
+            assert path.exists()
+            assert req.id in path.read_text(encoding="utf-8")
+        assert paths[Gate.UNIT].suffix == ".py"
+        assert paths[Gate.E2E].suffix == ".ts"
+        assert paths[Gate.MANUAL].suffix == ".md"
+
+    def test_write_stub_files_skips_existing(self, workspace):
+        from codeframe.core.proof.stubs import generate_stubs, write_stub_files
+        from codeframe.core.proof.models import Gate
+
+        req = self._req([Gate.UNIT])
+        stubs = generate_stubs(req)
+        paths = write_stub_files(workspace, req, stubs)
+
+        # Developer edits the stub; a re-run must not overwrite it
+        paths[Gate.UNIT].write_text("# my real test", encoding="utf-8")
+        paths2 = write_stub_files(workspace, req, stubs)
+        assert paths2[Gate.UNIT] == paths[Gate.UNIT]
+        assert paths[Gate.UNIT].read_text(encoding="utf-8") == "# my real test"
+
+    def test_write_stub_files_out_dir_override(self, workspace, tmp_path):
+        from codeframe.core.proof.stubs import generate_stubs, write_stub_files
+        from codeframe.core.proof.models import Gate
+
+        req = self._req([Gate.UNIT])
+        out = tmp_path / "custom"
+        paths = write_stub_files(workspace, req, generate_stubs(req), out_dir=out)
+        assert paths[Gate.UNIT].parent == out
+        assert paths[Gate.UNIT].exists()
+
 
 # --- Capture Tests ---
 
@@ -471,7 +526,13 @@ class TestCapture:
         assert req.id == "REQ-0001"
         assert req.glitch_type is not None
         assert len(req.obligations) > 0
+
+        # Stubs are written to disk under tests/proof/<req_id>/ (#730)
         assert len(stubs) > 0
+        for path in stubs.values():
+            assert path.parent == workspace.repo_path / "tests" / "proof" / req.id
+            assert path.exists()
+            assert req.id in path.read_text(encoding="utf-8")
 
         # Verify persisted
         loaded = ledger.get_requirement(workspace, "REQ-0001")

--- a/tests/core/test_proof9.py
+++ b/tests/core/test_proof9.py
@@ -480,6 +480,14 @@ class TestStubs:
         assert paths[Gate.E2E].suffix == ".ts"
         assert paths[Gate.MANUAL].suffix == ".md"
 
+        # Pytest stubs must stay outside pytest discovery (test_*.py /
+        # *_test.py) so their placeholder assert False bodies don't poison
+        # the user's plain pytest run
+        unit_name = paths[Gate.UNIT].name
+        assert unit_name.startswith("draft_")
+        assert not unit_name.startswith("test_")
+        assert not unit_name.endswith("_test.py")
+
     def test_write_stub_files_skips_existing(self, workspace):
         from codeframe.core.proof.stubs import generate_stubs, write_stub_files
         from codeframe.core.proof.models import Gate

--- a/tests/core/test_proof9.py
+++ b/tests/core/test_proof9.py
@@ -449,7 +449,8 @@ class TestStubs:
         assert Gate.UNIT in stubs
         assert Gate.E2E in stubs
 
-    def _req(self, gates):
+    @staticmethod
+    def _req(gates):
         from codeframe.core.proof.models import (
             Requirement, Severity, Source, RequirementScope, Obligation,
         )

--- a/tests/ui/test_proof_v2.py
+++ b/tests/ui/test_proof_v2.py
@@ -100,8 +100,24 @@ class TestCaptureRequirement:
         )
         data = response.json()
         for field in ["id", "title", "description", "severity", "source", "status",
-                      "obligations", "evidence_rules", "created_at", "stubs_count"]:
+                      "obligations", "evidence_rules", "created_at", "stubs_count",
+                      "stub_paths"]:
             assert field in data, f"Missing field: {field}"
+
+    def test_capture_writes_stub_files_and_returns_paths(self, test_client):
+        """stub_paths lists repo-relative files that really exist on disk (#730)."""
+        response = test_client.post(
+            "/api/v2/proof/requirements",
+            json=self._valid_body(),
+        )
+        data = response.json()
+        assert data["stub_paths"], "no stub paths returned"
+        assert data["stubs_count"] == len(data["stub_paths"])
+        repo = test_client.workspace.repo_path
+        for rel in data["stub_paths"]:
+            assert not Path(rel).is_absolute()
+            assert rel.startswith("tests/proof/")
+            assert (repo / rel).exists()
 
     def test_capture_with_optional_fields(self, test_client):
         """Optional fields (created_by, source_issue) are accepted."""


### PR DESCRIPTION
Closes #730

## Problem
`capture_requirement` built stub content in memory but nothing persisted it — the CLI printed line counts and the API returned a `stubs_count` documented as "Number of test stub files generated" while no file was ever created.

## Changes
- **`core/proof/stubs.py`**: new `write_stub_files(workspace, req, stubs, out_dir=None)` — writes stubs under `tests/proof/<req_id>/` with per-gate extensions (`.py` pytest gates, `.ts` E2E, `.md` DEMO/MANUAL), never overwrites existing files, returns `Gate → Path`.
- **`core/proof/capture.py`**: `capture_requirement` now writes stubs to disk and returns `tuple[Requirement, dict[Gate, Path]]`.
- **CLI**: `cf proof capture` prints the written file paths instead of synthetic line counts.
- **API**: `CaptureRequirementResponse` gains `stub_paths` (repo-relative, verified-on-disk); `stubs_count` description corrected to "written" and kept in sync.

## Cross-family review fixes (codex, pre-PR)
- `.py` stubs get a `draft_` filename prefix so their placeholder `assert False` bodies are **outside pytest discovery** — a capture no longer breaks the user's plain `pytest` run. The proof runner's scoped `-k test_id` run reports the named test missing → the obligation stays FAILED until the developer implements the stub and renames it to `test_*.py` (instruction embedded in each stub's docstring).
- E2E template rewritten with TS comments (was an invalid Python docstring in a `.ts` file); DEMO template converted to real markdown.

## Acceptance criteria → evidence
| Criterion | Evidence |
|---|---|
| Stubs written under a conventional path / returned in output | Real CLI run prints `Test stubs written: sec: tests/proof/REQ-0001/draft_test_..._sec.py`; file verified on disk with REQ id in content. API returns `stub_paths` whose entries all exist on disk (201, `stubs_count == len(stub_paths)`). |
| Wording no longer claims nonexistent files | CLI header now "Test stubs written:" + real paths; API description "Number of test stub files written". |
| (review) plain pytest not poisoned | In demo workspace after capture: `pytest -q` → `no tests ran`. |
| (review) developer edits preserved | Edited stub, re-ran `write_stub_files` → content untouched. |

## Testing
- `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` — **3992 passed, 0 failed**
- New tests: file creation per gate + extensions + discovery-safe naming, skip-if-exists, `out_dir` override, CLI path output (no "lines" claims), API `stub_paths` existence + repo-relative check
- `ruff check` clean

## Known limitations
- Filled-in pytest stubs require a rename from `draft_test_*.py` to `test_*.py` to enter discovery — deliberate (a placeholder that fails the whole suite is worse); each stub's docstring says exactly what to rename to.
- The written E2E `.ts` stub uses the repo's Playwright only if the target repo has one; the stub is a starting template, not wired into any runner (same as before this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test stubs are now written to disk during proof capture, making them available in the workspace after the request completes.
  * API and CLI responses now include the saved stub file paths, shown relative to the repository when possible.

* **Bug Fixes**
  * Improved stub file naming and placement for different test types.
  * Existing edited stub files are preserved and won’t be overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->