### PR TITLE
fix(server): offload blocking sync work out of async v2 handlers (#732)

### DIFF
--- a/codeframe/ui/routers/diagnose_v2.py
+++ b/codeframe/ui/routers/diagnose_v2.py
@@ -12,6 +12,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -164,7 +165,8 @@ async def diagnose_task(
 
         # Run diagnostic analysis
         agent = DiagnosticAgent(workspace)
-        report = agent.analyze(task.id, latest_run.id)
+        # Offload: synchronous LLM analysis (#732).
+        report = await run_in_threadpool(agent.analyze, task.id, latest_run.id)
 
         return _report_to_response(report)
 

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -267,7 +268,9 @@ async def generate_prd(
     """
     try:
         template_id = body.template_id if body else None
-        prd_record = prd_discovery.generate_prd_from_discovery(
+        # Offload: synchronous LLM call (#732).
+        prd_record = await run_in_threadpool(
+            prd_discovery.generate_prd_from_discovery,
             workspace,
             session_id,
             template_id=template_id,

--- a/codeframe/ui/routers/environment_v2.py
+++ b/codeframe/ui/routers/environment_v2.py
@@ -13,6 +13,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -216,7 +217,8 @@ async def install_tool(
             )
 
         # Attempt installation (confirm=False for non-interactive server usage)
-        result = installer.install_tool(body.tool_name, confirm=False)
+        # Offload: subprocess package installs — blocks for minutes (#732).
+        result = await run_in_threadpool(installer.install_tool, body.tool_name, confirm=False)
 
         return InstallResultResponse(
             success=result.success,

--- a/codeframe/ui/routers/gates_v2.py
+++ b/codeframe/ui/routers/gates_v2.py
@@ -12,6 +12,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -113,7 +114,8 @@ async def run_gates(
     verbose = body.verbose if body else False
 
     try:
-        result = gates.run(workspace, gates=gate_list, verbose=verbose)
+        # Offload: runs pytest/ruff — blocks for minutes (#732).
+        result = await run_in_threadpool(gates.run, workspace, gates=gate_list, verbose=verbose)
         return _result_to_response(result)
 
     except Exception as e:

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -21,6 +21,7 @@ from datetime import date
 from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from codeframe.core.proof.capture import capture_requirement
@@ -415,7 +416,9 @@ async def run_proof_endpoint(
     try:
         # Generate run_id before calling run_proof so the response ID matches evidence records
         run_id = str(uuid.uuid4())[:8]
-        results = run_proof(
+        # Offload: runs pytest/ruff etc. — blocks for minutes (#732).
+        results = await run_in_threadpool(
+            run_proof,
             workspace,
             full=body.full,
             gate_filter=body.gate,

--- a/docs/PHASE_2_DEVELOPER_GUIDE.md
+++ b/docs/PHASE_2_DEVELOPER_GUIDE.md
@@ -141,6 +141,21 @@ async def get_resource(
     )
 ```
 
+**Blocking core calls must be offloaded.** Handlers are `async def`, so a
+synchronous core call that takes more than a few milliseconds (test-suite/gate
+runs, LLM calls, subprocess installs) freezes the event loop — `/health`, SSE,
+and WebSockets all stall until it returns (#732). Wrap the heavy call:
+
+```python
+from fastapi.concurrency import run_in_threadpool
+
+result = await run_in_threadpool(core_module.heavy_call, workspace, arg, kwarg=value)
+```
+
+Fast SQLite reads/writes can stay inline. Core opens a fresh WAL connection per
+call in the executing thread (`workspace._open_db`), so core functions are safe
+to run from pool workers.
+
 ### 5. Error Handling
 
 Use standard error format from `response_models.py`:

--- a/tests/ui/test_event_loop_offload.py
+++ b/tests/ui/test_event_loop_offload.py
@@ -4,6 +4,11 @@ A long-blocking core call (e.g. run_proof running a full test suite) executed
 directly inside an ``async def`` handler freezes the event loop — SSE
 heartbeats, WebSockets, and /health all stall. These tests assert the heavy
 handlers offload to a worker thread so concurrent requests stay responsive.
+
+Only the proof-run path is exercised here — it is the criterion named in the
+issue, and the other four handlers (gates_v2, discovery_v2, diagnose_v2,
+environment_v2) use the identical ``run_in_threadpool`` wrapper, so one
+regression test pins the mechanism without duplicating it five times.
 """
 
 import asyncio
@@ -26,6 +31,8 @@ MAX_HEALTH_SECONDS = 1.0
 
 @pytest.fixture
 def test_workspace():
+    # Minimal on purpose: the test monkeypatches run_proof wholesale, so no
+    # proof tables or seed data are ever touched.
     temp_dir = Path(tempfile.mkdtemp())
     workspace_path = temp_dir / "test_workspace"
     workspace_path.mkdir(parents=True, exist_ok=True)

--- a/tests/ui/test_event_loop_offload.py
+++ b/tests/ui/test_event_loop_offload.py
@@ -1,0 +1,82 @@
+"""Event-loop offload tests for blocking v2 handlers (#732).
+
+A long-blocking core call (e.g. run_proof running a full test suite) executed
+directly inside an ``async def`` handler freezes the event loop — SSE
+heartbeats, WebSockets, and /health all stall. These tests assert the heavy
+handlers offload to a worker thread so concurrent requests stay responsive.
+"""
+
+import asyncio
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.v2
+
+BLOCK_SECONDS = 1.5
+# A concurrent /health must complete well before the blocking call would
+# release the loop. Generous margin for slow CI machines.
+MAX_HEALTH_SECONDS = 1.0
+
+
+@pytest.fixture
+def test_workspace():
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "test_workspace"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    from codeframe.core.workspace import create_or_load_workspace
+
+    yield create_or_load_workspace(workspace_path)
+
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def app(test_workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import proof_v2
+
+    app = FastAPI()
+    app.include_router(proof_v2.router)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    return app
+
+
+async def test_proof_run_does_not_block_health(app, monkeypatch):
+    """/health responds while a (blocking) proof run is in flight."""
+    from codeframe.ui.routers import proof_v2
+
+    def slow_run_proof(*args, **kwargs):
+        time.sleep(BLOCK_SECONDS)
+        return {}
+
+    monkeypatch.setattr(proof_v2, "run_proof", slow_run_proof)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.monotonic()
+        proof_task = asyncio.create_task(client.post("/api/v2/proof/run", json={}))
+        # Yield so the proof handler starts (and, unfixed, blocks the loop).
+        await asyncio.sleep(0.05)
+
+        health_response = await client.get("/health")
+        health_elapsed = time.monotonic() - start
+
+        proof_response = await proof_task
+
+    assert health_response.status_code == 200
+    assert proof_response.status_code == 200
+    assert health_elapsed < MAX_HEALTH_SECONDS, (
+        f"/health took {health_elapsed:.2f}s — the proof run blocked the event loop"
+    )


### PR DESCRIPTION
Closes #732

## Problem
Five `async def` v2 handlers called long-blocking core functions (full test-suite runs, LLM calls, subprocess installs) directly on the event-loop thread, freezing all other requests — SSE heartbeats, terminal/chat WebSockets, and `/health` — for minutes.

## Change
Wrap the heavy call in each handler with `await run_in_threadpool(...)` (`fastapi.concurrency`), the pattern already used in `settings_v2.py` / `prd_v2.py`:

| Handler | Blocking call |
|---|---|
| `proof_v2.py` `POST /proof/run` | `run_proof()` (pytest/ruff gate runs) |
| `gates_v2.py` `POST /gates/run` | `gates.run()` |
| `discovery_v2.py` `POST /{id}/generate-prd` | `generate_prd_from_discovery()` (LLM) |
| `diagnose_v2.py` `POST /{id}/diagnose` | `DiagnosticAgent.analyze()` (LLM) |
| `environment_v2.py` `POST /install` | `ToolInstaller.install_tool()` (subprocess) |

## Tests
- New `tests/ui/test_event_loop_offload.py`: TDD regression test (RED before fix) — monkeypatches `run_proof` with a 1.5s `time.sleep` blocker and asserts a concurrent `/health` request completes in <1s over `httpx.ASGITransport`.
- `tests/ui/test_proof_v2.py` + `tests/ui/test_v2_routers_integration.py`: 125 passed. `ruff check` clean.

## Acceptance criteria
- [x] Listed handlers offload via `run_in_threadpool`
- [x] A proof run no longer blocks a concurrent `/health` request (regression test)

## Known Limitations
- Only the heavy call per handler is offloaded; fast SQLite reads in the same handlers stay on the loop (sub-ms, intentional).
- Requests still occupy a threadpool worker for their full duration (default AnyIO pool, 40 threads) — true background-job semantics are out of scope for #732.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-running v2 operations now run in the background, helping the app stay responsive during report generation, installs, diagnostics, gates, and proof runs.
* **Bug Fixes**
  * Reduced the chance of request handling freezing while blocking tasks complete.
* **Tests**
  * Added coverage to verify that proof execution does not block the health endpoint and the event loop remains responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->