### PR TITLE
fix(security): validate webhook host at dispatch time, not only at save (#746)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,12 +315,16 @@ JWT_LIFETIME_SECONDS=86400            # JWT validity window; default 24h (was 7d
                                       # (web-ui/security-headers.js) to contain
                                       # XSS-based token exfiltration.
 
-# Outbound webhook SSRF guard (#656) — default OFF (block)
+# Outbound webhook SSRF guard (#656, #746) — default OFF (block)
 CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1    # Allow webhook URLs whose host resolves to
-                                      # private/loopback/link-local/metadata IPs.
-                                      # Off by default: such hosts are rejected by
-                                      # the notifications save + test endpoints to
-                                      # prevent SSRF (e.g. 169.254.169.254 IMDS).
+                                      # private/loopback/link-local/metadata/CGNAT
+                                      # IPs. Off by default: such hosts are
+                                      # rejected at save time (notifications save
+                                      # + test endpoints) AND at dispatch time
+                                      # (#746): send_event resolves-and-checks
+                                      # the host and pins the vetted IPs into the
+                                      # connector (defeats hand-edited config and
+                                      # DNS rebinding; e.g. 169.254.169.254 IMDS).
                                       # Set for self-hosted ops with legit internal
                                       # webhook targets (localhost, RFC1918).
 

--- a/codeframe/core/notifications_config.py
+++ b/codeframe/core/notifications_config.py
@@ -18,12 +18,14 @@ endpoint validates too — never trust just one layer.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
+import socket
 import tempfile
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Union
 
 from codeframe.core.workspace import Workspace
 
@@ -50,6 +52,90 @@ def _config_path(workspace: Workspace) -> Path:
     return workspace.state_dir / NOTIFICATIONS_CONFIG_FILENAME
 
 
+def allow_private_webhook_hosts() -> bool:
+    """Opt-out for the SSRF host check (issues #656/#746).
+
+    Off by default (block private/internal targets). Self-hosted operators
+    who legitimately point webhooks at ``localhost`` or an internal service
+    set ``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1`` — read at call time so it can
+    be toggled without a restart.
+    """
+    return os.getenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+class UnsafeWebhookHostError(Exception):
+    """A webhook host is (or resolves to) a private/internal/metadata IP."""
+
+    def __init__(
+        self,
+        hostname: str,
+        ip: Union[ipaddress.IPv4Address, ipaddress.IPv6Address],
+    ):
+        self.hostname = hostname
+        self.ip = ip
+        super().__init__(
+            f"Webhook host {hostname!r} resolves to a private/internal "
+            f"address ({ip}); refusing to avoid SSRF. Set "
+            f"CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1 to allow internal targets."
+        )
+
+
+def _is_disallowed_ip(
+    ip: Union[ipaddress.IPv4Address, ipaddress.IPv6Address],
+) -> bool:
+    # ::ffff:169.254.169.254 — judge by the embedded IPv4 address.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    # ``not is_global`` is the primary rule: it covers private/loopback/
+    # link-local/reserved/unspecified AND CGNAT 100.64.0.0/10, which none of
+    # the individual flags report. Multicast (224.0.0.1) reports
+    # ``is_global=True``, so check it explicitly.
+    return (not ip.is_global) or ip.is_multicast
+
+
+def vet_webhook_host(hostname: str) -> list[str]:
+    """Check a webhook host against private/internal IP ranges (issue #746).
+
+    IP literals are checked directly; DNS names are resolved (blocking —
+    call off the event loop) and **every** returned address is checked.
+    Returns the vetted IP strings so callers can pin them into the connector
+    (closing the resolve-to-connect DNS-rebinding window), or ``[]`` when the
+    host is unresolvable — the caller decides whether that blocks (save-time
+    allows a not-yet-live URL; dispatch-time refuses).
+
+    Raises ``UnsafeWebhookHostError`` on any private/loopback/link-local/
+    metadata address. Does NOT consult ``allow_private_webhook_hosts()`` —
+    callers gate on that first.
+    """
+    try:
+        literal = ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        if _is_disallowed_ip(literal):
+            raise UnsafeWebhookHostError(hostname, literal)
+        return [str(literal)]
+
+    try:
+        infos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        return []
+
+    ips: list[str] = []
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if _is_disallowed_ip(ip):
+            raise UnsafeWebhookHostError(hostname, ip)
+        if str(ip) not in ips:
+            ips.append(str(ip))
+    return ips
+
+
 def _is_safe_webhook_url(url: str) -> bool:
     """Defence-in-depth: scheme/host check on a stored URL before we POST.
 
@@ -57,11 +143,10 @@ def _is_safe_webhook_url(url: str) -> bool:
     file could carry a ``file://`` or schemeless URL. Used by
     ``is_webhook_active`` to fail-safe to ``None``.
 
-    TODO: This does NOT block RFC-1918 (10/8, 172.16/12, 192.168/16) or
-    loopback (127/8) addresses. For a self-hosted single-user tool that is
-    intentional — users want to point at local receivers. If CodeFRAME ever
-    runs as a shared / multi-tenant service, add a socket-level check here
-    that resolves the host and rejects private/loopback ranges.
+    Private/loopback ranges are NOT checked here — dispatch-time enforcement
+    (resolve-and-check + IP pinning, #746) lives in
+    ``WebhookNotificationService.send_event``, the single choke point every
+    outbound event webhook goes through.
     """
     from urllib.parse import urlparse
 

--- a/codeframe/notifications/webhook.py
+++ b/codeframe/notifications/webhook.py
@@ -45,7 +45,7 @@ class _PinnedResolver(aiohttp.abc.AbstractResolver):
     async def resolve(self, host, port=0, family=socket.AF_INET):
         if host != self._hostname:
             raise OSError(f"refusing to resolve unexpected host {host!r}")
-        return [
+        entries = [
             {
                 "hostname": host,
                 "host": ip,
@@ -56,6 +56,15 @@ class _PinnedResolver(aiohttp.abc.AbstractResolver):
             }
             for ip in self._ips
         ]
+        # Honor an explicit address-family request; fail closed rather than
+        # hand an AF_INET-restricted socket an IPv6 address (or vice versa).
+        if family in (socket.AF_INET, socket.AF_INET6):
+            entries = [e for e in entries if e["family"] == family]
+            if not entries:
+                raise OSError(
+                    f"no vetted addresses of requested family for {host!r}"
+                )
+        return entries
 
     async def close(self) -> None:
         pass
@@ -364,6 +373,12 @@ class WebhookNotificationService:
                 exc_info=True,
             )
             return WebhookSendResult(ok=False, status_code=None, error=str(e))
+        finally:
+            # The session owns and closes the pinned connector on normal exit;
+            # this covers the construction-failure path. close() is idempotent.
+            connector = session_kwargs.get("connector")
+            if connector is not None and not connector.closed:
+                await connector.close()
 
     def send_event_background(self, payload: dict, url: Optional[str] = None) -> None:
         """Fire-and-forget wrapper for ``send_event``.

--- a/codeframe/notifications/webhook.py
+++ b/codeframe/notifications/webhook.py
@@ -10,16 +10,55 @@ but never break the triggering operation.
 
 import asyncio
 import logging
+import socket
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import urlparse
 
 import aiohttp
 
 from codeframe.core.models import BlockerType
+from codeframe.core.notifications_config import (
+    UnsafeWebhookHostError,
+    allow_private_webhook_hosts,
+    vet_webhook_host,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class _PinnedResolver(aiohttp.abc.AbstractResolver):
+    """Resolver that only ever answers with pre-vetted addresses for one host.
+
+    SSRF (#746): ``send_event`` resolves and checks the target host before
+    connecting. Pinning those exact addresses into the connector closes the
+    check-to-connect DNS-rebinding window — the socket can only dial IPs
+    that passed the private-range check.
+    """
+
+    def __init__(self, hostname: str, ips: list[str]):
+        self._hostname = hostname
+        self._ips = ips
+
+    async def resolve(self, host, port=0, family=socket.AF_INET):
+        if host != self._hostname:
+            raise OSError(f"refusing to resolve unexpected host {host!r}")
+        return [
+            {
+                "hostname": host,
+                "host": ip,
+                "port": port,
+                "family": socket.AF_INET6 if ":" in ip else socket.AF_INET,
+                "proto": 0,
+                "flags": 0,
+            }
+            for ip in self._ips
+        ]
+
+    async def close(self) -> None:
+        pass
 
 
 @dataclass
@@ -254,8 +293,40 @@ class WebhookNotificationService:
                 ok=False, status_code=None, error="No webhook URL configured"
             )
 
+        # SSRF (#746): the save-time host check is not enough — the config
+        # file can be hand-edited, and a host can rebind after save. Resolve
+        # and check here, then pin the vetted IPs into the connector.
+        session_kwargs: dict = {}
+        if not allow_private_webhook_hosts():
+            hostname = urlparse(target_url).hostname
+            if not hostname:
+                return WebhookSendResult(
+                    ok=False, status_code=None, error="Webhook URL has no host"
+                )
+            try:
+                # Blocking DNS — keep it off the event loop.
+                vetted = await asyncio.get_running_loop().run_in_executor(
+                    None, vet_webhook_host, hostname
+                )
+            except UnsafeWebhookHostError as e:
+                logger.warning(
+                    "Refusing webhook dispatch for event %s: %s",
+                    payload.get("event"),
+                    e,
+                )
+                return WebhookSendResult(ok=False, status_code=None, error=str(e))
+            if not vetted:
+                return WebhookSendResult(
+                    ok=False,
+                    status_code=None,
+                    error=f"Could not resolve webhook host {hostname!r}",
+                )
+            session_kwargs["connector"] = aiohttp.TCPConnector(
+                resolver=_PinnedResolver(hostname, vetted), use_dns_cache=False
+            )
+
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(**session_kwargs) as session:
                 async with session.post(
                     target_url,
                     json=payload,

--- a/codeframe/notifications/webhook.py
+++ b/codeframe/notifications/webhook.py
@@ -304,18 +304,35 @@ class WebhookNotificationService:
 
         # SSRF (#746): the save-time host check is not enough — the config
         # file can be hand-edited, and a host can rebind after save. Resolve
-        # and check here, then pin the vetted IPs into the connector.
+        # and check here, then pin the vetted IPs into the connector. The
+        # whole vetting block must uphold send_event's never-raises contract:
+        # urlparse can raise on malformed IPv6 brackets, getaddrinfo can
+        # raise UnicodeError on bad IDN labels, and a hung resolver must not
+        # stall the caller past self.timeout.
         session_kwargs: dict = {}
         if not allow_private_webhook_hosts():
-            hostname = urlparse(target_url).hostname
-            if not hostname:
-                return WebhookSendResult(
-                    ok=False, status_code=None, error="Webhook URL has no host"
-                )
             try:
-                # Blocking DNS — keep it off the event loop.
-                vetted = await asyncio.get_running_loop().run_in_executor(
-                    None, vet_webhook_host, hostname
+                hostname = urlparse(target_url).hostname
+                if not hostname:
+                    return WebhookSendResult(
+                        ok=False, status_code=None, error="Webhook URL has no host"
+                    )
+                # Blocking DNS — keep it off the event loop, bounded by the
+                # same timeout as the HTTP request.
+                vetted = await asyncio.wait_for(
+                    asyncio.get_running_loop().run_in_executor(
+                        None, vet_webhook_host, hostname
+                    ),
+                    timeout=self.timeout,
+                )
+                if not vetted:
+                    return WebhookSendResult(
+                        ok=False,
+                        status_code=None,
+                        error=f"Could not resolve webhook host {hostname!r}",
+                    )
+                session_kwargs["connector"] = aiohttp.TCPConnector(
+                    resolver=_PinnedResolver(hostname, vetted), use_dns_cache=False
                 )
             except UnsafeWebhookHostError as e:
                 logger.warning(
@@ -324,15 +341,20 @@ class WebhookNotificationService:
                     e,
                 )
                 return WebhookSendResult(ok=False, status_code=None, error=str(e))
-            if not vetted:
+            except asyncio.TimeoutError:
                 return WebhookSendResult(
                     ok=False,
                     status_code=None,
-                    error=f"Could not resolve webhook host {hostname!r}",
+                    error=f"Timed out resolving webhook host after {self.timeout}s",
                 )
-            session_kwargs["connector"] = aiohttp.TCPConnector(
-                resolver=_PinnedResolver(hostname, vetted), use_dns_cache=False
-            )
+            except Exception as e:
+                logger.error(
+                    "Webhook host vetting failed for event %s: %s",
+                    payload.get("event"),
+                    e,
+                    exc_info=True,
+                )
+                return WebhookSendResult(ok=False, status_code=None, error=str(e))
 
         try:
             async with aiohttp.ClientSession(**session_kwargs) as session:

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -16,10 +16,7 @@ require a workspace. Env vars take precedence at read time. Notifications
 config is per-workspace and persisted under .codeframe/notifications_config.json.
 """
 
-import ipaddress
 import logging
-import os
-import socket
 
 from typing import Optional, cast
 
@@ -48,8 +45,11 @@ from codeframe.core.credentials import (
     validate_credential_format,
 )
 from codeframe.core.notifications_config import (
+    UnsafeWebhookHostError,
+    allow_private_webhook_hosts,
     load_notifications_config,
     save_notifications_config,
+    vet_webhook_host,
 )
 from codeframe.core.workspace import Workspace
 from codeframe.notifications.webhook import (
@@ -468,75 +468,27 @@ async def get_notification_settings(
 _ALLOWED_WEBHOOK_SCHEMES = frozenset({"http", "https"})
 
 
-def _allow_private_webhook_hosts() -> bool:
-    """Opt-out for the SSRF host check.
-
-    Off by default (block private/internal targets). Self-hosted operators who
-    legitimately point webhooks at ``localhost`` or an internal service set
-    ``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1`` — read at request time so it can be
-    toggled without a restart.
-    """
-    return os.getenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-
 def _assert_webhook_host_is_public(hostname: str) -> None:
     """Reject webhook hosts that resolve to internal/metadata/private IPs.
 
     Blocks the SSRF vector where an authenticated user points the webhook at
     ``169.254.169.254`` (cloud IMDS), ``127.0.0.1``, or an RFC1918 address —
     the ``/notifications/test`` endpoint fires the URL immediately and returns
-    the HTTP status, a blind-to-semi-blind SSRF primitive. IP literals are
-    checked directly; DNS names are resolved and every returned address is
-    checked. A host that cannot be resolved is allowed through — it isn't
+    the HTTP status, a blind-to-semi-blind SSRF primitive. Delegates to the
+    core guard (``vet_webhook_host``, shared with the #746 dispatch-time
+    check in ``send_event``, which also pins the resolved IPs to defeat DNS
+    rebinding). A host that cannot be resolved is allowed through — it isn't
     reachable right now, and we don't want to block saving a not-yet-live URL.
-
-    Known limitation: resolve-and-check, not a request-time pinned connector,
-    so DNS rebinding (public at save, private at fire) is out of scope.
-    Upgrade path: pin the resolved IP through a custom aiohttp connector in
-    ``send_event``.
     """
-    if _allow_private_webhook_hosts():
+    if allow_private_webhook_hosts():
         return
-
     try:
-        candidates = [ipaddress.ip_address(hostname)]
-    except ValueError:
-        try:
-            candidates = [
-                ipaddress.ip_address(info[4][0])
-                for info in socket.getaddrinfo(
-                    hostname, None, proto=socket.IPPROTO_TCP
-                )
-            ]
-        except socket.gaierror:
-            return  # unresolvable now → not reachable now; don't block the save
-
-    for ip in candidates:
-        # ::ffff:169.254.169.254 — judge by the embedded IPv4 address.
-        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
-            ip = ip.ipv4_mapped
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail=api_error(
-                    f"Webhook host resolves to a private/internal address "
-                    f"({ip}); refusing to avoid SSRF. Set "
-                    f"CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1 to allow internal targets.",
-                    ErrorCodes.VALIDATION_ERROR,
-                ),
-            )
+        vet_webhook_host(hostname)
+    except UnsafeWebhookHostError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=api_error(str(e), ErrorCodes.VALIDATION_ERROR),
+        )
 
 
 def _validate_webhook_url(url: Optional[str]) -> Optional[str]:

--- a/tests/notifications/test_webhook_send_event.py
+++ b/tests/notifications/test_webhook_send_event.py
@@ -20,6 +20,15 @@ from codeframe.notifications.webhook import (
 pytestmark = pytest.mark.v2
 
 
+@pytest.fixture(autouse=True)
+def _skip_ssrf_guard(monkeypatch):
+    """These tests cover transport behavior with fake hosts (example.com) and
+    a fully mocked ClientSession — opt out of the #746 dispatch-time host
+    check so no real DNS resolution happens. The guard itself is covered in
+    test_webhook_ssrf_guard.py."""
+    monkeypatch.setenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "1")
+
+
 def _mock_post(status: int):
     """Build the AsyncMock chain that mirrors aiohttp's session.post() context."""
     mock_response = AsyncMock()

--- a/tests/notifications/test_webhook_ssrf_guard.py
+++ b/tests/notifications/test_webhook_ssrf_guard.py
@@ -218,3 +218,44 @@ async def test_send_event_refuses_url_without_host():
         result = await svc.send_event({"event": "test"})
     assert result.ok is False
     session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_event_bounds_slow_dns_by_timeout():
+    """A hung resolver must not stall send_event past self.timeout — the
+    /notifications/test endpoint awaits this call directly."""
+    import time
+
+    svc = WebhookNotificationService(webhook_url="https://slow.example.com/hook", timeout=1)
+    svc.timeout = 0.1  # keep the test fast; int constructor arg, float works fine
+    session = _mock_session()
+    with patch(
+        "codeframe.notifications.webhook.vet_webhook_host",
+        side_effect=lambda h: time.sleep(5),
+    ):
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await svc.send_event({"event": "test"})
+    assert result.ok is False
+    assert "timed out resolving" in (result.error or "").lower()
+    session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_event_never_raises_on_vetting_error():
+    """send_event's contract is never-raises: malformed IPv6 brackets
+    (urlparse ValueError) and bad IDN labels (getaddrinfo UnicodeError)
+    must come back as error results, not exceptions."""
+    svc = WebhookNotificationService(webhook_url="http://[::1/hook", timeout=5)
+    result = await svc.send_event({"event": "test"})
+    assert result.ok is False
+
+    svc2 = WebhookNotificationService(webhook_url="https://ok.example.com/hook", timeout=5)
+    session = _mock_session()
+    with patch(
+        "codeframe.notifications.webhook.vet_webhook_host",
+        side_effect=UnicodeError("label too long"),
+    ):
+        with patch("aiohttp.ClientSession", return_value=session):
+            result2 = await svc2.send_event({"event": "test"})
+    assert result2.ok is False
+    session.post.assert_not_called()

--- a/tests/notifications/test_webhook_ssrf_guard.py
+++ b/tests/notifications/test_webhook_ssrf_guard.py
@@ -198,6 +198,19 @@ async def test_send_event_pins_vetted_ips_into_connector(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pinned_resolver_honors_address_family():
+    """An AF_INET-restricted socket must never be handed an IPv6 address
+    (and vice versa) — fail closed instead."""
+    from codeframe.notifications.webhook import _PinnedResolver
+
+    resolver = _PinnedResolver("hooks.example.com", ["93.184.216.34"])
+    entries = await resolver.resolve("hooks.example.com", port=443, family=socket.AF_INET)
+    assert [e["host"] for e in entries] == ["93.184.216.34"]
+    with pytest.raises(OSError):
+        await resolver.resolve("hooks.example.com", port=443, family=socket.AF_INET6)
+
+
+@pytest.mark.asyncio
 async def test_send_event_refuses_url_without_host():
     svc = WebhookNotificationService(webhook_url="http:///hook", timeout=5)
     session = _mock_session()

--- a/tests/notifications/test_webhook_ssrf_guard.py
+++ b/tests/notifications/test_webhook_ssrf_guard.py
@@ -1,0 +1,207 @@
+"""Dispatch-time SSRF guard for outbound webhooks (issue #746).
+
+The save-time check in ``settings_v2`` is not enough: a hand-edited
+``notifications_config.json`` or a host that rebinds after save must be
+refused when the webhook actually fires. ``send_event`` resolves and checks
+the target host, honoring ``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS``, and pins the
+vetted IPs into the connector so rebinding between check and connect is
+impossible.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from codeframe.core.notifications_config import (
+    UnsafeWebhookHostError,
+    allow_private_webhook_hosts,
+    vet_webhook_host,
+)
+from codeframe.notifications.webhook import WebhookNotificationService
+
+pytestmark = pytest.mark.v2
+
+
+def _addrinfo(*ips: str):
+    """Fake ``socket.getaddrinfo`` result for the given IPs."""
+    return [
+        (socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+        for ip in ips
+    ]
+
+
+def _mock_session(status: int = 200):
+    mock_response = AsyncMock()
+    mock_response.status = status
+    mock_post_context = AsyncMock()
+    mock_post_context.__aenter__.return_value = mock_response
+    mock_post_context.__aexit__.return_value = None
+    session = MagicMock()
+    session.post.return_value = mock_post_context
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Core: vet_webhook_host
+# ---------------------------------------------------------------------------
+
+
+class TestVetWebhookHost:
+    def test_public_ip_literal_allowed(self):
+        assert vet_webhook_host("93.184.216.34") == ["93.184.216.34"]
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",  # loopback
+            "169.254.169.254",  # link-local / cloud metadata
+            "10.0.0.5",  # RFC1918
+            "172.16.0.1",  # RFC1918
+            "192.168.1.1",  # RFC1918
+            "::1",  # IPv6 loopback
+            "::ffff:169.254.169.254",  # IPv4-mapped IPv6 metadata
+            "0.0.0.0",  # unspecified
+            "100.64.0.1",  # CGNAT shared space (no ipaddress flag reports it)
+            "224.0.0.1",  # multicast (is_global=True, needs explicit check)
+        ],
+    )
+    def test_private_ip_literal_refused(self, host):
+        with pytest.raises(UnsafeWebhookHostError):
+            vet_webhook_host(host)
+
+    def test_hostname_resolving_public_returns_ips(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _addrinfo("93.184.216.34"))
+        assert vet_webhook_host("hooks.example.com") == ["93.184.216.34"]
+
+    def test_hostname_resolving_private_refused(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _addrinfo("10.1.2.3"))
+        with pytest.raises(UnsafeWebhookHostError):
+            vet_webhook_host("rebinder.example.com")
+
+    def test_hostname_with_any_private_address_refused(self, monkeypatch):
+        """A rebinding host may return one public + one private A record."""
+        monkeypatch.setattr(
+            socket, "getaddrinfo", lambda *a, **k: _addrinfo("93.184.216.34", "127.0.0.1")
+        )
+        with pytest.raises(UnsafeWebhookHostError):
+            vet_webhook_host("rebinder.example.com")
+
+    def test_unresolvable_returns_empty(self, monkeypatch):
+        def boom(*a, **k):
+            raise socket.gaierror("NXDOMAIN")
+
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        assert vet_webhook_host("nope.invalid") == []
+
+
+def test_allow_private_webhook_hosts_env_flag(monkeypatch):
+    monkeypatch.delenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", raising=False)
+    assert allow_private_webhook_hosts() is False
+    for value in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", value)
+        assert allow_private_webhook_hosts() is True
+    monkeypatch.setenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "0")
+    assert allow_private_webhook_hosts() is False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: send_event refuses unsafe targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _block_private(monkeypatch):
+    monkeypatch.delenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", raising=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:9/hook",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/hook",
+        "http://[::1]/hook",
+    ],
+)
+async def test_send_event_refuses_private_ip_literal(url):
+    svc = WebhookNotificationService(webhook_url=url, timeout=5)
+    session = _mock_session()
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await svc.send_event({"event": "test"})
+    assert result.ok is False
+    assert result.status_code is None
+    assert "private" in (result.error or "").lower()
+    session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_event_refuses_hostname_resolving_private(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _addrinfo("192.168.0.10"))
+    svc = WebhookNotificationService(webhook_url="https://rebinder.example.com/hook", timeout=5)
+    session = _mock_session()
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await svc.send_event({"event": "test"})
+    assert result.ok is False
+    session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_event_refuses_unresolvable_host(monkeypatch):
+    def boom(*a, **k):
+        raise socket.gaierror("NXDOMAIN")
+
+    monkeypatch.setattr(socket, "getaddrinfo", boom)
+    svc = WebhookNotificationService(webhook_url="https://nope.invalid/hook", timeout=5)
+    session = _mock_session()
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await svc.send_event({"event": "test"})
+    assert result.ok is False
+    assert "resolve" in (result.error or "").lower()
+    session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_event_allows_private_when_env_flag_set(monkeypatch):
+    monkeypatch.setenv("CODEFRAME_ALLOW_PRIVATE_WEBHOOKS", "1")
+    svc = WebhookNotificationService(webhook_url="http://127.0.0.1:9/hook", timeout=5)
+    with patch("aiohttp.ClientSession", return_value=_mock_session(200)):
+        result = await svc.send_event({"event": "test"})
+    assert result.ok is True
+    assert result.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_send_event_pins_vetted_ips_into_connector(monkeypatch):
+    """The connector must resolve through the vetted IPs only — closing the
+    check-to-connect DNS-rebinding window."""
+    import aiohttp
+
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _addrinfo("93.184.216.34"))
+    svc = WebhookNotificationService(webhook_url="https://hooks.example.com/hook", timeout=5)
+    with patch("aiohttp.ClientSession", return_value=_mock_session(200)) as mock_cls:
+        result = await svc.send_event({"event": "test"})
+    assert result.ok is True
+    connector = mock_cls.call_args.kwargs.get("connector")
+    assert isinstance(connector, aiohttp.TCPConnector)
+    resolved = await connector._resolver.resolve("hooks.example.com", port=443)
+    assert [e["host"] for e in resolved] == ["93.184.216.34"]
+    # The pinned resolver must not answer for any other host.
+    with pytest.raises(OSError):
+        await connector._resolver.resolve("evil.example.com", port=443)
+    await connector.close()
+
+
+@pytest.mark.asyncio
+async def test_send_event_refuses_url_without_host():
+    svc = WebhookNotificationService(webhook_url="http:///hook", timeout=5)
+    session = _mock_session()
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await svc.send_event({"event": "test"})
+    assert result.ok is False
+    session.post.assert_not_called()

--- a/tests/ui/test_settings_notifications.py
+++ b/tests/ui/test_settings_notifications.py
@@ -163,7 +163,7 @@ class TestUpdateNotificationSettings:
         the test doesn't depend on how the CI image resolves ``localhost``
         (some return ::1, some 127.0.0.1, hardened ones not at all)."""
         with patch(
-            "codeframe.ui.routers.settings_v2.socket.getaddrinfo",
+            "codeframe.core.notifications_config.socket.getaddrinfo",
             return_value=[(2, 1, 6, "", ("127.0.0.1", 0))],
         ):
             r = client.put(
@@ -220,6 +220,18 @@ class TestUpdateNotificationSettings:
 
 
 class TestNotificationWebhookTest:
+    @pytest.fixture(autouse=True)
+    def _public_dns(self):
+        """Hermetic DNS: ``hooks.example.com`` must resolve to a public IP so
+        the save-time check and the #746 dispatch-time guard in ``send_event``
+        both pass without real lookups. IP-literal and scheme rejection tests
+        in this class never reach getaddrinfo, so the stub is safe for all."""
+        with patch(
+            "codeframe.core.notifications_config.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            yield
+
     def test_returns_400_when_no_url_configured(self, client):
         r = client.post("/api/v2/settings/notifications/test")
         assert r.status_code == 400


### PR DESCRIPTION
Closes #746

## Problem
The SSRF host check ran only on the notifications PUT/test endpoints. The fire-and-forget dispatch path (`send_event`, called from conductor / blockers / pr-merge) did no private-range check, so a hand-edited `notifications_config.json` pointing at `169.254.169.254` / `127.0.0.1` / RFC1918 — or a hostname that rebinds after save — reached internal targets.

## Change
- **Core guard** (`codeframe/core/notifications_config.py`, headless/stdlib): `vet_webhook_host()` checks IP literals directly, resolves DNS names and checks **every** returned address. Rule is `not ip.is_global` (covers private/loopback/link-local/reserved/unspecified **and CGNAT 100.64/10**, which no individual flag reports) plus an explicit multicast check; IPv4-mapped IPv6 is unwrapped first. `allow_private_webhook_hosts()` (env opt-out) and `UnsafeWebhookHostError` moved here too.
- **Dispatch enforcement** (`send_event`): unless `CODEFRAME_ALLOW_PRIVATE_WEBHOOKS` is set, the host is vetted off the event loop (`run_in_executor`); unsafe → refused with a logged `WebhookSendResult` error; unresolvable → refused; safe → the vetted IPs are **pinned into the connector** via a custom `aiohttp` resolver (`use_dns_cache=False`), so the socket can only dial addresses that passed the check — closing the check-to-connect DNS-rebinding window. Redirects were already disabled (#656).
- **Save-time check** (`settings_v2.py`) now delegates to the same core guard (−50 lines of duplicated logic; unresolvable hosts still allowed at save so a not-yet-live URL can be stored).

## Acceptance criteria (issue #746)
- ✅ `send_event` resolve-and-check with IP-pinned connector, honoring `CODEFRAME_ALLOW_PRIVATE_WEBHOOKS`
- ✅ Test: `send_event` refuses URLs resolving to private/loopback/metadata IPs (`tests/notifications/test_webhook_ssrf_guard.py`)

## Verification
- Full CI gate locally: **4033 passed**, 0 failed; `ruff` clean
- Cross-family review (codex) found the CGNAT gap; fixed + regression-tested
- Live demo: real local HTTP listener received **0** requests with the guard on (IP-literal and rebinding-shaped hostname) and **1** request with the env opt-out set

## Known limitations
- Legacy `send_blocker_notification` (env-var `BLOCKER_WEBHOOK_URL` SYNC-blocker path) is not guarded — operator-set env var, out of issue scope
- `is_webhook_active` keeps its cheap scheme/host check; dispatch-time enforcement is the single choke point in `send_event`, which all #560 dispatch sites route through
- IDN (unicode) webhook hostnames fail closed (urlparse vs yarl punycode normalization mismatch in the pinned resolver) — acceptable for a security guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outbound webhook checks now block unsafe private, loopback, and metadata-style hosts by default.
  * Webhook delivery now verifies and pins resolved IPs to reduce DNS rebinding risk.

* **Bug Fixes**
  * Webhook settings validation now returns clearer errors for unsafe or unresolvable targets.
  * Webhook test/send flows now consistently handle host safety checks before sending requests.

* **Tests**
  * Added coverage for safe/unsafe webhook hosts, DNS resolution behavior, and pinned connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->