### PR TITLE
fix(core): gate workspace schema migrations behind PRAGMA user_version (#733)

### DIFF
--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -24,6 +24,12 @@ def _utc_now() -> datetime:
 CODEFRAME_DIR = ".codeframe"
 STATE_DB_NAME = "state.db"
 
+# Stamped into ``PRAGMA user_version`` after ``_init_database`` /
+# ``_ensure_schema_upgrades``. Bump by 1 whenever either function gains a new
+# table/column/index so existing workspaces re-enter the (idempotent)
+# migration path exactly once. Gates #733: steady-state loads skip all DDL.
+SCHEMA_VERSION = 1
+
 # Per-workspace config file written by the Settings page (issue #556).
 # Owned by the UI layer today; kept here so a future core consumer can
 # read it without importing from codeframe/ui/.
@@ -52,13 +58,6 @@ class Workspace:
     def db_path(self) -> Path:
         """Path to the SQLite state database."""
         return self.state_dir / STATE_DB_NAME
-
-
-# Stamped into ``PRAGMA user_version`` after ``_init_database`` /
-# ``_ensure_schema_upgrades``. Bump by 1 whenever either function gains a new
-# table/column/index so existing workspaces re-enter the (idempotent)
-# migration path exactly once. Gates #733: steady-state loads skip all DDL.
-SCHEMA_VERSION = 1
 
 
 def _get_state_dir(repo_path: Path) -> Path:
@@ -463,6 +462,7 @@ def _init_database(db_path: Path) -> None:
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_run ON file_operations(run_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_step ON file_operations(step_id)")
 
+    # PRAGMA doesn't accept ? placeholders; SCHEMA_VERSION is a module int constant.
     cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
     conn.close()
@@ -479,11 +479,16 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
     zero DDL, zero write commits — so per-request workspace loads are cheap.
     """
     conn = _open_db(db_path)
-    cursor = conn.cursor()
-
-    if cursor.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_VERSION:
+    try:
+        current_version = conn.execute("PRAGMA user_version").fetchone()[0]
+    except Exception:
+        conn.close()
+        raise
+    if current_version >= SCHEMA_VERSION:
         conn.close()
         return
+
+    cursor = conn.cursor()
 
     # token_usage was added after the initial schema (issue #712); create it for
     # existing workspaces. CREATE TABLE IF NOT EXISTS keeps this idempotent.
@@ -799,6 +804,7 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             created_at TEXT NOT NULL
         )
     """)
+    # PRAGMA doesn't accept ? placeholders; SCHEMA_VERSION is a module int constant.
     cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
 

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -54,6 +54,13 @@ class Workspace:
         return self.state_dir / STATE_DB_NAME
 
 
+# Stamped into ``PRAGMA user_version`` after ``_init_database`` /
+# ``_ensure_schema_upgrades``. Bump by 1 whenever either function gains a new
+# table/column/index so existing workspaces re-enter the (idempotent)
+# migration path exactly once. Gates #733: steady-state loads skip all DDL.
+SCHEMA_VERSION = 1
+
+
 def _get_state_dir(repo_path: Path) -> Path:
     """Get the .codeframe/ directory path for a repository."""
     return repo_path / CODEFRAME_DIR
@@ -456,6 +463,7 @@ def _init_database(db_path: Path) -> None:
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_run ON file_operations(run_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_step ON file_operations(step_id)")
 
+    cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
     conn.close()
 
@@ -465,9 +473,17 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
 
     This function is idempotent and adds any new tables/columns
     that were added after the initial schema creation.
+
+    Gated behind ``PRAGMA user_version`` (#733): once a database is stamped
+    with the current ``SCHEMA_VERSION``, this returns after a single read —
+    zero DDL, zero write commits — so per-request workspace loads are cheap.
     """
     conn = _open_db(db_path)
     cursor = conn.cursor()
+
+    if cursor.execute("PRAGMA user_version").fetchone()[0] >= SCHEMA_VERSION:
+        conn.close()
+        return
 
     # token_usage was added after the initial schema (issue #712); create it for
     # existing workspaces. CREATE TABLE IF NOT EXISTS keeps this idempotent.
@@ -783,6 +799,7 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             created_at TEXT NOT NULL
         )
     """)
+    cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
 
     conn.close()

--- a/tests/core/test_task_requirement_ids.py
+++ b/tests/core/test_task_requirement_ids.py
@@ -125,6 +125,9 @@ class TestTaskRequirementIdsField:
             FROM tasks_old
         """)
         conn.execute("DROP TABLE tasks_old")
+        # A genuine pre-migration DB predates the schema-version stamp (#733);
+        # reset it so re-opening actually enters the migration path.
+        conn.execute("PRAGMA user_version = 0")
         conn.commit()
         conn.close()
 

--- a/tests/core/test_workspace.py
+++ b/tests/core/test_workspace.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from codeframe.core.workspace import (
+    SCHEMA_VERSION,
     Workspace,
     create_or_load_workspace,
     get_workspace,
@@ -261,3 +262,58 @@ class TestConcurrentWriters:
         finally:
             verify.close()
         assert count == 2
+
+
+class TestSchemaVersionGate:
+    """Issue #733: migrations run once, gated behind PRAGMA user_version."""
+
+    def _user_version(self, ws: Workspace) -> int:
+        conn = sqlite3.connect(ws.db_path)
+        try:
+            return conn.execute("PRAGMA user_version").fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_fresh_workspace_is_stamped(self, initialized_workspace: Workspace):
+        assert self._user_version(initialized_workspace) == SCHEMA_VERSION
+
+    def test_steady_state_load_issues_zero_writes(self, initialized_workspace: Workspace, temp_repo: Path):
+        # Warm load: stamps the version if needed.
+        get_workspace(temp_repo)
+
+        # PRAGMA data_version increments when any other connection commits a
+        # write to the database — steady-state loads must not move it.
+        monitor = sqlite3.connect(initialized_workspace.db_path)
+        try:
+            before = monitor.execute("PRAGMA data_version").fetchone()[0]
+            get_workspace(temp_repo)
+            get_workspace(temp_repo)
+            after = monitor.execute("PRAGMA data_version").fetchone()[0]
+        finally:
+            monitor.close()
+        assert after == before
+
+    def test_legacy_db_is_migrated_and_stamped(self, initialized_workspace: Workspace, temp_repo: Path):
+        # Simulate a legacy DB: drop a migrated column's table state by
+        # resetting user_version and removing a late-added column's index.
+        conn = sqlite3.connect(initialized_workspace.db_path)
+        conn.execute("PRAGMA user_version = 0")
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_external_url")
+        conn.commit()
+        conn.close()
+
+        ws = get_workspace(temp_repo)
+        assert ws.id == initialized_workspace.id
+        assert self._user_version(ws) == SCHEMA_VERSION
+
+        conn = sqlite3.connect(ws.db_path)
+        try:
+            indexes = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert "idx_tasks_external_url" in indexes


### PR DESCRIPTION
## Summary
Fixes #733 — `get_workspace()` ran `_ensure_schema_upgrades()` (~30 DDL statements + multiple write commits, each an fsync in WAL) on **every** call, i.e. on every authenticated v2 request via `get_v2_workspace`.

- New `SCHEMA_VERSION = 1` module constant, stamped into `PRAGMA user_version` by `_init_database` and after a completed migration run.
- `_ensure_schema_upgrades()` now returns after a single `PRAGMA user_version` read when the DB is current — zero DDL, zero write commits.
- Legacy DBs (`user_version = 0`) run the unchanged, idempotent migration path exactly once, then get stamped.
- Bump rule documented at the constant: increment whenever `_init_database`/`_ensure_schema_upgrades` gain a migration.

## Acceptance criteria (from issue)
- ✅ Migrations gated behind a `PRAGMA user_version` check
- ✅ Steady-state requests issue zero DDL and zero write commits — proven in-test by observing `PRAGMA data_version` (unchanged across repeated `get_workspace()` calls) from an independent connection

## Tests
- `TestSchemaVersionGate`: fresh-workspace stamp, steady-state zero-writes (via `data_version`), legacy-DB migration + re-stamp.
- Fixed `test_task_without_requirement_ids_in_existing_db`: its legacy-schema simulation now also resets `user_version = 0`, as a genuine pre-migration DB would have.
- Full CI subset: 4038 passed / 1 failed → fixed → related suites green. `ruff` clean. Cross-family `codex review`: no findings.

## Known limitations
- Migrations are per-DB idempotent and safe under concurrent first-load (both processes run the same idempotent DDL, then stamp).
- Forgetting to bump `SCHEMA_VERSION` when adding a migration would skip it on existing DBs; the bump rule is documented at the constant and at both stamp sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace upgrades now run only when needed, reducing unnecessary database work on repeated loads.
  * Older workspaces are now reliably brought up to date, preserving expected task data and indexes.
  * Fresh workspaces are marked as up to date immediately after initialization.

* **Tests**
  * Added coverage for schema version tracking, steady-state loading, and legacy workspace upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->