### PR TITLE
fix(core): enforce SubprocessAdapter timeout while agent streams output (#736)

### DIFF
--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import subprocess
 import threading
@@ -11,6 +12,8 @@ from typing import Callable
 from codeframe.core.adapters.agent_adapter import AgentEvent, AgentResult
 from codeframe.core.adapters.git_utils import detect_modified_files
 from codeframe.core.blocker_detection import classify_error_for_blocker
+
+logger = logging.getLogger(__name__)
 
 
 class SubprocessAdapter:
@@ -153,6 +156,12 @@ class SubprocessAdapter:
             # Process exited on its own; drain any buffered output.
             stdout_thread.join(timeout=10)
             stderr_thread.join(timeout=10)
+            if stdout_thread.is_alive() or stderr_thread.is_alive():
+                logger.warning(
+                    "Output drain timed out for '%s' after exit; "
+                    "trailing output may be truncated.",
+                    self._binary,
+                )
 
         except FileNotFoundError:
             return AgentResult(

--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -120,26 +120,39 @@ class SubprocessAdapter:
             stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
             stderr_thread.start()
 
-            # Stream stdout line-by-line
-            if process.stdout:
-                for line in process.stdout:
-                    stripped = line.rstrip("\n")
-                    stdout_lines.append(stripped)
-                    if on_event:
-                        on_event(AgentEvent(type="output", data={"line": stripped}))
+            # Stream stdout line-by-line in a background thread so the timeout
+            # below bounds the *whole* run. Reading stdout inline would block
+            # forever on a hung child that keeps stdout open, never reaching
+            # process.wait(timeout=...). (#736)
+            def _stream_stdout() -> None:
+                if process.stdout:
+                    for line in process.stdout:
+                        stripped = line.rstrip("\n")
+                        stdout_lines.append(stripped)
+                        if on_event:
+                            on_event(AgentEvent(type="output", data={"line": stripped}))
 
-            # Wait for stderr thread and process to finish
-            stderr_thread.join(timeout=10)
+            stdout_thread = threading.Thread(target=_stream_stdout, daemon=True)
+            stdout_thread.start()
+
+            # Bound the entire read+exit window. On expiry the child is killed,
+            # which closes its stdout and unblocks the reader thread.
             try:
                 process.wait(timeout=self._timeout_s)
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait()
+                stdout_thread.join(timeout=5)
+                stderr_thread.join(timeout=5)
                 return AgentResult(
                     status="failed",
                     output="\n".join(stdout_lines),
                     error=f"Process timed out after {self._timeout_s}s",
                 )
+
+            # Process exited on its own; drain any buffered output.
+            stdout_thread.join(timeout=10)
+            stderr_thread.join(timeout=10)
 
         except FileNotFoundError:
             return AgentResult(

--- a/tests/core/adapters/test_subprocess_adapter.py
+++ b/tests/core/adapters/test_subprocess_adapter.py
@@ -1,6 +1,8 @@
 """Tests for SubprocessAdapter base class."""
 
 import subprocess
+import sys
+import time
 
 import pytest
 from pathlib import Path
@@ -196,6 +198,36 @@ class TestSubprocessAdapterRun:
         assert result.status == "failed"
         assert "timed out" in result.error
         mock_process.kill.assert_called_once()
+
+    def test_real_child_stalling_with_stdout_open_is_killed_at_timeout(self, tmp_path):
+        """A real child that keeps stdout open past the timeout must be killed (#736).
+
+        Regression: previously stdout was read inline, so a child that wrote a
+        line then blocked with stdout open hung the run forever — the
+        process.wait(timeout=...) was never reached.
+        """
+        # Print one line, then block far longer than the timeout with stdout open.
+        script = "import sys, time; print('working', flush=True); time.sleep(60)"
+
+        class _PyAdapter(SubprocessAdapter):
+            def build_command(self, prompt, workspace_path):
+                return [sys.executable, "-c", script]
+
+            def get_stdin(self, prompt):
+                return None
+
+        with patch("shutil.which", return_value=sys.executable):
+            adapter = _PyAdapter("python", timeout_s=1)
+
+        with patch.object(SubprocessAdapter, "_detect_modified_files", return_value=[]):
+            start = time.monotonic()
+            result = adapter.run("task-1", "go", tmp_path)
+            elapsed = time.monotonic() - start
+
+        assert result.status == "failed"
+        assert "timed out" in result.error
+        assert "working" in result.output  # streamed output before the stall
+        assert elapsed < 30  # bounded by the timeout, not the 60s sleep
 
 
 class TestSubprocessAdapterBuildCommand:


### PR DESCRIPTION
Closes #736

## Problem
`SubprocessAdapter.run()` read stdout inline (`for line in process.stdout:`) *before* `process.wait(timeout=...)`. The timeout only bounded the window after stdout EOF, so a hung external agent (claude/codex/opencode) that keeps stdout open blocked the run — and the batch worker — forever.

## Fix
Move stdout streaming into a background thread and bound the whole read+exit window with `process.wait(timeout=self._timeout_s)`. On expiry the child is killed, which closes its stdout and unblocks the reader thread. stderr was already drained in a thread; this applies the same pattern to stdout.

## Acceptance criteria
- ✅ A deadline wraps the read loop (reader thread + overall `process.wait` timer); on expiry the child is killed and a timeout failure returned.
- ✅ Test: `test_real_child_stalling_with_stdout_open_is_killed_at_timeout` spawns a real child that prints a line then `sleep(60)` with stdout open, with a 1s timeout — asserts `status=="failed"`, `"timed out"` error, streamed output preserved, and elapsed < 30s.

## Testing
`uv run pytest tests/core/adapters/` → 147 passed; `ruff check` clean.