### PR TITLE
fix(core): write SubprocessAdapter stdin from a thread to avoid deadlock (#737)

### DIFF
--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -108,11 +108,6 @@ class SubprocessAdapter:
                 text=True,
             )
 
-            # Write stdin and close
-            if stdin_content and process.stdin:
-                process.stdin.write(stdin_content)
-                process.stdin.close()
-
             # Drain stderr in a background thread to prevent deadlock.
             # Without this, if the child fills the stderr pipe buffer (~64KB)
             # before finishing stdout, both processes block indefinitely.
@@ -138,6 +133,26 @@ class SubprocessAdapter:
             stdout_thread = threading.Thread(target=_stream_stdout, daemon=True)
             stdout_thread.start()
 
+            # Feed stdin from its own thread AFTER the drain threads start, so a
+            # large prompt (> ~64KB pipe buffer) can't deadlock against a child
+            # that writes output before consuming all of stdin. Writing inline
+            # here would also block before process.wait(timeout=...) is reached,
+            # defeating the #736 timeout. (#737)
+            def _write_stdin() -> None:
+                if stdin_content and process.stdin:
+                    try:
+                        process.stdin.write(stdin_content)
+                    except (BrokenPipeError, OSError):
+                        pass  # child exited/closed stdin early
+                    finally:
+                        try:
+                            process.stdin.close()
+                        except (BrokenPipeError, OSError):
+                            pass
+
+            stdin_thread = threading.Thread(target=_write_stdin, daemon=True)
+            stdin_thread.start()
+
             # Bound the entire read+exit window. On expiry the child is killed,
             # which closes its stdout and unblocks the reader thread.
             try:
@@ -145,6 +160,7 @@ class SubprocessAdapter:
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait()
+                stdin_thread.join(timeout=5)
                 stdout_thread.join(timeout=5)
                 stderr_thread.join(timeout=5)
                 return AgentResult(
@@ -154,6 +170,7 @@ class SubprocessAdapter:
                 )
 
             # Process exited on its own; drain any buffered output.
+            stdin_thread.join(timeout=10)
             stdout_thread.join(timeout=10)
             stderr_thread.join(timeout=10)
             if stdout_thread.is_alive() or stderr_thread.is_alive():

--- a/tests/core/adapters/test_subprocess_adapter.py
+++ b/tests/core/adapters/test_subprocess_adapter.py
@@ -229,6 +229,44 @@ class TestSubprocessAdapterRun:
         assert "working" in result.output  # streamed output before the stall
         assert elapsed < 30  # bounded by the timeout, not the 60s sleep
 
+    def test_large_stdin_with_early_child_output_does_not_deadlock(self, tmp_path):
+        """A >64KB prompt must not deadlock against a child that writes before
+
+        reading stdin (#737).
+
+        Regression: stdin was written+closed inline BEFORE the drain threads
+        started. If the child emitted output larger than the pipe buffer before
+        consuming stdin, both sides blocked forever on full pipes — and the write
+        blocked before process.wait(timeout=...) was ever reached, so the #736
+        timeout could not fire either.
+        """
+        # Child fills its stdout pipe (>64KB) BEFORE reading any stdin, then
+        # echoes how many bytes of stdin it received.
+        script = (
+            "import sys\n"
+            "sys.stdout.write('x' * (128 * 1024) + '\\n'); sys.stdout.flush()\n"
+            "data = sys.stdin.read()\n"
+            "print('RECEIVED', len(data))\n"
+        )
+        big_prompt = "y" * (128 * 1024)
+
+        class _PyAdapter(SubprocessAdapter):
+            def build_command(self, prompt, workspace_path):
+                return [sys.executable, "-c", script]
+
+        with patch("shutil.which", return_value=sys.executable):
+            # Bound the run so a regression fails (times out) instead of hanging CI.
+            adapter = _PyAdapter("python", timeout_s=30)
+
+        with patch.object(SubprocessAdapter, "_detect_modified_files", return_value=[]):
+            start = time.monotonic()
+            result = adapter.run("task-1", big_prompt, tmp_path)
+            elapsed = time.monotonic() - start
+
+        assert result.status == "completed"
+        assert f"RECEIVED {len(big_prompt)}" in result.output
+        assert elapsed < 30  # completed promptly, not bounded by the timeout
+
 
 class TestSubprocessAdapterBuildCommand:
     """Tests for command building."""

--- a/tests/core/adapters/test_subprocess_adapter.py
+++ b/tests/core/adapters/test_subprocess_adapter.py
@@ -267,6 +267,29 @@ class TestSubprocessAdapterRun:
         assert f"RECEIVED {len(big_prompt)}" in result.output
         assert elapsed < 30  # completed promptly, not bounded by the timeout
 
+    def test_child_exiting_before_reading_stdin_is_handled(self, tmp_path):
+        """A child that exits before draining a large stdin must not crash run().
+
+        Writing a >64KB payload to a pipe whose read end the child already closed
+        raises BrokenPipeError in the stdin thread; run() must swallow it and
+        still return a result based on the exit code. (#737)
+        """
+        # Exit immediately without reading stdin, so the write end breaks.
+        script = "import sys; sys.exit(0)"
+        big_prompt = "z" * (128 * 1024)
+
+        class _PyAdapter(SubprocessAdapter):
+            def build_command(self, prompt, workspace_path):
+                return [sys.executable, "-c", script]
+
+        with patch("shutil.which", return_value=sys.executable):
+            adapter = _PyAdapter("python", timeout_s=30)
+
+        with patch.object(SubprocessAdapter, "_detect_modified_files", return_value=[]):
+            result = adapter.run("task-1", big_prompt, tmp_path)
+
+        assert result.status == "completed"  # exit 0, BrokenPipeError swallowed
+
 
 class TestSubprocessAdapterBuildCommand:
     """Tests for command building."""


### PR DESCRIPTION
## Summary
Fixes #737 (P1.10). `SubprocessAdapter.run()` wrote the full stdin payload inline (`stdin.write(...); stdin.close()`) **before** starting the stdout/stderr drain threads. A prompt larger than the ~64KB pipe buffer (packaged PRD + file contents) deadlocked against a child that emits a banner/progress before consuming stdin. Worse, the write blocked **before** `process.wait(timeout=...)`, so the #736 timeout could never fire — the run hung indefinitely.

## Fix
Feed stdin from its own daemon thread started **after** the drain threads, so the parent drains stdout/stderr concurrently while feeding stdin. The thread is joined in both exit paths (timeout kill + normal exit). `BrokenPipeError`/`OSError` from an early child exit is swallowed.

This matches the acceptance criterion ("written ... from a separate thread after drain threads start") and fits the existing #736 threading design better than switching to `communicate()`, which would require rewriting the streaming + timeout structure.

## Acceptance criteria
- [x] stdin is written from a separate thread after the drain threads start.

## Testing / evidence
New regression test `test_large_stdin_with_early_child_output_does_not_deadlock`: a real child emits **128KB** of stdout *before* reading a **128KB** stdin payload.
- **Old code:** deadlocks indefinitely (verified — exceeded a 2-minute bound; the inline write blocks before the timeout can fire).
- **New code:** completes in ~0.03s with `RECEIVED 131072`.

All 251 `tests/core/adapters` + `tests/adapters` tests pass; `ruff` clean.

## Known limitations
None. Behavior for small prompts is unchanged (existing `test_sends_prompt_via_stdin` still asserts write+close, now async).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess input handling to avoid deadlocks when a child process writes output before reading input.
  * Added more robust cleanup for interrupted or failed input writes, reducing the chance of hangs during long-running commands.
  * Updated timeout handling to wait for background input processing to finish after a process is stopped.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->