### PR TITLE
fix(core): append assistant tool_use message in interactive chat loop (#738)

### DIFF
--- a/codeframe/core/adapters/streaming_chat.py
+++ b/codeframe/core/adapters/streaming_chat.py
@@ -365,6 +365,7 @@ class StreamingChatAdapter:
 
         while True:
             pending_tool_calls: list[dict] = []  # {id, name, input}
+            assistant_text = ""  # text emitted by the model this API turn
             stop_reason = "end_turn"
 
             async for chunk in self._provider.async_stream(
@@ -380,6 +381,7 @@ class StreamingChatAdapter:
                     return
 
                 if chunk.type == "text_delta":
+                    assistant_text += chunk.text or ""
                     yield ChatEvent(type=ChatEventType.TEXT_DELTA, content=chunk.text)
 
                 elif chunk.type == "thinking_delta":
@@ -451,9 +453,26 @@ class StreamingChatAdapter:
                     }
                 )
 
-            # Append the tool results as a user message for the next turn
+            # Replay the assistant turn (text + tool_use blocks) followed by the
+            # tool results. The Anthropic API rejects (400) a tool_result user
+            # message that isn't immediately preceded by the assistant message
+            # carrying the matching tool_use blocks.
+            assistant_content: list[dict] = []
+            if assistant_text:
+                assistant_content.append({"type": "text", "text": assistant_text})
+            for tc in pending_tool_calls:
+                assistant_content.append(
+                    {
+                        "type": "tool_use",
+                        "id": tc["id"],
+                        "name": tc["name"],
+                        "input": tc.get("input") or {},
+                    }
+                )
+
             current_messages = current_messages + [
-                {"role": "user", "content": tool_result_blocks}
+                {"role": "assistant", "content": assistant_content},
+                {"role": "user", "content": tool_result_blocks},
             ]
 
 

--- a/tests/core/test_streaming_chat.py
+++ b/tests/core/test_streaming_chat.py
@@ -318,6 +318,69 @@ class TestToolCallEvents:
         result = next(e for e in collected if e.type == ChatEventType.TOOL_RESULT)
         assert result.content == "file contents here"
 
+    async def test_second_turn_pairs_tool_use_with_tool_result(self, tmp_path):
+        """Contract: the assistant tool_use message must precede the tool_result
+        user message, or the Anthropic API rejects the second turn with a 400.
+
+        Asserts on the message list actually sent to the provider (via
+        MockProvider.calls) rather than only the emitted events.
+        """
+        tool_id = "tool_abc"
+        tool_input = {"path": "README.md"}
+
+        provider = MockProvider()
+        provider.add_stream_chunks([
+            StreamChunk(type="text_delta", text="Let me read that."),
+            StreamChunk(
+                type="tool_use_start",
+                tool_id=tool_id,
+                tool_name="read_file",
+                tool_input=tool_input,
+            ),
+            StreamChunk(type="tool_use_stop"),
+            _stop_chunk(
+                stop_reason="tool_use",
+                tool_inputs_by_id={tool_id: tool_input},
+            ),
+        ])
+        provider.add_stream_chunks([
+            StreamChunk(type="text_delta", text="Here is the file content."),
+            _stop_chunk(),
+        ])
+
+        adapter = _make_adapter(workspace_path=tmp_path, provider=provider)
+
+        with patch.object(adapter, "_execute_tool", new_callable=AsyncMock) as mock_tool:
+            mock_tool.return_value = "file contents here"
+            _ = [e async for e in adapter.send_message("read README", [])]
+
+        # Two API turns: initial + after tool results
+        assert len(provider.calls) == 2
+        second_turn = provider.calls[1]["messages"]
+
+        # Find the assistant tool_use message and the following tool_result message
+        assistant_idx = next(
+            i for i, m in enumerate(second_turn)
+            if m["role"] == "assistant"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_use" for b in m["content"])
+        )
+        tool_use_block = next(
+            b for b in second_turn[assistant_idx]["content"]
+            if b["type"] == "tool_use"
+        )
+        assert tool_use_block["id"] == tool_id
+        assert tool_use_block["name"] == "read_file"
+        assert tool_use_block["input"] == tool_input
+
+        # The very next message pairs the matching tool_result
+        result_msg = second_turn[assistant_idx + 1]
+        assert result_msg["role"] == "user"
+        result_block = next(
+            b for b in result_msg["content"] if b["type"] == "tool_result"
+        )
+        assert result_block["tool_use_id"] == tool_id
+
 
 # ---------------------------------------------------------------------------
 # Interrupt support

--- a/tests/core/test_streaming_chat.py
+++ b/tests/core/test_streaming_chat.py
@@ -365,10 +365,11 @@ class TestToolCallEvents:
             and isinstance(m["content"], list)
             and any(b.get("type") == "tool_use" for b in m["content"])
         )
-        tool_use_block = next(
-            b for b in second_turn[assistant_idx]["content"]
-            if b["type"] == "tool_use"
-        )
+        blocks = second_turn[assistant_idx]["content"]
+        # Any preceding text block must come before the tool_use block
+        types = [b["type"] for b in blocks]
+        assert types == ["text", "tool_use"]
+        tool_use_block = next(b for b in blocks if b["type"] == "tool_use")
         assert tool_use_block["id"] == tool_id
         assert tool_use_block["name"] == "read_file"
         assert tool_use_block["input"] == tool_input
@@ -380,6 +381,43 @@ class TestToolCallEvents:
             b for b in result_msg["content"] if b["type"] == "tool_result"
         )
         assert result_block["tool_use_id"] == tool_id
+
+    async def test_tool_use_with_no_preceding_text(self, tmp_path):
+        """The model may emit tool_use with no leading text. The assistant
+        message must then carry only the tool_use block (a valid pairing)."""
+        tool_id = "tool_xyz"
+        tool_input = {"path": "main.py"}
+
+        provider = MockProvider()
+        provider.add_stream_chunks([
+            StreamChunk(
+                type="tool_use_start",
+                tool_id=tool_id,
+                tool_name="read_file",
+                tool_input=tool_input,
+            ),
+            StreamChunk(type="tool_use_stop"),
+            _stop_chunk(stop_reason="tool_use", tool_inputs_by_id={tool_id: tool_input}),
+        ])
+        provider.add_stream_chunks([
+            StreamChunk(type="text_delta", text="Done."),
+            _stop_chunk(),
+        ])
+
+        adapter = _make_adapter(workspace_path=tmp_path, provider=provider)
+
+        with patch.object(adapter, "_execute_tool", new_callable=AsyncMock) as mock_tool:
+            mock_tool.return_value = "contents"
+            _ = [e async for e in adapter.send_message("read main", [])]
+
+        second_turn = provider.calls[1]["messages"]
+        assistant_msg = next(
+            m for m in second_turn
+            if m["role"] == "assistant" and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_use" for b in m["content"])
+        )
+        # Only the tool_use block, no empty text block
+        assert [b["type"] for b in assistant_msg["content"]] == ["tool_use"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #738

## Problem
`_stream_turn` appended only the `tool_result` user message, never the assistant message with the matching `tool_use` blocks. The Anthropic API requires the pairing, so the first time an interactive session used read_file/list_files/search_codebase the next turn returned a 400 and the turn died with an ERROR event. Only MockProvider (which doesn't validate message structure) was tested.

## Fix
`codeframe/core/adapters/streaming_chat.py` — before appending the tool results, replay the assistant turn: a `{"role": "assistant", "content": [text?, tool_use...]}` message carrying the `tool_use` blocks (and any preceding text), immediately followed by the `tool_result` user message.

## Acceptance criteria
- [x] The assistant `tool_use` message is appended before tool results so both providers produce a valid pairing.
- [x] A contract test validates the message sequence (not just MockProvider) — `test_second_turn_pairs_tool_use_with_tool_result` asserts on the actual `messages` list sent to the provider on the second turn; it fails against the pre-fix code (no assistant tool_use message) and passes after.

## Testing
`uv run pytest tests/core/test_streaming_chat.py` — 21 passed. `ruff` clean.