### PR TITLE
fix(adapters): grant claude-code write permissions + fail on zero-file completion (#739)

### DIFF
--- a/codeframe/core/adapters/claude_code.py
+++ b/codeframe/core/adapters/claude_code.py
@@ -17,21 +17,37 @@ class ClaudeCodeAdapter(SubprocessAdapter):
     https://docs.anthropic.com/en/docs/claude-code
     """
 
-    def __init__(self, allowlist: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        allowlist: list[str] | None = None,
+        require_file_changes: bool = True,
+    ) -> None:
         """Initialize the Claude Code adapter.
 
         Args:
             allowlist: Optional list of allowed tools/permissions.
                        If provided, uses ``--allowedTools`` flag for each tool.
-                       When omitted, no permission flags are added (the caller
-                       is responsible for configuring permissions externally).
+                       When omitted, the adapter runs with
+                       ``--permission-mode bypassPermissions`` so Edit/Write/Bash
+                       are auto-approved in non-interactive ``--print`` mode.
+                       Without this, ``--print`` silently denies those tools and
+                       the delegated agent can analyze but never modify files. (#739)
+            require_file_changes: If True (default), a run that exits 0 but touches
+                       no files is downgraded to ``failed`` — a coding task that
+                       writes nothing is a false completion.
         """
         cli_args = ["--print"]
         if allowlist:
             for tool in allowlist:
                 cli_args.extend(["--allowedTools", tool])
+        else:
+            cli_args.extend(["--permission-mode", "bypassPermissions"])
 
-        super().__init__(binary="claude", cli_args=cli_args)
+        super().__init__(
+            binary="claude",
+            cli_args=cli_args,
+            require_file_changes=require_file_changes,
+        )
         self._allowlist = allowlist
 
     @property

--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -41,11 +41,13 @@ class SubprocessAdapter:
             binary: Name of the CLI binary (e.g., 'claude', 'opencode')
             cli_args: Default CLI arguments appended to every invocation
             timeout_s: Max execution time in seconds (default: 1800, None = no limit)
-            require_file_changes: If True, a run that exits 0 but modifies no files
-                is downgraded to ``failed`` instead of ``completed``. Guards against
-                a delegated coding agent that "succeeds" without writing any code
-                (e.g. edits silently denied), which downstream gates would otherwise
-                pass on the unchanged tree. Default False (analysis-capable agents).
+            require_file_changes: If True, a run that exits 0 without producing any
+                work — no modified/untracked files and no new commit — is downgraded
+                to ``failed`` instead of ``completed``. Guards against a delegated
+                coding agent that "succeeds" without writing any code (e.g. edits
+                silently denied), which downstream gates would otherwise pass on the
+                unchanged tree. Only fires inside a resolvable git repo (a non-git
+                workspace can't be judged). Default False (analysis-capable agents).
 
         Raises:
             EnvironmentError: If the binary is not found on PATH
@@ -101,6 +103,12 @@ class SubprocessAdapter:
         """Execute the agent subprocess and return the result."""
         cmd = self.build_command(prompt, workspace_path)
         stdin_content = self.get_stdin(prompt)
+
+        # Baseline HEAD so a run that *commits* its work (bypassPermissions allows
+        # Bash) still counts as work despite an empty `git diff HEAD`. (#739)
+        head_before = (
+            self._git_head(workspace_path) if self._require_file_changes else None
+        )
 
         stdout_lines: list[str] = []
         stderr_chunks: list[str] = []
@@ -213,17 +221,24 @@ class SubprocessAdapter:
         # A coding task that "succeeds" without touching any file is a false
         # completion: edits were likely denied or the agent only analyzed. Fail
         # hard so downstream gates don't pass on the unchanged tree. (#739)
+        # Only fire when we can *positively* confirm no work: a resolvable git
+        # repo whose HEAD didn't advance (self-committed work) and whose tree has
+        # no changes. A non-git workspace can't be judged, so we don't fail it.
         if (
             self._require_file_changes
             and result.status == "completed"
             and not modified_files
         ):
-            result.status = "failed"
-            result.error = (
-                f"'{self._binary}' exited successfully but modified no files. "
-                "A coding task must change at least one file; the agent likely "
-                "lacked write permission or produced no edits."
-            )
+            head_after = self._git_head(workspace_path)
+            committed = head_after is not None and head_after != head_before
+            in_git_repo = head_after is not None
+            if in_git_repo and not committed:
+                result.status = "failed"
+                result.error = (
+                    f"'{self._binary}' exited successfully but modified no files. "
+                    "A coding task must change at least one file; the agent likely "
+                    "lacked write permission or produced no edits."
+                )
 
         return result
 
@@ -266,6 +281,26 @@ class SubprocessAdapter:
     def _detect_modified_files(self, workspace_path: Path) -> list[str]:
         """Detect files modified by the subprocess via git diff."""
         return detect_modified_files(workspace_path)
+
+    def _git_head(self, workspace_path: Path) -> str | None:
+        """Return the current HEAD commit sha, or None if HEAD is unresolvable.
+
+        None means "not a git repo, git unavailable, or an unborn HEAD" — i.e.
+        a state where modified-file detection can't judge whether work happened.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(workspace_path),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return None
+            return result.stdout.strip() or None
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            return None
 
     def _extract_blocker_question(self, output: str) -> str:
         """Extract a meaningful blocker question from output."""

--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -33,6 +33,7 @@ class SubprocessAdapter:
         binary: str,
         cli_args: list[str] | None = None,
         timeout_s: int | None = None,
+        require_file_changes: bool = False,
     ) -> None:
         """Initialize with the binary name and default CLI args.
 
@@ -40,6 +41,11 @@ class SubprocessAdapter:
             binary: Name of the CLI binary (e.g., 'claude', 'opencode')
             cli_args: Default CLI arguments appended to every invocation
             timeout_s: Max execution time in seconds (default: 1800, None = no limit)
+            require_file_changes: If True, a run that exits 0 but modifies no files
+                is downgraded to ``failed`` instead of ``completed``. Guards against
+                a delegated coding agent that "succeeds" without writing any code
+                (e.g. edits silently denied), which downstream gates would otherwise
+                pass on the unchanged tree. Default False (analysis-capable agents).
 
         Raises:
             EnvironmentError: If the binary is not found on PATH
@@ -47,6 +53,7 @@ class SubprocessAdapter:
         self._binary = binary
         self._cli_args = cli_args or []
         self._timeout_s = timeout_s if timeout_s is not None else self.DEFAULT_TIMEOUT_S
+        self._require_file_changes = require_file_changes
 
         resolved = shutil.which(binary)
         if resolved is None:
@@ -202,6 +209,22 @@ class SubprocessAdapter:
             workspace_path=workspace_path,
         )
         result.modified_files = modified_files
+
+        # A coding task that "succeeds" without touching any file is a false
+        # completion: edits were likely denied or the agent only analyzed. Fail
+        # hard so downstream gates don't pass on the unchanged tree. (#739)
+        if (
+            self._require_file_changes
+            and result.status == "completed"
+            and not modified_files
+        ):
+            result.status = "failed"
+            result.error = (
+                f"'{self._binary}' exited successfully but modified no files. "
+                "A coding task must change at least one file; the agent likely "
+                "lacked write permission or produced no edits."
+            )
+
         return result
 
     def _map_result(

--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -230,8 +230,17 @@ class SubprocessAdapter:
             and not modified_files
         ):
             head_after = self._git_head(workspace_path)
-            committed = head_after is not None and head_after != head_before
             in_git_repo = head_after is not None
+            # Require a known baseline to credit a commit: if the pre-run HEAD
+            # read failed (head_before is None) we must not let `None != sha`
+            # masquerade as "committed" and silently pass a real zero-file run.
+            # Bias toward failing loudly. (ponytail: a rare `git init` mid-run
+            # false-fails here — acceptable; a false COMPLETED is worse.)
+            committed = (
+                head_before is not None
+                and head_after is not None
+                and head_after != head_before
+            )
             if in_git_repo and not committed:
                 result.status = "failed"
                 result.error = (

--- a/tests/core/adapters/test_claude_code.py
+++ b/tests/core/adapters/test_claude_code.py
@@ -40,17 +40,23 @@ class TestClaudeCodeAdapter:
             assert cmd[0] == "/usr/bin/claude"
             assert "--print" in cmd
 
-    def test_build_command_without_allowlist(self) -> None:
+    def test_build_command_without_allowlist_grants_permissions(self) -> None:
+        """Default (no allowlist) must pass a permission config so --print mode
+        does not silently deny Edit/Write/Bash. (#739)"""
         with patch("shutil.which", return_value="/usr/bin/claude"):
             adapter = ClaudeCodeAdapter()
             cmd = adapter.build_command("prompt", Path("/tmp"))
             assert "--allowedTools" not in cmd
+            idx = cmd.index("--permission-mode")
+            assert cmd[idx + 1] == "bypassPermissions"
 
     def test_build_command_with_allowlist(self) -> None:
         with patch("shutil.which", return_value="/usr/bin/claude"):
             adapter = ClaudeCodeAdapter(allowlist=["Edit", "Write"])
             cmd = adapter.build_command("prompt", Path("/tmp"))
             assert "--allowedTools" in cmd
+            # Explicit allowlist path keeps its own permissions — no bypass mode.
+            assert "--permission-mode" not in cmd
             # Verify both tools are present after their respective flags
             idx_edit = cmd.index("Edit")
             idx_write = cmd.index("Write")
@@ -76,11 +82,58 @@ class TestClaudeCodeAdapter:
         mock_process.returncode = 0
         mock_process.wait.return_value = None
 
-        with patch("subprocess.Popen", return_value=mock_process):
+        with (
+            patch("subprocess.Popen", return_value=mock_process),
+            patch.object(
+                ClaudeCodeAdapter,
+                "_detect_modified_files",
+                return_value=["src/main.py"],
+            ),
+        ):
             result = adapter.run("task-1", "fix the bug", Path("/tmp/repo"))
 
         assert result.status == "completed"
         assert "All tests pass" in result.output
+        assert result.modified_files == ["src/main.py"]
+
+    def test_zero_modified_files_is_failed(self) -> None:
+        """A coding run that exits 0 but changes no files must fail, not
+        report a false completion. (#739)"""
+        with patch("shutil.which", return_value="/usr/bin/claude"):
+            adapter = ClaudeCodeAdapter()
+
+        mock_process = MagicMock()
+        mock_process.stdout = iter(["I analyzed the code but made no changes\n"])
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = ""
+        mock_process.stdin = MagicMock()
+        mock_process.returncode = 0
+        mock_process.wait.return_value = None
+
+        # _no_git fixture already patches _detect_modified_files -> []
+        with patch("subprocess.Popen", return_value=mock_process):
+            result = adapter.run("task-1", "fix the bug", Path("/tmp/repo"))
+
+        assert result.status == "failed"
+        assert "modified no files" in result.error
+
+    def test_require_file_changes_can_be_disabled(self) -> None:
+        """Opting out restores plain exit-code mapping for analysis-only runs."""
+        with patch("shutil.which", return_value="/usr/bin/claude"):
+            adapter = ClaudeCodeAdapter(require_file_changes=False)
+
+        mock_process = MagicMock()
+        mock_process.stdout = iter(["analysis complete\n"])
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = ""
+        mock_process.stdin = MagicMock()
+        mock_process.returncode = 0
+        mock_process.wait.return_value = None
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            result = adapter.run("task-1", "analyze", Path("/tmp/repo"))
+
+        assert result.status == "completed"
 
     def test_failed_execution(self) -> None:
         with patch("shutil.which", return_value="/usr/bin/claude"):

--- a/tests/core/adapters/test_claude_code.py
+++ b/tests/core/adapters/test_claude_code.py
@@ -14,8 +14,15 @@ class TestClaudeCodeAdapter:
 
     @pytest.fixture(autouse=True)
     def _no_git(self):
-        """Prevent _detect_modified_files from calling real git."""
-        with patch.object(ClaudeCodeAdapter, "_detect_modified_files", return_value=[]):
+        """Prevent git introspection from calling real git / the patched Popen.
+
+        _git_head -> None simulates a non-git workspace (guard won't fire);
+        tests that need the guard override it with an explicit sha.
+        """
+        with (
+            patch.object(ClaudeCodeAdapter, "_detect_modified_files", return_value=[]),
+            patch.object(ClaudeCodeAdapter, "_git_head", return_value=None),
+        ):
             yield
 
     def test_name(self) -> None:
@@ -110,8 +117,13 @@ class TestClaudeCodeAdapter:
         mock_process.returncode = 0
         mock_process.wait.return_value = None
 
-        # _no_git fixture already patches _detect_modified_files -> []
-        with patch("subprocess.Popen", return_value=mock_process):
+        # _no_git fixture already patches _detect_modified_files -> [].
+        # Stub HEAD to a stable sha so the guard sees a git repo with no new
+        # commit (before == after) and no working-tree changes.
+        with (
+            patch("subprocess.Popen", return_value=mock_process),
+            patch.object(ClaudeCodeAdapter, "_git_head", return_value="sha1"),
+        ):
             result = adapter.run("task-1", "fix the bug", Path("/tmp/repo"))
 
         assert result.status == "failed"

--- a/tests/core/adapters/test_subprocess_adapter.py
+++ b/tests/core/adapters/test_subprocess_adapter.py
@@ -416,6 +416,46 @@ class TestSubprocessAdapterModifiedFiles:
         assert result.status == "completed"
         assert result.modified_files == []
 
+    def test_require_file_changes_fails_on_empty_diff(self, tmp_path):
+        """With require_file_changes=True, exit 0 + no changed files -> failed. (#739)"""
+        with patch("shutil.which", return_value="/usr/bin/test-agent"):
+            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+        mock_process = self._make_mock_process(stdout_lines=["done\n"], returncode=0)
+        with (
+            patch("subprocess.Popen", return_value=mock_process),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    MagicMock(returncode=0, stdout=""),
+                    MagicMock(returncode=0, stdout=""),
+                ],
+            ),
+        ):
+            result = adapter.run("task-1", "fix", tmp_path)
+
+        assert result.status == "failed"
+        assert "modified no files" in result.error
+
+    def test_require_file_changes_passes_when_files_changed(self, tmp_path):
+        """require_file_changes must not disturb a run that did change files."""
+        with patch("shutil.which", return_value="/usr/bin/test-agent"):
+            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+        mock_process = self._make_mock_process(stdout_lines=["done\n"], returncode=0)
+        with (
+            patch("subprocess.Popen", return_value=mock_process),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    MagicMock(returncode=0, stdout="src/main.py\n"),
+                    MagicMock(returncode=0, stdout=""),
+                ],
+            ),
+        ):
+            result = adapter.run("task-1", "fix", tmp_path)
+
+        assert result.status == "completed"
+        assert result.modified_files == ["src/main.py"]
+
     def test_graceful_when_git_fails(self, adapter, tmp_path):
         """Should return empty modified_files if git diff fails."""
         mock_process = self._make_mock_process(

--- a/tests/core/adapters/test_subprocess_adapter.py
+++ b/tests/core/adapters/test_subprocess_adapter.py
@@ -468,6 +468,17 @@ class TestSubprocessAdapterModifiedFiles:
         )
         assert result.status == "completed"
 
+    def test_require_file_changes_fails_when_pre_run_head_unavailable(self, tmp_path):
+        """A transient pre-run HEAD read failure must not let `None != sha` fake
+        a commit and pass a real zero-file run. Fail safe. (#739 re-review)"""
+        with patch("shutil.which", return_value="/usr/bin/test-agent"):
+            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+        # head_before=None (pre-run read failed), head_after="sha1" (post succeeds).
+        result = self._run_with(
+            adapter, tmp_path, modified=[], head_before=None, head_after="sha1"
+        )
+        assert result.status == "failed"
+
     def test_require_file_changes_skips_non_git_workspace(self, tmp_path):
         """Outside a git repo, HEAD is unresolvable and we cannot judge work —
         do not fail the run. (#739 review)"""

--- a/tests/core/adapters/test_subprocess_adapter.py
+++ b/tests/core/adapters/test_subprocess_adapter.py
@@ -416,45 +416,67 @@ class TestSubprocessAdapterModifiedFiles:
         assert result.status == "completed"
         assert result.modified_files == []
 
-    def test_require_file_changes_fails_on_empty_diff(self, tmp_path):
-        """With require_file_changes=True, exit 0 + no changed files -> failed. (#739)"""
-        with patch("shutil.which", return_value="/usr/bin/test-agent"):
-            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+    def _run_with(self, adapter, tmp_path, *, modified, head_before, head_after):
+        """Run with _detect_modified_files and _git_head stubbed.
+
+        head_before/head_after become the two _git_head() return values (pre-run
+        baseline, then the guard's post-run check).
+        """
         mock_process = self._make_mock_process(stdout_lines=["done\n"], returncode=0)
         with (
             patch("subprocess.Popen", return_value=mock_process),
-            patch(
-                "subprocess.run",
-                side_effect=[
-                    MagicMock(returncode=0, stdout=""),
-                    MagicMock(returncode=0, stdout=""),
-                ],
+            patch.object(
+                type(adapter), "_detect_modified_files", return_value=modified
+            ),
+            patch.object(
+                type(adapter), "_git_head", side_effect=[head_before, head_after]
             ),
         ):
-            result = adapter.run("task-1", "fix", tmp_path)
+            return adapter.run("task-1", "fix", tmp_path)
 
+    def test_require_file_changes_fails_on_empty_diff(self, tmp_path):
+        """require_file_changes=True: exit 0, no changed files, HEAD unmoved -> failed. (#739)"""
+        with patch("shutil.which", return_value="/usr/bin/test-agent"):
+            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+        result = self._run_with(
+            adapter, tmp_path, modified=[], head_before="sha1", head_after="sha1"
+        )
         assert result.status == "failed"
         assert "modified no files" in result.error
 
     def test_require_file_changes_passes_when_files_changed(self, tmp_path):
-        """require_file_changes must not disturb a run that did change files."""
+        """A run that changed working-tree files stays completed."""
         with patch("shutil.which", return_value="/usr/bin/test-agent"):
             adapter = SubprocessAdapter("test-agent", require_file_changes=True)
-        mock_process = self._make_mock_process(stdout_lines=["done\n"], returncode=0)
-        with (
-            patch("subprocess.Popen", return_value=mock_process),
-            patch(
-                "subprocess.run",
-                side_effect=[
-                    MagicMock(returncode=0, stdout="src/main.py\n"),
-                    MagicMock(returncode=0, stdout=""),
-                ],
-            ),
-        ):
-            result = adapter.run("task-1", "fix", tmp_path)
-
+        result = self._run_with(
+            adapter,
+            tmp_path,
+            modified=["src/main.py"],
+            head_before="sha1",
+            head_after="sha1",
+        )
         assert result.status == "completed"
         assert result.modified_files == ["src/main.py"]
+
+    def test_require_file_changes_accepts_self_committed_work(self, tmp_path):
+        """An agent that commits its own work (HEAD advances) is not a false
+        completion even though `git diff HEAD` is empty. (#739 review)"""
+        with patch("shutil.which", return_value="/usr/bin/test-agent"):
+            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+        result = self._run_with(
+            adapter, tmp_path, modified=[], head_before="sha1", head_after="sha2"
+        )
+        assert result.status == "completed"
+
+    def test_require_file_changes_skips_non_git_workspace(self, tmp_path):
+        """Outside a git repo, HEAD is unresolvable and we cannot judge work —
+        do not fail the run. (#739 review)"""
+        with patch("shutil.which", return_value="/usr/bin/test-agent"):
+            adapter = SubprocessAdapter("test-agent", require_file_changes=True)
+        result = self._run_with(
+            adapter, tmp_path, modified=[], head_before=None, head_after=None
+        )
+        assert result.status == "completed"
 
     def test_graceful_when_git_fails(self, adapter, tmp_path):
         """Should return empty modified_files if git diff fails."""


### PR DESCRIPTION
Closes #739

## Problem
`ClaudeCodeAdapter` built `["--print"]` with **no permission config**. In non-interactive
`--print` mode Claude Code auto-denies Edit/Write/Bash, so the delegated agent could analyze
but never modify files. Combined with P0.5's gates-on-unchanged-tree, tasks were marked
**COMPLETED with zero code written** — the exact failure the audit flagged.

## Fix
**1. Permission config** (`claude_code.py`)
Default path (no allowlist — the only production caller) now appends
`--permission-mode bypassPermissions`, so Edit/Write/Bash are auto-approved in `--print` mode.
Chose `bypassPermissions` over the `acceptEdits` example in the issue because `acceptEdits`
alone still leaves **Bash** denied. The explicit-`allowlist` API path is unchanged.

**2. Zero-modified-files hard error** (`subprocess_adapter.py`)
Base `SubprocessAdapter` gains an opt-in `require_file_changes` flag (default **False**, so
codex/opencode and all plumbing tests are unaffected). `ClaudeCodeAdapter` defaults it **True**:
a run that exits 0 but modifies no files is downgraded `completed → failed` with a clear error,
so downstream gates can no longer pass on an unchanged tree.

## Acceptance criteria
- [x] Engine passes an explicit permission config covering Edit/Write/Bash
- [x] Hard error surfaces when the agent reports zero modified files on a coding task

## Verification
- Built command inspected: `claude --print --permission-mode bypassPermissions` — accepted by the real CLI (`claude --help` confirms the flag/mode).
- `require_file_changes=True` guard exercised in unit tests (zero-file → `failed`, files-changed → `completed`); opt-out restores plain exit-code mapping.
- Tests: full `tests/core` suite **2380 passed**; adapters+registry 151 green; `ruff check` clean.

## Known limitations
- `bypassPermissions` grants full Bash to the delegated agent — appropriate for an autonomous
  coder running in the workspace, matching the built-in ReAct engine's tool access.
- `require_file_changes` is enabled only for `claude-code`; codex/opencode keep exit-code
  mapping until a false-completion is observed there (default-off flag, opt-in later).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safer default permission mode for runs without an allowlist, enabling non-interactive approvals for common actions.
  * Added an option to require actual file changes before a run is considered successful.

* **Bug Fixes**
  * Runs that report success but make no changes now fail instead of appearing completed.
  * Analysis-only runs can still be allowed to complete when file changes are not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->