### PR TITLE
fix(react): stuck-loop detection returns FAILED, not COMPLETED (#740)

### DIFF
--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -170,6 +170,10 @@ class ReactAgent:
         # Debug logging setup
         self._debug_log_path: Optional[Path] = None
         self._failure_count = 0
+        # Set when the ReAct loop terminates early for a specific reason
+        # (e.g. a stuck loop) so FAILED can be reported distinctly from a
+        # plain max-iterations exhaustion. Reset per run().
+        self._early_termination_reason: Optional[str] = None
         if debug:
             self._setup_debug_log()
 
@@ -191,6 +195,7 @@ class ReactAgent:
             AgentStatus.FAILED — max iterations or verification exhausted.
         """
         self._current_task_id = task_id
+        self._early_termination_reason = None
         self._verbose_print(f"[ReactAgent] Starting task {task_id}")
         self._emit(EventType.AGENT_STARTED, {"task_id": task_id})
 
@@ -225,7 +230,12 @@ class ReactAgent:
             try:
                 status = self._react_loop(system_prompt)
                 if status == AgentStatus.FAILED:
-                    reason = _REASON_STALL_DETECTED if self._stall_triggered.is_set() else "max_iterations_reached"
+                    if self._early_termination_reason:
+                        reason = self._early_termination_reason
+                    elif self._stall_triggered.is_set():
+                        reason = _REASON_STALL_DETECTED
+                    else:
+                        reason = "max_iterations_reached"
                     self._emit(EventType.AGENT_FAILED, {
                         "task_id": task_id,
                         "reason": reason,
@@ -652,7 +662,12 @@ class ReactAgent:
                         "reason": "loop_detected",
                         "pattern": list(sig),
                     })
-                    return AgentStatus.COMPLETED
+                    # A stuck loop is a failure, not completion: returning
+                    # COMPLETED here would run final verification against the
+                    # already-green repo and mark a task DONE that implemented
+                    # nothing (#740).
+                    self._early_termination_reason = "loop_detected"
+                    return AgentStatus.FAILED
 
             # Add tool results as user message
             messages.append({"role": "user", "content": "", "tool_results": tool_results})

--- a/tests/core/test_react_agent.py
+++ b/tests/core/test_react_agent.py
@@ -2129,10 +2129,14 @@ class TestLoopDetection:
 
     @patch("codeframe.core.react_agent.gates")
     @patch("codeframe.core.react_agent.TaskContextPackager")
-    def test_loop_detected_returns_completed(
+    def test_loop_detected_returns_failed(
         self, mock_loader, mock_gates, workspace, provider, mock_context
     ):
-        """3 identical tool call patterns -> COMPLETED (not FAILED)."""
+        """3 identical tool call patterns -> FAILED, not COMPLETED (#740).
+
+        A stuck loop implemented nothing, so it must not run final
+        verification against the already-green repo and mark the task DONE.
+        """
         from codeframe.core.react_agent import ReactAgent
 
         mock_loader.return_value.load_context.return_value = mock_context
@@ -2153,9 +2157,13 @@ class TestLoopDetection:
         ):
             status = agent.run("task-1")
 
-        assert status == AgentStatus.COMPLETED
+        assert status == AgentStatus.FAILED
+        # The run result distinguishes a loop from plain exhaustion.
+        assert agent._early_termination_reason == "loop_detected"
         # Should have been detected in 3 iterations, not 10
         assert provider.call_count <= 4
+        # Final verification must NOT run for a stuck loop.
+        mock_gates.run.assert_not_called()
 
     @patch("codeframe.core.react_agent.gates")
     @patch("codeframe.core.react_agent.TaskContextPackager")


### PR DESCRIPTION
Closes #740

## Problem
When the same tool signature repeats 3×, `_react_loop` returned `AgentStatus.COMPLETED`. Final verification then passed against the already-green repo, so a stuck agent that implemented nothing → task DONE → (with auto-close) the linked GitHub issue closed. A stuck loop is a failure, not completion.

## Fix
- Loop detection now returns `AgentStatus.FAILED` (`codeframe/core/react_agent.py`).
- Records `self._early_termination_reason = "loop_detected"` (reset per `run()`) so the caller reports `loop_detected` in `AGENT_FAILED`, distinct from `max_iterations_reached` / `stall_detected`. The `AGENT_EARLY_TERMINATION` event already carried this reason.
- Because the loop returns FAILED, final verification no longer runs — so the task is not marked DONE and the linked issue is not auto-closed.

## Acceptance criteria
- [x] Loop detection returns FAILED — verified by `test_loop_detected_returns_failed`.
- [x] Run result distinguishes "completed" from "terminated early due to loop" — `_early_termination_reason == "loop_detected"` + `AGENT_EARLY_TERMINATION` event.

## Tests
`test_loop_detected_returns_completed` renamed to `test_loop_detected_returns_failed`; now asserts FAILED, the early-termination reason, and that `gates.run` is **not** called. No false-positive tests (different tools / different paths) unchanged and passing. Full `react_agent` + escalation + engine-integration suites (108 tests) green; ruff clean.

## Review
Pre-PR third-party review: codex `LGTM, no correctness/logic regressions` (opencode was unavailable — server error).

## Known limitations
None. Scope is the single `return AgentStatus.COMPLETED` → `FAILED` at the loop-detection site plus reason propagation.