### PR TITLE
fix(conductor): crashed/killed task subprocess is retryable (#742)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -964,8 +964,9 @@ def resume_batch(
         tasks_to_run = batch.task_ids
         logger.info(f"Resuming batch {batch_id[:8]}... (force mode: re-running all {len(tasks_to_run)} tasks)")
     else:
-        # Only re-run failed/blocked tasks
-        failed_statuses = {"FAILED", "BLOCKED"}
+        # Only re-run failed/blocked tasks. "RUNNING" is a stale result left by
+        # a crashed/killed subprocess (#742) — treat it as retryable too.
+        failed_statuses = {"FAILED", "BLOCKED", "RUNNING"}
         tasks_to_run = [
             tid for tid in batch.task_ids
             if batch.results.get(tid) in failed_statuses or tid not in batch.results
@@ -2159,6 +2160,21 @@ def _execute_task_subprocess(
         # The subprocess should have updated the run record
         run = get_active_run(workspace, task_id)
         if run:
+            # Child crashed/was SIGTERMed before finalizing its run row, so the
+            # run is still RUNNING. Returning "RUNNING" would record a stale
+            # terminal result (never retried by resume) and leave an active run
+            # that blocks the next start_task_run. Reconcile to FAILED (#742).
+            if run.status == RunStatus.RUNNING and returncode != 0:
+                from codeframe.core.runtime import fail_run
+                try:
+                    fail_run(
+                        workspace,
+                        run.id,
+                        reason=f"subprocess exited {returncode} with run still RUNNING",
+                    )
+                except ValueError:
+                    pass  # Raced to terminal elsewhere; FAILED is still correct.
+                return RunStatus.FAILED.value
             return run.status.value
 
         # If no active run, check if there's a recent completed/failed run

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -2172,8 +2172,13 @@ def _execute_task_subprocess(
                         run.id,
                         reason=f"subprocess exited {returncode} with run still RUNNING",
                     )
-                except ValueError:
-                    pass  # Raced to terminal elsewhere; FAILED is still correct.
+                except Exception as e:
+                    # fail_run writes the run row to FAILED before transitioning
+                    # the task, so the stale active run is cleared even if the
+                    # task-status transition raises (e.g. InvalidTransitionError
+                    # after a checkpoint restore desynced the task, or a race to
+                    # terminal). FAILED is still the correct batch result.
+                    logger.debug(f"Reconcile of run {run.id} raised (benign): {e}")
                 return RunStatus.FAILED.value
             return run.status.value
 

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -909,6 +909,26 @@ class TestResumeBatch:
         assert get_active_run(workspace, task.id) is None  # no stale active run
         assert get_run(workspace, run.id).status == RunStatus.FAILED
 
+    def test_subprocess_reconcile_survives_non_valueerror(self, workspace_with_tasks):
+        """If reconcile's task-status transition raises a non-ValueError (e.g.
+        InvalidTransitionError after a checkpoint restore desync), the run row is
+        still cleared and 'FAILED' is returned rather than propagating (#742)."""
+        from codeframe.core.conductor import _execute_task_subprocess
+        from codeframe.core.runtime import start_task_run, RunStatus
+
+        workspace, task_list = workspace_with_tasks
+        task = task_list[0]
+        run = start_task_run(workspace, task.id)
+        assert run.status == RunStatus.RUNNING
+
+        fake_proc = MagicMock()
+        fake_proc.wait.return_value = 1
+        with patch('codeframe.core.conductor.subprocess.Popen', return_value=fake_proc), \
+             patch('codeframe.core.runtime.fail_run', side_effect=RuntimeError("transition boom")):
+            result = _execute_task_subprocess(workspace, task.id)
+
+        assert result == "FAILED"  # did not propagate
+
     def test_resume_failed_batch(self, workspace_with_tasks):
         """Should resume a FAILED batch."""
         workspace, task_list = workspace_with_tasks

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -912,9 +912,14 @@ class TestResumeBatch:
     def test_subprocess_reconcile_survives_non_valueerror(self, workspace_with_tasks):
         """If reconcile's task-status transition raises a non-ValueError (e.g.
         InvalidTransitionError after a checkpoint restore desync), the run row is
-        still cleared and 'FAILED' is returned rather than propagating (#742)."""
+        still cleared to FAILED and 'FAILED' is returned rather than propagating.
+
+        Lets fail_run run for real and makes only the task-status transition
+        raise, so this exercises the ordering guarantee (run row committed to
+        FAILED *before* the task transition) that makes broadening the catch
+        safe — not just the swallow-and-return behavior (#742)."""
         from codeframe.core.conductor import _execute_task_subprocess
-        from codeframe.core.runtime import start_task_run, RunStatus
+        from codeframe.core.runtime import start_task_run, get_active_run, get_run, RunStatus
 
         workspace, task_list = workspace_with_tasks
         task = task_list[0]
@@ -924,10 +929,14 @@ class TestResumeBatch:
         fake_proc = MagicMock()
         fake_proc.wait.return_value = 1
         with patch('codeframe.core.conductor.subprocess.Popen', return_value=fake_proc), \
-             patch('codeframe.core.runtime.fail_run', side_effect=RuntimeError("transition boom")):
+             patch('codeframe.core.runtime.tasks.update_status',
+                   side_effect=RuntimeError("transition boom")):
             result = _execute_task_subprocess(workspace, task.id)
 
         assert result == "FAILED"  # did not propagate
+        # fail_run's run-row write committed before the task transition raised.
+        assert get_run(workspace, run.id).status == RunStatus.FAILED
+        assert get_active_run(workspace, task.id) is None  # no stale active run
 
     def test_resume_failed_batch(self, workspace_with_tasks):
         """Should resume a FAILED batch."""

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -862,6 +862,53 @@ class TestResumeBatch:
         assert resumed.status == BatchStatus.COMPLETED
         assert resumed.results[task_ids[1]] == "COMPLETED"
 
+    def test_resume_reruns_stale_running_task(self, workspace_with_tasks):
+        """A 'RUNNING' result left by a crashed subprocess is retryable on resume (#742)."""
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        def mock_first_run(ws, tid, batch_id=None, **kwargs):
+            if tid == task_ids[1]:
+                return "RUNNING"  # stale terminal result from a crashed child
+            return "COMPLETED"
+
+        with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_first_run):
+            batch = start_batch(workspace, task_ids, on_failure="continue")
+
+        assert batch.results[task_ids[1]] == "RUNNING"
+        assert batch.status == BatchStatus.PARTIAL
+
+        # Resume should re-run the stale RUNNING task (and only it).
+        with patch('codeframe.core.conductor._execute_task_subprocess') as mock_exec:
+            mock_exec.return_value = "COMPLETED"
+            resumed = resume_batch(workspace, batch.id)
+
+        assert mock_exec.call_count == 1
+        assert resumed.results[task_ids[1]] == "COMPLETED"
+        assert resumed.status == BatchStatus.COMPLETED
+
+    def test_subprocess_reconciles_stale_running_run_to_failed(self, workspace_with_tasks):
+        """A crashed subprocess (nonzero exit, run still RUNNING) is reconciled to
+        FAILED so no stale active run blocks the next start_task_run (#742)."""
+        from codeframe.core.conductor import _execute_task_subprocess
+        from codeframe.core.runtime import start_task_run, get_active_run, get_run, RunStatus
+
+        workspace, task_list = workspace_with_tasks
+        task = task_list[0]
+
+        # Child started a run then crashed without finalizing it.
+        run = start_task_run(workspace, task.id)
+        assert run.status == RunStatus.RUNNING
+
+        fake_proc = MagicMock()
+        fake_proc.wait.return_value = 1  # nonzero exit == crash/SIGTERM
+        with patch('codeframe.core.conductor.subprocess.Popen', return_value=fake_proc):
+            result = _execute_task_subprocess(workspace, task.id)
+
+        assert result == "FAILED"
+        assert get_active_run(workspace, task.id) is None  # no stale active run
+        assert get_run(workspace, run.id).status == RunStatus.FAILED
+
     def test_resume_failed_batch(self, workspace_with_tasks):
         """Should resume a FAILED batch."""
         workspace, task_list = workspace_with_tasks


### PR DESCRIPTION
Closes #742

## Problem
`_execute_task_subprocess` returned the active run's status verbatim even when the child crashed / was SIGTERMed before finalizing its run row (still `RUNNING`). The batch then recorded `results[task_id]="RUNNING"` as terminal. Because `resume_batch` only re-ran `FAILED`/`BLOCKED`/missing tasks, the task was permanently skipped, and the stale `RUNNING` run made the next `start_task_run` raise *"already has an active run"*.

## Fix
- **`_execute_task_subprocess`**: on nonzero exit with the run still `RUNNING`, reconcile it to `FAILED` via `fail_run` before returning. This clears the stale active run (so a later restart isn't blocked) and records a retryable result. Scoped to `returncode != 0`, which covers both crash exits (positive) and signal kills (negative, e.g. -15 SIGTERM / -9 SIGKILL).
- **`resume_batch`**: add `"RUNNING"` to the retryable set so any legacy batches that already recorded it can be resumed.

## Acceptance criteria
- [x] On nonzero exit with the run still RUNNING, the run is reconciled to FAILED before returning.
- [x] "RUNNING" is retryable on resume.

## Tests
- `test_subprocess_reconciles_stale_running_run_to_failed` — real RUNNING run + mocked nonzero-exit Popen → asserts `FAILED` returned, no stale active run, run row is FAILED.
- `test_resume_reruns_stale_running_task` — batch that records `RUNNING` → resume re-runs only that task and it completes.

Full `tests/core/test_conductor.py` (67) passes; `ruff` clean.

## Review
Pre-PR cross-family review via opencode (GLM): **No blocking issues** — confirmed `fail_run`'s `ValueError` contract, the `returncode != 0` scoping, and no double-transition/race.

## Known limitations
- The `returncode == 0` + still-`RUNNING` edge (child exited clean but never finalized) is a separate child-side bug, out of scope here (the criteria scope to nonzero exit). It is retryable via the resume change but costs one wasted resume cycle: the first retry hits the stale active run, self-heals it to FAILED on that retry's nonzero exit, and a second resume actually re-executes. Reconciling a clean-exit run to FAILED is deliberately avoided since it would risk misreporting a task that actually succeeded.
