### PR TITLE
fix(conductor): persist batch provider/model/stall/concurrency for resume (#741)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -753,7 +753,9 @@ def get_batch(workspace: Workspace, batch_id: str) -> Optional[BatchRun]:
     cursor.execute(
         """
         SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
-               on_failure, started_at, completed_at, results, engine
+               on_failure, started_at, completed_at, results, engine,
+               isolation, stall_timeout_s, stall_action, concurrency_by_status,
+               llm_provider, llm_model
         FROM batch_runs
         WHERE workspace_id = ? AND id = ?
         """,
@@ -790,7 +792,9 @@ def list_batches(
         cursor.execute(
             """
             SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
-                   on_failure, started_at, completed_at, results, engine
+                   on_failure, started_at, completed_at, results, engine,
+                   isolation, stall_timeout_s, stall_action, concurrency_by_status,
+                   llm_provider, llm_model
             FROM batch_runs
             WHERE workspace_id = ? AND status = ?
             ORDER BY started_at DESC
@@ -802,7 +806,9 @@ def list_batches(
         cursor.execute(
             """
             SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
-                   on_failure, started_at, completed_at, results, engine
+                   on_failure, started_at, completed_at, results, engine,
+                   isolation, stall_timeout_s, stall_action, concurrency_by_status,
+                   llm_provider, llm_model
             FROM batch_runs
             WHERE workspace_id = ?
             ORDER BY started_at DESC
@@ -2227,19 +2233,19 @@ def _save_batch(
     task_ids_json = json.dumps(batch.task_ids)
     results_json = json.dumps(batch.results) if batch.results else None
     completed_at = batch.completed_at.isoformat() if batch.completed_at else None
+    # by_status is the only ConcurrencyConfig field not already a column
+    # (max_parallel is). Persist it so resume restores per-status limits (#741).
+    concurrency_json = (
+        json.dumps(batch.concurrency.by_status) if batch.concurrency.by_status else None
+    )
 
     with _batch_db_lock:
         conn = get_db_connection(workspace)
         try:
             cursor = conn.cursor()
-            # Ensure isolation column exists (migration for existing databases)
-            try:
-                cursor.execute(
-                    "ALTER TABLE batch_runs ADD COLUMN isolation TEXT DEFAULT 'none'"
-                )
-                conn.commit()
-            except Exception:
-                pass  # Column already exists
+            # Schema columns (engine/isolation/stall/provider/concurrency) are
+            # guaranteed by workspace._ensure_schema_upgrades, which runs on
+            # get_workspace before any batch op.
 
             # Cancellation is authoritative (#726): don't let a whole-row write
             # from a still-running worker resurrect a batch a concurrent
@@ -2259,8 +2265,10 @@ def _save_batch(
                 """
                 INSERT OR REPLACE INTO batch_runs
                 (id, workspace_id, task_ids, status, strategy, max_parallel, on_failure,
-                 started_at, completed_at, results, engine, isolation)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 started_at, completed_at, results, engine, isolation,
+                 stall_timeout_s, stall_action, concurrency_by_status,
+                 llm_provider, llm_model)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     batch.id,
@@ -2275,6 +2283,11 @@ def _save_batch(
                     results_json,
                     batch.engine,
                     batch.isolation,
+                    batch.stall_timeout_s,
+                    batch.stall_action,
+                    concurrency_json,
+                    batch.llm_provider,
+                    batch.llm_model,
                 ),
             )
             conn.commit()
@@ -2283,18 +2296,34 @@ def _save_batch(
 
 
 def _row_to_batch(row: tuple) -> BatchRun:
-    """Convert a database row to a BatchRun object."""
+    """Convert a database row to a BatchRun object.
+
+    len() guards keep this tolerant of short rows from pre-#741 SELECTs and unit
+    tests. NULL engine defaults to "react" to match the new-batch default (a
+    legacy NULL previously restored as "plan", silently changing the engine).
+    """
+    max_parallel = row[5]
+    concurrency_by_status = (
+        json.loads(row[14]) if len(row) > 14 and row[14] else {}
+    )
     return BatchRun(
         id=row[0],
         workspace_id=row[1],
         task_ids=json.loads(row[2]),
         status=BatchStatus(row[3]),
         strategy=row[4],
-        max_parallel=row[5],
+        max_parallel=max_parallel,
         on_failure=OnFailure(row[6]),
         started_at=datetime.fromisoformat(row[7]),
         completed_at=datetime.fromisoformat(row[8]) if row[8] else None,
         results=json.loads(row[9]) if row[9] else {},
-        engine=row[10] if len(row) > 10 and row[10] else "plan",
+        engine=row[10] if len(row) > 10 and row[10] else "react",
         isolation=row[11] if len(row) > 11 and row[11] else "none",
+        stall_timeout_s=row[12] if len(row) > 12 and row[12] is not None else 300,
+        stall_action=row[13] if len(row) > 13 and row[13] else "blocker",
+        concurrency=ConcurrencyConfig(
+            max_parallel=max_parallel, by_status=concurrency_by_status
+        ),
+        llm_provider=row[15] if len(row) > 15 else None,
+        llm_model=row[16] if len(row) > 16 else None,
     )

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -28,7 +28,7 @@ STATE_DB_NAME = "state.db"
 # ``_ensure_schema_upgrades``. Bump by 1 whenever either function gains a new
 # table/column/index so existing workspaces re-enter the (idempotent)
 # migration path exactly once. Gates #733: steady-state loads skip all DDL.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # Per-workspace config file written by the Settings page (issue #556).
 # Owned by the UI layer today; kept here so a future core consumer can
@@ -297,6 +297,12 @@ def _init_database(db_path: Path) -> None:
             completed_at TEXT,
             results TEXT,
             engine TEXT NOT NULL DEFAULT 'plan',
+            isolation TEXT NOT NULL DEFAULT 'none',
+            stall_timeout_s INTEGER NOT NULL DEFAULT 300,
+            stall_action TEXT NOT NULL DEFAULT 'blocker',
+            concurrency_by_status TEXT,
+            llm_provider TEXT,
+            llm_model TEXT,
             FOREIGN KEY (workspace_id) REFERENCES workspace(id),
             CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
         )
@@ -513,6 +519,12 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
                 completed_at TEXT,
                 results TEXT,
                 engine TEXT NOT NULL DEFAULT 'plan',
+                isolation TEXT NOT NULL DEFAULT 'none',
+                stall_timeout_s INTEGER NOT NULL DEFAULT 300,
+                stall_action TEXT NOT NULL DEFAULT 'blocker',
+                concurrency_by_status TEXT,
+                llm_provider TEXT,
+                llm_model TEXT,
                 FOREIGN KEY (workspace_id) REFERENCES workspace(id),
                 CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
             )
@@ -521,12 +533,26 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_batch_runs_status ON batch_runs(status)")
         conn.commit()
     else:
-        # Add engine column if it doesn't exist (migration for existing databases)
+        # Add columns that were introduced after the initial batch_runs schema
+        # (migration for existing databases). Each ALTER is guarded by a column
+        # existence check so this is idempotent. isolation + stall/provider/
+        # concurrency columns were added for #741 so `batch resume` restores the
+        # original run settings instead of silently falling back to defaults.
         cursor.execute("PRAGMA table_info(batch_runs)")
         batch_columns = {row[1] for row in cursor.fetchall()}
-        if "engine" not in batch_columns:
-            cursor.execute("ALTER TABLE batch_runs ADD COLUMN engine TEXT NOT NULL DEFAULT 'plan'")
-            conn.commit()
+        batch_migrations = (
+            ("engine", "ALTER TABLE batch_runs ADD COLUMN engine TEXT NOT NULL DEFAULT 'plan'"),
+            ("isolation", "ALTER TABLE batch_runs ADD COLUMN isolation TEXT NOT NULL DEFAULT 'none'"),
+            ("stall_timeout_s", "ALTER TABLE batch_runs ADD COLUMN stall_timeout_s INTEGER NOT NULL DEFAULT 300"),
+            ("stall_action", "ALTER TABLE batch_runs ADD COLUMN stall_action TEXT NOT NULL DEFAULT 'blocker'"),
+            ("concurrency_by_status", "ALTER TABLE batch_runs ADD COLUMN concurrency_by_status TEXT"),
+            ("llm_provider", "ALTER TABLE batch_runs ADD COLUMN llm_provider TEXT"),
+            ("llm_model", "ALTER TABLE batch_runs ADD COLUMN llm_model TEXT"),
+        )
+        for column, ddl in batch_migrations:
+            if column not in batch_columns:
+                cursor.execute(ddl)
+        conn.commit()
 
     # Add tech_stack column to workspace table if it doesn't exist
     # First check if workspace table exists

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -573,7 +573,12 @@ class TestRowToBatch:
         assert batch.engine == "plan"
 
     def test_handles_missing_engine_column(self):
-        """Should default engine to 'plan' when column is absent (migration)."""
+        """Should default engine to 'react' when column is absent (migration).
+
+        A NULL/absent engine now restores as 'react' to match the new-batch
+        default; it previously defaulted to 'plan', silently switching the
+        engine on resume (#741).
+        """
         row = (
             "batch-id",
             "workspace-id",
@@ -588,7 +593,7 @@ class TestRowToBatch:
         )
 
         batch = _row_to_batch(row)
-        assert batch.engine == "plan"
+        assert batch.engine == "react"
 
 
 class TestBatchExecution:
@@ -812,6 +817,40 @@ class TestSaveBatch:
         assert loaded.status == BatchStatus.COMPLETED
         assert loaded.results[task_list[0].id] == "COMPLETED"
 
+    def test_persists_provider_stall_and_concurrency(self, workspace_with_tasks):
+        """Non-default provider/model/stall/concurrency survive a save+load (#741).
+
+        Before the fix these were dropped by _save_batch and reconstructed from
+        dataclass defaults on read, so a resume silently reran on default
+        Anthropic with default stall settings.
+        """
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        batch = start_batch(
+            workspace,
+            task_ids,
+            strategy="parallel",
+            max_parallel=2,
+            engine="react",
+            stall_timeout_s=120,
+            stall_action="retry",
+            concurrency_by_status={"READY": 3},
+            isolation="none",
+            llm_provider="openai",
+            llm_model="gpt-4o",
+            dry_run=True,
+        )
+
+        loaded = get_batch(workspace, batch.id)
+        assert loaded.llm_provider == "openai"
+        assert loaded.llm_model == "gpt-4o"
+        assert loaded.stall_timeout_s == 120
+        assert loaded.stall_action == "retry"
+        assert loaded.engine == "react"
+        assert loaded.concurrency.by_status == {"READY": 3}
+        assert loaded.concurrency.max_parallel == 2
+
 
 class TestResumeBatch:
     """Tests for resume_batch function."""
@@ -861,6 +900,42 @@ class TestResumeBatch:
         assert mock_exec.call_count == 1
         assert resumed.status == BatchStatus.COMPLETED
         assert resumed.results[task_ids[1]] == "COMPLETED"
+
+    def test_resume_reuses_original_provider_and_stall(self, workspace_with_tasks):
+        """Resume must reuse the batch's original provider/model/stall (#741).
+
+        The first run fails one task on ``openai``/``gpt-4o`` with a non-default
+        stall timeout; resuming (which reloads the batch from the DB) must pass
+        those same values to the subprocess, not silently fall back to defaults.
+        """
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        def mock_first_run(ws, tid, batch_id=None, **kwargs):
+            return "FAILED" if tid == task_ids[1] else "COMPLETED"
+
+        with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_first_run):
+            batch = start_batch(
+                workspace,
+                task_ids,
+                on_failure="continue",
+                llm_provider="openai",
+                llm_model="gpt-4o",
+                stall_timeout_s=120,
+                stall_action="retry",
+            )
+        assert batch.status == BatchStatus.PARTIAL
+
+        with patch('codeframe.core.conductor._execute_task_subprocess') as mock_exec:
+            mock_exec.return_value = "COMPLETED"
+            resume_batch(workspace, batch.id)
+
+        assert mock_exec.call_count == 1
+        _, kwargs = mock_exec.call_args
+        assert kwargs["llm_provider"] == "openai"
+        assert kwargs["llm_model"] == "gpt-4o"
+        assert kwargs["stall_timeout_s"] == 120
+        assert kwargs["stall_action"] == "retry"
 
     def test_resume_reruns_stale_running_task(self, workspace_with_tasks):
         """A 'RUNNING' result left by a crashed subprocess is retryable on resume (#742)."""

--- a/tests/core/test_workspace.py
+++ b/tests/core/test_workspace.py
@@ -317,3 +317,34 @@ class TestSchemaVersionGate:
         finally:
             conn.close()
         assert "idx_tasks_external_url" in indexes
+
+    def test_legacy_db_without_batch_runs_gets_full_v2_schema(
+        self, initialized_workspace: Workspace, temp_repo: Path
+    ):
+        """A legacy DB missing batch_runs must be recreated with the #741 columns.
+
+        The table-missing branch of _ensure_schema_upgrades creates the table
+        fresh; it must include isolation/stall/provider/concurrency columns so a
+        subsequent _save_batch doesn't fail with "no column named ...".
+        """
+        conn = sqlite3.connect(initialized_workspace.db_path)
+        conn.execute("DROP TABLE IF EXISTS batch_runs")
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        ws = get_workspace(temp_repo)
+
+        conn = sqlite3.connect(ws.db_path)
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(batch_runs)")}
+        finally:
+            conn.close()
+        assert {
+            "isolation",
+            "stall_timeout_s",
+            "stall_action",
+            "concurrency_by_status",
+            "llm_provider",
+            "llm_model",
+        } <= cols


### PR DESCRIPTION
Closes #741.

## Problem
`_save_batch` persisted only a subset of `batch_runs` columns; `_row_to_batch` reconstructed the rest from dataclass defaults. So `cf work batch resume` on a batch started with `--llm-provider openai --stall-timeout 120` silently reran on **default Anthropic** with **default stall settings**. NULL/absent `engine` also restored as `"plan"` while new batches default `"react"`.

## Fix
- **Persist** `llm_provider`, `llm_model`, `stall_timeout_s`, `stall_action`, and `concurrency.by_status` (as JSON) alongside the existing `isolation` column. The three read-path SELECTs (`get_batch`, `list_batches` ×2) now fetch them, and `_row_to_batch` restores them.
- **Migration home**: moved the `batch_runs` column migrations into `workspace._ensure_schema_upgrades` (`SCHEMA_VERSION` 1→2), which runs on `get_workspace` before any batch op — so columns exist for both reads and writes, on fresh DBs, legacy DBs, and the table-missing recreate branch. Dropped the now-redundant inline `ALTER` in `_save_batch`.
- **Engine default**: `_row_to_batch` now defaults NULL/absent `engine` to `"react"` to match the new-batch default. (The legacy pre-engine backfill stays `'plan'` — those rows genuinely were plan-era runs; real rows always write `engine` explicitly.)

## Tests (outcome evidence, not exit codes)
- `test_resume_reuses_original_provider_and_stall` — asserts the **subprocess call on resume** receives `llm_provider="openai"`, `llm_model="gpt-4o"`, `stall_timeout_s=120`, `stall_action="retry"` (the exact acceptance criterion).
- `test_persists_provider_stall_and_concurrency` — save→load round-trips all fields incl. `concurrency.by_status`.
- `test_legacy_db_without_batch_runs_gets_full_v2_schema` — regression for the table-missing recreate path.
- Updated `_row_to_batch` engine-default unit test to `"react"`.

`uv run pytest tests/core/test_conductor.py tests/core/test_workspace.py` → 93 passed. `ruff` clean.

## Review
Pre-PR third-party review: opencode (GLM) backend errored, fell back to `codex review`. Codex flagged a **High**: the table-missing CREATE-TABLE branch hadn't received the new columns (a `replace_all` indentation miss) → fixed and covered by the new legacy-DB test. Its Medium (engine backfill `'plan'`) was verified as intended/historically-correct and left as-is.

## Known limitations
None. Follows the existing `isolation` persistence pattern.