### PR TITLE
fix(ci): gate comment-triggered AI workflows on author association (#748)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (startsWith(github.event.comment.body, '/oc') ||
+       startsWith(github.event.comment.body, '/opencode'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Closes #748

## Problem
`opencode.yml` (`/oc`, `/opencode`) and `claude.yml` (`@claude`) triggered on `issue_comment` / review / `issues` events with **no `author_association` restriction**, spending `ZHIPU_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`. On a public repo, any external commenter could drain paid AI credits. The `/oc` match was also a loose substring.

## Fix
Both jobs now gate on `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` via `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), …)`.

- **claude.yml** — the association is read from the correct object for each of the four event branches:
  - `issue_comment` / `pull_request_review_comment` → `github.event.comment.author_association`
  - `pull_request_review` → `github.event.review.author_association`
  - `issues` → `github.event.issue.author_association`
- **opencode.yml** — association gate on `github.event.comment.author_association`, and the loose ` /oc` / ` /opencode` `contains` substrings are dropped; only `startsWith('/oc')` / `startsWith('/opencode')` prefix matches remain, so a command must **begin** the comment.

## Acceptance criteria
- [x] Jobs gate on `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`
- [x] The `/oc` match is tightened to a prefix

## Verification
- Both files parse as valid YAML (pyyaml).
- Cross-family review (opencode/GLM-4.7) confirmed correct per-event object mapping, `fromJSON` array + `contains` logic, boolean precedence, and prefix tightening — no blocking issues.
- Boolean logic walk-through below.

### Boolean truth-table (per event)
| Actor association | `@claude`/`/oc` present | Job runs? |
|---|---|---|
| OWNER/MEMBER/COLLABORATOR | yes | ✅ yes |
| CONTRIBUTOR/NONE/FIRST_TIMER | yes | 🚫 no (credit drain blocked) |
| any | no | 🚫 no |

## Known limitations
- GitHub Actions `if:` expression semantics can't be executed locally, so the gate is verified by static reasoning + cross-family review + YAML validity rather than a runtime unit test. A true end-to-end check requires a non-member comment against the live workflow, which isn't reproducible in CI.
- `startsWith('/oc')` still matches a hypothetical `/ocean …` prefix; treating the command as an exact token isn't expressible in GHA's expression language without regex. The credit-drain threat is fully closed by the association gate regardless.