### PR TITLE
fix(perf): offload sync SQLite in async task/costs handlers (#751)

### DIFF
--- a/codeframe/ui/routers/costs_v2.py
+++ b/codeframe/ui/routers/costs_v2.py
@@ -107,7 +107,7 @@ def _query_costs(db_path: str, days: int) -> Dict:
 
 @router.get("/summary", response_model=CostSummaryResponse)
 @rate_limit_standard()
-async def get_costs_summary(
+def get_costs_summary(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
     days: int = Query(30, ge=7, le=90, description="Window size in days (7-90)"),
@@ -279,7 +279,7 @@ def _query_costs_by_agent(db_path: str, days: int) -> Dict[str, Any]:
 
 @router.get("/tasks", response_model=TaskCostsResponse)
 @rate_limit_standard()
-async def get_costs_by_task(
+def get_costs_by_task(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
     days: int = Query(30, ge=1, le=365, description="Window size in days (1-365)"),
@@ -311,7 +311,7 @@ async def get_costs_by_task(
 
 @router.get("/by-agent", response_model=AgentCostsResponse)
 @rate_limit_standard()
-async def get_costs_by_agent_endpoint(
+def get_costs_by_agent_endpoint(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
     days: int = Query(30, ge=1, le=365, description="Window size in days (1-365)"),

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -202,7 +202,7 @@ class UpdateTaskRequest(BaseModel):
 
 @router.get("", response_model=TaskListResponse)
 @rate_limit_standard()
-async def list_tasks(
+def list_tasks(
     request: Request,
     status: Optional[str] = Query(None, description="Filter by status (BACKLOG, READY, IN_PROGRESS, DONE, BLOCKED, FAILED)"),
     limit: int = Query(100, ge=1, le=1000),
@@ -248,7 +248,7 @@ async def list_tasks(
 
 @router.get("/{task_id}", response_model=TaskResponse)
 @rate_limit_standard()
-async def get_task(
+def get_task(
     request: Request,
     task_id: str,
     workspace: Workspace = Depends(get_v2_workspace),
@@ -277,7 +277,7 @@ async def get_task(
 
 @router.patch("/{task_id}", response_model=TaskResponse)
 @rate_limit_standard()
-async def update_task(
+def update_task(
     request: Request,
     task_id: str,
     body: UpdateTaskRequest,
@@ -420,7 +420,7 @@ async def update_task(
 
 @router.delete("/{task_id}")
 @rate_limit_standard()
-async def delete_task(
+def delete_task(
     request: Request,
     task_id: str,
     workspace: Workspace = Depends(get_v2_workspace),
@@ -533,7 +533,7 @@ async def approve_tasks_endpoint(
 
 @router.get("/assignment-status", response_model=AssignmentStatusResponse)
 @rate_limit_standard()
-async def get_assignment_status(
+def get_assignment_status(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
 ) -> AssignmentStatusResponse:
@@ -1053,7 +1053,7 @@ async def stream_task_events(
 
 @router.get("/{task_id}/run")
 @rate_limit_standard()
-async def get_task_run(
+def get_task_run(
     request: Request,
     task_id: str,
     workspace: Workspace = Depends(get_v2_workspace),

--- a/tests/ui/test_async_handler_offload_751.py
+++ b/tests/ui/test_async_handler_offload_751.py
@@ -1,0 +1,88 @@
+"""Regression guard for #751: sync SQLite work must not run on the event loop.
+
+The task/costs read + CRUD handlers do blocking SQLite work directly. Declaring
+them ``async def`` pins that disk I/O to the event-loop thread, serializing every
+concurrent request behind it. The fix (per the issue's acceptance criteria) is to
+declare them plain ``def`` so FastAPI dispatches them to its anyio threadpool.
+
+These tests assert the offload structurally — a handler that regresses back to
+``async def`` (re-blocking the loop) fails here. Behavior is covered by the
+existing router tests; this file only guards *where* the work runs.
+"""
+
+import asyncio
+
+import pytest
+from fastapi.routing import APIRoute
+
+from codeframe.ui.routers import costs_v2, tasks_v2
+
+pytestmark = pytest.mark.v2
+
+
+def _endpoints_by_name(router):
+    """Map handler ``__name__`` -> route endpoint for a router's APIRoutes.
+
+    ``functools.wraps`` (used by slowapi's rate-limit wrapper) preserves
+    ``__name__``, so this works whether or not rate limiting is enabled.
+    """
+    return {
+        route.endpoint.__name__: route.endpoint
+        for route in router.routes
+        if isinstance(route, APIRoute)
+    }
+
+
+# Handlers whose body is purely synchronous SQLite work — must be offloaded.
+OFFLOADED_TASK_HANDLERS = [
+    "list_tasks",
+    "get_task",
+    "update_task",
+    "delete_task",
+    "get_assignment_status",
+    "get_task_run",
+]
+OFFLOADED_COST_HANDLERS = [
+    "get_costs_summary",
+    "get_costs_by_task",
+    "get_costs_by_agent_endpoint",
+]
+
+# Handlers intentionally left ``async``: they orchestrate the conductor/runtime,
+# spawn worker threads, use BackgroundTasks, or return a StreamingResponse — none
+# are the "blocking SQLite serializes requests" case this issue targets.
+STREAMING_OR_ORCHESTRATION_HANDLERS = [
+    "stream_task_output_lines",
+    "stream_task_events",
+    "start_single_task",
+]
+
+
+@pytest.mark.parametrize("name", OFFLOADED_TASK_HANDLERS)
+def test_task_db_handlers_are_offloaded(name):
+    endpoints = _endpoints_by_name(tasks_v2.router)
+    assert name in endpoints, f"{name} route missing from tasks_v2 router"
+    assert not asyncio.iscoroutinefunction(endpoints[name]), (
+        f"{name} is async — blocking SQLite would run on the event loop. "
+        "Declare it plain `def` so FastAPI offloads it to the threadpool (#751)."
+    )
+
+
+@pytest.mark.parametrize("name", OFFLOADED_COST_HANDLERS)
+def test_cost_handlers_are_offloaded(name):
+    endpoints = _endpoints_by_name(costs_v2.router)
+    assert name in endpoints, f"{name} route missing from costs_v2 router"
+    assert not asyncio.iscoroutinefunction(endpoints[name]), (
+        f"{name} is async — blocking SQLite would run on the event loop. "
+        "Declare it plain `def` so FastAPI offloads it to the threadpool (#751)."
+    )
+
+
+@pytest.mark.parametrize("name", STREAMING_OR_ORCHESTRATION_HANDLERS)
+def test_streaming_and_orchestration_handlers_stay_async(name):
+    endpoints = _endpoints_by_name(tasks_v2.router)
+    assert name in endpoints, f"{name} route missing from tasks_v2 router"
+    assert asyncio.iscoroutinefunction(endpoints[name]), (
+        f"{name} must stay async (it streams or orchestrates); converting it to "
+        "`def` is out of scope for #751 and risks breaking its event-loop usage."
+    )

--- a/tests/ui/test_async_handler_offload_751.py
+++ b/tests/ui/test_async_handler_offload_751.py
@@ -55,6 +55,10 @@ STREAMING_OR_ORCHESTRATION_HANDLERS = [
     "stream_task_output_lines",
     "stream_task_events",
     "start_single_task",
+    "start_execution",
+    "stop_task",
+    "resume_task",
+    "approve_tasks_endpoint",
 ]
 
 


### PR DESCRIPTION
Closes #751

## Problem
`async def` handlers in `tasks_v2.py` and `costs_v2.py` called blocking SQLite
directly, pinning that disk I/O to the event-loop thread and serializing every
concurrent request behind it.

## Fix
Declare the purely-synchronous handlers plain `def`. FastAPI then dispatches them
to its anyio threadpool instead of the event loop — the acceptance-criteria
option ("handlers declared plain `def`") and the pattern already used in
`interactive_sessions_v2.py`.

**Converted (9 handlers):**
- `tasks_v2.py`: `list_tasks`, `get_task`, `update_task`, `delete_task`, `get_assignment_status`, `get_task_run`
- `costs_v2.py`: `get_costs_summary`, `get_costs_by_task`, `get_costs_by_agent_endpoint`

### Why this is safe
- **Rate limiting unaffected**: `slowapi.Limiter.limit` branches on `iscoroutinefunction`, producing a sync wrapper for sync handlers (`extension.py:717`).
- **GitHub auto-close unaffected**: `update_task` → `tasks.update_status` fires `_close_issue_background`, which already handles the no-running-loop case (threadpool thread) by spawning a non-daemon thread — the same path the CLI uses.
- Zero `await` existed in any converted handler, so nothing needed unwinding.

## Evidence
**Regression test** (`tests/ui/test_async_handler_offload_751.py`): structurally
asserts the 9 handlers are sync and that streaming/orchestration handlers stay async.

**Concurrency demo** — 5 concurrent requests, 0.4s blocking DB call each:
```
handler is coroutine? False
status codes: [200, 200, 200, 200, 200]
  elapsed          = 0.41s   (parallel — offloaded ✔)
  serial would be  = 2.00s
```
Before the fix these would serialize to ~2.0s on the event loop.

**Existing suites**: 121 passed (`test_costs_v2`, `test_v2_routers_integration`,
`test_tasks_v2_engine`, `test_tasks_start_failure`) + ruff clean.

## Known Limitations
- **Execution-control and streaming handlers stay `async` by design** —
  `start_execution`, `start_single_task`, `stop_task`, `resume_task`,
  `approve_tasks_endpoint`, `stream_task_output_lines`, `stream_task_events`.
  These orchestrate the conductor/runtime, spawn worker threads, use
  `BackgroundTasks`, or return `StreamingResponse`, and rely on the running event
  loop. They're outside the cited "blocking SQLite serializes requests" scope and
  converting them carries real risk.