### PR TITLE
fix(security): populate request.state.user for per-user rate limits (#754)

### DIFF
--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -330,6 +330,7 @@ async def get_api_key_auth(
 
 
 async def require_auth(
+    request: Request = None,
     api_key_auth: Optional[Dict[str, Any]] = Depends(get_api_key_auth),
     jwt_user: Optional[User] = Depends(get_current_user_optional),
 ) -> Dict[str, Any]:
@@ -337,7 +338,14 @@ async def require_auth(
 
     API keys take precedence if both are present.
 
+    The resolved principal is also published to ``request.state.user`` so the
+    rate limiter's key function can key limits per user (issue #754). Without
+    this, ``request.state.user`` is never set and every rate limit — including
+    auth brute-force protection — collapses to per-IP, sharing one bucket
+    behind a NAT/proxy.
+
     Args:
+        request: FastAPI request object (injected; used to publish the principal)
         api_key_auth: Result from get_api_key_auth (if API key provided)
         jwt_user: Result from get_current_user_optional (if JWT provided)
 
@@ -347,28 +355,35 @@ async def require_auth(
     Raises:
         HTTPException: 401 if no valid authentication provided
     """
+
+    def _resolve(principal: Dict[str, Any]) -> Dict[str, Any]:
+        # Publish the principal for the rate limiter's key func (issue #754).
+        if request is not None:
+            request.state.user = principal
+        return principal
+
     # Prefer API key if provided
     if api_key_auth is not None:
-        return api_key_auth
+        return _resolve(api_key_auth)
 
     # Fall back to JWT
     if jwt_user is not None:
-        return {
+        return _resolve({
             "type": "jwt",
             "user_id": jwt_user.id,
             # JWT users get all scopes for backward compatibility
             "scopes": [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN],
             "user": jwt_user,
-        }
+        })
 
     # Auth disabled (local opt-out): return a synthetic local-admin principal
     # instead of raising. Real credentials above always take precedence.
     if not auth_required():
-        return {
+        return _resolve({
             "type": "disabled",
             "user_id": None,
             "scopes": [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN],
-        }
+        })
 
     # No authentication provided
     raise HTTPException(

--- a/codeframe/lib/rate_limiter.py
+++ b/codeframe/lib/rate_limiter.py
@@ -20,7 +20,7 @@ Security:
 """
 
 import logging
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -99,6 +99,22 @@ def get_client_ip(request: Request) -> str:
     return "unknown"
 
 
+def _principal_id(principal: object) -> Any:
+    """Extract the user id from a resolved auth principal (native type).
+
+    ``require_auth`` publishes its principal dict (``{"user_id": ...}``) on
+    ``request.state.user`` (issue #754); direct/mocked call sites may instead
+    store an object exposing an ``.id`` attribute. Returns the id unchanged
+    (int for real users — so the audit log keeps its native type), or ``None``
+    when there is no authenticated user: unauthenticated, or the auth-disabled
+    synthetic principal whose ``user_id`` is ``None``.
+    """
+    if principal is None:
+        return None
+    uid = principal.get("user_id") if isinstance(principal, dict) else getattr(principal, "id", None)
+    return uid or None
+
+
 def get_rate_limit_key(request: Request) -> str:
     """Generate rate limit key for a request.
 
@@ -111,11 +127,10 @@ def get_rate_limit_key(request: Request) -> str:
     Returns:
         Rate limit key string in format "user:{id}" or "ip:{address}"
     """
-    # Check if user is authenticated (set by auth middleware)
-    user = getattr(getattr(request, "state", None), "user", None)
-
-    if user and hasattr(user, "id") and user.id:
-        return f"user:{user.id}"
+    # Prefer the resolved principal published by require_auth (issue #754).
+    user_id = _principal_id(getattr(getattr(request, "state", None), "user", None))
+    if user_id:
+        return f"user:{user_id}"
 
     # Fall back to IP address
     client_ip = get_client_ip(request)
@@ -182,8 +197,7 @@ async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) 
     """
     # Extract request info
     client_ip = get_client_ip(request)
-    user = getattr(getattr(request, "state", None), "user", None)
-    user_id = user.id if user and hasattr(user, "id") and user.id else None
+    user_id = _principal_id(getattr(getattr(request, "state", None), "user", None))
     endpoint = request.url.path
 
     # Log to standard logger
@@ -320,9 +334,9 @@ def get_auth_rate_limit_key(request: Request) -> str:
         "ip:{address}" — including a stable "ip:unknown" when the client IP cannot
         be determined.
     """
-    user = getattr(getattr(request, "state", None), "user", None)
-    if user and getattr(user, "id", None):
-        return f"user:{user.id}"
+    user_id = _principal_id(getattr(getattr(request, "state", None), "user", None))
+    if user_id:
+        return f"user:{user_id}"
     return f"ip:{get_client_ip(request)}"
 
 

--- a/tests/auth/test_auth_mode.py
+++ b/tests/auth/test_auth_mode.py
@@ -7,6 +7,8 @@ Auth is controlled by CODEFRAME_AUTH_REQUIRED:
 - when disabled, require_auth returns a synthetic auth dict instead of raising
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from codeframe.auth.dependencies import auth_required, require_auth
@@ -67,3 +69,65 @@ class TestRequireAuthBypass:
         result = await require_auth(api_key_auth=api_key_auth, jwt_user=None)
         assert result["type"] == "api_key"
         assert result["user_id"] == 7
+
+
+class _FakeState:
+    pass
+
+
+class _FakeRequest:
+    """Minimal request stub with a settable ``state`` for require_auth (#754)."""
+
+    def __init__(self):
+        self.state = _FakeState()
+
+
+class TestRequireAuthPublishesPrincipal:
+    """require_auth must publish the principal to request.state.user (#754)."""
+
+    @pytest.mark.asyncio
+    async def test_sets_state_user_for_api_key(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        req = _FakeRequest()
+        api_key_auth = {"type": "api_key", "user_id": 7, "scopes": [SCOPE_READ]}
+        result = await require_auth(request=req, api_key_auth=api_key_auth, jwt_user=None)
+        assert req.state.user is result
+        assert req.state.user["user_id"] == 7
+
+    @pytest.mark.asyncio
+    async def test_sets_state_user_for_jwt(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        req = _FakeRequest()
+        jwt_user = SimpleNamespace(id=42)
+        result = await require_auth(request=req, api_key_auth=None, jwt_user=jwt_user)
+        assert req.state.user is result
+        assert req.state.user["user_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_sets_state_user_for_disabled(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        req = _FakeRequest()
+        await require_auth(request=req, api_key_auth=None, jwt_user=None)
+        assert req.state.user["type"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_published_principal_enables_per_user_rate_key(self, monkeypatch):
+        """End-to-end: require_auth's write drives the rate-limit key func (#754)."""
+        from codeframe.lib.rate_limiter import get_rate_limit_key
+
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        req = _FakeRequest()
+        req.client = SimpleNamespace(host="10.0.0.1")
+        req.headers = {}
+        req.url = SimpleNamespace(path="/api/v2/tasks")
+
+        # Before auth resolves, no principal → keyed by IP.
+        assert get_rate_limit_key(req) == "ip:10.0.0.1"
+
+        await require_auth(
+            request=req,
+            api_key_auth={"type": "api_key", "user_id": 99, "scopes": [SCOPE_READ]},
+            jwt_user=None,
+        )
+        # After auth resolves, keyed per user.
+        assert get_rate_limit_key(req) == "user:99"

--- a/tests/lib/test_rate_limiter.py
+++ b/tests/lib/test_rate_limiter.py
@@ -178,6 +178,45 @@ class TestRateLimiterKeyGeneration:
         key = get_rate_limit_key(mock_request)
         assert key == "user:user_12345"
 
+    def test_key_for_principal_dict(self):
+        """Key func reads require_auth's principal dict on state.user (#754)."""
+        from codeframe.lib.rate_limiter import get_rate_limit_key
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.client.host = "192.168.1.100"
+        mock_request.headers = {}
+        mock_request.state = MagicMock()
+        mock_request.state.user = {"type": "api_key", "user_id": 42, "scopes": []}
+        mock_request.url.path = "/test"
+
+        assert get_rate_limit_key(mock_request) == "user:42"
+
+    def test_key_for_disabled_principal_falls_back_to_ip(self):
+        """The auth-disabled synthetic principal (user_id=None) keys by IP (#754)."""
+        from codeframe.lib.rate_limiter import get_rate_limit_key
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.client.host = "192.168.1.100"
+        mock_request.headers = {}
+        mock_request.state = MagicMock()
+        mock_request.state.user = {"type": "disabled", "user_id": None, "scopes": []}
+        mock_request.url.path = "/test"
+
+        assert get_rate_limit_key(mock_request) == "ip:192.168.1.100"
+
+    def test_auth_key_for_principal_dict(self):
+        """The auth-tier key func also reads the principal dict (#754)."""
+        from codeframe.lib.rate_limiter import get_auth_rate_limit_key
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.client.host = "192.168.1.100"
+        mock_request.headers = {}
+        mock_request.state = MagicMock()
+        mock_request.state.user = {"type": "jwt", "user_id": 7, "scopes": []}
+        mock_request.url.path = "/auth/jwt/login"
+
+        assert get_auth_rate_limit_key(mock_request) == "user:7"
+
     def test_key_for_unknown_ip_is_unique(self):
         """Unknown IPs should get unique keys to prevent shared bucket DoS."""
         from codeframe.lib.rate_limiter import get_rate_limit_key


### PR DESCRIPTION
Closes #754

## Problem
`codeframe/lib/rate_limiter.py` keys rate limits on `request.state.user`, but **nothing ever set it**. Auth resolves through FastAPI dependency *return values* (`require_auth` → a principal dict), never by mutating request state. So the `user:{id}` branch was dead and every limit — standard, AI, and **auth brute-force** — collapsed to per-IP. Behind a shared NAT/proxy, all users share one bucket.

## Root cause & fix
A seam between two subsystems: the rate limiter assumed auth wrote `request.state.user`; auth assumed its return value was enough. Fixed at the single chokepoint every v2 router routes through — `require_auth`:

- **`codeframe/auth/dependencies.py`** — `require_auth` now publishes the resolved principal to `request.state.user` (for the api-key, jwt, and auth-disabled branches). Added an injected `request: Request` param (matches the existing `get_api_key_auth` convention in the same file).
- **`codeframe/lib/rate_limiter.py`** — a shared `_principal_id()` helper reads the principal (the `require_auth` dict `{"user_id": ...}`, or any object with `.id`) and returns the native id. Used by `get_rate_limit_key`, `get_auth_rate_limit_key`, and `rate_limit_exceeded_handler`. The audit log keeps its native `int` user_id (no stringification).

## Timing (why this actually engages)
`SlowAPIMiddleware` exempts any route carrying a `@rate_limit_*` decorator (`_should_exempt`), and the Limiter has no `default_limits` — so the middleware never keys anything. All real limiting runs either in the **decorator wrapper** (inside the endpoint call, *after* FastAPI resolves the router-level `require_method_scope` → `require_auth` dependency) or in the **`enforce_auth_rate_limit` dependency**. Both run after `require_auth`, so `request.state.user` is populated before any key func executes.

## Acceptance criteria
> Auth sets `request.state.user`, or the key func reads the resolved principal; the dead branch is removed if IP-only is intended (and documented).

✅ Both — auth sets it, and the key funcs read the resolved principal. Per-user limits now apply; login/register correctly stay IP-keyed (no principal yet). The auth-disabled synthetic principal (`user_id=None`) correctly falls back to IP.

## Tests
- `tests/lib/test_rate_limiter.py` — key funcs resolve `user:{id}` from the principal dict; disabled principal falls back to IP; auth-tier key func reads the dict.
- `tests/auth/test_auth_mode.py` — `require_auth` publishes the principal for api-key/jwt/disabled; **end-to-end**: before auth the request keys by IP, after `require_auth` runs the same request keys by user.
- Full auth + v2 enforcement suites (165) and rate-limit-adjacent suites (131) pass; mypy + ruff clean.

## Known limitations
Multi-worker deployments with in-memory storage still keep per-worker counters (pre-existing; documented — set `RATE_LIMIT_STORAGE=redis`). This PR only fixes the key *dimension*, not the storage backend.