### PR TITLE
Add GLM inline review workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,10 @@ version: 2
 updates:
   # Keep GitHub Actions SHA pins current (security patches to pinned actions).
   - package-ecosystem: github-actions
+    # Note: semver-*-days cooldown keys are unsupported for the github-actions
+    # ecosystem — only default-days is valid here.
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.pull_request.changed_files >= 5 ||
       github.event.pull_request.additions >= 20 ||
       github.event.pull_request.deletions >= 20
-    uses: frankbria/glm-review/.github/workflows/review.yml@main
+    uses: frankbria/glm-review/.github/workflows/review.yml@b877d15a0f8c0855d0d2ebdcce32ae09cec1bb2d # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -1,0 +1,23 @@
+name: GLM Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - "**/*.md"
+      - ".gitignore"
+
+jobs:
+  review:
+    # Only review substantial changes (5+ files, or 20+ additions, or 20+ deletions)
+    if: |
+      github.event.pull_request.changed_files >= 5 ||
+      github.event.pull_request.additions >= 20 ||
+      github.event.pull_request.deletions >= 20
+    uses: frankbria/glm-review/.github/workflows/review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}


### PR DESCRIPTION
Adds the reusable GLM-5.2 inline PR reviewer (frankbria/glm-review): CodeRabbit-style inline comments on defective lines with committable suggestions, bugs-only scope. ZHIPU_API_KEY secret is set. Verified on hai-sh#75.