### PR TITLE
fix(openai): recover from malformed tool-call JSON in non-streaming path (#755)

### DIFF
--- a/codeframe/adapters/llm/openai.py
+++ b/codeframe/adapters/llm/openai.py
@@ -463,11 +463,25 @@ class OpenAIProvider(LLMProvider):
 
         if message.tool_calls:
             for tc in message.tool_calls:
+                raw_args = tc.function.arguments or "{}"
+                try:
+                    tool_input = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    # Local models (Ollama/vLLM) often emit truncated tool args;
+                    # substitute {} so the tool layer returns a recoverable error
+                    # instead of crashing the run. Mirrors the streaming path.
+                    logger.warning(
+                        "Failed to parse tool arguments for tool '%s' (id=%s): %r",
+                        tc.function.name,
+                        tc.id,
+                        raw_args,
+                    )
+                    tool_input = {}
                 tool_calls.append(
                     ToolCall(
                         id=tc.id,
                         name=tc.function.name,
-                        input=json.loads(tc.function.arguments),
+                        input=tool_input,
                     )
                 )
 

--- a/tests/adapters/test_llm_openai.py
+++ b/tests/adapters/test_llm_openai.py
@@ -167,6 +167,36 @@ class TestOpenAIProviderComplete:
         assert response.tool_calls[0].name == "read_file"
         assert response.tool_calls[0].input == {"path": "/foo.py"}
 
+    def test_malformed_tool_arguments_recovered(self):
+        """Truncated/invalid tool-call JSON substitutes {} instead of crashing (#755).
+
+        Mirrors the streaming path so local Ollama/vLLM models that emit
+        malformed tool args let the tool layer return a recoverable error.
+        """
+        from codeframe.adapters.llm.openai import OpenAIProvider
+        from codeframe.adapters.llm.base import Tool
+
+        provider = OpenAIProvider(api_key="sk-test")
+        tc = _make_tool_call("id1", "read_file", {"path": "/foo.py"})
+        tc.function.arguments = '{"path": "/foo.py'  # truncated, invalid JSON
+        mock_resp = _make_completion(tool_calls=[tc], finish_reason="tool_calls")
+
+        with patch.object(provider, "_client", None):
+            with patch("openai.OpenAI") as mock_cls:
+                mock_client = MagicMock()
+                mock_cls.return_value = mock_client
+                mock_client.chat.completions.create.return_value = mock_resp
+
+                tools = [Tool(name="read_file", description="Read a file", input_schema={"type": "object"})]
+                response = provider.complete(
+                    [{"role": "user", "content": "Read /foo.py"}],
+                    tools=tools,
+                )
+
+        assert response.has_tool_calls
+        assert response.tool_calls[0].name == "read_file"
+        assert response.tool_calls[0].input == {}
+
     def test_system_prompt_prepended(self):
         """System prompt is prepended as system role message."""
         from codeframe.adapters.llm.openai import OpenAIProvider


### PR DESCRIPTION
Closes #755

## Problem
`json.loads(tc.function.arguments)` in `_parse_response` (the non-streaming path) had no error handling, unlike `async_stream()`. Local Ollama/vLLM models frequently emit truncated tool-call JSON, so a `JSONDecodeError` propagated and failed the whole task instead of letting the agent recover.

## Fix
Wrap the parse in try/except, log a warning, and substitute `{}` — so the tool layer returns a recoverable error. This mirrors the streaming path (`openai.py:324-334`) exactly, making the two paths symmetric.

## Acceptance criteria
- [x] Catch `JSONDecodeError`, log, substitute `{}` — mirroring the streaming path

## Testing
- New test `test_malformed_tool_arguments_recovered` feeds truncated JSON (`{"path": "/foo.py`) and asserts the tool call survives with `input == {}` (confirmed red before the fix, green after).
- Full adapter suite: 23 passed. `ruff` clean, `mypy` clean.

## Known limitations
None — behavior now matches the streaming path.