### PR TITLE
fix(terminal-ws): release per-user slot when handshake fails (#756)

### DIFF
--- a/codeframe/ui/routers/terminal_ws.py
+++ b/codeframe/ui/routers/terminal_ws.py
@@ -116,8 +116,6 @@ async def session_terminal_ws(session_id: str, websocket: WebSocket) -> None:
         return
     _user_terminal_counts[user_id] = current + 1
 
-    await websocket.accept()
-
     # --- Spawn bash with a minimal, explicit environment ---
     # Do NOT use os.environ.copy() — it would expose server secrets (API keys, DB creds)
     # to the subprocess. Only pass variables required for a functional terminal.
@@ -137,6 +135,11 @@ async def session_terminal_ws(session_id: str, websocket: WebSocket) -> None:
     stdout_to_ws_task: asyncio.Task | None = None
 
     try:
+        # Accept inside the try so a failed handshake (client aborts) still hits
+        # the finally that releases the reserved per-user slot — otherwise the
+        # slot leaks and three aborts lock the user out (#756).
+        await websocket.accept()
+
         process = await asyncio.create_subprocess_exec(
             shell_exe,
             stdin=asyncio.subprocess.PIPE,

--- a/tests/ui/test_terminal_ws.py
+++ b/tests/ui/test_terminal_ws.py
@@ -243,6 +243,42 @@ class TestTerminalWsRelay:
             with client.websocket_connect("/ws/sessions/s1/terminal") as ws:
                 pass  # Connected without error → no-auth path works
 
+    async def test_accept_failure_releases_per_user_slot(self):
+        """If the WS handshake (accept) raises, the reserved slot must be freed (#756).
+
+        A client aborting the handshake after the cap check would otherwise leak the
+        per-user slot permanently; three leaks lock the user out.
+        """
+        from codeframe.ui.routers import terminal_ws
+
+        terminal_ws._user_terminal_counts.clear()
+
+        ws = MagicMock()
+        ws.accept = AsyncMock(side_effect=RuntimeError("client aborted handshake"))
+        ws.close = AsyncMock()
+        fake_db = MagicMock()
+        fake_db.interactive_sessions.get.return_value = {
+            "state": "active",
+            "workspace_path": "/tmp",
+            "user_id": 1,
+        }
+        ws.app.state.db = fake_db
+
+        with (
+            patch(
+                "codeframe.ui.routers.terminal_ws._authenticate_websocket",
+                new=AsyncMock(return_value=(True, 1)),
+            ),
+            patch(
+                "codeframe.ui.routers.terminal_ws.revalidate_workspace_path",
+                return_value="/tmp",
+            ),
+        ):
+            await terminal_ws.session_terminal_ws("s1", ws)
+
+        # Slot released despite the failed handshake — no leak.
+        assert terminal_ws._user_terminal_counts.get(1, 0) == 0
+
     def test_resize_message_does_not_crash(self):
         """Sending a resize JSON message should be silently ignored."""
         app = self._make_authenticated_app()


### PR DESCRIPTION
Closes #756

## Problem
The per-user terminal counter (`_user_terminal_counts`) was incremented at `terminal_ws.py:117`, but `await websocket.accept()` sat **outside** the `try/finally` that releases the slot. If a client aborts the WebSocket handshake, `accept()` raises and unwinds the function before entering the `try`, so the reserved slot is never freed. Three such aborts exhaust the cap (`_MAX_TERMINALS_PER_USER = 3`) and permanently lock the user out. In no-auth mode all terminals share the `user_id=None` bucket, so one aborting client can lock out everyone.

## Fix
Move `await websocket.accept()` to the first statement **inside** the existing `try`, so its `finally` always releases the slot on a failed handshake.

The atomic check-then-increment stays before the `try` (no `await` between the cap check and the increment), so there is **no TOCTOU regression** on the concurrency cap — this is why the fix reserves-then-guards rather than reserving only after accept.

## Acceptance criteria
> Increment paired with a guaranteed decrement (inside try/finally or reserved only after successful accept).

✅ The increment is now guaranteed-paired with the `finally` decrement even when `accept()` raises.

## Test
`tests/ui/test_terminal_ws.py::TestTerminalWsRelay::test_accept_failure_releases_per_user_slot` — drives the endpoint with `accept()` raising and asserts the slot returns to 0. Confirmed red before the fix, green after.

## Verification
- New + existing `test_terminal_ws.py`: 11 passed
- Relevant neighbors (`test_websocket_auth.py`, `test_stream_ticket_endpoint.py`): 27 passed
- `ruff check` clean, `mypy` clean, pre-commit hooks passed