### PR TITLE
fix(sse): close /tasks/{id}/stream completion race that hangs the client (#757)

### DIFF
--- a/codeframe/ui/routers/streaming_v2.py
+++ b/codeframe/ui/routers/streaming_v2.py
@@ -9,7 +9,7 @@ The actual SSE endpoint for tasks is in tasks_v2.py:
 
 import asyncio
 import logging
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator, Callable, Optional
 
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse  # noqa: F401 — re-exported
@@ -86,6 +86,7 @@ async def event_stream_generator(
     publisher: EventPublisher,
     request: Request,
     heartbeat_interval: float = 15.0,
+    after_subscribe: Optional[Callable[[], Optional[ExecutionEvent]]] = None,
 ) -> AsyncGenerator[str, None]:
     """Generate SSE events for a task with heartbeat keep-alive.
 
@@ -98,6 +99,11 @@ async def event_stream_generator(
         publisher: EventPublisher to subscribe to
         request: FastAPI request (for disconnect detection)
         heartbeat_interval: Seconds between heartbeat comments
+        after_subscribe: Optional callback run *after* the subscription is
+            registered. If it returns an ExecutionEvent, that event is emitted
+            and the stream ends — used to backstop the race where a run finished
+            just before we subscribed (see #757). Returning None means "still
+            live"; real events then flow through the subscription.
 
     Yields:
         SSE-formatted event strings or comment heartbeats
@@ -114,6 +120,18 @@ async def event_stream_generator(
         publisher._subscribers[task_id].append(subscription)
 
     try:
+        # Race guard (#757): now that we're subscribed, any completion published
+        # from here on lands in `queue`. This callback backstops one published
+        # just *before* the subscribe (the EventPublisher has no buffering, so
+        # such an event would otherwise be lost and the client would hang on
+        # heartbeats). A duplicate completion is harmless — the loop below stops
+        # on the first one it sees.
+        if after_subscribe is not None:
+            terminal_event = after_subscribe()
+            if terminal_event is not None:
+                yield format_sse_event(terminal_event)
+                return
+
         while True:
             if await request.is_disconnected():
                 logger.info(f"Client disconnected from task {task_id} stream")

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -994,15 +994,39 @@ async def stream_task_events(
 
     publisher = get_event_publisher()
 
-    # Check if the task already has a terminal run — if so, send a synthetic
-    # completion event immediately instead of waiting for events that will
-    # never arrive (the agent is done, the EventPublisher has no buffering).
-    run = runtime.get_active_run(workspace, task_id)
-    latest_run = runtime.get_latest_run(workspace, task_id) if not run else None
-    already_terminal = (
-        latest_run is not None
-        and latest_run.status in (RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.BLOCKED)
-    ) if not run else False
+    def _terminal_completion() -> Optional[CompletionEvent]:
+        """Race guard (#757): checked *after* the SSE subscription is live.
+
+        If the run already reached a terminal state, emit a synthetic completion
+        so a client that connected just after the agent finished isn't left
+        hanging on heartbeats (the EventPublisher has no buffering). Running this
+        after subscribing — rather than before — closes the window where a
+        completion published between the check and the subscribe would be lost.
+        Returns None while the run is still live; real events then flow through
+        the subscription.
+        """
+        if runtime.get_active_run(workspace, task_id):
+            return None
+        latest_run = runtime.get_latest_run(workspace, task_id)
+        if latest_run is None or latest_run.status not in (
+            RunStatus.COMPLETED,
+            RunStatus.FAILED,
+            RunStatus.BLOCKED,
+        ):
+            return None
+        status_map = {
+            RunStatus.COMPLETED: "completed",
+            RunStatus.FAILED: "failed",
+            RunStatus.BLOCKED: "blocked",
+        }
+        duration = 0.0
+        if latest_run.started_at and latest_run.completed_at:
+            duration = (latest_run.completed_at - latest_run.started_at).total_seconds()
+        return CompletionEvent(
+            task_id=task_id,
+            status=status_map[latest_run.status],
+            duration_seconds=duration,
+        )
 
     async def _generate():
         # Always send an initial progress event so the browser's EventSource
@@ -1017,27 +1041,10 @@ async def stream_task_events(
             )
         )
 
-        if already_terminal:
-            # Task already finished — emit a synthetic completion event.
-            status_map = {
-                RunStatus.COMPLETED: "completed",
-                RunStatus.FAILED: "failed",
-                RunStatus.BLOCKED: "blocked",
-            }
-            duration = 0.0
-            if latest_run.started_at and latest_run.completed_at:
-                duration = (latest_run.completed_at - latest_run.started_at).total_seconds()
-            yield format_sse_event(
-                CompletionEvent(
-                    task_id=task_id,
-                    status=status_map[latest_run.status],
-                    duration_seconds=duration,
-                )
-            )
-            return
-
-        # Live stream — subscribe to the EventPublisher for real-time events.
-        async for chunk in event_stream_generator(task_id, publisher, request):
+        # Subscribe first, then check for an already-terminal run (see #757).
+        async for chunk in event_stream_generator(
+            task_id, publisher, request, after_subscribe=_terminal_completion
+        ):
             yield chunk
 
     return StreamingResponse(

--- a/tests/ui/test_streaming_router.py
+++ b/tests/ui/test_streaming_router.py
@@ -4,6 +4,7 @@ Tests for SSE event formatting, publisher management, and
 the event_stream_generator used by /api/v2/tasks/{task_id}/stream.
 """
 
+import asyncio
 import json
 
 from codeframe.core.models import (
@@ -12,6 +13,17 @@ from codeframe.core.models import (
     CompletionEvent,
     HeartbeatEvent,
 )
+
+
+class _ConnectedRequest:
+    """Fake Request that never reports a disconnect."""
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+def _parse_sse(chunk: str) -> dict:
+    return json.loads(chunk[len("data:"):].strip())
 
 
 class TestSSEEventFormat:
@@ -156,3 +168,71 @@ class TestEventPublisherGlobal:
 
         # Clean up
         set_event_publisher(None)
+
+
+class TestStreamCompletionRaceGuard:
+    """Race guard for GET /api/v2/tasks/{task_id}/stream (#757).
+
+    The terminal-run check must happen *after* the subscription is registered,
+    otherwise a completion published in the window between "not terminal yet"
+    and "subscribed" is dropped (EventPublisher has no buffering) and the client
+    hangs on heartbeats forever.
+    """
+
+    async def test_after_subscribe_terminal_emits_synthetic_and_stops(self):
+        """If the run is already terminal, emit a synthetic completion and end."""
+        from codeframe.core.streaming import EventPublisher
+        from codeframe.ui.routers.streaming_v2 import event_stream_generator
+
+        publisher = EventPublisher()
+        terminal = CompletionEvent(task_id="t1", status="completed", duration_seconds=1.0)
+
+        chunks = [
+            chunk
+            async for chunk in event_stream_generator(
+                "t1", publisher, _ConnectedRequest(), after_subscribe=lambda: terminal
+            )
+        ]
+
+        assert len(chunks) == 1
+        parsed = _parse_sse(chunks[0])
+        assert parsed["event_type"] == "completion"
+        assert parsed["data"]["status"] == "completed"
+        # Subscription is cleaned up on exit.
+        assert "t1" not in publisher._subscribers
+
+    async def test_completion_published_after_subscribe_is_delivered(self):
+        """A completion racing in right after subscribe must reach the client.
+
+        Reproduces the #757 window: the callback returns None ("still live"),
+        then a completion is published — because we already subscribed, it lands
+        in the queue and is delivered instead of being lost.
+        """
+        from codeframe.core.streaming import EventPublisher
+        from codeframe.ui.routers.streaming_v2 import event_stream_generator
+
+        publisher = EventPublisher()
+        gen = event_stream_generator(
+            "t2", publisher, _ConnectedRequest(),
+            heartbeat_interval=5.0, after_subscribe=lambda: None,
+        )
+
+        first = asyncio.ensure_future(gen.__anext__())
+        # Let the generator subscribe and reach its queue-wait.
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if publisher._subscribers.get("t2"):
+                break
+        assert publisher._subscribers.get("t2"), "generator never subscribed"
+
+        await publisher.publish(
+            "t2", CompletionEvent(task_id="t2", status="completed", duration_seconds=0.0)
+        )
+
+        # On regression (event lost) this awaits the full heartbeat and yields a
+        # comment instead — fail fast rather than hang.
+        chunk = await asyncio.wait_for(first, timeout=2.0)
+        parsed = _parse_sse(chunk)
+        assert parsed["event_type"] == "completion"
+
+        await gen.aclose()


### PR DESCRIPTION
Closes #757

## Problem
`GET /api/v2/tasks/{task_id}/stream` computed `already_terminal` **before** the
SSE subscription was registered. If the run completed in the window between that
check and the subscribe, the published `CompletionEvent` was dropped
(`EventPublisher` has no buffering — `streaming.py` silently discards events with
no subscribers) and no synthetic completion was emitted. The client then saw
only heartbeats forever.

The window is real because the agent publishes its completion event
(`react_agent._emit_stream_completion`) **before** `runtime.complete_run()`
persists `RunStatus.COMPLETED` to the DB — so a client connecting mid-completion
could read a non-terminal DB status, miss the live event, and hang.

## Fix
Subscribe first, then check for a terminal run (acceptance criteria):

- `event_stream_generator` gains an optional `after_subscribe` callback, invoked
  **after** the subscription is registered. If it returns a terminal
  `CompletionEvent`, that event is emitted and the stream ends.
- `stream_task_events` moves its terminal-run check into that callback.

Now any completion published **after** subscribe lands in the queue and is
delivered live; the callback backstops one published just **before** subscribe.
A duplicate completion is harmless — the stream stops on the first one.

## Tests
`tests/ui/test_streaming_router.py::TestStreamCompletionRaceGuard`:
- terminal-at-connect emits a synthetic completion and ends the stream
- a completion racing in right after subscribe is delivered (not lost); on
  regression the test fails fast via `wait_for` instead of hanging

All streaming-router tests (10) and the `/stream` integration tests (3) pass;
`ruff` and strict `mypy` clean on the changed files.

## Known limitation
A microscopic residual window remains between the agent *publishing* the
completion event and `complete_run` *committing* the terminal DB status. A
client subscribing in that sub-millisecond gap could still miss both the live
event and the terminal DB read. Fully closing it would require reordering the
runtime to persist-before-publish (broader, riskier change across
agent/executor/react_agent) and is out of scope for this medium-severity fix.
The change here eliminates the wide race (the entire run duration) that the
issue reports.