### PR TITLE
fix(sse): async /tasks/{id}/output tailer so abandoned streams don't pin threadpool threads (#758)

### DIFF
--- a/codeframe/core/streaming.py
+++ b/codeframe/core/streaming.py
@@ -24,6 +24,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import (
     AsyncIterator,
+    Awaitable,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -245,6 +247,62 @@ def tail_run_output(
 
         time.sleep(poll_interval)
         iterations += 1
+
+
+async def atail_run_output(
+    workspace: Workspace,
+    run_id: str,
+    since_line: int = 0,
+    poll_interval: float = 0.5,
+    max_wait: Optional[float] = None,
+    should_stop: Optional["Callable[[], Awaitable[bool]]"] = None,
+) -> AsyncIterator[str]:
+    """Async counterpart to :func:`tail_run_output` for SSE endpoints (#758).
+
+    The sync tailer blocks its thread on ``time.sleep`` for the whole poll loop
+    (up to ``max_wait``). When driven by Starlette's ``StreamingResponse`` that
+    thread comes from the shared threadpool, so abandoned tabs pin threads and
+    starve every other sync handler. This variant runs on the event loop and
+    ``await``s ``asyncio.sleep`` instead, so no threadpool thread is held.
+
+    Args:
+        workspace: Target workspace
+        run_id: Run identifier
+        since_line: Start after this line number (0-based)
+        poll_interval: How often to check for new lines (seconds)
+        max_wait: Maximum total wait time in seconds (None = no limit)
+        should_stop: Optional async predicate checked each poll (e.g.
+            ``request.is_disconnected``); when it returns True the loop exits
+            promptly, releasing the connection instead of waiting out max_wait.
+
+    Yields:
+        Lines from the log file as they appear
+    """
+    log_path = get_run_output_path(workspace, run_id)
+    current_line = since_line
+    start_time = time.monotonic()
+
+    while True:
+        if max_wait is not None and (time.monotonic() - start_time) >= max_wait:
+            break
+
+        if should_stop is not None and await should_stop():
+            break
+
+        # ponytail: full-file readlines each poll (same as the sync tailer);
+        # fine for agent logs. Switch to incremental seek reads if they grow large.
+        if log_path.exists():
+            try:
+                with open(log_path, "r", encoding="utf-8") as f:
+                    all_lines = f.readlines()
+
+                while current_line < len(all_lines):
+                    yield all_lines[current_line]
+                    current_line += 1
+            except Exception:
+                pass  # File might be temporarily unavailable
+
+        await asyncio.sleep(poll_interval)
 
 
 # =============================================================================

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -909,8 +909,14 @@ async def stream_task_output_lines(
             ),
         )
 
-    def generate_events():
-        """Generator that yields SSE events."""
+    async def generate_events():
+        """Async generator that yields SSE events.
+
+        Async (not sync) so the 5-minute poll loop runs on the event loop and
+        does not pin a shared threadpool thread; abandoned tabs previously
+        starved the pool (#758). ``request.is_disconnected`` is checked each
+        poll so a closed connection is released promptly.
+        """
         run_id = run.id
         current_line = 0
 
@@ -932,14 +938,14 @@ async def stream_task_output_lines(
 
                 current_line = total
 
-        # Stream new lines as they appear
-        # Use a reasonable timeout to allow the connection to close gracefully
-        for line in streaming.tail_run_output(
+        # Stream new lines as they appear, bailing when the client disconnects.
+        async for line in streaming.atail_run_output(
             workspace,
             run_id,
             since_line=current_line,
             poll_interval=0.5,
             max_wait=300.0,  # 5 minute timeout
+            should_stop=request.is_disconnected,
         ):
             yield f"event: line\ndata: {line.rstrip()}\n\n"
 

--- a/tests/core/test_streaming.py
+++ b/tests/core/test_streaming.py
@@ -221,6 +221,100 @@ class TestTailRunOutput:
         assert len(lines) == 0  # No lines, but no exception
 
 
+class TestATailRunOutput:
+    """Tests for the async tailer (#758) used by the SSE /output endpoint."""
+
+    async def test_atail_yields_existing_lines(
+        self, temp_workspace: Workspace, run_id: str
+    ):
+        """Async tail should yield lines already in the file, then stop at max_wait."""
+        from codeframe.core.streaming import RunOutputLogger, atail_run_output
+
+        with RunOutputLogger(temp_workspace, run_id) as logger:
+            logger.write("Line 1\n")
+            logger.write("Line 2\n")
+
+        lines = [
+            line
+            async for line in atail_run_output(
+                temp_workspace, run_id, poll_interval=0.01, max_wait=0.05
+            )
+        ]
+
+        assert len(lines) == 2
+        assert "Line 1" in lines[0]
+        assert "Line 2" in lines[1]
+
+    async def test_atail_since_line_skips_seen_content(
+        self, temp_workspace: Workspace, run_id: str
+    ):
+        """since_line should skip already-streamed lines."""
+        from codeframe.core.streaming import RunOutputLogger, atail_run_output
+
+        with RunOutputLogger(temp_workspace, run_id) as logger:
+            logger.write("Line 1\n")
+            logger.write("Line 2\n")
+            logger.write("Line 3\n")
+
+        lines = [
+            line
+            async for line in atail_run_output(
+                temp_workspace, run_id, since_line=2, poll_interval=0.01, max_wait=0.05
+            )
+        ]
+
+        assert len(lines) == 1
+        assert "Line 3" in lines[0]
+
+    async def test_atail_stops_when_should_stop_true(
+        self, temp_workspace: Workspace, run_id: str
+    ):
+        """A truthy should_stop (e.g. request.is_disconnected) ends the poll loop
+        promptly instead of waiting out max_wait — this is what frees the thread/loop
+        when a browser tab is abandoned."""
+        from codeframe.core.streaming import RunOutputLogger, atail_run_output
+
+        with RunOutputLogger(temp_workspace, run_id) as logger:
+            logger.write("Line 1\n")
+
+        # Stay connected for the first poll (drain the buffered line), then drop.
+        calls = {"n": 0}
+
+        async def disconnected() -> bool:
+            calls["n"] += 1
+            return calls["n"] > 1
+
+        start = time.monotonic()
+        lines = [
+            line
+            async for line in atail_run_output(
+                temp_workspace,
+                run_id,
+                poll_interval=0.01,
+                max_wait=300.0,
+                should_stop=disconnected,
+            )
+        ]
+        elapsed = time.monotonic() - start
+
+        # Existing line delivered, then loop exits on disconnect — nowhere near max_wait.
+        assert any("Line 1" in line for line in lines)
+        assert elapsed < 5.0
+
+    async def test_atail_handles_missing_file(self, temp_workspace: Workspace):
+        """Missing file should not raise; loop simply exits at max_wait."""
+        from codeframe.core.streaming import atail_run_output
+
+        lines = [
+            line
+            async for line in atail_run_output(
+                temp_workspace, "nonexistent-run", poll_interval=0.01, max_wait=0.05
+            )
+        ]
+
+        assert lines == []
+
+
 class TestGetLatestRunLines:
     """Tests for reading buffered output (--tail N functionality)."""
 


### PR DESCRIPTION
## Problem
`GET /api/v2/tasks/{id}/output` streamed via a **sync** generator (`generate_events` → `streaming.tail_run_output`) that blocks on `time.sleep` for the entire poll loop (`max_wait=300`). Starlette runs sync generators in the shared anyio threadpool (~40 threads), so every abandoned browser tab **pinned a thread for up to 5 minutes**, exhausting the pool and stalling all other sync handlers and `run_in_threadpool`/`to_thread` calls. (`codeframe/ui/routers/tasks_v2.py:899`)

## Fix
- **`core/streaming.py`**: add `atail_run_output`, an async counterpart to `tail_run_output` that `await`s `asyncio.sleep` (holds no threadpool thread) and accepts an optional async `should_stop` predicate checked each poll. Stays headless — the predicate is passed in, no FastAPI import.
- **`tasks_v2.py`**: `generate_events` becomes `async def` and iterates `atail_run_output(..., should_stop=request.is_disconnected)`, so a closed connection is released promptly instead of waiting out the 300s timeout.
- Sync `tail_run_output` is unchanged — the CLI (`cf work follow`) still uses it correctly (no event loop, no pool to starve).

Matches the acceptance criteria: *async generator with `await asyncio.sleep` polling and `request.is_disconnected()` checks each poll.*

## Tests & verification
- New `TestATailRunOutput` (4 tests): yields existing lines, respects `since_line`, **exits promptly on `should_stop`** instead of blocking to `max_wait`, handles missing file.
- Existing `#751` guard `test_streaming_and_orchestration_handlers_stay_async` still passes — the handler was already `async`; only its inner generator changed.
- End-to-end demo: while tailing a live-appended log, a concurrent heartbeat task fired all 10 ticks (loop stayed responsive → no thread pinned) and the tailer exited in 0.36s via the disconnect check despite `max_wait=300`.
- `ruff` clean, `mypy` (CI gate) clean on both source files.

## Known limitations
- The per-poll read is still a full-file `readlines()` (same as the sync tailer) — fine for agent logs; a `ponytail:` note flags the incremental-seek upgrade path if logs ever grow large. Out of scope for this fix.

Closes #758