### PR TITLE
fix(session-chat): reject second concurrent WS connection instead of clobbering per-session state (#759)

### DIFF
--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -162,7 +162,14 @@ async def session_chat_ws(session_id: str, websocket: WebSocket) -> None:
 
     try:
         await asyncio.to_thread(db.interactive_sessions.update_state, session_id, "active")
-        await session_chat_manager.register(session_id, websocket)
+        # Reject a second concurrent socket for the same session instead of
+        # overwriting the first's interrupt/queue state (#759). unregister() in
+        # the finally is identity-guarded, so it won't tear down the incumbent.
+        if not await session_chat_manager.register(session_id, websocket):
+            await websocket.close(
+                code=4009, reason="Session already has an active chat connection"
+            )
+            return
 
         token_queue = await session_chat_manager.get_token_queue(session_id)
 

--- a/codeframe/ui/shared.py
+++ b/codeframe/ui/shared.py
@@ -193,11 +193,22 @@ class SessionChatManager:
         self._token_queues: Dict[str, asyncio.Queue] = {}
         self._lock = asyncio.Lock()
 
-    async def register(self, session_id: str, websocket: "WebSocket") -> None:
+    async def register(self, session_id: str, websocket: "WebSocket") -> bool:
+        """Register websocket as the active connection for session_id.
+
+        Returns True if registered. Returns False when another live socket
+        already owns this session_id (the caller should reject with close code
+        4009) — the existing connection's interrupt event and token queue are
+        left untouched so it stays interruptible (#759).
+        """
         async with self._lock:
+            existing = self._connections.get(session_id)
+            if existing is not None and existing is not websocket:
+                return False
             self._connections[session_id] = websocket
             self._interrupt_events[session_id] = asyncio.Event()
             self._token_queues[session_id] = asyncio.Queue()
+            return True
 
     async def unregister(self, session_id: str, websocket: "WebSocket" = None) -> None:
         """Remove tracking state for session_id.

--- a/tests/api/test_session_chat_ws.py
+++ b/tests/api/test_session_chat_ws.py
@@ -221,6 +221,29 @@ class TestSessionChatWSSession:
             data = ws.receive_json()
             assert data["type"] == "pong"
 
+    def test_rejects_second_concurrent_connection(self, api_client: TestClient):
+        """A second socket for the same session_id is refused with 4009 (#759).
+
+        The first connection's interrupt event / token queue must NOT be
+        overwritten — the second is rejected instead, leaving tab 1 intact.
+        """
+        session_id = _create_session(api_client)
+        ticket1 = mint_ticket(user_id=1)
+        ticket2 = mint_ticket(user_id=1)
+        with api_client.websocket_connect(_ws_url(session_id, ticket1)) as ws1:
+            ws1.send_json({"type": "ping"})
+            assert ws1.receive_json()["type"] == "pong"
+
+            # Second connection to the same session is rejected with 4009.
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with api_client.websocket_connect(_ws_url(session_id, ticket2)) as ws2:
+                    ws2.receive_json()
+            assert exc_info.value.code == 4009
+
+            # First connection is unaffected and still responsive.
+            ws1.send_json({"type": "ping"})
+            assert ws1.receive_json()["type"] == "pong"
+
 
 # ---------------------------------------------------------------------------
 # Protocol tests


### PR DESCRIPTION
Closes #759

## Problem
`SessionChatManager.register` unconditionally overwrote `_connections` /
`_interrupt_events` / `_token_queues`, all keyed by `session_id` alone. When a
second tab connected to the same session, `register` replaced tab 1's
`asyncio.Event` and `Queue`. `signal_interrupt(session_id)` then set the *new*
tab's event while tab 1's already-running adapter was still awaiting the old
one — so **tab 1 became un-interruptible**, and either tab could clear the
other's interrupt.

Evidence: `codeframe/ui/shared.py:196`.

## Fix (acceptance criteria: reject 2nd connection, close 4009)
- `register()` now returns `bool`: `False` when a live socket already owns the
  `session_id`, leaving the incumbent's interrupt event and token queue
  **untouched**.
- The WS handler closes the newcomer with **4009** and returns.
- Mirrors the existing `terminal_ws` per-user-slot precedent (#756, close 4029).
- `unregister()` is already identity-guarded (`shared.py:210`), so the rejected
  socket's `finally` cleanup is a no-op against the incumbent — the fix composes
  with existing teardown.

Chose "reject" over "key state by `(session_id, websocket)`" (the other listed
option) because every manager method — `signal_interrupt`, `get_token_queue`,
`reset_interrupt` — is `session_id`-scoped, and two tabs driving one agent +
one workspace has no coherent "interrupt which socket?" semantics. One active
chat socket per session matches the product model.

## Testing
- New: `test_rejects_second_concurrent_connection` — drives the real endpoint:
  tab 1 connects, tab 2 is rejected with **4009**, tab 1 still ping/pongs
  (proving its state survived).
- `tests/api/test_session_chat_ws.py`: **16 passed** (`--timeout=60`).
- Adjacent WS suites: **40 passed / 30 skipped**.
- `ruff check` clean; strict `mypy` clean on both changed modules.

## Known limitations
- API/server-side only. The frontend receives a normal WS close on 4009; no
  dedicated "session already open elsewhere" UI is added (out of scope for the
  AC). A rejected reconnect during the incumbent's `finally` teardown window is
  a narrow race the user resolves by retrying — same slot-based behavior as
  `terminal_ws`.
