### PR TITLE
fix(auth): surface API-key auth errors + close leaked fallback DB (#760)

### DIFF
--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -273,13 +273,15 @@ async def get_api_key_auth(
     if not api_key:
         return None
 
+    fallback_db = None
     try:
         # Get database from app state (singleton) or request state
         db = getattr(request.app.state, "db", None)
         if db is None:
             db = getattr(request.state, "db", None)
         if db is None:
-            # Fallback: create database connection
+            # Fallback: create a short-lived connection. There is no request
+            # cleanup middleware, so it is closed in the finally below (#760).
             logger.warning("No db in app.state, creating fallback connection for API key auth")
             import os
             from codeframe.platform_store.database import Database
@@ -288,11 +290,9 @@ async def get_api_key_auth(
                 "DATABASE_PATH",
                 os.path.join(os.getcwd(), ".codeframe", "state.db")
             )
-            db = Database(db_path)
-            db.initialize()
-            # Store on request state so it can be cleaned up by middleware
-            if request is not None:
-                request.state.db = db
+            fallback_db = Database(db_path)
+            fallback_db.initialize()
+            db = fallback_db
 
         # Extract prefix and look up key
         try:
@@ -324,9 +324,18 @@ async def get_api_key_auth(
             "key_id": key_record["id"],
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.debug(f"API key authentication error: {e}")
+        # Unexpected failure (e.g. transient DB error). Surface it loudly — a
+        # valid key must not silently degrade to 401 with the cause hidden at
+        # debug level (#760). Matches the bearer path's logging; still degrades
+        # to no-auth (returns None) per this module's degrade-to-401 policy.
+        logger.error(f"API key authentication error: {e}", exc_info=True)
         return None
+    finally:
+        if fallback_db is not None:
+            fallback_db.close()
 
 
 async def require_auth(

--- a/tests/auth/test_api_key_auth_errors.py
+++ b/tests/auth/test_api_key_auth_errors.py
@@ -1,0 +1,66 @@
+"""Error-path tests for get_api_key_auth (issue #760).
+
+Two regressions are guarded here:
+  1. An unexpected DB failure must be surfaced at warning+ (not swallowed at
+     debug), so a valid key degrading to 401 leaves a visible root cause.
+  2. The per-request fallback Database connection must be closed — there is no
+     cleanup middleware, so leaving it open leaks a connection every request.
+
+Following TDD: written before the fix.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeframe.auth.api_keys import generate_api_key
+from codeframe.auth.dependencies import get_api_key_auth
+
+
+def _fake_request(app_db=None, req_db=None):
+    """Minimal stand-in for a FastAPI Request with app/request state."""
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(db=app_db)),
+        state=SimpleNamespace(db=req_db),
+    )
+
+
+@pytest.mark.asyncio
+async def test_transient_db_error_surfaced_at_warning_plus(caplog):
+    """A DB failure during lookup is logged at ERROR (not DEBUG) and returns None."""
+    full_key, _hash, _prefix = generate_api_key()
+
+    db = MagicMock()
+    db.api_keys.get_by_prefix.side_effect = RuntimeError("database is locked")
+    request = _fake_request(app_db=db)
+
+    with caplog.at_level(logging.DEBUG, logger="codeframe.auth.dependencies"):
+        result = await get_api_key_auth(api_key=full_key, request=request)
+
+    assert result is None
+    # The failure must be visible in normal logs, not hidden at DEBUG.
+    surfaced = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and "database is locked" in r.getMessage()
+    ]
+    assert surfaced, "transient DB error must be logged at WARNING or above"
+
+
+@pytest.mark.asyncio
+async def test_fallback_db_is_closed(monkeypatch):
+    """When no db is in state, the fallback Database is created and then closed."""
+    fallback = MagicMock()
+    fallback.api_keys.get_by_prefix.return_value = None  # key not found -> returns None
+
+    ctor = MagicMock(return_value=fallback)
+    monkeypatch.setattr("codeframe.platform_store.database.Database", ctor)
+
+    full_key, _hash, _prefix = generate_api_key()
+    request = _fake_request(app_db=None, req_db=None)
+
+    result = await get_api_key_auth(api_key=full_key, request=request)
+
+    assert result is None
+    ctor.assert_called_once()
+    fallback.close.assert_called_once()


### PR DESCRIPTION
Closes #760

## Problem
`get_api_key_auth` caught **every** exception and logged it at `debug` level, so a transient DB failure made a *valid* API key silently degrade to 401 with the root cause visible only at DEBUG. Separately, the per-request fallback `Database` connection was created but never closed — there is no request-cleanup middleware, so it leaked a connection each time the fallback path ran.

## Fix
- **Surface unexpected errors** at `logger.error(..., exc_info=True)` — matches the bearer path (`get_current_user`) exactly. Preserves this module's deliberate *degrade-to-401* policy (still returns `None`), so behavior is unchanged except the failure is now visible in normal logs.
- **Narrow the catch**: `except HTTPException: raise` before the broad handler.
- **Close the fallback DB** in a `finally`, tracked via `fallback_db`. Stopped stashing it on `request.state.db` — nothing reads it and nothing closed it (the "cleaned up by middleware" comment was aspirational; no such middleware exists).

## Acceptance criteria (demonstrated)
| Criterion | Evidence |
|---|---|
| Narrow except; surface unexpected errors at warning+ | Transient DB error now logs at **ERROR** with traceback (was silent DEBUG); result still `None` |
| Explicitly close the fallback Database | `fallback_db.close()` called exactly once on every exit path |

## Tests
`tests/auth/test_api_key_auth_errors.py` (TDD, red→green):
- `test_transient_db_error_surfaced_at_warning_plus`
- `test_fallback_db_is_closed`

Quality gate: **158 passed** (full `tests/auth` + `test_v2_auth_enforcement`), `ruff` clean, `mypy` clean.

## Known limitations / follow-ups (out of scope for #760)
- `codeframe/auth/api_key_router.py:125` has the same fallback-DB stash-on-`request.state` pattern and would benefit from the same close-in-finally treatment. Not touched — this issue is scoped to `dependencies.py:276`.