### PR TITLE
fix(github): bound the issue-browse cache (#761)

### DIFF
--- a/codeframe/ui/routers/github_integrations_v2.py
+++ b/codeframe/ui/routers/github_integrations_v2.py
@@ -119,9 +119,25 @@ class ImportResponse(BaseModel):
 # In-process TTL cache for issue listings (#564). Keyed by the full query
 # (repo + page + per_page + search + label); entries expire after 60s to avoid
 # hammering GitHub's rate limit on repeated browses. Module-level so it is
-# shared across requests within the same server process.
+# shared across requests within the same server process. Bounded to
+# _ISSUE_CACHE_MAX_SIZE entries and swept on every set so search text (an
+# unbounded key space) can't accumulate stale payloads forever (#761).
 _ISSUE_CACHE_TTL_SECONDS = 60.0
+_ISSUE_CACHE_MAX_SIZE = 256
 _ISSUE_CACHE: dict[str, tuple[float, Any]] = {}
+
+
+def _evict_issue_cache() -> None:
+    """Drop expired entries and trim to max size (oldest expiry first)."""
+    now = time.monotonic()
+    for key in [k for k, (exp, _) in _ISSUE_CACHE.items() if now >= exp]:
+        del _ISSUE_CACHE[key]
+    if len(_ISSUE_CACHE) > _ISSUE_CACHE_MAX_SIZE:
+        # expires_at == insert_time + constant TTL, so it doubles as an
+        # insertion-order stamp — smallest expiry == oldest entry.
+        oldest = sorted(_ISSUE_CACHE, key=lambda k: _ISSUE_CACHE[k][0])
+        for key in oldest[: len(_ISSUE_CACHE) - _ISSUE_CACHE_MAX_SIZE]:
+            del _ISSUE_CACHE[key]
 
 
 def _issue_cache_get(key: str) -> Optional[Any]:
@@ -137,6 +153,7 @@ def _issue_cache_get(key: str) -> Optional[Any]:
 
 def _issue_cache_set(key: str, payload: Any) -> None:
     _ISSUE_CACHE[key] = (time.monotonic() + _ISSUE_CACHE_TTL_SECONDS, payload)
+    _evict_issue_cache()
 
 
 def _issue_cache_invalidate(repo: str) -> None:

--- a/tests/ui/test_github_integrations_v2.py
+++ b/tests/ui/test_github_integrations_v2.py
@@ -275,6 +275,37 @@ def _clear_issue_cache():
     github_integrations_v2._ISSUE_CACHE.clear()
 
 
+class TestIssueCacheEviction:
+    """Bound the issue-browse cache: sweep expired + cap size (#761)."""
+
+    def test_expired_entries_swept_on_set(self, monkeypatch):
+        from codeframe.ui.routers import github_integrations_v2 as gi
+
+        _clear_issue_cache()
+        # An expired entry under a key never re-requested lingers until any set.
+        gi._ISSUE_CACHE["stale|1"] = (gi.time.monotonic() - 1.0, "old")
+        gi._issue_cache_set("fresh|1", "new")
+        assert "stale|1" not in gi._ISSUE_CACHE
+        assert gi._issue_cache_get("fresh|1") == "new"
+
+    def test_size_capped_evicting_oldest(self, monkeypatch):
+        from codeframe.ui.routers import github_integrations_v2 as gi
+
+        _clear_issue_cache()
+        monkeypatch.setattr(gi, "_ISSUE_CACHE_MAX_SIZE", 3)
+        # Distinct, non-expired keys (search text is an unbounded key space).
+        # Real inserts share one TTL, so expiry order == insertion order;
+        # mirror that with ascending expiries all below the real set below.
+        base = gi.time.monotonic()
+        for i in range(6):
+            gi._ISSUE_CACHE[f"repo|{i}"] = (base + 1.0 + i, i)
+        gi._issue_cache_set("repo|new", "n")  # real expiry ~base+60 → newest
+        # Cap holds; the newest survives; the oldest is gone.
+        assert len(gi._ISSUE_CACHE) == 3
+        assert "repo|new" in gi._ISSUE_CACHE
+        assert "repo|0" not in gi._ISSUE_CACHE
+
+
 class TestListIssues:
     def test_requires_connection(self, client, monkeypatch):
         _clear_issue_cache()


### PR DESCRIPTION
## Summary
Closes #761.

`_ISSUE_CACHE` (GitHub issue-browse listings, `github_integrations_v2.py`) is keyed partly on **arbitrary user search text**, expired **only lazily** (a key was dropped only when that exact key was re-requested), and **never capped its size**. A long-lived server serving varied searches accumulated stale payloads unboundedly — a slow memory leak.

## Fix
Add `_evict_issue_cache()`, mirroring the existing `proof_v2._evict_run_cache` pattern, called on every `_issue_cache_set`:
1. Sweep all expired entries (`now >= expires_at`).
2. If still over `_ISSUE_CACHE_MAX_SIZE` (256), trim oldest-first.

Every entry shares one constant TTL, so `expires_at` doubles as an insertion-order stamp — smallest expiry == oldest entry, no separate timestamp field needed. Eviction runs on write (bounded work per set), so no background task.

## Acceptance criteria
> Sweep-and-cap (reuse proof_v2's `_evict_run_cache`) or a small LRU/TTL cache.

✅ Sweep-and-cap on insert, reusing the proof_v2 approach.

## Tests
- `test_expired_entries_swept_on_set` — an expired entry under a never-re-requested key is dropped on the next `set`.
- `test_size_capped_evicting_oldest` — cache holds at the cap; newest survives, oldest evicted.

Full `tests/ui/test_github_integrations_v2.py` suite passes (38 tests); `ruff` and `mypy` clean.

## Known limitations
- In-process cache only (already the case): multiple uvicorn workers keep separate caches. Same caveat documented on `proof_v2._run_cache`.