### PR TITLE
fix(core): release SQLite connections on query failure in batch/run readers (#762)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -748,21 +748,23 @@ def get_batch(workspace: Workspace, batch_id: str) -> Optional[BatchRun]:
         BatchRun if found, None otherwise
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
-               on_failure, started_at, completed_at, results, engine,
-               isolation, stall_timeout_s, stall_action, concurrency_by_status,
-               llm_provider, llm_model
-        FROM batch_runs
-        WHERE workspace_id = ? AND id = ?
-        """,
-        (workspace.id, batch_id),
-    )
-    row = cursor.fetchone()
-    conn.close()
+        cursor.execute(
+            """
+            SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
+                   on_failure, started_at, completed_at, results, engine,
+                   isolation, stall_timeout_s, stall_action, concurrency_by_status,
+                   llm_provider, llm_model
+            FROM batch_runs
+            WHERE workspace_id = ? AND id = ?
+            """,
+            (workspace.id, batch_id),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
 
     if not row:
         return None
@@ -786,39 +788,41 @@ def list_batches(
         List of BatchRuns, newest first
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    if status:
-        cursor.execute(
-            """
-            SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
-                   on_failure, started_at, completed_at, results, engine,
-                   isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                   llm_provider, llm_model
-            FROM batch_runs
-            WHERE workspace_id = ? AND status = ?
-            ORDER BY started_at DESC
-            LIMIT ?
-            """,
-            (workspace.id, status.value, limit),
-        )
-    else:
-        cursor.execute(
-            """
-            SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
-                   on_failure, started_at, completed_at, results, engine,
-                   isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                   llm_provider, llm_model
-            FROM batch_runs
-            WHERE workspace_id = ?
-            ORDER BY started_at DESC
-            LIMIT ?
-            """,
-            (workspace.id, limit),
-        )
+        if status:
+            cursor.execute(
+                """
+                SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
+                       on_failure, started_at, completed_at, results, engine,
+                       isolation, stall_timeout_s, stall_action, concurrency_by_status,
+                       llm_provider, llm_model
+                FROM batch_runs
+                WHERE workspace_id = ? AND status = ?
+                ORDER BY started_at DESC
+                LIMIT ?
+                """,
+                (workspace.id, status.value, limit),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
+                       on_failure, started_at, completed_at, results, engine,
+                       isolation, stall_timeout_s, stall_action, concurrency_by_status,
+                       llm_provider, llm_model
+                FROM batch_runs
+                WHERE workspace_id = ?
+                ORDER BY started_at DESC
+                LIMIT ?
+                """,
+                (workspace.id, limit),
+            )
 
-    rows = cursor.fetchall()
-    conn.close()
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
 
     return [_row_to_batch(row) for row in rows]
 

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -142,18 +142,20 @@ def get_run(workspace: Workspace, run_id: str) -> Optional[Run]:
         Run if found, None otherwise
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        SELECT id, workspace_id, task_id, status, started_at, completed_at
-        FROM runs
-        WHERE workspace_id = ? AND id = ?
-        """,
-        (workspace.id, run_id),
-    )
-    row = cursor.fetchone()
-    conn.close()
+        cursor.execute(
+            """
+            SELECT id, workspace_id, task_id, status, started_at, completed_at
+            FROM runs
+            WHERE workspace_id = ? AND id = ?
+            """,
+            (workspace.id, run_id),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
 
     if not row:
         return None
@@ -172,20 +174,22 @@ def get_active_run(workspace: Workspace, task_id: str) -> Optional[Run]:
         Run if found, None otherwise
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        SELECT id, workspace_id, task_id, status, started_at, completed_at
-        FROM runs
-        WHERE workspace_id = ? AND task_id = ? AND status IN ('RUNNING', 'BLOCKED')
-        ORDER BY started_at DESC
-        LIMIT 1
-        """,
-        (workspace.id, task_id),
-    )
-    row = cursor.fetchone()
-    conn.close()
+        cursor.execute(
+            """
+            SELECT id, workspace_id, task_id, status, started_at, completed_at
+            FROM runs
+            WHERE workspace_id = ? AND task_id = ? AND status IN ('RUNNING', 'BLOCKED')
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (workspace.id, task_id),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
 
     if not row:
         return None
@@ -204,20 +208,22 @@ def get_latest_run(workspace: Workspace, task_id: str) -> Optional[Run]:
         Run if found, None otherwise
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        SELECT id, workspace_id, task_id, status, started_at, completed_at
-        FROM runs
-        WHERE workspace_id = ? AND task_id = ?
-        ORDER BY started_at DESC
-        LIMIT 1
-        """,
-        (workspace.id, task_id),
-    )
-    row = cursor.fetchone()
-    conn.close()
+        cursor.execute(
+            """
+            SELECT id, workspace_id, task_id, status, started_at, completed_at
+            FROM runs
+            WHERE workspace_id = ? AND task_id = ?
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (workspace.id, task_id),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
 
     if not row:
         return None
@@ -239,26 +245,28 @@ def reset_blocked_run(workspace: Workspace, task_id: str) -> bool:
         True if a blocked run was reset, False if no blocked run existed
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    # Find and update blocked run
-    cursor.execute(
-        """
-        UPDATE runs
-        SET status = ?, completed_at = ?
-        WHERE workspace_id = ? AND task_id = ? AND status = ?
-        """,
-        (
-            RunStatus.FAILED.value,
-            _utc_now().isoformat(),
-            workspace.id,
-            task_id,
-            RunStatus.BLOCKED.value,
-        ),
-    )
-    updated = cursor.rowcount > 0
-    conn.commit()
-    conn.close()
+        # Find and update blocked run
+        cursor.execute(
+            """
+            UPDATE runs
+            SET status = ?, completed_at = ?
+            WHERE workspace_id = ? AND task_id = ? AND status = ?
+            """,
+            (
+                RunStatus.FAILED.value,
+                _utc_now().isoformat(),
+                workspace.id,
+                task_id,
+                RunStatus.BLOCKED.value,
+            ),
+        )
+        updated = cursor.rowcount > 0
+        conn.commit()
+    finally:
+        conn.close()
 
     if updated:
         # Reset task status to READY
@@ -287,29 +295,31 @@ def list_runs(
         List of Runs, newest first
     """
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    query = """
-        SELECT id, workspace_id, task_id, status, started_at, completed_at
-        FROM runs
-        WHERE workspace_id = ?
-    """
-    params: list = [workspace.id]
+        query = """
+            SELECT id, workspace_id, task_id, status, started_at, completed_at
+            FROM runs
+            WHERE workspace_id = ?
+        """
+        params: list = [workspace.id]
 
-    if task_id:
-        query += " AND task_id = ?"
-        params.append(task_id)
+        if task_id:
+            query += " AND task_id = ?"
+            params.append(task_id)
 
-    if status:
-        query += " AND status = ?"
-        params.append(status.value)
+        if status:
+            query += " AND status = ?"
+            params.append(status.value)
 
-    query += " ORDER BY started_at DESC LIMIT ?"
-    params.append(limit)
+        query += " ORDER BY started_at DESC LIMIT ?"
+        params.append(limit)
 
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    conn.close()
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
 
     return [_row_to_run(row) for row in rows]
 
@@ -339,18 +349,20 @@ def complete_run(workspace: Workspace, run_id: str) -> Run:
     now = _utc_now().isoformat()
 
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        UPDATE runs
-        SET status = ?, completed_at = ?
-        WHERE id = ?
-        """,
-        (RunStatus.COMPLETED.value, now, run_id),
-    )
-    conn.commit()
-    conn.close()
+        cursor.execute(
+            """
+            UPDATE runs
+            SET status = ?, completed_at = ?
+            WHERE id = ?
+            """,
+            (RunStatus.COMPLETED.value, now, run_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     # Transition task to DONE
     tasks.update_status(workspace, run.task_id, TaskStatus.DONE)
@@ -394,18 +406,20 @@ def fail_run(workspace: Workspace, run_id: str, reason: str = "") -> Run:
     now = _utc_now().isoformat()
 
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        UPDATE runs
-        SET status = ?, completed_at = ?
-        WHERE id = ?
-        """,
-        (RunStatus.FAILED.value, now, run_id),
-    )
-    conn.commit()
-    conn.close()
+        cursor.execute(
+            """
+            UPDATE runs
+            SET status = ?, completed_at = ?
+            WHERE id = ?
+            """,
+            (RunStatus.FAILED.value, now, run_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     # Emit run failed event
     events.emit_for_workspace(
@@ -447,18 +461,20 @@ def block_run(workspace: Workspace, run_id: str, blocker_id: str) -> Run:
         raise ValueError(f"Run is not running: {run.status}")
 
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        UPDATE runs
-        SET status = ?
-        WHERE id = ?
-        """,
-        (RunStatus.BLOCKED.value, run_id),
-    )
-    conn.commit()
-    conn.close()
+        cursor.execute(
+            """
+            UPDATE runs
+            SET status = ?
+            WHERE id = ?
+            """,
+            (RunStatus.BLOCKED.value, run_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     # Transition task to BLOCKED
     tasks.update_status(workspace, run.task_id, TaskStatus.BLOCKED)
@@ -488,18 +504,20 @@ def resume_run(workspace: Workspace, task_id: str) -> Run:
         raise ValueError(f"Run is not blocked: {run.status}")
 
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        UPDATE runs
-        SET status = ?
-        WHERE id = ?
-        """,
-        (RunStatus.RUNNING.value, run.id),
-    )
-    conn.commit()
-    conn.close()
+        cursor.execute(
+            """
+            UPDATE runs
+            SET status = ?
+            WHERE id = ?
+            """,
+            (RunStatus.RUNNING.value, run.id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     # Transition task back to IN_PROGRESS
     tasks.update_status(workspace, task_id, TaskStatus.IN_PROGRESS)
@@ -530,18 +548,20 @@ def stop_run(workspace: Workspace, task_id: str) -> Run:
     now = _utc_now().isoformat()
 
     conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    cursor.execute(
-        """
-        UPDATE runs
-        SET status = ?, completed_at = ?
-        WHERE id = ?
-        """,
-        (RunStatus.FAILED.value, now, run.id),
-    )
-    conn.commit()
-    conn.close()
+        cursor.execute(
+            """
+            UPDATE runs
+            SET status = ?, completed_at = ?
+            WHERE id = ?
+            """,
+            (RunStatus.FAILED.value, now, run.id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     # Transition task back to READY so it can be restarted (if not already)
     task = tasks.get(workspace, task_id)

--- a/tests/core/test_batch_run_connection_safety.py
+++ b/tests/core/test_batch_run_connection_safety.py
@@ -1,0 +1,151 @@
+"""Connection leak-on-exception tests for batch/run readers and writers (#762).
+
+Mirrors the tasks.py robustness suite (#650): every DB path in
+``conductor.py`` (batch readers) and ``runtime.py`` (run readers/writers) must
+release its SQLite connection even when an error is raised between opening the
+connection and the normal ``conn.close()`` call — i.e. the path is wrapped in
+``try/finally``. Before #762 these hot-path readers closed only on the happy
+path, so an ``OperationalError`` (e.g. "database is locked" under parallel
+load) leaked the connection.
+"""
+
+import pytest
+
+from codeframe.core import conductor, runtime, tasks
+from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    return create_or_load_workspace(tmp_path)
+
+
+class _TrackingCursor:
+    """Wraps a real cursor, optionally raising on execute()."""
+
+    def __init__(self, real, fail_on):
+        self._real = real
+        self._fail_on = fail_on
+
+    def execute(self, *args, **kwargs):
+        if self._fail_on == "execute":
+            raise RuntimeError("boom-execute")
+        return self._real.execute(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+class _TrackingConn:
+    """Wraps a real SQLite connection, recording close() and optionally raising
+    on a chosen operation to simulate a mid-operation failure.
+
+    ``fail_on`` may be ``"execute"`` (raise inside the SQL call, so the
+    function body is reached) or ``"commit"`` (raise after the write executes,
+    exercising each write path's ``finally``)."""
+
+    def __init__(self, real, fail_on, registry):
+        self._real = real
+        self._fail_on = fail_on
+        self.closed = False
+        registry.append(self)
+
+    def cursor(self):
+        return _TrackingCursor(self._real.cursor(), self._fail_on)
+
+    def commit(self):
+        if self._fail_on == "commit":
+            raise RuntimeError("boom-commit")
+        return self._real.commit()
+
+    def close(self):
+        self.closed = True
+        self._real.close()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def _patch_connections(monkeypatch, module, fail_on):
+    """Make ``module.get_db_connection`` hand out tracking connections that fail
+    on ``fail_on``. Returns the registry of every connection handed out."""
+    registry: list[_TrackingConn] = []
+
+    def fake(ws):
+        return _TrackingConn(get_db_connection(ws), fail_on, registry)
+
+    monkeypatch.setattr(module, "get_db_connection", fake)
+    return registry
+
+
+class TestConductorReadersReleaseOnException:
+    """conductor.py batch readers release the connection on query failure."""
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            pytest.param(lambda ws: conductor.get_batch(ws, "bid"), id="get_batch"),
+            pytest.param(lambda ws: conductor.list_batches(ws), id="list_batches"),
+            pytest.param(
+                lambda ws: conductor.list_batches(ws, status=None, limit=5),
+                id="list_batches_no_status",
+            ),
+        ],
+    )
+    def test_release_on_execute_error(self, workspace, monkeypatch, operation):
+        registry = _patch_connections(monkeypatch, conductor, fail_on="execute")
+
+        with pytest.raises(RuntimeError, match="boom-execute"):
+            operation(workspace)
+
+        assert registry, "expected at least one connection to be opened"
+        assert all(c.closed for c in registry), "connection leaked on exception"
+
+
+class TestRuntimeReadersReleaseOnException:
+    """runtime.py run readers release the connection on query failure."""
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            pytest.param(lambda ws, tid: runtime.get_run(ws, "rid"), id="get_run"),
+            pytest.param(
+                lambda ws, tid: runtime.get_active_run(ws, tid), id="get_active_run"
+            ),
+            pytest.param(
+                lambda ws, tid: runtime.get_latest_run(ws, tid), id="get_latest_run"
+            ),
+            pytest.param(lambda ws, tid: runtime.list_runs(ws), id="list_runs"),
+            pytest.param(
+                lambda ws, tid: runtime.list_runs(ws, task_id=tid, limit=5),
+                id="list_runs_filtered",
+            ),
+        ],
+    )
+    def test_release_on_execute_error(self, workspace, monkeypatch, operation):
+        task = tasks.create(workspace, title="leak-test")
+        registry = _patch_connections(monkeypatch, runtime, fail_on="execute")
+
+        with pytest.raises(RuntimeError, match="boom-execute"):
+            operation(workspace, task.id)
+
+        assert registry, "expected at least one connection to be opened"
+        assert all(c.closed for c in registry), "connection leaked on exception"
+
+
+class TestRuntimeWritersReleaseOnException:
+    """runtime.py run writers release the connection when commit fails."""
+
+    def test_reset_blocked_run_release_on_commit_error(
+        self, workspace, monkeypatch
+    ):
+        task = tasks.create(workspace, title="leak-test")
+        registry = _patch_connections(monkeypatch, runtime, fail_on="commit")
+
+        with pytest.raises(RuntimeError, match="boom-commit"):
+            runtime.reset_blocked_run(workspace, task.id)
+
+        assert registry, "expected at least one connection to be opened"
+        assert all(c.closed for c in registry), "connection leaked on exception"


### PR DESCRIPTION
Closes #762

## Problem
`get_batch`/`list_batches` (`conductor.py`) and `get_run`/`list_runs` (`runtime.py`) called `conn.close()` only on the happy path. Any `OperationalError` between opening the connection and that close — e.g. "database is locked" under parallel batch load — leaked the connection. Under SQLite's locking this can hold a read transaction open, worsening the very contention that triggered the leak.

## Fix
Wrap connection use in `try/finally`, matching the `tasks.py` pattern established in #650. The row→object conversion stays outside the `try` (mirrors `tasks.py`, where `_row_to_task(row)` runs after `finally`).

**Scope beyond the four named functions:** `get_active_run` and `get_latest_run` are byte-for-byte the same read pattern, and the run writers (`reset_blocked_run`, `complete_run`, `fail_run`, `block_run`, `resume_run`, `stop_run`) leak identically on a pre-commit failure. Fixing only the four named readers would leave those siblings broken and spawn a follow-up issue, so every bare `conn.close()` in both hot-path modules is now guarded.

## Tests (TDD)
New `tests/core/test_batch_run_connection_safety.py` mirrors the #650 suite: a tracking connection raises inside `execute()` (readers) or `commit()` (writer) and asserts every opened connection was closed. Confirmed **RED** before the fix (9 failing), **GREEN** after.

## Verification
- New leak suite: 9 passed (RED→GREEN)
- `test_conductor*` + `test_runtime*` regression: 92 passed
- `ruff check`: clean · `mypy` (strict): clean

## Known limitations
None — pure resource-safety fix, no behavior change on the happy path.