### PR TITLE
fix(session-chat): resolve provider + honor model from session agent_type (#764)

### DIFF
--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -47,6 +47,14 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["websocket"])
 
+# Maps a session ``agent_type`` (agent vocabulary: "claude", "codex", ...) to an
+# LLM ``provider_type`` understood by ``get_provider`` ("anthropic", ...). Only
+# agent types backed by a real streaming ``LLMProvider`` can be served through
+# ``StreamingChatAdapter``; CLI agents (codex, opencode) have no streaming
+# provider, so they are absent here and rejected at chat time with a clear error
+# rather than silently served by Anthropic on the default model (#764).
+_AGENT_TYPE_TO_PROVIDER = {"claude": "anthropic", "anthropic": "anthropic"}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,6 +77,8 @@ async def _run_streaming_adapter(
     interrupt_event: asyncio.Event,
     db_repo,
     workspace_path: Path,
+    agent_type: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> None:
     """Drive the StreamingChatAdapter and forward ChatEvents into the token queue.
 
@@ -79,15 +89,34 @@ async def _run_streaming_adapter(
         interrupt_event: Signals the adapter to stop mid-stream.
         db_repo: ``InteractiveSessionRepository`` for history load/persist.
         workspace_path: Absolute path to the workspace for file-system tools.
+        agent_type: Session's stored agent type; resolves the LLM provider
+            (#764). Defaults to ``"claude"`` when unset (legacy rows).
+        model: Session's stored model; honored instead of the adapter default.
     """
     try:
-        from codeframe.adapters.llm.anthropic import AnthropicProvider
-        provider = AnthropicProvider()
+        provider_type = _AGENT_TYPE_TO_PROVIDER.get((agent_type or "claude").lower())
+        if provider_type is None:
+            # An agent_type with no streaming provider (e.g. codex/opencode) must
+            # not be silently served by Anthropic — fail loudly (#764).
+            await token_queue.put({
+                "type": "error",
+                "message": (
+                    f"Interactive chat cannot serve agent_type '{agent_type}'. "
+                    "Only Claude/Anthropic sessions are supported."
+                ),
+            })
+            return
+        from codeframe.adapters.llm import get_provider
+        provider = get_provider(provider_type)
+        # Honor the session's stored model; fall back to the adapter default only
+        # when unset, instead of always using the hardcoded default (#764).
+        adapter_kwargs = {"model": model} if model else {}
         adapter = StreamingChatAdapter(
             session_id=session_id,
             db_repo=db_repo,
             workspace_path=workspace_path,
             provider=provider,
+            **adapter_kwargs,
         )
         async for event in adapter.send_message(
             content=user_message,
@@ -320,6 +349,8 @@ async def session_chat_ws(session_id: str, websocket: WebSocket) -> None:
                             interrupt_event,
                             db.interactive_sessions,
                             workspace_path,
+                            session.get("agent_type"),
+                            session.get("model"),
                         )
                     )
 

--- a/tests/api/test_session_chat_ws.py
+++ b/tests/api/test_session_chat_ws.py
@@ -266,7 +266,7 @@ class TestSessionChatWSProtocol:
         session_id = _create_session(api_client)
         ticket = mint_ticket(user_id=1)
 
-        async def fake_adapter(session_id, user_message, token_queue, interrupt_event, db_repo, workspace_path):
+        async def fake_adapter(session_id, user_message, token_queue, interrupt_event, db_repo, workspace_path, agent_type=None, model=None):
             await token_queue.put({"type": "text_delta", "content": "Hello"})
             await token_queue.put({"type": "text_delta", "content": " world"})
             await token_queue.put({"type": "cost_update", "cost_usd": 0.001, "input_tokens": 10, "output_tokens": 5})
@@ -303,7 +303,7 @@ class TestSessionChatWSProtocol:
         session_id = _create_session(api_client)
         ticket = mint_ticket(user_id=1)
 
-        async def slow_adapter(session_id, user_message, token_queue, interrupt_event, db_repo, workspace_path):
+        async def slow_adapter(session_id, user_message, token_queue, interrupt_event, db_repo, workspace_path, agent_type=None, model=None):
             for i in range(10):
                 if interrupt_event.is_set():
                     await token_queue.put({"type": "done"})
@@ -342,7 +342,7 @@ class TestSessionChatWSProtocol:
         session_id = _create_session(api_client)
         ticket = mint_ticket(user_id=1)
 
-        async def fake_adapter(session_id, user_message, token_queue, interrupt_event, db_repo, workspace_path):
+        async def fake_adapter(session_id, user_message, token_queue, interrupt_event, db_repo, workspace_path, agent_type=None, model=None):
             await token_queue.put(
                 {"type": "cost_update", "cost_usd": 0.005, "input_tokens": 100, "output_tokens": 50}
             )
@@ -366,6 +366,77 @@ class TestSessionChatWSProtocol:
         assert data["cost_usd"] == pytest.approx(0.005, abs=1e-6)
         assert data["input_tokens"] == 100
         assert data["output_tokens"] == 50
+
+
+# ---------------------------------------------------------------------------
+# Provider / model resolution (#764)
+# ---------------------------------------------------------------------------
+
+
+class TestRunStreamingAdapterResolution:
+    """`_run_streaming_adapter` resolves provider + model from the session (#764)."""
+
+    @staticmethod
+    def _fake_adapter_factory(captured: dict):
+        """Return a StreamingChatAdapter stand-in that records ctor kwargs."""
+
+        class _FakeAdapter:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def send_message(self, content, history, interrupt_event):
+                return
+                yield  # pragma: no cover - makes this an async generator
+
+        return _FakeAdapter
+
+    def _run(self, agent_type, model):
+        """Drive _run_streaming_adapter once, returning (ctor_kwargs, events)."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        import codeframe.ui.routers.session_chat_ws as mod
+
+        captured: dict = {}
+        events: list = []
+
+        async def drive():
+            q = asyncio.Queue()
+            await mod._run_streaming_adapter(
+                "sess-1", "hi", q, asyncio.Event(), MagicMock(), object(),
+                agent_type, model,
+            )
+            while not q.empty():
+                events.append(q.get_nowait())
+
+        with patch.object(mod, "StreamingChatAdapter", self._fake_adapter_factory(captured)), \
+                patch("codeframe.adapters.llm.get_provider") as get_provider:
+            get_provider.return_value = MagicMock(name="provider")
+            asyncio.run(drive())
+            self._last_get_provider = get_provider
+        return captured, events
+
+    def test_claude_session_resolves_anthropic_and_honors_model(self):
+        captured, events = self._run("claude", "claude-opus-4-6")
+        self._last_get_provider.assert_called_once_with("anthropic")
+        assert captured["model"] == "claude-opus-4-6"
+        assert captured["provider"] is self._last_get_provider.return_value
+        assert not any(e["type"] == "error" for e in events)
+
+    def test_missing_agent_type_defaults_to_claude(self):
+        captured, events = self._run(None, None)
+        self._last_get_provider.assert_called_once_with("anthropic")
+        # No model override → adapter default used (no "model" kwarg passed).
+        assert "model" not in captured
+        assert not any(e["type"] == "error" for e in events)
+
+    def test_unsupported_agent_type_errors_without_anthropic_fallback(self):
+        captured, events = self._run("codex", "gpt-4o")
+        # No provider constructed, no adapter built — a clear error is emitted.
+        self._last_get_provider.assert_not_called()
+        assert captured == {}
+        assert events and events[0]["type"] == "error"
+        assert "codex" in events[0]["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #764.

## Problem
The interactive-session chat WebSocket hardcoded `AnthropicProvider()` and omitted `model=`, so the session's persisted `agent_type`/`model` were both ignored:
- A session created with a non-default model (the frontend offers `claude-opus-4-6`, `claude-haiku-4-5`) was silently served on the adapter default `claude-sonnet-4-5` — wrong model **and** wrong cost estimate.
- A non-anthropic `agent_type` (`codex`/`opencode`) was silently served by Anthropic.

Evidence: `codeframe/ui/routers/session_chat_ws.py:84`.

## Fix
Thread the session's stored `agent_type` + `model` through `_run_streaming_adapter`:
- Resolve the LLM provider via a small `agent_type → provider_type` map + the standard `get_provider()` factory (the agent-vocabulary `"claude"` → provider-vocabulary `"anthropic"`).
- Pass the stored `model` to `StreamingChatAdapter` (falls back to the adapter default only when unset).
- Emit a clear `error` event for agent types with no streaming provider, instead of a silent Anthropic fallback.

## Scope decision (deviates from the CodeRabbit plan's "do both")
The acceptance criteria is an **OR**: resolve in the chat path *or* reject non-anthropic at creation. I implemented **only the chat-path resolution** because:
1. It also fixes the *model* half of the bug (rejection wouldn't).
2. `terminal_ws` serves **any** `agent_type` as a plain shell (it never reads `agent_type`), so rejecting non-anthropic at session creation would regress the ability to create `codex`/`opencode` **terminal** sessions.
3. The chat path now fails loudly for unservable types, fully closing the "silently served by Anthropic" complaint.

## Tests
`tests/api/test_session_chat_ws.py::TestRunStreamingAdapterResolution` (3 cases): claude+model → anthropic provider + model honored; missing agent_type → defaults to claude, no model override; unsupported `codex` → error event, **no** Anthropic fallback. Verified they fail without the fix. ruff + strict mypy clean; full WS module (19 tests) green.

## Known limitations
- Only `claude`/`anthropic` agent types are servable through streaming chat today (by design — CLI agents have no streaming `LLMProvider`). Adding OpenAI-compatible chat sessions would extend `_AGENT_TYPE_TO_PROVIDER`.
- Legacy/API-created sessions with an unservable `agent_type` now surface an explicit error at chat time (fail-late) rather than being blocked at creation (fail-early).