### PR TITLE
fix(session-chat): normalize persisted roles on history replay (#765)

### DIFF
--- a/codeframe/core/adapters/streaming_chat.py
+++ b/codeframe/core/adapters/streaming_chat.py
@@ -41,6 +41,17 @@ _DEFAULT_MODEL = "claude-sonnet-4-5"
 # claude-sonnet-4 context window is 200k; leave 20k for response headroom.
 _MAX_HISTORY_TOKENS = 180_000
 
+# Maps the persisted (display-oriented) message roles onto the two roles the
+# Anthropic Messages API accepts. Roles absent from this map (e.g. "system",
+# "error") are UI-only and dropped from the replay list. See _load_history.
+_REPLAY_ROLE_MAP = {
+    "user": "user",
+    "assistant": "assistant",
+    "thinking": "assistant",
+    "tool_use": "assistant",
+    "tool_result": "user",
+}
+
 # ---------------------------------------------------------------------------
 # Event types
 # ---------------------------------------------------------------------------
@@ -190,11 +201,25 @@ class StreamingChatAdapter:
     def _load_history(self) -> list[dict]:
         """Load conversation history from the DB for this session.
 
+        The REST layer persists richer display roles (``tool_use``,
+        ``tool_result``, ``thinking``, ``system``, ``error``) so the session
+        transcript UI can render them. The Anthropic Messages API only accepts
+        ``user``/``assistant``, so those roles are collapsed here — otherwise the
+        next chat turn 400s on replay (#765). ``system``/``error`` rows are
+        UI-only artifacts and are dropped from the replay list entirely.
+
         Returns:
-            List of ``{"role": str, "content": str}`` dicts in chronological order.
+            List of ``{"role": "user"|"assistant", "content": str}`` dicts in
+            chronological order.
         """
         rows = self._db_repo.get_messages(self._session_id)
-        return [{"role": r["role"], "content": r["content"]} for r in rows]
+        history: list[dict] = []
+        for r in rows:
+            role = _REPLAY_ROLE_MAP.get(r["role"])
+            if role is None:
+                continue  # drop system/error and any unknown display-only role
+            history.append({"role": role, "content": r["content"]})
+        return history
 
     def _truncate_history(self, messages: list[dict]) -> list[dict]:
         """Drop oldest messages when the history exceeds the token budget.

--- a/tests/core/test_streaming_chat.py
+++ b/tests/core/test_streaming_chat.py
@@ -131,6 +131,46 @@ class TestLoadHistory:
             {"role": "assistant", "content": "Hi there"},
         ]
 
+    def test_normalizes_rich_roles_to_user_assistant(self):
+        # REST persists richer display roles for the transcript UI; the replay
+        # list handed to Anthropic must only ever contain user/assistant, or the
+        # next turn 400s (#765).
+        stored = [
+            {"role": "user", "content": "Read foo.py"},
+            {"role": "thinking", "content": "I should read the file"},
+            {"role": "tool_use", "content": "read_file(foo.py)"},
+            {"role": "tool_result", "content": "print('hi')"},
+            {"role": "assistant", "content": "It prints hi"},
+        ]
+        repo = _make_db_repo(stored)
+        adapter = _make_adapter(db_repo=repo)
+        history = adapter._load_history()
+        assert {m["role"] for m in history} <= {"user", "assistant"}
+        assert history == [
+            {"role": "user", "content": "Read foo.py"},
+            {"role": "assistant", "content": "I should read the file"},
+            {"role": "assistant", "content": "read_file(foo.py)"},
+            {"role": "user", "content": "print('hi')"},
+            {"role": "assistant", "content": "It prints hi"},
+        ]
+
+    def test_drops_non_conversational_roles(self):
+        # system/error rows are UI-only artifacts and must be dropped from the
+        # replay list entirely — they are not valid Anthropic message roles.
+        stored = [
+            {"role": "system", "content": "Session started"},
+            {"role": "user", "content": "Hi"},
+            {"role": "error", "content": "stream failed"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        repo = _make_db_repo(stored)
+        adapter = _make_adapter(db_repo=repo)
+        history = adapter._load_history()
+        assert history == [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # History truncation


### PR DESCRIPTION
## Summary
Closes #765 (P2.16, correctness).

Interactive-session REST (`POST /api/v2/sessions/{id}/messages`) deliberately accepts seven display roles — `user`, `assistant`, `tool_use`, `tool_result`, `thinking`, `system`, `error` — so the session transcript UI can render a rich message stream. But `StreamingChatAdapter._load_history` replayed those roles **verbatim** into the Anthropic Messages API, which only accepts `user`/`assistant`. Any session whose stored history contained a non-`user`/`assistant` row would **400 on the next chat turn**.

## Fix
Normalize roles at replay time in `_load_history` (the single choke point every replay routes through — the WS layer always calls `send_message(history=[])`):

- `thinking`, `tool_use` → `assistant`
- `tool_result` → `user`
- `system`, `error` (and any unknown role) → **dropped** from the replay list (UI-only artifacts, not conversational turns)

Storage and `VALID_ROLES` are left untouched, so the transcript UI keeps persisting and displaying the rich roles — only the API replay list is collapsed. `_truncate_history` already guarantees the first replayed message is `user`.

Chose replay-time normalization over narrowing `VALID_ROLES` (the other option in the acceptance criteria) precisely because narrowing would break the transcript UI, which relies on those roles for display.

## Tests
- `test_normalizes_rich_roles_to_user_assistant` — mixed rich-role history collapses to `user`/`assistant` only.
- `test_drops_non_conversational_roles` — `system`/`error` rows dropped.
- Full `tests/core/test_streaming_chat.py` (24), `tests/api/test_session_chat_ws.py` (19), and session router tests (15) pass. ruff + mypy clean.

## Known limitations
- Rich roles are folded to plain text content, not reconstructed into real `tool_use`/`tool_result` content blocks (which would need matching IDs and be fragile). This preserves transcript context for the model without ever 400ing; it does not restore structured tool-call replay.