### PR TITLE
fix(adapters): enable extended thinking via beta namespace, narrow except (#766)

### DIFF
--- a/codeframe/adapters/llm/anthropic.py
+++ b/codeframe/adapters/llm/anthropic.py
@@ -214,18 +214,33 @@ class AnthropicProvider(LLMProvider):
             "max_tokens": max_tokens,
         }
 
-        if extended_thinking:
+        # Interleaved extended thinking requires the beta namespace:
+        # messages.stream() rejects betas= with TypeError (that was the #766 bug —
+        # a blanket except swallowed it and retried without thinking every turn).
+        # budget_tokens must be >=1024 and < max_tokens, so only enable when the
+        # cap leaves room.
+        use_thinking = extended_thinking and max_tokens > 1024
+        if use_thinking:
             kwargs["betas"] = ["interleaved-thinking-2025-05-14"]
+            kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": max(1024, max_tokens // 2),
+            }
 
         active_tool_id: Optional[str] = None
 
-        # When extended_thinking is set, the beta header may be unsupported on
-        # older SDK versions.  Retry without it rather than hard-failing.
+        # On an SDK too old to accept betas=/thinking=, degrade to a plain stream
+        # rather than hard-failing.  Narrowed to TypeError so real API errors
+        # (auth/rate-limit/connection) surface instead of being swallowed.
         try:
-            stream_ctx = self._async_client.messages.stream(**kwargs)
-        except Exception:  # pragma: no cover
-            if extended_thinking:
+            if use_thinking:
+                stream_ctx = self._async_client.beta.messages.stream(**kwargs)
+            else:
+                stream_ctx = self._async_client.messages.stream(**kwargs)
+        except TypeError:  # pragma: no cover
+            if use_thinking:
                 kwargs.pop("betas", None)
+                kwargs.pop("thinking", None)
                 stream_ctx = self._async_client.messages.stream(**kwargs)
             else:
                 raise

--- a/codeframe/adapters/llm/anthropic.py
+++ b/codeframe/adapters/llm/anthropic.py
@@ -237,7 +237,7 @@ class AnthropicProvider(LLMProvider):
                 stream_ctx = self._async_client.beta.messages.stream(**kwargs)
             else:
                 stream_ctx = self._async_client.messages.stream(**kwargs)
-        except TypeError:  # pragma: no cover
+        except TypeError:
             if use_thinking:
                 kwargs.pop("betas", None)
                 kwargs.pop("thinking", None)

--- a/tests/adapters/test_llm_async.py
+++ b/tests/adapters/test_llm_async.py
@@ -145,6 +145,107 @@ class TestMockProviderAsyncStream:
         assert provider.last_call["extended_thinking"] is True
 
 
+class _FakeStreamCtx:
+    """Async ctx-manager + iterator that yields no SDK events."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _FakeMessages:
+    def __init__(self, rec, name, raises=None):
+        self._rec = rec
+        self._name = name
+        self._raises = raises
+
+    def stream(self, **kwargs):
+        self._rec.append((self._name, kwargs))
+        if self._raises is not None:
+            raise self._raises
+        return _FakeStreamCtx()
+
+
+class _FakeClient:
+    """Stand-in for AsyncAnthropic with plain + beta message namespaces."""
+
+    def __init__(self, rec, beta_raises=None):
+        self.messages = _FakeMessages(rec, "plain")
+        self.beta = type("_Beta", (), {"messages": _FakeMessages(rec, "beta", beta_raises)})()
+
+
+class TestAnthropicExtendedThinkingRouting:
+    """#766 — extended thinking must route to the beta namespace with thinking=."""
+
+    def _provider(self, rec, beta_raises=None):
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="test-key")
+        provider._async_client = _FakeClient(rec, beta_raises=beta_raises)
+        return provider
+
+    async def _drain(self, provider, **kw):
+        async for _ in provider.async_stream(
+            messages=[{"role": "user", "content": "hi"}],
+            system="s", tools=[], model="claude-x", max_tokens=4096, **kw,
+        ):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_extended_thinking_uses_beta_namespace(self):
+        rec = []
+        await self._drain(self._provider(rec), extended_thinking=True)
+        name, kwargs = rec[-1]
+        assert name == "beta"
+        assert kwargs["betas"] == ["interleaved-thinking-2025-05-14"]
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert 1024 <= kwargs["thinking"]["budget_tokens"] < 4096
+
+    @pytest.mark.asyncio
+    async def test_no_thinking_uses_plain_namespace(self):
+        rec = []
+        await self._drain(self._provider(rec), extended_thinking=False)
+        name, kwargs = rec[-1]
+        assert name == "plain"
+        assert "betas" not in kwargs
+        assert "thinking" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_small_max_tokens_skips_thinking(self):
+        """budget_tokens needs >=1024 headroom; tiny caps fall back to plain."""
+        rec = []
+        async for _ in self._provider(rec).async_stream(
+            messages=[{"role": "user", "content": "hi"}],
+            system="s", tools=[], model="claude-x", max_tokens=512,
+            extended_thinking=True,
+        ):
+            pass
+        name, kwargs = rec[-1]
+        assert name == "plain"
+        assert "thinking" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_typeerror_degrades_to_plain_stream(self):
+        """An SDK too old to accept betas=/thinking= degrades, not crashes."""
+        rec = []
+        await self._drain(
+            self._provider(rec, beta_raises=TypeError("unexpected kwarg")),
+            extended_thinking=True,
+        )
+        # First attempt hits beta (raises), fallback lands on plain without thinking.
+        assert rec[0][0] == "beta"
+        assert rec[-1][0] == "plain"
+        assert "thinking" not in rec[-1][1]
+
+
 class TestLLMExceptions:
     """Common LLM exception hierarchy."""
 


### PR DESCRIPTION
Closes #766

## Problem
`messages.stream(betas=[...])` raises `TypeError` on anthropic 0.70.0 — `betas=`
is only accepted by `beta.messages.stream`, not the plain namespace. A blanket
`except Exception` swallowed the error and retried without `betas`, so:

- interleaved extended thinking **never activated**, and
- every interactive turn wasted a failed call + a retry.

SDK probe (0.70.0): `messages.stream` accepts `thinking=` but **not** `betas=`;
`beta.messages.stream` accepts both.

## Fix
- Route to `beta.messages.stream(..., betas=["interleaved-thinking-2025-05-14"],
  thinking={"type":"enabled","budget_tokens":N})` when `extended_thinking` is
  requested. Guarded on `max_tokens > 1024`; `budget_tokens = max(1024, max_tokens // 2)`
  (always ≥1024 and < `max_tokens`, per the API invariant).
- Narrow the fallback `except Exception` → `except TypeError`, so genuine API
  errors (auth / rate-limit / connection) surface instead of being swallowed and
  retried. The TypeError branch still degrades to a plain stream on an SDK too
  old to accept the kwargs.

## Tests
`tests/adapters/test_llm_async.py::TestAnthropicExtendedThinkingRouting` — a fake
async client records which namespace + kwargs `async_stream` sends:
- `extended_thinking=True` → `beta.messages.stream` with `betas` + `thinking`
- `extended_thinking=False` → plain `messages.stream`, no thinking kwargs
- tiny `max_tokens` → skips thinking (no room for the ≥1024 budget)
- `beta.messages.stream` raising `TypeError` → degrades to plain stream

## Verification
- `uv run pytest tests/adapters/ tests/core/test_streaming_chat.py` → 132 passed
- `uv run ruff check` → clean
- `uv run --extra dev mypy codeframe/adapters/llm/anthropic.py` → clean

## Known limitations
- `budget_tokens` is a fixed `max_tokens // 2` heuristic, not caller-tunable — the
  only caller (`streaming_chat.py`) uses a fixed `max_tokens=4096`. Can be plumbed
  through if a caller needs to size it.