### PR TITLE
ci(glm-review): skip GLM review on Dependabot PRs

### DIFF
--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -8,11 +8,15 @@ on:
 
 jobs:
   review:
-    # Only review substantial changes (5+ files, or 20+ additions, or 20+ deletions)
+    # Skip bot-authored PRs (Dependabot): the reusable GLM review workflow
+    # rejects non-human actors and hard-fails, which surfaced as a red X on
+    # every Dependabot PR touching 5+ files. Skipping is neutral, not a failure.
+    # Otherwise only review substantial changes (5+ files, or 20+ additions/deletions).
     if: |
-      github.event.pull_request.changed_files >= 5 ||
-      github.event.pull_request.additions >= 20 ||
-      github.event.pull_request.deletions >= 20
+      github.actor != 'dependabot[bot]' &&
+      (github.event.pull_request.changed_files >= 5 ||
+       github.event.pull_request.additions >= 20 ||
+       github.event.pull_request.deletions >= 20)
     uses: frankbria/glm-review/.github/workflows/review.yml@b877d15a0f8c0855d0d2ebdcce32ae09cec1bb2d # main
     permissions:
       contents: read


### PR DESCRIPTION
## Problem
The `GLM Review` workflow (`.github/workflows/glm-review.yml`) calls a reusable workflow that **rejects non-human actors and exits 1**:

```
Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Any Dependabot PR that meets the review threshold (5+ changed files, or 20+ additions/deletions) triggers the job, which then hard-fails — surfacing a red `review / review` X. This just hit #837 (bump actions/checkout), which touches 7 workflow files. It's not a required status check so it didn't block merges, but it's recurring noise on every workflow/lockfile-heavy Dependabot PR.

## Fix
Gate the `review` job on `github.actor != 'dependabot[bot]'`. When Dependabot is the author the `if` evaluates false and the job **skips cleanly (neutral)** instead of running-and-failing. Human PRs are unaffected — the existing size thresholds still apply.

```yaml
if: |
  github.actor != 'dependabot[bot]' &&
  (github.event.pull_request.changed_files >= 5 ||
   github.event.pull_request.additions >= 20 ||
   github.event.pull_request.deletions >= 20)
```

## Verification
- `yaml.safe_load` parses the file; the `if` expression is valid GitHub Actions syntax (`&&` with a parenthesized `||` group).
- This PR is human-authored and small, so its own GLM review job correctly skips (below threshold) — no self-block.

## Alternative considered
Adding `dependabot` to the reusable workflow's `allowed_bots` input — rejected: it lives in the external `frankbria/glm-review` repo, and we don't *want* to spend GLM review budget on dependency bumps anyway. Skipping is the right behavior.