### PR TITLE
ci(deploy): serialize deploys to fix intermittent health-check failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,14 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: test  # Gate: do not deploy unless the test suite passes
+    # Serialize staging deploys: overlapping runs SSH to the same VPS and run
+    # `uv venv --clear`, `npm run build`, and `pm2 restart` concurrently, which
+    # clears a venv another run is using and races the backend port rebind →
+    # the backend crash-loops and the health check fails. Queue instead of
+    # cancel: never interrupt an in-flight deploy and leave the server half-updated.
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
@@ -247,6 +255,15 @@ jobs:
           done
 
           echo "❌ Health check failed after $MAX_ATTEMPTS attempts"
+          # Surface the cause: a silent `curl -sf` gave no reason. Dump PM2
+          # status and the backend error log so a crash-loop is diagnosable.
+          echo "::group::Backend diagnostics (PM2 status + recent error log)"
+          ssh ${{ secrets.USER }}@${{ secrets.HOST }} "
+            pm2 describe '${{ secrets.PM2_BACKEND_NAME }}' 2>/dev/null | grep -Ei 'status|restarts|uptime|script|pid|exit' || true
+            echo '--- last 40 lines of logs/backend-error.log ---'
+            tail -n 40 '${{ secrets.PROJECT_PATH }}/logs/backend-error.log' 2>/dev/null || echo '(no backend-error.log found)'
+          " || true
+          echo "::endgroup::"
           exit 1
 
       - name: Deployment summary
@@ -265,6 +282,10 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: test  # Gate: do not deploy to production unless the test suite passes
+    # Serialize production deploys (own group, independent of staging).
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     if: |
       (github.event_name == 'release') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
@@ -582,6 +603,15 @@ jobs:
           done
 
           echo "❌ Health check failed after $MAX_ATTEMPTS attempts"
+          # Surface the cause: a silent `curl -sf` gave no reason. Dump PM2
+          # status and the backend error log so a crash-loop is diagnosable.
+          echo "::group::Backend diagnostics (PM2 status + recent error log)"
+          ssh ${{ secrets.USER }}@${{ secrets.HOST }} "
+            pm2 describe '${{ secrets.PM2_BACKEND_NAME }}' 2>/dev/null | grep -Ei 'status|restarts|uptime|script|pid|exit' || true
+            echo '--- last 40 lines of logs/backend-error.log ---'
+            tail -n 40 '${{ secrets.PROJECT_PATH }}/logs/backend-error.log' 2>/dev/null || echo '(no backend-error.log found)'
+          " || true
+          echo "::endgroup::"
           exit 1
 
       - name: Deployment summary


### PR DESCRIPTION
## Root cause
Deploy runs on `main` were failing intermittently at the **Verify deployment** health check. The test suite and the deploy step both pass, but the post-deploy `curl -sf .../health` fails all 12 attempts.

Inspecting the PM2 table in a failed run, the **backend process is crash-looping** (`pid=0`, `uptime=0`, climbing restart count) while the frontend is healthy. The health check hits the backend port, so it correctly reports failure.

**Why intermittent:** the Deploy workflow had **no concurrency control**. Merging 5 PRs in quick succession triggered overlapping deploys to the *same VPS*. Their timings overlap directly:

| Deploy | Window (UTC) | Result |
|--------|--------------|--------|
| setup-uv #838 | 22:59:51–23:06:07 | ❌ |
| jest-dom #851 | 22:59:55–23:07:01 | ✅ |
| date-fns #852 | 23:08:14–23:15:44 | ❌ |
| checkout #837 | 23:08:49–23:17:01 | ❌ |
| (isolated) #855 | 19:14:17–19:22:24 | ✅ |

Concurrent runs execute `uv venv --clear`, `npm run build`, and `pm2 restart` on one server at the same time — one clears the venv another is using, and the backend's port rebind races → crash-loop. The only **isolated** deploy passed; overlapping ones failed. Not a code bug — a deploy-orchestration bug.

## Fix
1. **Serialize deploys** with a per-environment `concurrency` group (`deploy-staging` / `deploy-production`), `cancel-in-progress: false` so runs **queue** instead of colliding, and an in-flight deploy is never interrupted mid-update (which could leave the server half-updated).
2. **Surface the cause on failure** — the silent `curl -sf` is *why* this was hard to diagnose. On final health-check failure, dump `pm2 describe` + the tail of `logs/backend-error.log`, so any future crash-loop shows the Python traceback directly in the Actions log.

## Verification
- `yaml.safe_load` parses; both jobs carry their `concurrency` block.
- Behavioral proof will be on merge: this deploy runs alone (queued), and prior isolated deploys (#855) were green — the collision condition is removed.

## Not included
No app-code change: the backend itself is fine (backend unit tests, which import the FastAPI app, are green). If a *genuine* startup crash ever recurs, the new diagnostics block will now show it instead of an opaque "failed after 12 attempts".