### PR TITLE
fix(core): mark batch terminal on worker exception in resume/retry paths (#848)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1026,6 +1026,42 @@ def _execute_serial_resume(
     Similar to _execute_serial but only runs specified tasks and
     merges results with existing batch results.
     """
+    # resume_batch pinned the batch to RUNNING before calling us, so an
+    # unexpected worker error must not leave it stuck RUNNING (#848 — the same
+    # failure mode #763 fixed for _execute_serial/_execute_parallel). Unlike
+    # those paths, resume does not start a reconciliation thread, so there is
+    # nothing to stop in a finally here. `finalized` flips to True the instant a
+    # terminal status is persisted, so a finalization-tail error (after the
+    # terminal _save_batch) preserves that correct record instead of clobbering
+    # it with FAILED.
+    finalized = {"done": False}
+    try:
+        _run_serial_resume(workspace, batch, tasks_to_run, finalized, on_event)
+    except Exception:
+        logger.exception("Batch resume failed unexpectedly")
+        if not finalized["done"]:
+            batch.status = BatchStatus.FAILED
+            batch.completed_at = _utc_now()
+            _save_batch(workspace, batch)
+            events.emit_for_workspace(
+                workspace,
+                events.EventType.BATCH_FAILED,
+                {"batch_id": batch.id, "error": "unexpected execution error", "is_resume": True},
+                print_event=True,
+            )
+        raise
+
+
+def _run_serial_resume(
+    workspace: Workspace,
+    batch: BatchRun,
+    tasks_to_run: list[str],
+    finalized: dict[str, bool],
+    on_event: Optional[Callable[[str, dict], None]] = None,
+) -> None:
+    """Resume task loop + finalization. Sets ``finalized['done'] = True`` once a
+    terminal status is persisted so the caller preserves it on a tail error (#848).
+    """
     completed_count = 0
     failed_count = 0
     blocked_count = 0
@@ -1155,6 +1191,7 @@ def _execute_serial_resume(
 
     batch.completed_at = _utc_now()
     _save_batch(workspace, batch)
+    finalized["done"] = True  # terminal status persisted — caller must not override (#848)
 
     # Emit batch completion event
     events.emit_for_workspace(
@@ -1197,6 +1234,26 @@ def _execute_retries(
         max_retries: Maximum retry attempts per task
         on_event: Optional callback for events
     """
+    # The initial execution pass already persisted a terminal status before we
+    # were called, and retries never set the batch back to RUNNING — so there is
+    # no stuck-RUNNING risk here (unlike resume, #848). An unexpected worker
+    # error must therefore preserve that prior terminal record (never clobber a
+    # correct COMPLETED/PARTIAL with FAILED); we just log and re-raise. Retries
+    # also start no reconciliation thread, so nothing to stop in a finally.
+    try:
+        _run_retries(workspace, batch, max_retries, on_event)
+    except Exception:
+        logger.exception("Batch retry failed unexpectedly; preserving prior terminal status")
+        raise
+
+
+def _run_retries(
+    workspace: Workspace,
+    batch: BatchRun,
+    max_retries: int,
+    on_event: Optional[Callable[[str, dict], None]] = None,
+) -> None:
+    """Retry loop + finalization for :func:`_execute_retries` (#848)."""
     failed_statuses = {RunStatus.FAILED.value}  # Only retry FAILED, not BLOCKED
 
     for retry_num in range(1, max_retries + 1):

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -725,6 +725,123 @@ class TestBatchExecution:
                     + list_batches(workspace, status=BatchStatus.PARTIAL))
         assert len(terminal) == 1
 
+    def test_parallel_unexpected_exception_marks_failed_and_stops_reconcile(self, workspace_with_tasks):
+        """Parallel sibling of the serial #763 test — guards against serial/parallel drift (#848).
+
+        The exception-handling fix is hand-duplicated across _execute_serial and
+        _execute_parallel; PR #847's tests were serial-only. This exercises the
+        parallel copy so a copy-paste slip (wrong stop-event var, wrong strategy
+        tag) is caught.
+        """
+        from codeframe.core import conductor
+
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        captured = {}
+        real_start = conductor._start_reconciliation_thread
+
+        def capture_start(ws, batch, **kwargs):
+            ev = real_start(ws, batch, **kwargs)
+            captured["event"] = ev
+            return ev
+
+        with patch('codeframe.core.conductor._start_reconciliation_thread', side_effect=capture_start), \
+             patch('codeframe.core.conductor._execute_task_subprocess', side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                start_batch(workspace, task_ids, strategy="parallel", max_parallel=2)
+
+        # Reconciliation thread was signalled to stop — no daemon leak.
+        assert captured["event"].is_set()
+
+        # Batch is terminal FAILED, not stuck RUNNING.
+        assert list_batches(workspace, status=BatchStatus.RUNNING) == []
+        assert len(list_batches(workspace, status=BatchStatus.FAILED)) == 1
+
+    def test_resume_unexpected_exception_marks_failed(self, workspace_with_tasks):
+        """A raised worker error during resume marks the batch FAILED, not stuck RUNNING (#848).
+
+        resume_batch pins the batch to RUNNING before _execute_serial_resume runs,
+        so an unexpected worker exception used to leave it RUNNING forever — the
+        same failure mode #763 fixed for the initial serial/parallel passes.
+        """
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        # Build a PARTIAL batch (task[1] fails) that is eligible for resume.
+        def mock_initial(ws, tid, batch_id=None, **kwargs):
+            return "FAILED" if tid == task_ids[1] else "COMPLETED"
+
+        with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_initial):
+            batch = start_batch(workspace, task_ids, on_failure="continue")
+        assert batch.status == BatchStatus.PARTIAL
+
+        # Resume re-runs task[1]; this time the worker raises unexpectedly.
+        with patch('codeframe.core.conductor._execute_task_subprocess',
+                   side_effect=RuntimeError("resume boom")):
+            with pytest.raises(RuntimeError, match="resume boom"):
+                resume_batch(workspace, batch.id)
+
+        # Terminal FAILED, not pinned at RUNNING.
+        assert list_batches(workspace, status=BatchStatus.RUNNING) == []
+        assert get_batch(workspace, batch.id).status == BatchStatus.FAILED
+
+    def test_resume_finalization_tail_error_preserves_terminal_status(self, workspace_with_tasks):
+        """An error AFTER resume persists its terminal status must not flip it to FAILED (#848)."""
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        def mock_initial(ws, tid, batch_id=None, **kwargs):
+            return "FAILED" if tid == task_ids[1] else "COMPLETED"
+
+        with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_initial):
+            batch = start_batch(workspace, task_ids, on_failure="continue")
+        assert batch.status == BatchStatus.PARTIAL
+
+        # Resume finalizes (still PARTIAL — task[1] fails again → terminal saved),
+        # then the post-save webhook dispatch raises: a finalization-tail failure.
+        with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_initial), \
+             patch('codeframe.core.conductor._dispatch_batch_completed_webhook',
+                   side_effect=RuntimeError("resume tail boom")):
+            with pytest.raises(RuntimeError, match="resume tail boom"):
+                resume_batch(workspace, batch.id)
+
+        # The correct terminal record must survive — not overwritten with FAILED.
+        assert list_batches(workspace, status=BatchStatus.RUNNING) == []
+        assert list_batches(workspace, status=BatchStatus.FAILED) == []
+        assert get_batch(workspace, batch.id).status == BatchStatus.PARTIAL
+
+    def test_retries_unexpected_exception_preserves_terminal_status(self, workspace_with_tasks):
+        """A raised worker error during retries preserves the prior terminal status (#848).
+
+        Unlike resume, _execute_retries runs only after the initial pass persisted
+        a terminal status and never sets RUNNING — so there is no stuck-RUNNING
+        window, and an unexpected retry error must NOT clobber a correct PARTIAL
+        with FAILED.
+        """
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]
+
+        # task[1] fails on the initial pass (→ PARTIAL), then the retry raises.
+        attempts = {"n": 0}
+
+        def mock_execute(ws, tid, batch_id=None, **kwargs):
+            if tid == task_ids[1]:
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    return "FAILED"
+                raise RuntimeError("retry boom")
+            return "COMPLETED"
+
+        with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_execute):
+            with pytest.raises(RuntimeError, match="retry boom"):
+                start_batch(workspace, task_ids, on_failure="continue", max_retries=2)
+
+        # Prior terminal PARTIAL preserved — not stuck RUNNING, not clobbered to FAILED.
+        assert list_batches(workspace, status=BatchStatus.RUNNING) == []
+        assert list_batches(workspace, status=BatchStatus.FAILED) == []
+        assert len(list_batches(workspace, status=BatchStatus.PARTIAL)) == 1
+
     def test_task_blocked(self, workspace_with_tasks):
         """Batch should handle BLOCKED tasks and continue."""
         workspace, task_list = workspace_with_tasks


### PR DESCRIPTION
## Summary

Follow-up to #763 (PR #847), which fixed the stuck-`RUNNING` + reconcile-thread-leak failure mode in `_execute_serial` / `_execute_parallel`. This applies the surviving half of that guarantee — **terminal batch status on unexpected worker exception** — to the two sibling paths the #847 reviews flagged as still open:

- **`_execute_serial_resume`** (`resume_batch` → `conductor.py`) — the real bug. `resume_batch` pins the batch to `RUNNING` immediately before calling it, so an unexpected worker exception left the batch stuck `RUNNING` forever. Now wrapped in `try/except`: an unfinalized exception marks the batch `FAILED` and emits `BATCH_FAILED`. A `finalized` flag flips the instant the terminal status is persisted, so a **finalization-tail error (after the terminal `_save_batch`) preserves** the correct `COMPLETED`/`PARTIAL` record instead of clobbering it — mirroring #847's `batch_finalized` guard.
- **`_execute_retries`** (`start_batch` → `conductor.py`) — defense-in-depth + intent. It runs only *after* the initial pass already persisted a terminal status and never sets `RUNNING`, so there is **no stuck-`RUNNING` window**. An unexpected retry error must therefore *preserve* that prior terminal status (never clobber a correct `PARTIAL` with `FAILED`); the handler logs and re-raises.

Both bodies are extracted verbatim into internal helpers (`_run_serial_resume`, `_run_retries`) so the fix is a small additive diff rather than a 130-line re-indent. The public entry points keep their signatures.

## Clarification on the "reconcile thread leak" framing

The issue title says these paths "leak reconcile thread," but **neither `_execute_serial_resume` nor `_execute_retries` starts a reconciliation thread** — those threads are owned entirely by `_execute_serial`/`_execute_parallel`, which start *and* stop them in their own `finally`. So there is no thread to leak or "stop in finally" on the resume/retry paths; the acceptance-criteria wording is carried over verbatim from the #763 template. The concrete, verifiable bug is the stuck-`RUNNING` case, which is what this PR fixes. (Whether resume/retry *should* run a reconciliation thread at all is a separate design question, out of scope here.)

## Tests (`tests/core/test_conductor.py`)

- `test_resume_unexpected_exception_marks_failed` — resume worker raises → batch `FAILED`, not stuck `RUNNING`. **Verified this fails against un-fixed source.**
- `test_resume_finalization_tail_error_preserves_terminal_status` — resume finalizes `PARTIAL`, then webhook raises → `PARTIAL` preserved, not flipped to `FAILED`.
- `test_retries_unexpected_exception_preserves_terminal_status` — initial pass `PARTIAL`, retry worker raises → `PARTIAL` preserved, not clobbered to `FAILED`, not `RUNNING`.
- `test_parallel_unexpected_exception_marks_failed_and_stops_reconcile` — the requested serial/parallel drift guard: exercises `_execute_parallel`'s except/finally (mark `FAILED`, reconcile thread stopped).

Ruff + strict mypy clean.

## Known limitations

- The `retries` handler changes no observable batch state (the prior terminal status is preserved with or without it); its value is the logged exception context plus an invariant test guarding against a future "parity fix" incorrectly copying resume's `FAILED`-marking into retries.

Closes #848

https://claude.ai/code/session_01Fp1qJtg5BycW9TXiRHkQRj
