### PR TITLE
[P2.19] Provider-aware pre-flight key checks + Think-phase provider resolution (#768)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,9 +174,10 @@ cf status
 # PRD
 cf prd add <file.md>
 cf prd show
+cf prd stress-test [--llm-provider openai --llm-model gpt-4o]
 
 # Tasks
-cf tasks generate
+cf tasks generate [--llm-provider openai --llm-model gpt-4o]
 cf tasks list [--status READY]
 cf tasks show <id>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Follow on X](https://img.shields.io/twitter/follow/FrankBria18044?style=social)](https://x.com/FrankBria18044)
 
 > [!WARNING]
-> **Prerequisite:** CodeFRAME requires an `ANTHROPIC_API_KEY` from [console.anthropic.com](https://console.anthropic.com/). Get your key before running any `cf` command.
+> **Prerequisite:** CodeFRAME requires an API key matching your LLM provider — by default an `ANTHROPIC_API_KEY` from [console.anthropic.com](https://console.anthropic.com/), or `OPENAI_API_KEY` when using `--llm-provider openai` (local providers like Ollama need no key). Get your key before running any `cf` command.
 
 ---
 

--- a/codeframe/adapters/llm/__init__.py
+++ b/codeframe/adapters/llm/__init__.py
@@ -85,7 +85,21 @@ def get_provider(provider_type: str = "anthropic", **kwargs) -> LLMProvider:
             base_url=kwargs.get("base_url", os.environ.get("OPENAI_BASE_URL")),
         )
     elif provider_type == "anthropic":
-        return AnthropicProvider()
+        model_selector = None
+        model = kwargs.get("model")
+        if model:
+            # A single model override applies to every purpose; otherwise
+            # ModelSelector falls back to CODEFRAME_*_MODEL env / defaults.
+            model_selector = ModelSelector(
+                planning_model=model,
+                execution_model=model,
+                generation_model=model,
+                correction_model=model,
+                supervision_model=model,
+            )
+        return AnthropicProvider(
+            api_key=kwargs.get("api_key"), model_selector=model_selector
+        )
     elif provider_type == "mock":
         return MockProvider()
     else:

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1651,6 +1651,16 @@ def prd_stress_test(
         "--interactive", "-i",
         help="Resolve ambiguities inline and update PRD",
     ),
+    llm_provider: Optional[str] = typer.Option(
+        None,
+        "--llm-provider",
+        help="LLM provider: anthropic, openai (default: anthropic or $CODEFRAME_LLM_PROVIDER)",
+    ),
+    llm_model: Optional[str] = typer.Option(
+        None,
+        "--llm-model",
+        help="Model override (default: provider default or $CODEFRAME_LLM_MODEL)",
+    ),
 ) -> None:
     """Stress-test a PRD via recursive decomposition.
 
@@ -1664,18 +1674,20 @@ def prd_stress_test(
 
     Use --interactive to resolve ambiguities inline and update the PRD.
 
-    Requires ANTHROPIC_API_KEY environment variable.
+    Requires the API key matching the resolved LLM provider
+    (e.g. ANTHROPIC_API_KEY for the default anthropic provider).
 
     Example:
         codeframe prd stress-test
         codeframe prd stress-test --max-depth 4
         codeframe prd stress-test --output spec.md
         codeframe prd stress-test --interactive
+        codeframe prd stress-test --llm-provider openai --llm-model gpt-4o
     """
-    import os
     from codeframe.core.workspace import get_workspace
     from codeframe.core import prd as prd_module
-    from codeframe.adapters.llm.anthropic import AnthropicProvider
+    from codeframe.core.llm_resolution import resolve_llm_settings, create_provider
+    from codeframe.cli.validators import require_api_key_for_provider
     from codeframe.core.prd_stress_test import (
         stress_test_prd,
         resolve_ambiguities_into_prd,
@@ -1703,13 +1715,13 @@ def prd_stress_test(
 
     console.print(f"[dim]Stress-testing PRD: {record.title} (v{record.version})[/dim]")
 
-    # Build provider
-    api_key = os.getenv("ANTHROPIC_API_KEY")
-    if not api_key:
-        console.print("[red]Error:[/red] ANTHROPIC_API_KEY environment variable required.")
-        raise typer.Exit(1)
-
-    provider = AnthropicProvider(api_key=api_key)
+    # Build provider: flag → env → config → anthropic, validating the
+    # matching API key (#768)
+    settings = resolve_llm_settings(
+        workspace.repo_path, provider_flag=llm_provider, model_flag=llm_model
+    )
+    require_api_key_for_provider(settings.provider_type)
+    provider = create_provider(settings)
 
     # Run stress test
     console.print(f"[dim]Recursively decomposing (max depth: {max_depth})...[/dim]")
@@ -1820,6 +1832,16 @@ def tasks_generate(
         min=1,
         max=5,
     ),
+    llm_provider: Optional[str] = typer.Option(
+        None,
+        "--llm-provider",
+        help="LLM provider: anthropic, openai (default: anthropic or $CODEFRAME_LLM_PROVIDER)",
+    ),
+    llm_model: Optional[str] = typer.Option(
+        None,
+        "--llm-model",
+        help="Model override (default: provider default or $CODEFRAME_LLM_MODEL)",
+    ),
 ) -> None:
     """Generate tasks from the PRD.
 
@@ -1857,18 +1879,27 @@ def tasks_generate(
 
         console.print(f"Generating tasks from PRD: [bold]{prd_record.title}[/bold]")
 
+        provider = None
         if not no_llm:
-            from codeframe.cli.validators import require_anthropic_api_key
-            require_anthropic_api_key()
+            # Validate the key matching the resolved provider
+            # (flag → env → config → anthropic), #768
+            from codeframe.cli.validators import require_api_key_for_provider
+            from codeframe.core.llm_resolution import (
+                create_provider,
+                resolve_llm_settings,
+            )
+            settings = resolve_llm_settings(
+                workspace.repo_path, provider_flag=llm_provider, model_flag=llm_model
+            )
+            require_api_key_for_provider(settings.provider_type)
+            provider = create_provider(settings)
 
         try:
             if recursive:
                 console.print(f"[dim]Using recursive decomposition (max depth: {max_depth})...[/dim]")
 
-                from codeframe.adapters.llm import get_provider
                 from codeframe.core.task_tree import generate_task_tree, flatten_task_tree
 
-                provider = get_provider()
                 tree = generate_task_tree(
                     provider,
                     prd_record.content,
@@ -1882,7 +1913,9 @@ def tasks_generate(
                 created = tasks.generate_from_prd(workspace, prd_record, use_llm=False)
             else:
                 console.print("[dim]Using LLM for task generation...[/dim]")
-                created = tasks.generate_from_prd(workspace, prd_record, use_llm=True)
+                created = tasks.generate_from_prd(
+                    workspace, prd_record, use_llm=True, provider=provider
+                )
         except Exception:
             # Roll back any partial new tasks; the originals were never deleted.
             # A failure *during* rollback must not mask the original generation
@@ -2468,8 +2501,14 @@ def work_start(
                 from codeframe.cli.validators import require_e2b_api_key
                 require_e2b_api_key()
             elif not is_external_engine(engine):
-                from codeframe.cli.validators import require_anthropic_api_key
-                require_anthropic_api_key()
+                # Builtin engines: validate the key matching the resolved
+                # provider (flag → env → config → anthropic), #768
+                from codeframe.cli.validators import require_api_key_for_provider
+                from codeframe.core.llm_resolution import resolve_llm_settings
+                settings = resolve_llm_settings(
+                    workspace.repo_path, provider_flag=llm_provider
+                )
+                require_api_key_for_provider(settings.provider_type)
 
         # Start the run
         run = runtime.start_task_run(workspace, task.id)
@@ -2994,9 +3033,12 @@ def work_retry(
 
         task = matching[0]
 
-        # Validate API key before any state modifications
-        from codeframe.cli.validators import require_anthropic_api_key
-        require_anthropic_api_key()
+        # Validate the key matching the resolved provider (env → config →
+        # anthropic) before any state modifications, #768
+        from codeframe.cli.validators import require_api_key_for_provider
+        from codeframe.core.llm_resolution import resolve_llm_settings
+        settings = resolve_llm_settings(workspace.repo_path)
+        require_api_key_for_provider(settings.provider_type)
 
         # Reset task to READY if it's FAILED or BLOCKED
         if task.status in (TaskStatus.FAILED, TaskStatus.BLOCKED):
@@ -3842,8 +3884,14 @@ def batch_run(
             from codeframe.cli.validators import require_e2b_api_key
             require_e2b_api_key()
         elif not is_external_engine(engine):
-            from codeframe.cli.validators import require_anthropic_api_key
-            require_anthropic_api_key()
+            # Builtin engines: validate the key matching the resolved
+            # provider (flag → env → config → anthropic), #768
+            from codeframe.cli.validators import require_api_key_for_provider
+            from codeframe.core.llm_resolution import resolve_llm_settings
+            settings = resolve_llm_settings(
+                workspace.repo_path, provider_flag=llm_provider
+            )
+            require_api_key_for_provider(settings.provider_type)
 
         # Execute batch
         if max_retries > 0:

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2380,7 +2380,7 @@ def work_start(
         False,
         "--execute",
         "-x",
-        help="Run the agent to execute the task (builtin engines require ANTHROPIC_API_KEY)",
+        help="Run the agent to execute the task (builtin engines require the API key matching the resolved LLM provider)",
     ),
     dry_run: bool = typer.Option(
         False,

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1879,6 +1879,13 @@ def tasks_generate(
 
         console.print(f"Generating tasks from PRD: [bold]{prd_record.title}[/bold]")
 
+        if recursive and no_llm:
+            console.print(
+                "[red]Error:[/red] --recursive requires LLM generation and "
+                "cannot be combined with --no-llm."
+            )
+            raise typer.Exit(1)
+
         provider = None
         if not no_llm:
             # Validate the key matching the resolved provider

--- a/codeframe/cli/validators.py
+++ b/codeframe/cli/validators.py
@@ -85,6 +85,26 @@ def require_openai_api_key() -> str:
     raise typer.Exit(1)
 
 
+def require_api_key_for_provider(provider_type: str) -> str | None:
+    """Validate the API key matching the resolved LLM provider (#768).
+
+    anthropic → ANTHROPIC_API_KEY, openai → OPENAI_API_KEY. Local /
+    OpenAI-compatible providers (ollama, vllm, compatible) and mock
+    require no key.
+
+    Returns:
+        The API key string, or None when the provider needs no key.
+
+    Raises:
+        typer.Exit: If a required key cannot be found anywhere.
+    """
+    if provider_type == "anthropic":
+        return require_anthropic_api_key()
+    if provider_type == "openai":
+        return require_openai_api_key()
+    return None
+
+
 def require_e2b_api_key() -> str:
     """Ensure E2B_API_KEY is available, loading from .env if needed.
 

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -1,0 +1,95 @@
+"""Shared LLM provider resolution (#768).
+
+Single source of truth for the effective-provider chain used by the CLI,
+runtime, and server surfaces:
+
+    CLI flag → CODEFRAME_LLM_PROVIDER → .codeframe/config.yaml ``llm:`` → "anthropic"
+
+and for the provider → required-API-key-env mapping, so pre-flight checks
+validate the key that actually matches the resolved provider.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# Providers that need an API key up front. Local / OpenAI-compatible
+# providers (ollama, vllm, compatible) and mock need none.
+REQUIRED_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
+
+
+@dataclass(frozen=True)
+class LLMSettings:
+    """Resolved LLM provider settings."""
+
+    provider_type: str
+    model: Optional[str] = None
+    base_url: Optional[str] = None
+
+    @property
+    def required_key_env(self) -> Optional[str]:
+        """Env var holding the API key this provider requires, or None."""
+        return REQUIRED_KEY_ENV.get(self.provider_type)
+
+    def provider_kwargs(self) -> dict:
+        """Constructor overrides for ``get_provider`` (only set values)."""
+        kwargs: dict = {}
+        if self.model:
+            kwargs["model"] = self.model
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        return kwargs
+
+
+def resolve_llm_settings(
+    repo_path: Optional[Path] = None,
+    provider_flag: Optional[str] = None,
+    model_flag: Optional[str] = None,
+) -> LLMSettings:
+    """Resolve effective provider/model/base_url.
+
+    Provider: flag → CODEFRAME_LLM_PROVIDER → config → "anthropic".
+    Model: flag → CODEFRAME_LLM_MODEL → config.
+    Base URL: config → OPENAI_BASE_URL.
+
+    Args:
+        repo_path: Workspace repo path for ``.codeframe/config.yaml``
+            lookup; None skips the config tier.
+        provider_flag: CLI ``--llm-provider`` value.
+        model_flag: CLI ``--llm-model`` value.
+    """
+    from codeframe.core.config import load_environment_config
+
+    llm_cfg = None
+    if repo_path is not None:
+        env_cfg = load_environment_config(repo_path)
+        llm_cfg = env_cfg.llm if (env_cfg and env_cfg.llm) else None
+
+    provider_type = (
+        provider_flag
+        or os.getenv("CODEFRAME_LLM_PROVIDER")
+        or (llm_cfg.provider if llm_cfg else None)
+        or "anthropic"
+    )
+    model = (
+        model_flag
+        or os.getenv("CODEFRAME_LLM_MODEL")
+        or (llm_cfg.model if llm_cfg else None)
+    )
+    base_url = (llm_cfg.base_url if llm_cfg else None) or os.getenv(
+        "OPENAI_BASE_URL"
+    )
+    return LLMSettings(provider_type=provider_type, model=model, base_url=base_url)
+
+
+def create_provider(settings: LLMSettings):
+    """Build the LLM provider for resolved settings."""
+    from codeframe.adapters.llm import get_provider
+
+    return get_provider(settings.provider_type, **settings.provider_kwargs())

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -646,7 +646,8 @@ def execute_agent(
         Final AgentState after execution
 
     Raises:
-        ValueError: If ANTHROPIC_API_KEY is not set (for builtin engines) or engine is invalid
+        ValueError: If the API key matching the resolved LLM provider is not
+            set (for builtin engines) or engine is invalid
     """
     import os
     from codeframe.core.agent import AgentState, AgentStatus

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -650,7 +650,6 @@ def execute_agent(
     """
     import os
     from codeframe.core.agent import AgentState, AgentStatus
-    from codeframe.adapters.llm import get_provider
     from codeframe.core.diagnostics import RunLogger, LogCategory
     from codeframe.core.engine_registry import (
         is_external_engine, resolve_engine, get_external_adapter, get_builtin_adapter,
@@ -661,41 +660,22 @@ def execute_agent(
     engine = resolve_engine(engine)
 
     # Resolve LLM provider: CLI flag → env var → workspace config → default "anthropic"
-    from codeframe.core.config import load_environment_config as _load_cfg
-    _env_cfg = _load_cfg(workspace.repo_path)
-    _cfg_provider = _env_cfg.llm.provider if (_env_cfg and _env_cfg.llm) else None
-    _cfg_model = _env_cfg.llm.model if (_env_cfg and _env_cfg.llm) else None
-    _cfg_base_url = _env_cfg.llm.base_url if (_env_cfg and _env_cfg.llm) else None
+    from codeframe.core.llm_resolution import resolve_llm_settings, create_provider
 
-    provider_type = (
-        llm_provider
-        or os.getenv("CODEFRAME_LLM_PROVIDER")
-        or _cfg_provider
-        or "anthropic"
+    llm_settings = resolve_llm_settings(
+        workspace.repo_path, provider_flag=llm_provider, model_flag=llm_model
     )
-    model_override = (
-        llm_model
-        or os.getenv("CODEFRAME_LLM_MODEL")
-        or _cfg_model
-    )
-    base_url_override = _cfg_base_url or os.getenv("OPENAI_BASE_URL")
 
-    # External engines manage their own authentication
+    # Only create LLM provider for builtin engines (external engines manage
+    # their own authentication)
     if not is_external_engine(engine):
-        if provider_type == "anthropic" and not os.getenv("ANTHROPIC_API_KEY"):
+        key_env = llm_settings.required_key_env
+        if key_env and not os.getenv(key_env):
             raise ValueError(
-                "ANTHROPIC_API_KEY environment variable is required for agent execution. "
-                "Set it with: export ANTHROPIC_API_KEY=your-key"
+                f"{key_env} environment variable is required for agent execution. "
+                f"Set it with: export {key_env}=your-key"
             )
-
-    # Only create LLM provider for builtin engines (external engines manage their own)
-    if not is_external_engine(engine):
-        provider_kwargs = {}
-        if model_override:
-            provider_kwargs["model"] = model_override
-        if base_url_override:
-            provider_kwargs["base_url"] = base_url_override
-        provider = get_provider(provider_type, **provider_kwargs)
+        provider = create_provider(llm_settings)
     else:
         provider = None
 

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -930,6 +930,7 @@ def generate_from_prd(
     workspace: Workspace,
     prd: PrdRecord,
     use_llm: bool = True,
+    provider=None,
 ) -> list[Task]:
     """Generate tasks from a PRD.
 
@@ -940,13 +941,15 @@ def generate_from_prd(
         workspace: Target workspace
         prd: PRD to generate tasks from
         use_llm: Whether to use LLM for generation (default True)
+        provider: LLM provider to use; None falls back to the default
+            ``get_provider()`` (anthropic), #768
 
     Returns:
         List of created Tasks
     """
     if use_llm:
         try:
-            tasks_data = _generate_tasks_with_llm(prd.content)
+            tasks_data = _generate_tasks_with_llm(prd.content, provider)
         except json.JSONDecodeError as e:
             # Invalid JSON from LLM response — fall back to simple extraction
             logger.warning(f"LLM generation failed ({e}), using simple extraction")
@@ -986,11 +989,12 @@ def generate_from_prd(
     return created_tasks
 
 
-def _generate_tasks_with_llm(prd_content: str) -> list[dict]:
+def _generate_tasks_with_llm(prd_content: str, provider=None) -> list[dict]:
     """Use LLM to generate tasks from PRD content.
 
     Args:
         prd_content: PRD text
+        provider: LLM provider (None falls back to the default anthropic)
 
     Returns:
         List of task dicts with rich metadata fields
@@ -998,7 +1002,8 @@ def _generate_tasks_with_llm(prd_content: str) -> list[dict]:
     # Use the LLM adapter for provider-agnostic access
     from codeframe.adapters.llm import get_provider, Purpose
 
-    provider = get_provider()
+    if provider is None:
+        provider = get_provider()
 
     prompt = f"""Analyze the following PRD and generate a list of actionable development tasks.
 

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -389,11 +389,24 @@ async def generate_tasks_from_prd(
                     detail="No PRD found. Generate a PRD first with POST /api/v2/discovery/start",
                 )
 
+        # Resolve the LLM provider via the standard chain (#768) so this
+        # endpoint honors CODEFRAME_LLM_PROVIDER / .codeframe/config.yaml
+        # like its CLI equivalent and the PRD stress-test endpoint.
+        provider = None
+        if use_llm:
+            from codeframe.core.llm_resolution import (
+                create_provider,
+                resolve_llm_settings,
+            )
+
+            provider = create_provider(resolve_llm_settings(workspace.repo_path))
+
         # Generate tasks
         generated_tasks = tasks.generate_from_prd(
             workspace,
             prd_record,
             use_llm=use_llm,
+            provider=provider,
         )
 
         return GenerateTasksResponse(

--- a/codeframe/ui/routers/prd_v2.py
+++ b/codeframe/ui/routers/prd_v2.py
@@ -236,38 +236,17 @@ def _resolve_llm_provider(workspace: Workspace):
     this is the web surface.) Mirrors ``runtime.py`` and the stress-test stream.
 
     Raises:
-        ValueError: with a user-facing message when the Anthropic API key is
+        ValueError: with a user-facing message when the required API key is
             missing or the provider cannot be constructed.
     """
-    from codeframe.adapters.llm import get_provider
-    from codeframe.core.config import load_environment_config
+    from codeframe.core.llm_resolution import create_provider, resolve_llm_settings
 
-    env_cfg = load_environment_config(workspace.repo_path)
-    llm_cfg = env_cfg.llm if (env_cfg and env_cfg.llm) else None
-    provider_type = (
-        os.getenv("CODEFRAME_LLM_PROVIDER")
-        or (llm_cfg.provider if llm_cfg else None)
-        or "anthropic"
-    )
+    settings = resolve_llm_settings(workspace.repo_path)
+    key_env = settings.required_key_env
+    if key_env and not os.getenv(key_env):
+        raise ValueError(f"{key_env} environment variable required.")
 
-    # Only the Anthropic provider needs an API key up front; local providers
-    # (ollama/vllm/compatible) do not.
-    if provider_type == "anthropic" and not os.getenv("ANTHROPIC_API_KEY"):
-        raise ValueError("ANTHROPIC_API_KEY environment variable required.")
-
-    provider_kwargs: dict = {}
-    model_override = os.getenv("CODEFRAME_LLM_MODEL") or (
-        llm_cfg.model if llm_cfg else None
-    )
-    base_url_override = (llm_cfg.base_url if llm_cfg else None) or os.getenv(
-        "OPENAI_BASE_URL"
-    )
-    if model_override:
-        provider_kwargs["model"] = model_override
-    if base_url_override:
-        provider_kwargs["base_url"] = base_url_override
-
-    return get_provider(provider_type, **provider_kwargs)
+    return create_provider(settings)
 
 
 async def _stress_test_event_stream(

--- a/tests/cli/test_tasks_tree_cli.py
+++ b/tests/cli/test_tasks_tree_cli.py
@@ -98,6 +98,9 @@ class TestTasksGenerateRecursiveFlag:
             patch("codeframe.core.workspace.get_workspace", return_value=mock_workspace),
             patch("codeframe.core.prd.get_latest", return_value=mock_prd),
             patch("codeframe.cli.validators.require_anthropic_api_key"),
+            # Provider construction now happens before generate_from_prd (#768);
+            # patch the factory so no real key (env or CredentialManager) is needed.
+            patch("codeframe.adapters.llm.get_provider"),
             patch("codeframe.core.tasks.generate_from_prd", return_value=[mock_task]) as mock_gen,
             patch("codeframe.core.events.emit_for_workspace"),
         ):

--- a/tests/core/test_cli_llm_flags.py
+++ b/tests/core/test_cli_llm_flags.py
@@ -41,3 +41,21 @@ class TestWorkStartLLMFlags:
         result = runner.invoke(app, ["work", "batch", "run", "--help"])
         assert result.exit_code == 0
         assert "--llm-model" in _plain(result.output)
+
+
+class TestThinkPhaseLLMFlags:
+    """--llm-provider and --llm-model on Think-phase commands (#768)."""
+
+    def test_prd_stress_test_has_llm_flags(self):
+        result = runner.invoke(app, ["prd", "stress-test", "--help"])
+        assert result.exit_code == 0
+        output = _plain(result.output)
+        assert "--llm-provider" in output
+        assert "--llm-model" in output
+
+    def test_tasks_generate_has_llm_flags(self):
+        result = runner.invoke(app, ["tasks", "generate", "--help"])
+        assert result.exit_code == 0
+        output = _plain(result.output)
+        assert "--llm-provider" in output
+        assert "--llm-model" in output

--- a/tests/core/test_cli_validators.py
+++ b/tests/core/test_cli_validators.py
@@ -355,6 +355,21 @@ class TestThinkPhaseProviderResolution:
         assert result.exit_code != 0
         assert "OPENAI_API_KEY" in result.output
 
+    def test_tasks_generate_recursive_no_llm_rejected(
+        self, workspace_with_prd, isolated_keys
+    ):
+        """--recursive needs the LLM; combining it with --no-llm must be a
+        clear error, not an AttributeError on a None provider."""
+        from codeframe.cli.app import app
+
+        result = runner.invoke(
+            app,
+            ["tasks", "generate", "--recursive", "--no-llm",
+             "-w", str(workspace_with_prd)],
+        )
+        assert result.exit_code != 0
+        assert "--no-llm" in result.output and "--recursive" in result.output
+
     def test_tasks_generate_ollama_provider_skips_anthropic_key(
         self, workspace_with_prd, isolated_keys, monkeypatch
     ):

--- a/tests/core/test_cli_validators.py
+++ b/tests/core/test_cli_validators.py
@@ -163,6 +163,218 @@ class TestTasksGenerateValidation:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def isolated_keys(monkeypatch, tmp_path):
+    """No API keys anywhere: env cleared, cwd + home have no .env files."""
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "CODEFRAME_LLM_PROVIDER",
+        "CODEFRAME_LLM_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+
+def _completed_agent_state():
+    from types import SimpleNamespace
+
+    from codeframe.core.agent import AgentStatus
+
+    return SimpleNamespace(
+        status=AgentStatus.COMPLETED, blocker=None, step_results=[]
+    )
+
+
+class TestProviderAwarePreflight:
+    """Pre-flight key checks must honor the resolved provider (#768)."""
+
+    def test_work_start_openai_provider_requires_openai_key(
+        self, workspace_with_ready_task, isolated_keys
+    ):
+        from codeframe.cli.app import app
+
+        workspace_path, task_id = workspace_with_ready_task
+        result = runner.invoke(
+            app,
+            ["work", "start", task_id, "--execute",
+             "--llm-provider", "openai", "-w", str(workspace_path)],
+        )
+        assert result.exit_code != 0
+        assert "OPENAI_API_KEY" in result.output
+        assert "ANTHROPIC_API_KEY" not in result.output
+
+    def test_work_start_ollama_provider_skips_anthropic_key(
+        self, workspace_with_ready_task, isolated_keys, monkeypatch
+    ):
+        from codeframe.cli.app import app
+        from codeframe.core import runtime
+
+        workspace_path, task_id = workspace_with_ready_task
+        monkeypatch.setattr(
+            runtime, "execute_agent",
+            lambda *a, **kw: _completed_agent_state(),
+        )
+        result = runner.invoke(
+            app,
+            ["work", "start", task_id, "--execute",
+             "--llm-provider", "ollama", "-w", str(workspace_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "ANTHROPIC_API_KEY" not in result.output
+
+    def test_batch_run_openai_provider_requires_openai_key(
+        self, workspace_with_ready_task, isolated_keys
+    ):
+        from codeframe.cli.app import app
+
+        workspace_path, task_id = workspace_with_ready_task
+        result = runner.invoke(
+            app,
+            ["work", "batch", "run", task_id,
+             "--llm-provider", "openai", "-w", str(workspace_path)],
+        )
+        assert result.exit_code != 0
+        assert "OPENAI_API_KEY" in result.output
+
+    def test_batch_run_ollama_provider_skips_anthropic_key(
+        self, workspace_with_ready_task, isolated_keys, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from codeframe.cli.app import app
+        from codeframe.core import conductor
+
+        workspace_path, task_id = workspace_with_ready_task
+        fake_batch = SimpleNamespace(
+            id="deadbeefcafe",
+            status=SimpleNamespace(value="COMPLETED"),
+            results={task_id: "COMPLETED"},
+        )
+        monkeypatch.setattr(
+            conductor, "start_batch", lambda *a, **kw: fake_batch
+        )
+        result = runner.invoke(
+            app,
+            ["work", "batch", "run", task_id,
+             "--llm-provider", "ollama", "-w", str(workspace_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "ANTHROPIC_API_KEY" not in result.output
+
+    def test_work_retry_non_anthropic_provider_skips_anthropic_key(
+        self, workspace_with_ready_task, isolated_keys, monkeypatch
+    ):
+        from codeframe.cli.app import app
+        from codeframe.core import runtime
+
+        workspace_path, task_id = workspace_with_ready_task
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "ollama")
+        monkeypatch.setattr(
+            runtime, "execute_agent",
+            lambda *a, **kw: _completed_agent_state(),
+        )
+        result = runner.invoke(
+            app, ["work", "retry", task_id, "-w", str(workspace_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "ANTHROPIC_API_KEY" not in result.output
+
+    def test_work_retry_default_provider_still_requires_anthropic_key(
+        self, workspace_with_ready_task, isolated_keys
+    ):
+        from codeframe.cli.app import app
+
+        workspace_path, task_id = workspace_with_ready_task
+        result = runner.invoke(
+            app, ["work", "retry", task_id, "-w", str(workspace_path)]
+        )
+        assert result.exit_code != 0
+        assert "ANTHROPIC_API_KEY" in result.output
+
+
+class TestThinkPhaseProviderResolution:
+    """prd stress-test and tasks generate must honor the provider chain (#768)."""
+
+    def test_stress_test_default_provider_requires_anthropic_key(
+        self, workspace_with_prd, isolated_keys
+    ):
+        from codeframe.cli.app import app
+
+        result = runner.invoke(
+            app, ["prd", "stress-test", "-w", str(workspace_with_prd)]
+        )
+        assert result.exit_code != 0
+        assert "ANTHROPIC_API_KEY" in result.output
+
+    def test_stress_test_ollama_provider_skips_anthropic_key(
+        self, workspace_with_prd, isolated_keys, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from codeframe.adapters.llm import OpenAIProvider
+        from codeframe.cli.app import app
+        from codeframe.core import prd_stress_test
+
+        seen_providers = []
+
+        def fake_stress_test(content, provider, max_depth=3):
+            seen_providers.append(provider)
+            return SimpleNamespace(
+                ambiguities=[], tree=[], tech_spec_markdown="# Spec"
+            )
+
+        monkeypatch.setattr(
+            prd_stress_test, "stress_test_prd", fake_stress_test
+        )
+        result = runner.invoke(
+            app,
+            ["prd", "stress-test", "--llm-provider", "ollama",
+             "-w", str(workspace_with_prd)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "ANTHROPIC_API_KEY" not in result.output
+        assert len(seen_providers) == 1
+        assert isinstance(seen_providers[0], OpenAIProvider)
+
+    def test_tasks_generate_openai_provider_requires_openai_key(
+        self, workspace_with_prd, isolated_keys
+    ):
+        from codeframe.cli.app import app
+
+        result = runner.invoke(
+            app,
+            ["tasks", "generate", "--llm-provider", "openai",
+             "-w", str(workspace_with_prd)],
+        )
+        assert result.exit_code != 0
+        assert "OPENAI_API_KEY" in result.output
+
+    def test_tasks_generate_ollama_provider_skips_anthropic_key(
+        self, workspace_with_prd, isolated_keys, monkeypatch
+    ):
+        from codeframe.cli.app import app
+        from codeframe.core import tasks as tasks_module
+
+        monkeypatch.setattr(
+            tasks_module,
+            "_generate_tasks_with_llm",
+            lambda *a, **kw: [{"title": "Task A", "description": "do a"}],
+        )
+        result = runner.invoke(
+            app,
+            ["tasks", "generate", "--llm-provider", "ollama",
+             "-w", str(workspace_with_prd)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "ANTHROPIC_API_KEY" not in result.output
+
+
 class TestWorkStartValidation:
     """Test that work start --execute validates API key."""
 

--- a/tests/core/test_llm_resolution.py
+++ b/tests/core/test_llm_resolution.py
@@ -110,6 +110,18 @@ class TestCreateProvider:
         provider = create_provider(LLMSettings(provider_type="mock"))
         assert isinstance(provider, MockProvider)
 
+    def test_anthropic_model_override_is_honored(self, monkeypatch):
+        """A resolved model override must reach the Anthropic provider, not
+        be silently dropped (#768 review finding)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+        provider = create_provider(
+            LLMSettings(provider_type="anthropic", model="claude-test-model")
+        )
+        selector = provider.model_selector
+        assert selector.planning_model == "claude-test-model"
+        assert selector.execution_model == "claude-test-model"
+        assert selector.generation_model == "claude-test-model"
+
     def test_creates_openai_compatible_for_ollama(self, monkeypatch):
         from codeframe.adapters.llm import OpenAIProvider
 

--- a/tests/core/test_llm_resolution.py
+++ b/tests/core/test_llm_resolution.py
@@ -1,0 +1,124 @@
+"""Tests for codeframe.core.llm_resolution — shared provider resolution chain (#768)."""
+
+import pytest
+
+from codeframe.core.llm_resolution import (
+    LLMSettings,
+    create_provider,
+    resolve_llm_settings,
+)
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Isolate from ambient provider env vars (CI vs dev machines)."""
+    for var in (
+        "CODEFRAME_LLM_PROVIDER",
+        "CODEFRAME_LLM_MODEL",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _write_llm_config(repo, **llm):
+    cfg_dir = repo / ".codeframe"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["llm:"] + [f"  {k}: {v}" for k, v in llm.items()]
+    (cfg_dir / "config.yaml").write_text("\n".join(lines) + "\n")
+
+
+class TestProviderPrecedence:
+    def test_defaults_to_anthropic(self, tmp_path):
+        settings = resolve_llm_settings(tmp_path)
+        assert settings.provider_type == "anthropic"
+
+    def test_config_beats_default(self, tmp_path):
+        _write_llm_config(tmp_path, provider="ollama")
+        settings = resolve_llm_settings(tmp_path)
+        assert settings.provider_type == "ollama"
+
+    def test_env_beats_config(self, tmp_path, monkeypatch):
+        _write_llm_config(tmp_path, provider="ollama")
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+        settings = resolve_llm_settings(tmp_path)
+        assert settings.provider_type == "openai"
+
+    def test_flag_beats_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+        settings = resolve_llm_settings(tmp_path, provider_flag="vllm")
+        assert settings.provider_type == "vllm"
+
+    def test_no_repo_path_uses_env_chain(self, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "ollama")
+        settings = resolve_llm_settings(None)
+        assert settings.provider_type == "ollama"
+
+
+class TestModelAndBaseUrl:
+    def test_model_flag_beats_env_and_config(self, tmp_path, monkeypatch):
+        _write_llm_config(tmp_path, provider="openai", model="cfg-model")
+        monkeypatch.setenv("CODEFRAME_LLM_MODEL", "env-model")
+        settings = resolve_llm_settings(tmp_path, model_flag="flag-model")
+        assert settings.model == "flag-model"
+
+    def test_model_env_beats_config(self, tmp_path, monkeypatch):
+        _write_llm_config(tmp_path, provider="openai", model="cfg-model")
+        monkeypatch.setenv("CODEFRAME_LLM_MODEL", "env-model")
+        assert resolve_llm_settings(tmp_path).model == "env-model"
+
+    def test_base_url_config_beats_env(self, tmp_path, monkeypatch):
+        _write_llm_config(
+            tmp_path, provider="ollama", base_url="http://cfg:11434/v1"
+        )
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://env:8000/v1")
+        assert resolve_llm_settings(tmp_path).base_url == "http://cfg:11434/v1"
+
+    def test_provider_kwargs_only_includes_set_values(self, tmp_path):
+        settings = resolve_llm_settings(tmp_path)
+        assert settings.provider_kwargs() == {}
+        full = LLMSettings(
+            provider_type="openai", model="gpt-4o", base_url="http://x/v1"
+        )
+        assert full.provider_kwargs() == {
+            "model": "gpt-4o",
+            "base_url": "http://x/v1",
+        }
+
+
+class TestRequiredKeyEnv:
+    @pytest.mark.parametrize(
+        "provider,expected",
+        [
+            ("anthropic", "ANTHROPIC_API_KEY"),
+            ("openai", "OPENAI_API_KEY"),
+            ("ollama", None),
+            ("vllm", None),
+            ("compatible", None),
+            ("mock", None),
+        ],
+    )
+    def test_mapping(self, provider, expected):
+        assert LLMSettings(provider_type=provider).required_key_env == expected
+
+
+class TestCreateProvider:
+    def test_creates_mock_provider(self):
+        from codeframe.adapters.llm import MockProvider
+
+        provider = create_provider(LLMSettings(provider_type="mock"))
+        assert isinstance(provider, MockProvider)
+
+    def test_creates_openai_compatible_for_ollama(self, monkeypatch):
+        from codeframe.adapters.llm import OpenAIProvider
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        provider = create_provider(
+            LLMSettings(
+                provider_type="ollama",
+                model="qwen2.5-coder:7b",
+                base_url="http://localhost:11434/v1",
+            )
+        )
+        assert isinstance(provider, OpenAIProvider)

--- a/tests/core/test_prd_stress_test.py
+++ b/tests/core/test_prd_stress_test.py
@@ -546,8 +546,10 @@ class TestStressTestCLI:
         result = runner.invoke(app, ["prd", "stress-test", "-w", str(tmp_path)])
         assert result.exit_code == 1
 
-    @patch("codeframe.adapters.llm.anthropic.AnthropicProvider")
-    def test_stress_test_with_prd(self, mock_provider_cls, workspace, sample_prd, mock_provider, tmp_path, monkeypatch):
+    # Patched at the shared-resolution seam: the CLI now builds the provider
+    # via llm_resolution.create_provider (#768), not AnthropicProvider directly.
+    @patch("codeframe.core.llm_resolution.create_provider")
+    def test_stress_test_with_prd(self, mock_create_provider, workspace, sample_prd, mock_provider, tmp_path, monkeypatch):
         """Should run stress test on existing PRD."""
         from typer.testing import CliRunner
         from codeframe.cli.app import app
@@ -557,15 +559,15 @@ class TestStressTestCLI:
         # Store a PRD first
         prd_module.store(workspace, "Test PRD", sample_prd, {})
 
-        mock_provider_cls.return_value = mock_provider
+        mock_create_provider.return_value = mock_provider
 
         runner = CliRunner()
         result = runner.invoke(app, ["prd", "stress-test", "-w", str(tmp_path)])
         assert result.exit_code == 0
         assert "ambiguit" in result.output.lower() or "AUTH SCOPE" in result.output
 
-    @patch("codeframe.adapters.llm.anthropic.AnthropicProvider")
-    def test_stress_test_output_flag(self, mock_provider_cls, workspace, sample_prd, mock_provider, tmp_path, monkeypatch):
+    @patch("codeframe.core.llm_resolution.create_provider")
+    def test_stress_test_output_flag(self, mock_create_provider, workspace, sample_prd, mock_provider, tmp_path, monkeypatch):
         """--output should write tech spec to file."""
         from typer.testing import CliRunner
         from codeframe.cli.app import app
@@ -573,7 +575,7 @@ class TestStressTestCLI:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-fake-key")
 
         prd_module.store(workspace, "Test PRD", sample_prd, {})
-        mock_provider_cls.return_value = mock_provider
+        mock_create_provider.return_value = mock_provider
 
         output_path = tmp_path / "spec.md"
         runner = CliRunner()

--- a/tests/ui/test_discovery_generate_tasks.py
+++ b/tests/ui/test_discovery_generate_tasks.py
@@ -1,0 +1,82 @@
+"""POST /api/v2/discovery/generate-tasks must honor the provider chain (#768).
+
+The endpoint previously called ``tasks.generate_from_prd`` with no provider,
+falling through to the hardcoded-Anthropic ``get_provider()`` default and
+ignoring CODEFRAME_LLM_PROVIDER / ``.codeframe/config.yaml``.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core import prd as prd_module
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def test_workspace():
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "test_workspace"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    workspace = create_or_load_workspace(workspace_path)
+    prd_module.store(workspace, content="# PRD\n\n## Feature: Login\n- Add login")
+    yield workspace
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def test_client(test_workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import discovery_v2
+
+    app = FastAPI()
+    app.include_router(discovery_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    return TestClient(app)
+
+
+class TestGenerateTasksProviderResolution:
+    def test_resolved_provider_is_passed_to_generation(
+        self, test_client, monkeypatch
+    ):
+        """With CODEFRAME_LLM_PROVIDER set, the endpoint builds that provider
+        and threads it into generate_from_prd — no Anthropic key needed."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "ollama")
+
+        fake_provider = MagicMock()
+        with (
+            patch(
+                "codeframe.core.llm_resolution.create_provider",
+                return_value=fake_provider,
+            ) as mock_create,
+            patch(
+                "codeframe.core.tasks._generate_tasks_with_llm",
+                return_value=[{"title": "Task A", "description": "do a"}],
+            ) as mock_llm_gen,
+        ):
+            response = test_client.post("/api/v2/discovery/generate-tasks")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["task_count"] == 1
+        mock_create.assert_called_once()
+        assert mock_llm_gen.call_args.args[1] is fake_provider
+
+    def test_no_llm_skips_provider_resolution(self, test_client, monkeypatch):
+        """use_llm=false must not construct any provider."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with patch(
+            "codeframe.core.llm_resolution.create_provider"
+        ) as mock_create:
+            response = test_client.post(
+                "/api/v2/discovery/generate-tasks?use_llm=false"
+            )
+        assert response.status_code == 200, response.text
+        mock_create.assert_not_called()


### PR DESCRIPTION
## Summary
Implements #768: provider-selection gaps — pre-flight key check and Think-phase ignored `--llm-provider`.

- New `codeframe/core/llm_resolution.py`: single source of truth for the effective-provider chain (`--llm-provider` flag → `CODEFRAME_LLM_PROVIDER` → `.codeframe/config.yaml llm:` → `anthropic`) and the provider → required-key-env mapping (`anthropic → ANTHROPIC_API_KEY`, `openai → OPENAI_API_KEY`, local providers → none).
- `runtime.py` and `ui/routers/prd_v2.py` deduped onto the shared helper; runtime pre-flight now also fails loudly on a missing `OPENAI_API_KEY` for the openai provider.
- `cf work start` / `cf work batch run`: builtin-engine key check validates the key matching the resolved provider instead of always `ANTHROPIC_API_KEY`; `cf work retry` resolves env → config → default.
- `cf prd stress-test` and `cf tasks generate`: new `--llm-provider` / `--llm-model` flags; both route through the shared resolution instead of hardcoding Anthropic; provider threaded through `generate_from_prd`.
- Cross-family review fixes: `--recursive --no-llm` is now rejected explicitly, and a model override for the anthropic provider is honored via a pinned `ModelSelector` (previously silently dropped).

## Acceptance Criteria
- [x] A shared helper resolves the effective provider (flag→env→config→default) and validates the matching key
- [x] `work start/batch/retry` pre-flight honors the resolved provider (non-anthropic no longer demands ANTHROPIC_API_KEY; openai demands OPENAI_API_KEY)
- [x] `prd stress-test` and `tasks generate` route through the same provider resolution

## Test Plan
- [x] Unit tests written (TDD approach) — new `tests/core/test_llm_resolution.py`, +9 CLI integration tests
- [x] All tests passing — full CI-equivalent gate: 4206 passed, 12 skipped
- [x] Diff coverage 100% on changed lines (threshold 85%)
- [x] Linting clean (`ruff check .`)
- [x] Internal code review (advisory) — spawned; no findings reported at PR time (see limitations)
- [x] Cross-family review pass: **codex** (2 Major findings, both fixed). opencode/GLM was attempted first but modified the working tree instead of staying read-only, so it was terminated and codex used as fallback.
- [x] Test mutation sanity check completed (precedence-chain and openai-dispatch mutations both made the new tests fail)

## Known Limitations / Intentionally Deferred
- `cf work retry` gets no `--llm-provider`/`--llm-model` flags — it re-executes via `execute_agent`, which already honors env/config; only its pre-flight became provider-aware.
- `generate_from_prd(provider=None)` (core default path, no CLI in play) still falls back to plain `get_provider()` (anthropic) rather than the full env/config chain — existing test seams patch the zero-arg `get_provider()`; all CLI/server paths pass an explicitly resolved provider.
- `base_url` remains config → `OPENAI_BASE_URL` only (no dedicated CLI flag), matching pre-existing behavior.

## Implementation Notes
Plan was self-authored (issue had no implementation plan). Two runtime behavior improvements ride along by design: missing `OPENAI_API_KEY` for the openai provider now fails loudly at execution pre-flight, and model overrides now reach `AnthropicProvider` via a purpose-pinned `ModelSelector`.

Closes #768