### PR TITLE
fix(cli): remove unimplemented 'cloud' from --isolation choices (#769)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2422,8 +2422,8 @@ def work_start(
     isolation: str = typer.Option(
         "none",
         "--isolation",
-        help="Task execution isolation: none (default), worktree, or cloud",
-        click_type=click.Choice(["none", "worktree", "cloud"], case_sensitive=False),
+        help="Task execution isolation: none (default) or worktree",
+        click_type=click.Choice(["none", "worktree"], case_sensitive=False),
     ),
     cloud_timeout: int = typer.Option(
         30,
@@ -3767,8 +3767,8 @@ def batch_run(
     isolation: str = typer.Option(
         "none",
         "--isolation",
-        help="Task execution isolation: none (default), worktree, or cloud",
-        click_type=click.Choice(["none", "worktree", "cloud"], case_sensitive=False),
+        help="Task execution isolation: none (default) or worktree",
+        click_type=click.Choice(["none", "worktree"], case_sensitive=False),
     ),
     cloud_timeout: int = typer.Option(
         30,

--- a/tests/cli/test_work_exit_codes.py
+++ b/tests/cli/test_work_exit_codes.py
@@ -250,3 +250,25 @@ class TestIsolationRejection:
             ["work", "start", task.id[:8], "--isolation", "none", "-w", str(repo)],
         )
         assert "worktree isolation is temporarily disabled" not in result.output
+
+    def test_work_start_rejects_cloud_at_parse_time(self, tmp_path):
+        """Issue #769: 'cloud' is not a valid --isolation choice — Click rejects
+        it before any run is created (no dangling IN_PROGRESS task)."""
+        repo, ws, task = self._workspace_with_task(tmp_path)
+        result = runner.invoke(
+            app,
+            ["work", "start", task.id[:8], "--execute", "--isolation", "cloud", "-w", str(repo)],
+        )
+        assert result.exit_code != 0
+        assert "cloud" in result.output and "is not one of" in result.output
+        assert tasks.get(ws, task.id).status != TaskStatus.IN_PROGRESS
+
+    def test_work_batch_run_rejects_cloud_at_parse_time(self, tmp_path):
+        repo, ws, task = self._workspace_with_task(tmp_path)
+        result = runner.invoke(
+            app,
+            ["work", "batch", "run", task.id[:8], "--isolation", "cloud", "-w", str(repo)],
+        )
+        assert result.exit_code != 0
+        assert "cloud" in result.output and "is not one of" in result.output
+        assert tasks.get(ws, task.id).status != TaskStatus.IN_PROGRESS


### PR DESCRIPTION
Closes #769

## Problem
`cf work start` / `cf work batch run` exposed `--isolation cloud`, but `create_execution_context` raises `NotImplementedError` for CLOUD *after* `start_task_run` has already flipped the task to IN_PROGRESS — leaving the task dangling with a raw traceback.

## Fix
Remove `"cloud"` from the `--isolation` `click.Choice` in both commands (per the CodeRabbit plan on the issue, option 1). Click now rejects it at parse time — `'cloud' is not one of 'none', 'worktree'` — before any state mutation.

- `codeframe/core/sandbox/context.py` is intentionally unchanged: `IsolationLevel.CLOUD` + its `NotImplementedError` guard stay as reserved scaffolding for the E2B phase and defense-in-depth for programmatic callers.
- `--engine cloud` / `--cloud-timeout` are an unrelated, working feature and are untouched.

## Tests
- New: `TestIsolationRejection::test_work_start_rejects_cloud_at_parse_time` and `::test_work_batch_run_rejects_cloud_at_parse_time` — non-zero exit, Click invalid-choice error, task not left IN_PROGRESS.
- Full `tests/cli/` suite: 443 passed, 9 skipped. `ruff check` clean.

## Third-party review
Pre-PR `codex review` (GLM/opencode skipped — reviewer mutates the tree): no findings; codex independently re-ran the CLI tests (14 passed).

## Known limitations
- `IsolationLevel.CLOUD` remains in the enum, so a *programmatic* caller could still pass it and hit `NotImplementedError` — but `create_execution_context` raises before doing any work, and no server route accepts an isolation parameter today.
- `--isolation worktree` remains selectable-but-rejected at runtime (existing #714 behavior, unchanged here).