### PR TITLE
fix(cli): wire stub commands 'cf events tail' and 'cf gates run' (#770)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -4549,7 +4549,7 @@ events_app = typer.Typer(
 
 @events_app.command("tail")
 def events_tail(
-    limit: int = typer.Option(20, "--limit", "-n", help="Number of events to show"),
+    limit: int = typer.Option(20, "--limit", "-n", min=1, help="Number of events to show"),
     workspace_path: Optional[Path] = typer.Option(
         None,
         "--workspace",

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -4550,10 +4550,42 @@ events_app = typer.Typer(
 @events_app.command("tail")
 def events_tail(
     limit: int = typer.Option(20, "--limit", "-n", help="Number of events to show"),
+    workspace_path: Optional[Path] = typer.Option(
+        None,
+        "--workspace",
+        "-w",
+        help="Workspace path (defaults to current directory)",
+    ),
 ) -> None:
-    """Tail the event log."""
-    # Stub for Phase 3
-    console.print("[yellow]Not yet implemented.[/yellow] Coming in Phase 3.")
+    """Tail the event log.
+
+    Shows the most recent events, then follows new ones until Ctrl+C.
+
+    Example:
+        codeframe events tail
+        codeframe events tail -n 50
+    """
+    from codeframe.core import events
+    from codeframe.core.workspace import get_workspace
+
+    path = workspace_path or Path.cwd()
+
+    try:
+        workspace = get_workspace(path)
+    except FileNotFoundError:
+        console.print(f"[red]Error:[/red] No workspace found at {path}")
+        raise typer.Exit(1)
+
+    recent = events.list_recent(workspace, limit=limit)
+    for event in reversed(recent):  # list_recent is newest-first
+        events.print_event(event)
+
+    since_id = recent[0].id if recent else 0
+    try:
+        for event in events.tail(workspace, since_id=since_id):
+            events.print_event(event)
+    except KeyboardInterrupt:
+        pass
 
 
 # Blocker commands
@@ -5281,10 +5313,28 @@ gates_app = typer.Typer(
 
 
 @gates_app.command("run")
-def gates_run() -> None:
-    """Run verification gates (tests, lint)."""
-    # Stub for Phase 5
-    console.print("[yellow]Not yet implemented.[/yellow] Coming in Phase 5.")
+def gates_run(
+    gates_to_run: Optional[list[str]] = typer.Option(
+        None,
+        "--gate",
+        "-g",
+        help="Specific gate to run (can be repeated)",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show full output from gates",
+    ),
+    workspace_path: Optional[Path] = typer.Option(
+        None,
+        "--workspace",
+        "-w",
+        help="Workspace path (defaults to current directory)",
+    ),
+) -> None:
+    """Run verification gates (tests, lint). Alias for `cf review`."""
+    review(gates_to_run, verbose, workspace_path)
 
 
 # =============================================================================

--- a/codeframe/core/events.py
+++ b/codeframe/core/events.py
@@ -338,10 +338,10 @@ def tail(
         time.sleep(0.5)  # Poll interval
 
 
-def _print_event(event: Event) -> None:
+def print_event(event: Event) -> None:
     """Print an event to the console in a readable format."""
     timestamp = event.created_at.strftime("%H:%M:%S")
-    type_color = _get_event_color(event.event_type)
+    type_color = get_event_color(event.event_type)
 
     console.print(
         f"[dim]{timestamp}[/dim] [{type_color}]{event.event_type}[/{type_color}]",
@@ -362,7 +362,7 @@ def _print_event(event: Event) -> None:
         console.print()
 
 
-def _get_event_color(event_type: str) -> str:
+def get_event_color(event_type: str) -> str:
     """Get the Rich color for an event type."""
     if "ERROR" in event_type or "FAILED" in event_type:
         return "red"
@@ -373,3 +373,8 @@ def _get_event_color(event_type: str) -> str:
     if "BLOCKED" in event_type or "BLOCKER" in event_type:
         return "yellow"
     return "cyan"
+
+
+# emit()/emit_for_workspace() have a `print_event` keyword argument that
+# shadows the public function inside their scope; they call this alias.
+_print_event = print_event

--- a/tests/cli/test_events_gates_commands.py
+++ b/tests/cli/test_events_gates_commands.py
@@ -1,0 +1,170 @@
+"""Tests for 'cf events tail' and 'cf gates run' (issue #770).
+
+Both commands were help-advertised stubs printing "Not yet implemented".
+These tests lock in the wired behavior: events tail wraps
+core.events.list_recent/tail; gates run wraps core.gates.run (via review).
+
+Real SQLite workspace via CliRunner; only the infinite tail loop and the
+gate subprocess runner are mocked.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.app import app
+from codeframe.core import events
+from codeframe.core.events import Event
+from codeframe.core.gates import GateCheck, GateResult, GateStatus
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def ws(tmp_path: Path):
+    """Initialised workspace — returns (workspace_object, workspace_path)."""
+    workspace = create_or_load_workspace(tmp_path)
+    return workspace, tmp_path
+
+
+@pytest.fixture()
+def ws_with_events(ws):
+    """Workspace seeded with two events; returns (workspace, path, [event, event])."""
+    workspace, path = ws
+    e1 = events.emit_for_workspace(
+        workspace, "TASK_STARTED", {"task_id": "abc12345"}, print_event=False
+    )
+    e2 = events.emit_for_workspace(
+        workspace, "TASK_COMPLETED", {"task_id": "abc12345"}, print_event=False
+    )
+    return workspace, path, [e1, e2]
+
+
+def _fake_event(event_id: int, event_type: str = "GATE_PASSED") -> Event:
+    return Event(
+        id=event_id,
+        workspace_id="w1",
+        event_type=event_type,
+        payload={},
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# cf events tail
+# ---------------------------------------------------------------------------
+
+
+class TestEventsTail:
+    def test_prints_recent_events_then_exits_when_tail_ends(self, ws_with_events):
+        _, path, seeded = ws_with_events
+        with patch("codeframe.core.events.tail", return_value=iter([])) as mock_tail:
+            result = runner.invoke(app, ["events", "tail", "-w", str(path)])
+        assert result.exit_code == 0, result.output
+        assert "Not yet implemented" not in result.output
+        assert "TASK_STARTED" in result.output
+        assert "TASK_COMPLETED" in result.output
+        # follows from the newest already-printed event
+        assert mock_tail.call_args.kwargs.get("since_id") == seeded[-1].id
+
+    def test_respects_limit_option(self, ws_with_events):
+        _, path, _ = ws_with_events
+        with patch("codeframe.core.events.tail", return_value=iter([])):
+            result = runner.invoke(app, ["events", "tail", "-w", str(path), "-n", "1"])
+        assert result.exit_code == 0, result.output
+        # newest only
+        assert "TASK_COMPLETED" in result.output
+        assert "TASK_STARTED" not in result.output
+
+    def test_prints_followed_events(self, ws_with_events):
+        _, path, _ = ws_with_events
+        new_event = _fake_event(99, "BATCH_COMPLETED")
+        with patch("codeframe.core.events.tail", return_value=iter([new_event])):
+            result = runner.invoke(app, ["events", "tail", "-w", str(path)])
+        assert result.exit_code == 0, result.output
+        assert "BATCH_COMPLETED" in result.output
+
+    def test_keyboard_interrupt_exits_cleanly(self, ws_with_events):
+        _, path, _ = ws_with_events
+
+        def interrupted(*args, **kwargs):
+            yield _fake_event(50)
+            raise KeyboardInterrupt
+
+        with patch("codeframe.core.events.tail", side_effect=interrupted):
+            result = runner.invoke(app, ["events", "tail", "-w", str(path)])
+        assert result.exit_code == 0, result.output
+
+    def test_no_workspace_exits_with_error(self, tmp_path):
+        result = runner.invoke(app, ["events", "tail", "-w", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "No workspace found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# cf gates run
+# ---------------------------------------------------------------------------
+
+
+def _gate_result(passed: bool) -> GateResult:
+    status = GateStatus.PASSED if passed else GateStatus.FAILED
+    check = GateCheck(name="pytest", status=status, output="" if passed else "boom", duration_ms=5)
+    return GateResult(passed=passed, checks=[check])
+
+
+class TestGatesRun:
+    def test_runs_gates_and_reports_pass(self, ws):
+        _, path = ws
+        with patch("codeframe.core.gates.run", return_value=_gate_result(True)) as mock_run:
+            result = runner.invoke(app, ["gates", "run", "-w", str(path)])
+        assert result.exit_code == 0, result.output
+        assert "Not yet implemented" not in result.output
+        assert "pytest" in result.output
+        assert "PASSED" in result.output
+        assert mock_run.call_count == 1
+
+    def test_failure_exits_nonzero_and_shows_output(self, ws):
+        _, path = ws
+        with patch("codeframe.core.gates.run", return_value=_gate_result(False)):
+            result = runner.invoke(app, ["gates", "run", "-w", str(path)])
+        assert result.exit_code == 1
+        assert "FAILED" in result.output
+        assert "boom" in result.output
+
+    def test_gate_option_passthrough(self, ws):
+        _, path = ws
+        with patch("codeframe.core.gates.run", return_value=_gate_result(True)) as mock_run:
+            result = runner.invoke(
+                app, ["gates", "run", "-w", str(path), "--gate", "pytest"]
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs.get("gates") == ["pytest"]
+
+    def test_no_workspace_exits_with_error(self, tmp_path):
+        result = runner.invoke(app, ["gates", "run", "-w", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "No workspace found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# public event formatter (promoted from _print_event/_get_event_color)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicEventFormatter:
+    def test_public_functions_exist(self):
+        assert callable(events.print_event)
+        assert callable(events.get_event_color)
+
+    def test_color_mapping_preserved(self):
+        assert events.get_event_color("TASK_FAILED") == "red"
+        assert events.get_event_color("TASK_COMPLETED") == "green"
+        assert events.get_event_color("TASK_STARTED") == "blue"
+        assert events.get_event_color("TASK_BLOCKED") == "yellow"
+        assert events.get_event_color("SOMETHING_ELSE") == "cyan"

--- a/tests/cli/test_events_gates_commands.py
+++ b/tests/cli/test_events_gates_commands.py
@@ -106,6 +106,12 @@ class TestEventsTail:
         assert result.exit_code == 1
         assert "No workspace found" in result.output
 
+    def test_zero_limit_rejected(self, ws_with_events):
+        # limit=0 would reset since_id to 0 and make tail replay old events
+        _, path, _ = ws_with_events
+        result = runner.invoke(app, ["events", "tail", "-w", str(path), "-n", "0"])
+        assert result.exit_code != 0
+
 
 # ---------------------------------------------------------------------------
 # cf gates run


### PR DESCRIPTION
Closes #770

## Summary
Both help-advertised commands printed "Not yet implemented" although their backends have existed since Phases 3/5. They are now wired:

- **`cf events tail`** — prints the most recent events via `core.events.list_recent` (chronological), then follows new events via `core.events.tail` until Ctrl+C (clean exit). Adds `--workspace/-w`; `--limit/-n` now requires ≥1 (a 0 limit would reset the tail cursor and replay old events).
- **`cf gates run`** — same option surface as `cf review` (`--gate/-g`, `--verbose/-v`, `--workspace/-w`) and delegates directly to it, so it wraps `core.gates.run` with identical output and exit-code behavior.
- **`core/events.py`** — `_print_event`/`_get_event_color` promoted to public `print_event`/`get_event_color` for CLI reuse (a `_print_event` alias remains because `emit()`'s `print_event` keyword shadows the public name in its scope).

Plan source: CodeRabbit comment on #770, adapted — `gates_run` delegates to the `review` function directly instead of extracting a shared helper (typer commands are plain functions; identical behavior, smaller diff).

## Testing
- 12 new tests in `tests/cli/test_events_gates_commands.py` (TDD, RED confirmed before implementation): real SQLite workspace via CliRunner; only `events.tail` (infinite loop) and `gates.run` (shells out) mocked.
- Full `tests/cli/`: 454 passed. Event core tests: 29 passed. ruff clean.
- Live verification against `cf-test`: `events tail` printed recent events, followed, exited 0 on SIGINT; `gates run` ran 3 real gates (pytest/ruff/python-build) and exited 0.
- Pre-PR third-party review: `codex review` — one P3 (the `--limit 0` cursor reset), fixed in 8466291.

## Known Limitations
- `events tail` uses the pre-existing 0.5s polling loop in `core.events.tail` (not a file watcher).
- `cf gates run` and `cf review` are intentionally identical; if they ever diverge, extract a shared helper then.