### PR TITLE
ci(claude-review): allow dependabot PRs in Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,9 @@ jobs:
         uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow Dependabot PRs to be reviewed (default policy rejects bot actors
+          # and fails the check on every dependency PR).
+          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Every Dependabot PR currently gets a red `claude-review` check, not because of any code problem but because the action rejects bot actors by default:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

(Seen on #868 — the only failing check on an otherwise green PR.)

## Change

Add `allowed_bots: "dependabot[bot]"` to the `anthropics/claude-code-action` step in `.github/workflows/claude-code-review.yml`, so dependency PRs get reviewed instead of erroring.

## Notes

- Scoped to `dependabot[bot]` only, not `*`.
- The job's permissions stay read-only (`contents: read`, `pull-requests: read`, `issues: read`), so blast radius of reviewing bot PRs is minimal.

Refs: failed run on #868 (job 88123303723).