### PR TITLE
feat(web-ui): migrate @hugeicons/react 0.3.4 → 1.x (#869)

### DIFF
--- a/web-ui/__mocks__/@hugeicons/core-free-icons.js
+++ b/web-ui/__mocks__/@hugeicons/core-free-icons.js
@@ -1,0 +1,22 @@
+// Test mock for @hugeicons/core-free-icons (1.x icon data package).
+//
+// In production, each icon is a readonly array of [tag, attrs] tuples (an
+// `IconSvgElement`). For unit tests we don't need real SVG data — we just
+// need a stable sentinel that the @hugeicons/react mock can identify. Each
+// accessed `XxxIcon` property returns `{ __iconName: '<name>' }`, which the
+// HugeiconsIcon mock renders as `<svg data-testid="icon-<name>" />`.
+//
+// A Proxy keeps this resilient to new icons being added without touching
+// this file.
+
+module.exports = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (typeof prop !== 'string') return undefined;
+      // Non-string symbols (e.g. Symbol.toStringTag, inspect customs) → undefined.
+      // Any string property access returns a stable sentinel object.
+      return { __iconName: prop };
+    },
+  },
+);

--- a/web-ui/__mocks__/@hugeicons/react.js
+++ b/web-ui/__mocks__/@hugeicons/react.js
@@ -1,88 +1,23 @@
 const React = require('react');
 
-const createIconMock = (name) => {
-  const IconComponent = React.forwardRef((props, ref) => {
-    return React.createElement('svg', {
-      'data-testid': `icon-${name}`,
-      ref,
-      ...props,
-    });
+const HugeiconsIcon = React.forwardRef(function HugeiconsIcon(
+  { icon, altIcon, showAlt, size, color, strokeWidth, absoluteStrokeWidth, primaryColor, secondaryColor, disableSecondaryOpacity, ...rest },
+  ref,
+) {
+  const iconName = icon && typeof icon === 'object' && '__iconName' in icon ? icon.__iconName : 'unknown';
+  const effectiveIcon = showAlt && altIcon ? altIcon : icon;
+  const effectiveName =
+    effectiveIcon && typeof effectiveIcon === 'object' && '__iconName' in effectiveIcon
+      ? effectiveIcon.__iconName
+      : iconName;
+  return React.createElement('svg', {
+    'data-testid': `icon-${effectiveName}`,
+    ref,
+    ...rest,
   });
-  IconComponent.displayName = name;
-  return IconComponent;
-};
+});
 
 module.exports = {
-  // WorkspaceHeader
-  Folder01Icon: createIconMock('Folder01Icon'),
-  Loading03Icon: createIconMock('Loading03Icon'),
-  // WorkspaceStatsCards
-  CodeIcon: createIconMock('CodeIcon'),
-  Task01Icon: createIconMock('Task01Icon'),
-  PlayIcon: createIconMock('PlayIcon'),
-  // QuickActions
-  FileEditIcon: createIconMock('FileEditIcon'),
-  GitBranchIcon: createIconMock('GitBranchIcon'),
-  // RecentActivityFeed
-  Time01Icon: createIconMock('Time01Icon'),
-  CheckmarkCircle01Icon: createIconMock('CheckmarkCircle01Icon'),
-  Alert02Icon: createIconMock('Alert02Icon'),
-  // WorkspaceSelector
-  Cancel01Icon: createIconMock('Cancel01Icon'),
-  // PRD components
-  Upload04Icon: createIconMock('Upload04Icon'),
-  MessageSearch01Icon: createIconMock('MessageSearch01Icon'),
-  TaskEdit01Icon: createIconMock('TaskEdit01Icon'),
-  TestTube01Icon: createIconMock('TestTube01Icon'),
-  ArtificialIntelligence01Icon: createIconMock('ArtificialIntelligence01Icon'),
-  SentIcon: createIconMock('SentIcon'),
-  // AppSidebar
-  Home01Icon: createIconMock('Home01Icon'),
-  Add01Icon: createIconMock('Add01Icon'),
-  // PipelineProgressBar
-  Tick01Icon: createIconMock('Tick01Icon'),
-  // Task Board components
-  PlayCircleIcon: createIconMock('PlayCircleIcon'),
-  LinkCircleIcon: createIconMock('LinkCircleIcon'),
-  ViewIcon: createIconMock('ViewIcon'),
-  Search01Icon: createIconMock('Search01Icon'),
-  CheckListIcon: createIconMock('CheckListIcon'),
-  // Execution Monitor components
-  Idea01Icon: createIconMock('Idea01Icon'),
-  ArrowTurnBackwardIcon: createIconMock('ArrowTurnBackwardIcon'),
-  CommandLineIcon: createIconMock('CommandLineIcon'),
-  AlertDiamondIcon: createIconMock('AlertDiamondIcon'),
-  WifiDisconnected01Icon: createIconMock('WifiDisconnected01Icon'),
-  SidebarLeftIcon: createIconMock('SidebarLeftIcon'),
-  ArrowDown01Icon: createIconMock('ArrowDown01Icon'),
-  ArrowUp01Icon: createIconMock('ArrowUp01Icon'),
-  StopIcon: createIconMock('StopIcon'),
-  // AgentChatPanel
-  ArrowRight01Icon: createIconMock('ArrowRight01Icon'),
-  Alert01Icon: createIconMock('Alert01Icon'),
-  // SplitPane
-  ArrowLeft01Icon: createIconMock('ArrowLeft01Icon'),
-  // Proof page
-  InformationCircleIcon: createIconMock('InformationCircleIcon'),
-  // FileTreePanel / DiffViewer
-  FileAddIcon: createIconMock('FileAddIcon'),
-  FileRemoveIcon: createIconMock('FileRemoveIcon'),
-  // BlockerCard origin badges
-  Settings01Icon: createIconMock('Settings01Icon'),
-  UserCircle02Icon: createIconMock('UserCircle02Icon'),
-  // PRHistoryPanel
-  ArrowUpRight01Icon: createIconMock('ArrowUpRight01Icon'),
-  // Costs page
-  MoneyBag02Icon: createIconMock('MoneyBag02Icon'),
-  Analytics01Icon: createIconMock('Analytics01Icon'),
-  ChartLineData01Icon: createIconMock('ChartLineData01Icon'),
-  // NotificationCenter
-  Notification02Icon: createIconMock('Notification02Icon'),
-  // GitHub issue import (issue #564)
-  GithubIcon: createIconMock('GithubIcon'),
-  // Auth / login (issue #336)
-  Login01Icon: createIconMock('Login01Icon'),
-  Logout01Icon: createIconMock('Logout01Icon'),
-  LockIcon: createIconMock('LockIcon'),
-  Mail01Icon: createIconMock('Mail01Icon'),
+  HugeiconsIcon,
+  default: HugeiconsIcon,
 };

--- a/web-ui/jest.config.js
+++ b/web-ui/jest.config.js
@@ -12,6 +12,7 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@hugeicons/react$': '<rootDir>/__mocks__/@hugeicons/react.js',
+    '^@hugeicons/core-free-icons$': '<rootDir>/__mocks__/@hugeicons/core-free-icons.js',
   },
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
   testPathIgnorePatterns: [

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -8,7 +8,8 @@
       "name": "codeframe-web-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@hugeicons/react": "^0.3.0",
+        "@hugeicons/core-free-icons": "^4.2.2",
+        "@hugeicons/react": "^1.1.9",
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-checkbox": "^1.3.7",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -967,10 +968,17 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@hugeicons/core-free-icons": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@hugeicons/core-free-icons/-/core-free-icons-4.2.2.tgz",
+      "integrity": "sha512-fjQW3p6cwoJmwK3oCnV8Z3PC5sHihDvr2jkAHax8cxqp62GaV/D7B/Rnao+JwicW8fmLZUQ6QrzWfoyMFOEQlQ==",
+      "license": "MIT"
+    },
     "node_modules/@hugeicons/react": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-0.3.4.tgz",
-      "integrity": "sha512-qBAszSxM9kAj1h5WJVurgV9bWFdPFVoXL+1bbfxvChn6kv7g74v6Ymimah4iZ88+1JvpQCmn2zs9O05/+00Czg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.9.tgz",
+      "integrity": "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.0.0"
       }
@@ -2366,9 +2374,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2384,9 +2389,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2404,9 +2406,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2422,9 +2421,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3501,9 +3497,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3521,9 +3514,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3541,9 +3531,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3561,9 +3548,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8286,9 +8270,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8310,9 +8291,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8334,9 +8312,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8358,9 +8333,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9826,6 +9798,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -15,7 +15,8 @@
     "test:e2e:headed": "npx playwright test --headed"
   },
   "dependencies": {
-    "@hugeicons/react": "^0.3.0",
+    "@hugeicons/core-free-icons": "^4.2.2",
+    "@hugeicons/react": "^1.1.9",
     "@radix-ui/react-alert-dialog": "^1.1.19",
     "@radix-ui/react-checkbox": "^1.3.7",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/web-ui/src/app/costs/page.tsx
+++ b/web-ui/src/app/costs/page.tsx
@@ -2,11 +2,8 @@
 
 import { useState } from 'react';
 import useSWR from 'swr';
-import {
-  MoneyBag02Icon,
-  Task01Icon,
-  Analytics01Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { MoneyBag02Icon, Task01Icon, Analytics01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { SpendBarChart } from '@/components/costs/SpendBarChart';
 import { TopTasksTable } from '@/components/costs/TopTasksTable';
@@ -126,7 +123,7 @@ export default function CostsPage() {
               <Card>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">Total Spend</CardTitle>
-                  <MoneyBag02Icon className="h-4 w-4 text-muted-foreground" />
+                  <HugeiconsIcon icon={MoneyBag02Icon} className="h-4 w-4 text-muted-foreground" />
                 </CardHeader>
                 <CardContent>
                   <p
@@ -141,7 +138,7 @@ export default function CostsPage() {
               <Card>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">Tasks Run</CardTitle>
-                  <Task01Icon className="h-4 w-4 text-muted-foreground" />
+                  <HugeiconsIcon icon={Task01Icon} className="h-4 w-4 text-muted-foreground" />
                 </CardHeader>
                 <CardContent>
                   <p
@@ -156,7 +153,7 @@ export default function CostsPage() {
               <Card>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">Avg Cost / Task</CardTitle>
-                  <Analytics01Icon className="h-4 w-4 text-muted-foreground" />
+                  <HugeiconsIcon icon={Analytics01Icon} className="h-4 w-4 text-muted-foreground" />
                 </CardHeader>
                 <CardContent>
                   <p

--- a/web-ui/src/app/execution/page.tsx
+++ b/web-ui/src/app/execution/page.tsx
@@ -3,7 +3,8 @@
 import { Suspense, useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon } from '@hugeicons/core-free-icons';
 import { tasksApi } from '@/lib/api';
 import { BatchExecutionMonitor } from '@/components/execution/BatchExecutionMonitor';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
@@ -20,7 +21,7 @@ export default function ExecutionLandingPage() {
     <Suspense
       fallback={
         <main className="flex min-h-screen items-center justify-center bg-background">
-          <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+          <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" />
         </main>
       }
     >
@@ -109,7 +110,7 @@ function ExecutionLandingContent() {
   if (taskIdParam || resolving) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-background">
-        <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+        <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" />
       </main>
     );
   }

--- a/web-ui/src/app/login/page.tsx
+++ b/web-ui/src/app/login/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Login01Icon, Mail01Icon, LockIcon, Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Login01Icon, Mail01Icon, LockIcon, Loading03Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -78,7 +79,7 @@ export default function LoginPage() {
         role="status"
         aria-label="Redirecting"
       >
-        <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
+        <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
       </div>
     );
   }
@@ -88,7 +89,7 @@ export default function LoginPage() {
       <Card className="w-full max-w-sm">
         <CardHeader className="space-y-1.5">
           <div className="flex items-center gap-2">
-            <Login01Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+            <HugeiconsIcon icon={Login01Icon} className="h-5 w-5 text-primary" aria-hidden="true" />
             <CardTitle>{isRegister ? 'Create your account' : 'Sign in'}</CardTitle>
           </div>
           <CardDescription>
@@ -114,7 +115,7 @@ export default function LoginPage() {
                 htmlFor="email"
                 className="flex items-center gap-1.5 text-sm font-medium text-foreground"
               >
-                <Mail01Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                <HugeiconsIcon icon={Mail01Icon} className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                 Email
               </label>
               <Input
@@ -134,7 +135,7 @@ export default function LoginPage() {
                 htmlFor="password"
                 className="flex items-center gap-1.5 text-sm font-medium text-foreground"
               >
-                <LockIcon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                <HugeiconsIcon icon={LockIcon} className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                 Password
               </label>
               <Input
@@ -153,7 +154,7 @@ export default function LoginPage() {
           <CardFooter className="flex flex-col gap-3">
             <Button type="submit" className="w-full" disabled={submitting}>
               {submitting && (
-                <Loading03Icon className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                <HugeiconsIcon icon={Loading03Icon} className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
               )}
               {isRegister ? 'Create account' : 'Sign in'}
             </Button>

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useMemo, useRef, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
-import { InformationCircleIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { InformationCircleIcon } from '@hugeicons/core-free-icons';
 import {
   Tooltip,
   TooltipTrigger,
@@ -436,7 +437,7 @@ function ProofPageContent() {
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button type="button" aria-label="Explain Glitch Type" className="inline-flex cursor-help text-muted-foreground/60 hover:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-                              <InformationCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                              <HugeiconsIcon icon={InformationCircleIcon} className="h-3.5 w-3.5" aria-hidden="true" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent>The category of quality issue this requirement addresses</TooltipContent>
@@ -449,7 +450,7 @@ function ProofPageContent() {
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button type="button" aria-label="Explain Severity" className="inline-flex cursor-help text-muted-foreground/60 hover:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-                              <InformationCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                              <HugeiconsIcon icon={InformationCircleIcon} className="h-3.5 w-3.5" aria-hidden="true" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent>Impact level: critical, high, medium, or low</TooltipContent>
@@ -462,7 +463,7 @@ function ProofPageContent() {
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button type="button" aria-label="Explain Gates" className="inline-flex cursor-help text-muted-foreground/60 hover:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-                              <InformationCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                              <HugeiconsIcon icon={InformationCircleIcon} className="h-3.5 w-3.5" aria-hidden="true" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent>Number of evidence gates that must pass to satisfy this requirement</TooltipContent>

--- a/web-ui/src/app/sessions/[id]/SessionDetailClient.tsx
+++ b/web-ui/src/app/sessions/[id]/SessionDetailClient.tsx
@@ -4,7 +4,8 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import useSWR from 'swr';
-import { ArrowLeft01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowLeft01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { AgentChatPanel } from '@/components/sessions/AgentChatPanel';
@@ -107,7 +108,7 @@ export function SessionDetailClient({ sessionId }: SessionDetailClientProps) {
           <div className="mb-6">
             <Button asChild variant="ghost" size="sm">
               <Link href="/sessions">
-                <ArrowLeft01Icon className="h-4 w-4 mr-1" />
+                <HugeiconsIcon icon={ArrowLeft01Icon} className="h-4 w-4 mr-1" />
                 Back to Sessions
               </Link>
             </Button>
@@ -148,7 +149,7 @@ export function SessionDetailClient({ sessionId }: SessionDetailClientProps) {
       <header className="flex shrink-0 items-center gap-3 border-b bg-background px-4 py-2">
         <Button asChild variant="ghost" size="sm" className="shrink-0">
           <Link href="/sessions">
-            <ArrowLeft01Icon className="h-4 w-4 mr-1" />
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="h-4 w-4 mr-1" />
             Sessions
           </Link>
         </Button>

--- a/web-ui/src/components/blockers/BlockerCard.tsx
+++ b/web-ui/src/components/blockers/BlockerCard.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import type { IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Alert02Icon,
   Loading03Icon,
@@ -9,7 +11,7 @@ import {
   ArtificialIntelligence01Icon,
   Settings01Icon,
   UserCircle02Icon,
-} from '@hugeicons/react';
+} from '@hugeicons/core-free-icons';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -19,7 +21,7 @@ import type { Blocker, BlockerOrigin, ApiError } from '@/types';
 
 const ORIGIN_CONFIG: Record<BlockerOrigin, {
   label: string;
-  Icon: React.ComponentType<{ className?: string }>;
+  Icon: IconSvgElement;
   badgeClass: string;
   guidance: string;
 }> = {
@@ -82,7 +84,7 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
       >
         <CardContent className="flex items-center justify-between gap-4 p-4">
           <div className="flex items-center gap-2">
-            <CheckmarkCircle01Icon className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
+            <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
             <p className="text-sm font-medium text-green-800 dark:text-green-300">
               Answer recorded. Go to Tasks and restart execution to resume the agent.
             </p>
@@ -111,7 +113,7 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
         {/* Question */}
         <div className="rounded-md border-2 border-red-300 bg-red-50 p-3 dark:border-red-700 dark:bg-red-950/30">
           <div className="flex items-start gap-2">
-            <Alert02Icon className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+            <HugeiconsIcon icon={Alert02Icon} className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
             <p className="text-sm font-medium text-foreground">{blocker.question}</p>
           </div>
         </div>
@@ -123,7 +125,7 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
             data-testid="origin-badge"
             className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${origin.badgeClass}`}
           >
-            <origin.Icon className="h-3 w-3" />
+            <HugeiconsIcon icon={origin.Icon} className="h-3 w-3" />
             {origin.label}
           </span>
           <span className="text-xs text-muted-foreground">
@@ -189,7 +191,7 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
                 onClick={handleSubmit}
                 disabled={!answer.trim() || isSubmitting}
               >
-                {isSubmitting && <Loading03Icon className="h-3 w-3 animate-spin" />}
+                {isSubmitting && <HugeiconsIcon icon={Loading03Icon} className="h-3 w-3 animate-spin" />}
                 Answer Blocker
               </Button>
             </div>

--- a/web-ui/src/components/blockers/BlockerCard.tsx
+++ b/web-ui/src/components/blockers/BlockerCard.tsx
@@ -21,25 +21,25 @@ import type { Blocker, BlockerOrigin, ApiError } from '@/types';
 
 const ORIGIN_CONFIG: Record<BlockerOrigin, {
   label: string;
-  Icon: IconSvgElement;
+  icon: IconSvgElement;
   badgeClass: string;
   guidance: string;
 }> = {
   system: {
     label: 'System',
-    Icon: Settings01Icon,
+    icon: Settings01Icon,
     badgeClass: 'bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300',
     guidance: 'System-initiated pause. Review the context and answer to continue.',
   },
   agent: {
     label: 'Agent',
-    Icon: ArtificialIntelligence01Icon,
+    icon: ArtificialIntelligence01Icon,
     badgeClass: 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300',
     guidance: 'Agent requested information. Provide the answer below.',
   },
   human: {
     label: 'Manual',
-    Icon: UserCircle02Icon,
+    icon: UserCircle02Icon,
     badgeClass: 'bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-300',
     guidance: 'Manually created blocker. Resolve and mark answered.',
   },
@@ -125,7 +125,7 @@ export function BlockerCard({ blocker, workspacePath, onAnswered }: BlockerCardP
             data-testid="origin-badge"
             className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${origin.badgeClass}`}
           >
-            <HugeiconsIcon icon={origin.Icon} className="h-3 w-3" />
+            <HugeiconsIcon icon={origin.icon} className="h-3 w-3" />
             {origin.label}
           </span>
           <span className="text-xs text-muted-foreground">

--- a/web-ui/src/components/blockers/BlockerResolutionView.tsx
+++ b/web-ui/src/components/blockers/BlockerResolutionView.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo, useCallback } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
-import { CheckmarkCircle01Icon, Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CheckmarkCircle01Icon, Loading03Icon } from '@hugeicons/core-free-icons';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { BlockerCard } from './BlockerCard';
@@ -46,7 +47,7 @@ export function BlockerResolutionView({ workspacePath }: BlockerResolutionViewPr
           <h1 className="text-2xl font-bold tracking-tight">Blockers</h1>
         </div>
         <div className="flex items-center justify-center py-12">
-          <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+          <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" />
           <span className="ml-2 text-sm text-muted-foreground">Loading blockers...</span>
         </div>
       </div>
@@ -95,7 +96,7 @@ export function BlockerResolutionView({ workspacePath }: BlockerResolutionViewPr
       {/* Open blockers */}
       {openBlockers.length === 0 ? (
         <div className="rounded-lg border bg-muted/50 p-8 text-center">
-          <CheckmarkCircle01Icon className="mx-auto mb-3 h-10 w-10 text-green-500" />
+          <HugeiconsIcon icon={CheckmarkCircle01Icon} className="mx-auto mb-3 h-10 w-10 text-green-500" />
           <p className="text-sm font-medium text-foreground">No open blockers</p>
           <p className="mt-1 text-xs text-muted-foreground">
             Agents are running smoothly — no questions need your attention.

--- a/web-ui/src/components/blockers/ResolvedBlockersSection.tsx
+++ b/web-ui/src/components/blockers/ResolvedBlockersSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { ArrowDown01Icon, ArrowUp01Icon, CheckmarkCircle01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon, ArrowUp01Icon, CheckmarkCircle01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -35,13 +36,13 @@ export function ResolvedBlockersSection({ blockers }: ResolvedBlockersSectionPro
         aria-controls="resolved-blockers-list"
       >
         <span className="flex items-center gap-2">
-          <CheckmarkCircle01Icon className="h-4 w-4 text-muted-foreground" />
+          <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-4 w-4 text-muted-foreground" />
           Resolved Blockers ({blockers.length})
         </span>
         {expanded ? (
-          <ArrowUp01Icon className="h-4 w-4" />
+          <HugeiconsIcon icon={ArrowUp01Icon} className="h-4 w-4" />
         ) : (
-          <ArrowDown01Icon className="h-4 w-4" />
+          <HugeiconsIcon icon={ArrowDown01Icon} className="h-4 w-4" />
         )}
       </Button>
 

--- a/web-ui/src/components/execution/BatchExecutionMonitor.tsx
+++ b/web-ui/src/components/execution/BatchExecutionMonitor.tsx
@@ -2,13 +2,9 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  CheckmarkCircle01Icon,
-  Cancel01Icon,
-  Loading03Icon,
-  Alert02Icon,
-  StopIcon,
-} from '@hugeicons/react';
+import type { IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CheckmarkCircle01Icon, Cancel01Icon, Loading03Icon, Alert02Icon, StopIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -28,7 +24,7 @@ import type { BatchResponse, Task } from '@/types';
 
 // ── Status icon helper ────────────────────────────────────────────────
 
-const statusConfig: Record<string, { icon: typeof CheckmarkCircle01Icon; className: string; label: string }> = {
+const statusConfig: Record<string, { icon: IconSvgElement; className: string; label: string }> = {
   COMPLETED: { icon: CheckmarkCircle01Icon, className: 'text-green-600', label: 'Completed' },
   DONE: { icon: CheckmarkCircle01Icon, className: 'text-green-600', label: 'Done' },
   FAILED: { icon: Cancel01Icon, className: 'text-red-600', label: 'Failed' },
@@ -145,7 +141,7 @@ export function BatchExecutionMonitor({ batchId, workspacePath }: BatchExecution
   if (!batch) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+        <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" />
       </div>
     );
   }
@@ -173,7 +169,7 @@ export function BatchExecutionMonitor({ batchId, workspacePath }: BatchExecution
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button variant="outline" size="sm" className="h-8 gap-1.5 px-3">
-                  <StopIcon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={StopIcon} className="h-3.5 w-3.5" />
                   Stop Batch
                 </Button>
               </AlertDialogTrigger>
@@ -197,7 +193,7 @@ export function BatchExecutionMonitor({ batchId, workspacePath }: BatchExecution
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button variant="destructive" size="sm" className="h-8 gap-1.5 px-3">
-                  <Cancel01Icon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={Cancel01Icon} className="h-3.5 w-3.5" />
                   Cancel Batch
                 </Button>
               </AlertDialogTrigger>
@@ -269,7 +265,6 @@ function BatchTaskRow({
   workspacePath: string;
 }) {
   const config = getStatusConfig(status);
-  const StatusIcon = config.icon;
 
   // Only connect SSE when expanded and task is in progress or blocked
   const shouldStream = isExpanded && (status === 'IN_PROGRESS' || status === 'BLOCKED');
@@ -283,7 +278,7 @@ function BatchTaskRow({
         className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/50"
         aria-expanded={isExpanded}
       >
-        <StatusIcon className={`h-4 w-4 shrink-0 ${config.className}`} />
+        <HugeiconsIcon icon={config.icon} className={`h-4 w-4 shrink-0 ${config.className}`} />
         <span className="min-w-0 flex-1 truncate text-sm font-medium">
           {task?.title ?? taskId}
         </span>

--- a/web-ui/src/components/execution/BlockerEvent.tsx
+++ b/web-ui/src/components/execution/BlockerEvent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Alert02Icon, Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Alert02Icon, Loading03Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { blockersApi } from '@/lib/api';
 import type { BlockerEvent as BlockerEventType } from '@/hooks/useTaskStream';
@@ -55,7 +56,7 @@ export function BlockerEvent({ event, workspacePath, onAnswered }: BlockerEventP
     <div className="rounded-md border-2 border-red-300 bg-red-50 p-3 dark:border-red-700 dark:bg-red-950/30">
       {/* Header */}
       <div className="mb-2 flex items-center gap-2">
-        <Alert02Icon className="h-4 w-4 text-red-600" />
+        <HugeiconsIcon icon={Alert02Icon} className="h-4 w-4 text-red-600" />
         <span className="text-sm font-semibold text-red-800 dark:text-red-300">
           Agent needs your help
         </span>
@@ -100,7 +101,7 @@ export function BlockerEvent({ event, workspacePath, onAnswered }: BlockerEventP
           onClick={handleSubmit}
           disabled={!answer.trim() || isSubmitting}
         >
-          {isSubmitting && <Loading03Icon className="h-3 w-3 animate-spin" />}
+          {isSubmitting && <HugeiconsIcon icon={Loading03Icon} className="h-3 w-3 animate-spin" />}
           Answer Blocker
         </Button>
       </div>

--- a/web-ui/src/components/execution/ChangesSidebar.tsx
+++ b/web-ui/src/components/execution/ChangesSidebar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { FileEditIcon, SidebarLeftIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileEditIcon, SidebarLeftIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -44,7 +45,7 @@ export function ChangesSidebar({ changedFiles }: ChangesSidebarProps) {
           title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           aria-expanded={!collapsed}
         >
-          <SidebarLeftIcon className="h-3.5 w-3.5" />
+          <HugeiconsIcon icon={SidebarLeftIcon} className="h-3.5 w-3.5" />
         </Button>
       </div>
 
@@ -58,7 +59,7 @@ export function ChangesSidebar({ changedFiles }: ChangesSidebarProps) {
                 className="flex items-center gap-1.5 rounded px-2 py-1 text-xs hover:bg-muted/50"
                 title={filePath}
               >
-                <FileEditIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <HugeiconsIcon icon={FileEditIcon} className="h-3 w-3 shrink-0 text-muted-foreground" />
                 <span className="truncate font-mono">{filePath}</span>
               </div>
             ))}

--- a/web-ui/src/components/execution/EventStream.tsx
+++ b/web-ui/src/components/execution/EventStream.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { editGroupBadgeStyles } from '@/lib/eventStyles';
 import { EventItem } from './EventItem';
@@ -95,7 +96,7 @@ function ReadGroupRow({
         aria-expanded={expanded}
         aria-label={`${expanded ? 'Collapse' : 'Expand'} ${group.count} file read events`}
       >
-        <ArrowRight01Icon
+        <HugeiconsIcon icon={ArrowRight01Icon}
           className={`h-3 w-3 shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
         />
         <span className="font-mono text-[11px]">
@@ -265,7 +266,7 @@ export function EventStream({ events, workspacePath, onBlockerAnswered }: EventS
             className="h-7 gap-1 rounded-full px-3 text-xs shadow-md"
             onClick={scrollToBottom}
           >
-            <ArrowDown01Icon className="h-3.5 w-3.5" />
+            <HugeiconsIcon icon={ArrowDown01Icon} className="h-3.5 w-3.5" />
             New events
           </Button>
         </div>

--- a/web-ui/src/components/execution/ExecutionHeader.tsx
+++ b/web-ui/src/components/execution/ExecutionHeader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { StopIcon, Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { StopIcon, Loading03Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -40,7 +41,7 @@ export function ExecutionHeader({
   isCompleted,
 }: ExecutionHeaderProps) {
   const [isStopping, setIsStopping] = useState(false);
-  const StateIcon = agentStateIcons[agentState];
+  const stateIcon = agentStateIcons[agentState];
 
   const handleStop = async () => {
     setIsStopping(true);
@@ -73,7 +74,7 @@ export function ExecutionHeader({
             agentStateBadgeStyles[agentState]
           )}
         >
-          <StateIcon className="h-3.5 w-3.5" />
+          <HugeiconsIcon icon={stateIcon} className="h-3.5 w-3.5" />
           {agentStateLabels[agentState]}
         </span>
       </div>
@@ -102,9 +103,9 @@ export function ExecutionHeader({
               disabled={isCompleted || isStopping}
             >
               {isStopping ? (
-                <Loading03Icon className="h-3.5 w-3.5 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="h-3.5 w-3.5 animate-spin" />
               ) : (
-                <StopIcon className="h-3.5 w-3.5" />
+                <HugeiconsIcon icon={StopIcon} className="h-3.5 w-3.5" />
               )}
               Stop
             </Button>

--- a/web-ui/src/components/execution/FileChangeEvent.tsx
+++ b/web-ui/src/components/execution/FileChangeEvent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { FileEditIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileEditIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import type { ProgressEvent } from '@/hooks/useTaskStream';
 
@@ -25,7 +26,7 @@ export function FileChangeEvent({ event }: FileChangeEventProps) {
   return (
     <div className="text-sm">
       <div className="flex items-center gap-2">
-        <FileEditIcon className="h-4 w-4 shrink-0 text-green-600" />
+        <HugeiconsIcon icon={FileEditIcon} className="h-4 w-4 shrink-0 text-green-600" />
         <span className="truncate font-mono text-xs">{filePath || event.message}</span>
         <Button
           variant="ghost"

--- a/web-ui/src/components/execution/PlanningEvent.tsx
+++ b/web-ui/src/components/execution/PlanningEvent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Idea01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Idea01Icon } from '@hugeicons/core-free-icons';
 import type { ProgressEvent } from '@/hooks/useTaskStream';
 
 interface PlanningEventProps {
@@ -10,7 +11,7 @@ interface PlanningEventProps {
 export function PlanningEvent({ event }: PlanningEventProps) {
   return (
     <div className="flex items-start gap-2 text-sm">
-      <Idea01Icon className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+      <HugeiconsIcon icon={Idea01Icon} className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
       <div className="min-w-0">
         {event.total_steps > 0 && (
           <span className="text-xs text-muted-foreground">

--- a/web-ui/src/components/execution/ShellCommandEvent.tsx
+++ b/web-ui/src/components/execution/ShellCommandEvent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { CommandLineIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CommandLineIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import type { OutputEvent } from '@/hooks/useTaskStream';
 
@@ -21,7 +22,7 @@ export function ShellCommandEvent({ event }: ShellCommandEventProps) {
   return (
     <div className="text-sm">
       <div className="flex items-center gap-2">
-        <CommandLineIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <HugeiconsIcon icon={CommandLineIcon} className="h-4 w-4 shrink-0 text-muted-foreground" />
         <span className="truncate font-mono text-xs text-muted-foreground">
           {isError ? 'stderr' : 'stdout'}
         </span>

--- a/web-ui/src/components/execution/VerificationEvent.tsx
+++ b/web-ui/src/components/execution/VerificationEvent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { CheckmarkCircle01Icon, Cancel01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CheckmarkCircle01Icon, Cancel01Icon } from '@hugeicons/core-free-icons';
 import type { ProgressEvent } from '@/hooks/useTaskStream';
 
 interface VerificationEventProps {
@@ -17,11 +18,12 @@ interface VerificationEventProps {
  */
 export function VerificationEvent({ event }: VerificationEventProps) {
   const passed = /\bpassed?\b/i.test(event.message ?? '');
-  const Icon = passed ? CheckmarkCircle01Icon : Cancel01Icon;
+  const icon = passed ? CheckmarkCircle01Icon : Cancel01Icon;
 
   return (
     <div className="flex items-center gap-2 text-sm">
-      <Icon
+      <HugeiconsIcon
+        icon={icon}
         className={`h-4 w-4 shrink-0 ${
           passed ? 'text-green-600' : 'text-red-600'
         }`}

--- a/web-ui/src/components/layout/AppLayout.tsx
+++ b/web-ui/src/components/layout/AppLayout.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon } from '@hugeicons/core-free-icons';
 import { isAuthenticated } from '@/lib/auth';
 import { checkAuthAccess } from '@/lib/api';
 import { AppSidebar } from './AppSidebar';
@@ -24,7 +25,7 @@ function FullPageLoader() {
       role="status"
       aria-label="Loading"
     >
-      <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
+      <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
     </div>
   );
 }

--- a/web-ui/src/components/layout/AppSidebar.tsx
+++ b/web-ui/src/components/layout/AppSidebar.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import useSWR from 'swr';
+import type { IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Home01Icon,
   FileEditIcon,
@@ -17,7 +19,7 @@ import {
   Settings01Icon,
   ChartLineData01Icon,
   Logout01Icon,
-} from '@hugeicons/react';
+} from '@hugeicons/core-free-icons';
 import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
 import { logout } from '@/lib/auth';
 import { blockersApi, sessionsApi } from '@/lib/api';
@@ -28,7 +30,7 @@ import type { BlockerListResponse, SessionListResponse, ProofRequirement } from 
 interface NavItem {
   href: string;
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconSvgElement;
   enabled: boolean;
 }
 
@@ -104,7 +106,7 @@ export function AppSidebar() {
 
       {/* Navigation */}
       <nav className="flex flex-1 flex-col gap-1 px-2">
-        {NAV_ITEMS.map(({ href, label, icon: Icon, enabled }) => {
+        {NAV_ITEMS.map(({ href, label, icon: navIcon, enabled }) => {
           const isActive = href === '/'
             ? pathname === '/'
             : pathname.startsWith(href);
@@ -116,7 +118,7 @@ export function AppSidebar() {
                 className="flex items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground/50 lg:px-3"
                 title={`${label} (coming soon)`}
               >
-                <Icon className="h-5 w-5 shrink-0" />
+                <HugeiconsIcon icon={navIcon} className="h-5 w-5 shrink-0" />
                 <span className="hidden lg:inline">{label}</span>
               </span>
             );
@@ -132,7 +134,7 @@ export function AppSidebar() {
                   : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
               }`}
             >
-              <Icon className="h-5 w-5 shrink-0" />
+              <HugeiconsIcon icon={navIcon} className="h-5 w-5 shrink-0" />
               <span className="hidden lg:inline">{label}</span>
               {label === 'Sessions' && activeSessionCount > 0 && (
                 <span className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[10px] font-bold text-foreground">
@@ -158,7 +160,7 @@ export function AppSidebar() {
           onClick={() => setShowCaptureModal(true)}
           className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground lg:px-3"
         >
-          <Add01Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+          <HugeiconsIcon icon={Add01Icon} className="h-5 w-5 shrink-0" aria-hidden="true" />
           <span className="hidden lg:inline" aria-hidden="true">Capture Glitch</span>
         </button>
         <button
@@ -167,7 +169,7 @@ export function AppSidebar() {
           onClick={() => logout()}
           className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground lg:px-3"
         >
-          <Logout01Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+          <HugeiconsIcon icon={Logout01Icon} className="h-5 w-5 shrink-0" aria-hidden="true" />
           <span className="hidden lg:inline" aria-hidden="true">Sign out</span>
         </button>
       </div>

--- a/web-ui/src/components/layout/NotificationCenter.tsx
+++ b/web-ui/src/components/layout/NotificationCenter.tsx
@@ -1,17 +1,19 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import type { IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Notification02Icon,
   Cancel01Icon,
   Alert02Icon,
   CheckmarkCircle01Icon,
-} from '@hugeicons/react';
+} from '@hugeicons/core-free-icons';
 import { formatDistanceToNow } from 'date-fns';
 import { useNotificationContext } from '@/contexts/NotificationContext';
 import type { AppNotification } from '@/types';
 
-function iconForNotification(n: AppNotification) {
+function iconForNotification(n: AppNotification): { Icon: IconSvgElement; color: string } {
   if (n.type === 'batch.completed' && n.batchStatus && n.batchStatus !== 'COMPLETED') {
     return { Icon: Cancel01Icon, color: n.batchStatus === 'FAILED' ? 'text-red-600' : 'text-muted-foreground' };
   }
@@ -62,7 +64,7 @@ export function NotificationCenter() {
         onClick={() => setOpen((prev) => !prev)}
         className="relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground lg:px-3"
       >
-        <Notification02Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <HugeiconsIcon icon={Notification02Icon} className="h-5 w-5 shrink-0" aria-hidden="true" />
         <span className="hidden lg:inline" aria-hidden="true">Notifications</span>
         {unreadCount > 0 && (
           <span
@@ -133,7 +135,7 @@ function NotificationRow({
       data-testid="notification-item"
       className={`flex items-start gap-2 px-3 py-2 text-sm ${notification.read ? 'opacity-60' : ''}`}
     >
-      <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden="true" />
+      <HugeiconsIcon icon={Icon} className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden="true" />
       <div className="min-w-0 flex-1">
         <p className="break-words">{notification.message}</p>
         <p className="mt-0.5 text-xs text-muted-foreground">{formatTimestamp(notification.timestamp)}</p>
@@ -145,7 +147,7 @@ function NotificationRow({
           onClick={() => onMarkRead(notification.id)}
           className="text-muted-foreground hover:text-foreground"
         >
-          <Cancel01Icon className="h-3.5 w-3.5" aria-hidden="true" />
+          <HugeiconsIcon icon={Cancel01Icon} className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       )}
     </li>

--- a/web-ui/src/components/layout/NotificationCenter.tsx
+++ b/web-ui/src/components/layout/NotificationCenter.tsx
@@ -13,13 +13,13 @@ import { formatDistanceToNow } from 'date-fns';
 import { useNotificationContext } from '@/contexts/NotificationContext';
 import type { AppNotification } from '@/types';
 
-function iconForNotification(n: AppNotification): { Icon: IconSvgElement; color: string } {
+function iconForNotification(n: AppNotification): { icon: IconSvgElement; color: string } {
   if (n.type === 'batch.completed' && n.batchStatus && n.batchStatus !== 'COMPLETED') {
-    return { Icon: Cancel01Icon, color: n.batchStatus === 'FAILED' ? 'text-red-600' : 'text-muted-foreground' };
+    return { icon: Cancel01Icon, color: n.batchStatus === 'FAILED' ? 'text-red-600' : 'text-muted-foreground' };
   }
-  if (n.type === 'batch.completed') return { Icon: CheckmarkCircle01Icon, color: 'text-green-600' };
-  if (n.type === 'blocker.created') return { Icon: Alert02Icon, color: 'text-amber-600' };
-  return { Icon: Alert02Icon, color: 'text-red-600' };
+  if (n.type === 'batch.completed') return { icon: CheckmarkCircle01Icon, color: 'text-green-600' };
+  if (n.type === 'blocker.created') return { icon: Alert02Icon, color: 'text-amber-600' };
+  return { icon: Alert02Icon, color: 'text-red-600' };
 }
 
 function formatTimestamp(iso: string): string {
@@ -129,13 +129,13 @@ function NotificationRow({
   notification: AppNotification;
   onMarkRead: (id: string) => void;
 }) {
-  const { Icon, color: colorClass } = iconForNotification(notification);
+  const { icon, color: colorClass } = iconForNotification(notification);
   return (
     <li
       data-testid="notification-item"
       className={`flex items-start gap-2 px-3 py-2 text-sm ${notification.read ? 'opacity-60' : ''}`}
     >
-      <HugeiconsIcon icon={Icon} className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden="true" />
+      <HugeiconsIcon icon={icon} className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden="true" />
       <div className="min-w-0 flex-1">
         <p className="break-words">{notification.message}</p>
         <p className="mt-0.5 text-xs text-muted-foreground">{formatTimestamp(notification.timestamp)}</p>

--- a/web-ui/src/components/layout/PipelineProgressBar.tsx
+++ b/web-ui/src/components/layout/PipelineProgressBar.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Tick01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Tick01Icon } from '@hugeicons/core-free-icons';
 import { cn } from '@/lib/utils';
 import { usePipelineStatus } from '@/hooks/usePipelineStatus';
 
@@ -63,7 +64,7 @@ export function PipelineProgressBar() {
               aria-current={isActive ? 'step' : undefined}
             >
               {isComplete ? (
-                <Tick01Icon className="h-4 w-4 shrink-0" />
+                <HugeiconsIcon icon={Tick01Icon} className="h-4 w-4 shrink-0" />
               ) : (
                 <span
                   className={cn(

--- a/web-ui/src/components/prd/DiscoveryInput.tsx
+++ b/web-ui/src/components/prd/DiscoveryInput.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { SentIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { SentIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 
 interface DiscoveryInputProps {
@@ -49,7 +50,7 @@ export function DiscoveryInput({
           disabled={disabled || !value.trim()}
           className="shrink-0 self-end"
         >
-          <SentIcon className="h-4 w-4" />
+          <HugeiconsIcon icon={SentIcon} className="h-4 w-4" />
         </Button>
       </div>
       <p className="mt-1 text-xs text-muted-foreground">

--- a/web-ui/src/components/prd/DiscoveryPanel.tsx
+++ b/web-ui/src/components/prd/DiscoveryPanel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { Cancel01Icon, Loading03Icon, ArrowReloadHorizontalIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Cancel01Icon, Loading03Icon, ArrowReloadHorizontalIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { DiscoveryTranscript } from './DiscoveryTranscript';
 import { DiscoveryInput } from './DiscoveryInput';
@@ -227,7 +228,7 @@ export function DiscoveryPanel({
               aria-label="Start over"
               title="Start over"
             >
-              <ArrowReloadHorizontalIcon className="h-4 w-4" />
+              <HugeiconsIcon icon={ArrowReloadHorizontalIcon} className="h-4 w-4" />
             </button>
           )}
           <button
@@ -235,7 +236,7 @@ export function DiscoveryPanel({
             className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
             aria-label="Close discovery panel"
           >
-            <Cancel01Icon className="h-4 w-4" />
+            <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" />
           </button>
         </div>
       </div>
@@ -281,7 +282,7 @@ export function DiscoveryPanel({
           >
             {isGenerating ? (
               <>
-                <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
                 Generating PRD...
               </>
             ) : (

--- a/web-ui/src/components/prd/DiscoveryTranscript.tsx
+++ b/web-ui/src/components/prd/DiscoveryTranscript.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { ArtificialIntelligence01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArtificialIntelligence01Icon } from '@hugeicons/core-free-icons';
 import type { DiscoveryMessage } from '@/types';
 
 interface DiscoveryTranscriptProps {
@@ -30,7 +31,7 @@ export function DiscoveryTranscript({
           {/* Avatar */}
           {msg.role === 'assistant' && (
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
-              <ArtificialIntelligence01Icon className="h-4 w-4 text-primary" />
+              <HugeiconsIcon icon={ArtificialIntelligence01Icon} className="h-4 w-4 text-primary" />
             </div>
           )}
 
@@ -51,7 +52,7 @@ export function DiscoveryTranscript({
       {isThinking && (
         <div className="flex gap-3">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
-            <ArtificialIntelligence01Icon className="h-4 w-4 text-primary" />
+            <HugeiconsIcon icon={ArtificialIntelligence01Icon} className="h-4 w-4 text-primary" />
           </div>
           <div className="rounded-lg bg-muted px-3 py-2">
             <div className="flex gap-1">

--- a/web-ui/src/components/prd/MarkdownEditor.tsx
+++ b/web-ui/src/components/prd/MarkdownEditor.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
@@ -58,7 +59,7 @@ export function MarkdownEditor({
             <Button size="sm" onClick={handleSave} disabled={isSaving}>
               {isSaving ? (
                 <>
-                  <Loading03Icon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                   Saving...
                 </>
               ) : (

--- a/web-ui/src/components/prd/PRDHeader.tsx
+++ b/web-ui/src/components/prd/PRDHeader.tsx
@@ -1,14 +1,7 @@
 'use client';
 
-import {
-  FileEditIcon,
-  Upload04Icon,
-  MessageSearch01Icon,
-  TaskEdit01Icon,
-  TestTube01Icon,
-  Loading03Icon,
-  Time01Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileEditIcon, Upload04Icon, MessageSearch01Icon, TaskEdit01Icon, TestTube01Icon, Loading03Icon, Time01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import type { PrdResponse } from '@/types';
 
@@ -34,7 +27,7 @@ export function PRDHeader({
   return (
     <header className="flex items-center justify-between">
       <div className="flex items-center gap-3">
-        <FileEditIcon className="h-6 w-6 text-muted-foreground" />
+        <HugeiconsIcon icon={FileEditIcon} className="h-6 w-6 text-muted-foreground" />
         <div>
           <h2 className="text-2xl font-bold tracking-tight">
             {prd ? prd.title : 'Product Requirements'}
@@ -51,12 +44,12 @@ export function PRDHeader({
       <div className="flex gap-2">
         {prd && onViewHistory && (
           <Button variant="outline" size="sm" onClick={onViewHistory}>
-            <Time01Icon className="mr-1.5 h-4 w-4" />
+            <HugeiconsIcon icon={Time01Icon} className="mr-1.5 h-4 w-4" />
             History
           </Button>
         )}
         <Button variant="outline" size="sm" onClick={onUploadPrd}>
-          <Upload04Icon className="mr-1.5 h-4 w-4" />
+          <HugeiconsIcon icon={Upload04Icon} className="mr-1.5 h-4 w-4" />
           {prd ? 'Upload New' : 'Upload PRD'}
         </Button>
         {onStressTest && (
@@ -66,12 +59,12 @@ export function PRDHeader({
             onClick={onStressTest}
             disabled={!prd}
           >
-            <TestTube01Icon className="mr-1.5 h-4 w-4" />
+            <HugeiconsIcon icon={TestTube01Icon} className="mr-1.5 h-4 w-4" />
             Stress Test
           </Button>
         )}
         <Button variant="outline" size="sm" onClick={onStartDiscovery}>
-          <MessageSearch01Icon className="mr-1.5 h-4 w-4" />
+          <HugeiconsIcon icon={MessageSearch01Icon} className="mr-1.5 h-4 w-4" />
           Discovery
         </Button>
         <Button
@@ -81,12 +74,12 @@ export function PRDHeader({
         >
           {isGeneratingTasks ? (
             <>
-              <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+              <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
               Generating...
             </>
           ) : (
             <>
-              <TaskEdit01Icon className="mr-1.5 h-4 w-4" />
+              <HugeiconsIcon icon={TaskEdit01Icon} className="mr-1.5 h-4 w-4" />
               Generate Tasks
             </>
           )}

--- a/web-ui/src/components/prd/PRDVersionHistoryModal.tsx
+++ b/web-ui/src/components/prd/PRDVersionHistoryModal.tsx
@@ -3,11 +3,8 @@
 import { useState } from 'react';
 import useSWR from 'swr';
 import { toast } from 'sonner';
-import {
-  ArrowLeft01Icon,
-  Loading03Icon,
-  Time01Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowLeft01Icon, Loading03Icon, Time01Icon } from '@hugeicons/core-free-icons';
 import {
   Dialog,
   DialogContent,
@@ -117,7 +114,7 @@ export function PRDVersionHistoryModal({
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Time01Icon className="h-5 w-5 text-muted-foreground" />
+            <HugeiconsIcon icon={Time01Icon} className="h-5 w-5 text-muted-foreground" />
             {view === 'list' ? 'Version History' : `Version ${preview?.version.version} Preview`}
           </DialogTitle>
         </DialogHeader>
@@ -163,7 +160,7 @@ function VersionList({ versions, currentVersion, isLoading, error, onViewVersion
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
-        <Loading03Icon className="mr-2 h-4 w-4 animate-spin" />
+        <HugeiconsIcon icon={Loading03Icon} className="mr-2 h-4 w-4 animate-spin" />
         Loading versions...
       </div>
     );
@@ -242,7 +239,7 @@ function VersionPreview({
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         <Button variant="ghost" size="sm" onClick={onBack}>
-          <ArrowLeft01Icon className="mr-1.5 h-4 w-4" />
+          <HugeiconsIcon icon={ArrowLeft01Icon} className="mr-1.5 h-4 w-4" />
           Back to list
         </Button>
         <div className="ml-auto flex gap-2">
@@ -254,7 +251,7 @@ function VersionPreview({
           >
             {diffLoading ? (
               <>
-                <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
                 Loading diff...
               </>
             ) : (
@@ -286,7 +283,7 @@ function VersionPreview({
             >
               {restoring ? (
                 <>
-                  <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                  <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
                   Restoring...
                 </>
               ) : (

--- a/web-ui/src/components/prd/PRDView.tsx
+++ b/web-ui/src/components/prd/PRDView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { FileEditIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileEditIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { PRDHeader } from './PRDHeader';
@@ -69,7 +70,7 @@ export function PRDView({
 
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-16">
-            <FileEditIcon className="mb-4 h-12 w-12 text-muted-foreground/50" />
+            <HugeiconsIcon icon={FileEditIcon} className="mb-4 h-12 w-12 text-muted-foreground/50" />
             <h3 className="text-lg font-semibold">No PRD yet</h3>
             <p className="mt-1 max-w-sm text-center text-sm text-muted-foreground">
               Upload a PRD document or start an AI-powered discovery session to

--- a/web-ui/src/components/prd/StressTestModal.tsx
+++ b/web-ui/src/components/prd/StressTestModal.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Loading03Icon,
-  TestTube01Icon,
-  CheckmarkCircle01Icon,
-  Alert01Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon, TestTube01Icon, CheckmarkCircle01Icon, Alert01Icon } from '@hugeicons/core-free-icons';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -129,7 +125,7 @@ export function StressTestModal({
       >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <TestTube01Icon className="h-5 w-5 text-muted-foreground" />
+            <HugeiconsIcon icon={TestTube01Icon} className="h-5 w-5 text-muted-foreground" />
             Stress Test PRD
           </DialogTitle>
           <DialogDescription>
@@ -139,14 +135,14 @@ export function StressTestModal({
 
         {status === 'streaming' && (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loading03Icon className="h-4 w-4 animate-spin" />
+            <HugeiconsIcon icon={Loading03Icon} className="h-4 w-4 animate-spin" />
             Analyzing PRD...
           </div>
         )}
 
         {status === 'complete' && (
           <div className="flex items-center gap-2 text-sm font-medium text-green-600 dark:text-green-500">
-            <CheckmarkCircle01Icon className="h-4 w-4" />
+            <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-4 w-4" />
             {result && result.ambiguityCount > 0
               ? `Found ${result.ambiguityCount} ambiguit${result.ambiguityCount === 1 ? 'y' : 'ies'}`
               : 'No ambiguities found — PRD is well-specified'}
@@ -201,7 +197,7 @@ export function StressTestModal({
         {status === 'error' && (
           <div className="rounded-md border border-destructive bg-destructive/10 p-4">
             <div className="flex items-center gap-2 text-sm font-medium text-destructive">
-              <Alert01Icon className="h-4 w-4" />
+              <HugeiconsIcon icon={Alert01Icon} className="h-4 w-4" />
               Stress test failed
             </div>
             <p className="mt-1 text-xs text-muted-foreground">
@@ -227,7 +223,7 @@ export function StressTestModal({
                 !prdId
               }
             >
-              {isRefining && <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />}
+              {isRefining && <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />}
               Refine PRD
             </Button>
           )}

--- a/web-ui/src/components/prd/UploadPRDModal.tsx
+++ b/web-ui/src/components/prd/UploadPRDModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { Upload04Icon, Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Upload04Icon, Loading03Icon } from '@hugeicons/core-free-icons';
 import {
   Dialog,
   DialogContent,
@@ -163,7 +164,7 @@ export function UploadPRDModal({
 
           <TabsContent value="file">
             <div className="flex flex-col items-center gap-4 rounded-lg border-2 border-dashed p-8">
-              <Upload04Icon className="h-10 w-10 text-muted-foreground/50" />
+              <HugeiconsIcon icon={Upload04Icon} className="h-10 w-10 text-muted-foreground/50" />
               <div className="text-center">
                 {fileName ? (
                   <p className="text-sm font-medium">{fileName}</p>
@@ -214,7 +215,7 @@ export function UploadPRDModal({
           >
             {isSubmitting ? (
               <>
-                <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
                 Creating...
               </>
             ) : (

--- a/web-ui/src/components/proof/CaptureGlitchModal.tsx
+++ b/web-ui/src/components/proof/CaptureGlitchModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Cancel01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Cancel01Icon } from '@hugeicons/core-free-icons';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -170,7 +171,7 @@ export function CaptureGlitchModal({
                 aria-label="Close"
                 className="rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2"
               >
-                <Cancel01Icon className="h-4 w-4" aria-hidden="true" />
+                <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" aria-hidden="true" />
               </button>
             </DialogPrimitive.Close>
           </div>

--- a/web-ui/src/components/proof/ProofStatusWidget.tsx
+++ b/web-ui/src/components/proof/ProofStatusWidget.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link';
 import useSWR from 'swr';
-import { CheckmarkCircle01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CheckmarkCircle01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { proofApi } from '@/lib/api';
@@ -23,7 +24,7 @@ export function ProofStatusWidget({ workspacePath }: ProofStatusWidgetProps) {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">PROOF9 Status</CardTitle>
-        <CheckmarkCircle01Icon className="h-4 w-4 text-muted-foreground" />
+        <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-4 w-4 text-muted-foreground" />
       </CardHeader>
       <CardContent>
         {isLoading && (

--- a/web-ui/src/components/review/CommitPanel.tsx
+++ b/web-ui/src/components/review/CommitPanel.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Loading03Icon,
-  GitBranchIcon,
-  Idea01Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon, GitBranchIcon, Idea01Icon } from '@hugeicons/core-free-icons';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -66,9 +63,9 @@ export function CommitPanel({
           className="self-start transition-all"
         >
           {isGenerating ? (
-            <Loading03Icon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-3.5 w-3.5 animate-spin" />
           ) : (
-            <Idea01Icon className="mr-1.5 h-3.5 w-3.5" />
+            <HugeiconsIcon icon={Idea01Icon} className="mr-1.5 h-3.5 w-3.5" />
           )}
           Generate Message
         </Button>
@@ -109,7 +106,7 @@ export function CommitPanel({
         className="w-full transition-all"
       >
         {isCommitting && (
-          <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+          <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
         )}
         {isCommitting ? 'Committing...' : 'Commit'}
       </Button>
@@ -162,9 +159,9 @@ export function CommitPanel({
               className="w-full transition-all"
             >
               {isCreatingPR ? (
-                <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
               ) : (
-                <GitBranchIcon className="mr-1.5 h-4 w-4" />
+                <HugeiconsIcon icon={GitBranchIcon} className="mr-1.5 h-4 w-4" />
               )}
               {isCreatingPR ? 'Creating PR...' : 'Create PR'}
             </Button>

--- a/web-ui/src/components/review/DiffNavigation.tsx
+++ b/web-ui/src/components/review/DiffNavigation.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ArrowLeft01Icon, ArrowRight01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowLeft01Icon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 
 interface DiffNavigationProps {
@@ -41,7 +42,7 @@ export function DiffNavigation({
         disabled={isFirst}
         aria-label="Previous file"
       >
-        <ArrowLeft01Icon className="mr-1 h-3.5 w-3.5" />
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="mr-1 h-3.5 w-3.5" />
         Prev
       </Button>
 
@@ -61,7 +62,7 @@ export function DiffNavigation({
         aria-label="Next file"
       >
         Next
-        <ArrowRight01Icon className="ml-1 h-3.5 w-3.5" />
+        <HugeiconsIcon icon={ArrowRight01Icon} className="ml-1 h-3.5 w-3.5" />
       </Button>
     </nav>
   );

--- a/web-ui/src/components/review/DiffViewer.tsx
+++ b/web-ui/src/components/review/DiffViewer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Fragment, useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import type { DiffFile, DiffHunkLine } from '@/lib/diffParser';
@@ -161,9 +162,9 @@ export function DiffViewer({ diffFiles, selectedFile, tasks, contextTask, change
                   aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${key}`}
                 >
                   {isCollapsed ? (
-                    <ArrowRight01Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <HugeiconsIcon icon={ArrowRight01Icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   ) : (
-                    <ArrowDown01Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <HugeiconsIcon icon={ArrowDown01Icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   )}
                   <span className="truncate font-mono text-sm font-medium">
                     {key}

--- a/web-ui/src/components/review/ExportPatchModal.tsx
+++ b/web-ui/src/components/review/ExportPatchModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { Copy01Icon, Download04Icon, CheckmarkCircle01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Copy01Icon, Download04Icon, CheckmarkCircle01Icon } from '@hugeicons/core-free-icons';
 import {
   Dialog,
   DialogContent,
@@ -74,14 +75,14 @@ export function ExportPatchModal({
         <DialogFooter>
           <Button variant="outline" onClick={handleCopy}>
             {copied ? (
-              <CheckmarkCircle01Icon className="mr-1.5 h-3.5 w-3.5 text-green-500" />
+              <HugeiconsIcon icon={CheckmarkCircle01Icon} className="mr-1.5 h-3.5 w-3.5 text-green-500" />
             ) : (
-              <Copy01Icon className="mr-1.5 h-3.5 w-3.5" />
+              <HugeiconsIcon icon={Copy01Icon} className="mr-1.5 h-3.5 w-3.5" />
             )}
             {copied ? 'Copied!' : 'Copy to Clipboard'}
           </Button>
           <Button variant="default" onClick={handleDownload}>
-            <Download04Icon className="mr-1.5 h-3.5 w-3.5" />
+            <HugeiconsIcon icon={Download04Icon} className="mr-1.5 h-3.5 w-3.5" />
             Download
           </Button>
         </DialogFooter>

--- a/web-ui/src/components/review/FileTreePanel.tsx
+++ b/web-ui/src/components/review/FileTreePanel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { FileAddIcon, FileRemoveIcon, FileEditIcon, ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/react';
+import type { IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileAddIcon, FileRemoveIcon, FileEditIcon, ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { getDirectory, getFilename } from '@/lib/diffParser';
@@ -15,7 +17,7 @@ interface FileTreePanelProps {
   contextTask?: Task | null;
 }
 
-const changeTypeIcon: Record<FileChange['change_type'], React.ComponentType<{ className?: string }>> = {
+const changeTypeIcon: Record<FileChange['change_type'], IconSvgElement> = {
   added: FileAddIcon,
   deleted: FileRemoveIcon,
   modified: FileEditIcon,
@@ -142,9 +144,9 @@ export function FileTreePanel({ files, selectedFile, onFileSelect, tasks, contex
                       aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${dir}`}
                     >
                       {isCollapsed ? (
-                        <ArrowRight01Icon className="h-3 w-3 shrink-0" />
+                        <HugeiconsIcon icon={ArrowRight01Icon} className="h-3 w-3 shrink-0" />
                       ) : (
-                        <ArrowDown01Icon className="h-3 w-3 shrink-0" />
+                        <HugeiconsIcon icon={ArrowDown01Icon} className="h-3 w-3 shrink-0" />
                       )}
                       <span className="truncate font-mono">{dir}</span>
                       <span className="ml-auto text-[10px] text-muted-foreground/70">
@@ -155,7 +157,7 @@ export function FileTreePanel({ files, selectedFile, onFileSelect, tasks, contex
                     {!isCollapsed && (
                       <div className="ml-2">
                         {dirFiles.map((file) => {
-                          const Icon = changeTypeIcon[file.change_type];
+                          const icon = changeTypeIcon[file.change_type];
                           const iconColor = changeTypeColor[file.change_type];
                           const isSelected = selectedFile === file.path;
 
@@ -173,7 +175,7 @@ export function FileTreePanel({ files, selectedFile, onFileSelect, tasks, contex
                               title={file.path}
                               aria-current={isSelected ? 'true' : undefined}
                             >
-                              <Icon className={cn('h-3.5 w-3.5 shrink-0', iconColor)} />
+                              <HugeiconsIcon icon={icon} className={cn('h-3.5 w-3.5 shrink-0', iconColor)} />
                               <span className="truncate font-mono">
                                 {getFilename(file.path)}
                               </span>
@@ -211,9 +213,9 @@ export function FileTreePanel({ files, selectedFile, onFileSelect, tasks, contex
                       aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${taskTitle}`}
                     >
                       {isCollapsed ? (
-                        <ArrowRight01Icon className="h-3 w-3 shrink-0" />
+                        <HugeiconsIcon icon={ArrowRight01Icon} className="h-3 w-3 shrink-0" />
                       ) : (
-                        <ArrowDown01Icon className="h-3 w-3 shrink-0" />
+                        <HugeiconsIcon icon={ArrowDown01Icon} className="h-3 w-3 shrink-0" />
                       )}
                       <span className="h-2 w-2 rounded-full bg-amber-500" />
                       <span className="truncate">{taskTitle}</span>
@@ -225,7 +227,7 @@ export function FileTreePanel({ files, selectedFile, onFileSelect, tasks, contex
                     {!isCollapsed && (
                       <div className="ml-2">
                         {taskFiles.map((file) => {
-                          const Icon = changeTypeIcon[file.change_type];
+                          const icon = changeTypeIcon[file.change_type];
                           const iconColor = changeTypeColor[file.change_type];
                           const isSelected = selectedFile === file.path;
 
@@ -243,7 +245,7 @@ export function FileTreePanel({ files, selectedFile, onFileSelect, tasks, contex
                               title={file.path}
                               aria-current={isSelected ? 'true' : undefined}
                             >
-                              <Icon className={cn('h-3.5 w-3.5 shrink-0', iconColor)} />
+                              <HugeiconsIcon icon={icon} className={cn('h-3.5 w-3.5 shrink-0', iconColor)} />
                               <span className="truncate font-mono">
                                 {getFilename(file.path)}
                               </span>

--- a/web-ui/src/components/review/PRCreatedModal.tsx
+++ b/web-ui/src/components/review/PRCreatedModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback } from 'react';
-import { CheckmarkCircle01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CheckmarkCircle01Icon } from '@hugeicons/core-free-icons';
 import {
   Dialog,
   DialogContent,
@@ -33,7 +34,7 @@ export function PRCreatedModal({
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <DialogContent className="max-w-md">
         <DialogHeader className="items-center">
-          <CheckmarkCircle01Icon className="mx-auto h-12 w-12 text-green-500" />
+          <HugeiconsIcon icon={CheckmarkCircle01Icon} className="mx-auto h-12 w-12 text-green-500" />
           <DialogTitle>Pull Request Created</DialogTitle>
           <DialogDescription className="sr-only">
             Pull request #{prNumber} has been created successfully

--- a/web-ui/src/components/review/PRHistoryPanel.tsx
+++ b/web-ui/src/components/review/PRHistoryPanel.tsx
@@ -2,14 +2,8 @@
 
 import { useState } from 'react';
 import useSWR from 'swr';
-import {
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  ArrowUpRight01Icon,
-  CheckmarkCircle01Icon,
-  Cancel01Icon,
-  Alert02Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon, ArrowUp01Icon, ArrowUpRight01Icon, CheckmarkCircle01Icon, Cancel01Icon, Alert02Icon } from '@hugeicons/core-free-icons';
 import { prApi } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -135,9 +129,9 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                       {proofBadgeText(pr.proof_snapshot)}
                     </Badge>
                     {expandedPR === pr.number ? (
-                      <ArrowUp01Icon className="h-4 w-4 text-muted-foreground" />
+                      <HugeiconsIcon icon={ArrowUp01Icon} className="h-4 w-4 text-muted-foreground" />
                     ) : (
-                      <ArrowDown01Icon className="h-4 w-4 text-muted-foreground" />
+                      <HugeiconsIcon icon={ArrowDown01Icon} className="h-4 w-4 text-muted-foreground" />
                     )}
                   </div>
                 </button>
@@ -151,7 +145,7 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                   {loadingFiles === pr.number ? (
                     <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
                   ) : (
-                    <Alert02Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                    <HugeiconsIcon icon={Alert02Icon} className="h-3.5 w-3.5" aria-hidden="true" />
                   )}
                   Report Glitch
                 </Button>
@@ -162,7 +156,7 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                   className="shrink-0 text-muted-foreground transition-all hover:text-foreground focus-visible:outline-hidden focus-visible:ring-[3px] focus-visible:ring-ring rounded"
                   aria-label={`Open PR #${pr.number} on GitHub`}
                 >
-                  <ArrowUpRight01Icon className="h-4 w-4" />
+                  <HugeiconsIcon icon={ArrowUpRight01Icon} className="h-4 w-4" />
                 </a>
               </div>
 
@@ -176,9 +170,9 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                         className="flex items-center gap-2 text-xs"
                       >
                         {gate.status === 'satisfied' ? (
-                          <CheckmarkCircle01Icon className="h-3.5 w-3.5 text-green-600" />
+                          <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-3.5 w-3.5 text-green-600" />
                         ) : (
-                          <Cancel01Icon className="h-3.5 w-3.5 text-red-600" />
+                          <HugeiconsIcon icon={Cancel01Icon} className="h-3.5 w-3.5 text-red-600" />
                         )}
                         <span className="text-muted-foreground">
                           {gate.gate}

--- a/web-ui/src/components/review/PRStatusPanel.tsx
+++ b/web-ui/src/components/review/PRStatusPanel.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import useSWR from 'swr';
-import { Loading03Icon, CheckmarkCircle01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon, CheckmarkCircle01Icon } from '@hugeicons/core-free-icons';
 import { prApi, proofApi } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
@@ -213,7 +214,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
               </p>
             ) : openRequirements.length === 0 ? (
               <p className="flex items-center gap-1 text-xs text-muted-foreground">
-                <CheckmarkCircle01Icon className="h-3 w-3 text-green-600" />
+                <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-3 w-3 text-green-600" />
                 All clear
               </p>
             ) : (
@@ -256,7 +257,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
       {/* Success banner or Merge button */}
       {alreadyMerged ? (
         <div className="flex items-center gap-1 rounded bg-green-50 px-3 py-2 text-xs text-green-700">
-          <CheckmarkCircle01Icon className="h-3 w-3" />
+          <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-3 w-3" />
           PR #{prNumber} merged successfully
         </div>
       ) : (
@@ -273,7 +274,7 @@ export function PRStatusPanel({ prNumber, workspacePath }: PRStatusPanelProps) {
                 >
                   {isMerging ? (
                     <>
-                      <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                      <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
                       Merging...
                     </>
                   ) : (

--- a/web-ui/src/components/review/ReviewHeader.tsx
+++ b/web-ui/src/components/review/ReviewHeader.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import {
-  FileEditIcon,
-  Loading03Icon,
-  CheckmarkCircle01Icon,
-  Cancel01Icon,
-  Download04Icon,
-  PlayIcon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileEditIcon, Loading03Icon, CheckmarkCircle01Icon, Cancel01Icon, Download04Icon, PlayIcon } from '@hugeicons/core-free-icons';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -39,7 +33,7 @@ export function ReviewHeader({
         {/* Left: Change summary */}
         <div className="flex items-center gap-4 text-sm">
           <span className="flex items-center gap-1.5 text-muted-foreground">
-            <FileEditIcon className="h-4 w-4" />
+            <HugeiconsIcon icon={FileEditIcon} className="h-4 w-4" />
             <span>
               {filesChanged} {filesChanged === 1 ? 'file' : 'files'} changed
             </span>
@@ -69,9 +63,9 @@ export function ReviewHeader({
                 }
               >
                 {check.status === 'PASSED' ? (
-                  <CheckmarkCircle01Icon className="h-3 w-3" />
+                  <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-3 w-3" />
                 ) : check.status === 'FAILED' ? (
-                  <Cancel01Icon className="h-3 w-3" />
+                  <HugeiconsIcon icon={Cancel01Icon} className="h-3 w-3" />
                 ) : null}
                 {check.name}
               </Badge>
@@ -93,9 +87,9 @@ export function ReviewHeader({
             className="transition-all"
           >
             {isRunningGates ? (
-              <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+              <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
             ) : (
-              <PlayIcon className="mr-1.5 h-4 w-4" />
+              <HugeiconsIcon icon={PlayIcon} className="mr-1.5 h-4 w-4" />
             )}
             Run Gates
           </Button>
@@ -105,7 +99,7 @@ export function ReviewHeader({
             onClick={onExportPatch}
             className="transition-all"
           >
-            <Download04Icon className="mr-1.5 h-4 w-4" />
+            <HugeiconsIcon icon={Download04Icon} className="mr-1.5 h-4 w-4" />
             Export Patch
           </Button>
         </div>

--- a/web-ui/src/components/sessions/AgentChatPanel.tsx
+++ b/web-ui/src/components/sessions/AgentChatPanel.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import { useRef, useEffect, useState, useCallback } from 'react';
-import {
-  ArtificialIntelligence01Icon,
-  ArrowRight01Icon,
-  Alert01Icon,
-  Idea01Icon,
-  Cancel01Icon,
-  SentIcon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArtificialIntelligence01Icon, ArrowRight01Icon, Alert01Icon, Idea01Icon, Cancel01Icon, SentIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useAgentChat } from '@/hooks/useAgentChat';
@@ -64,7 +58,7 @@ function AssistantBubble({
   return (
     <div className="flex flex-row gap-3">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
-        <ArtificialIntelligence01Icon className="h-4 w-4 text-primary" />
+        <HugeiconsIcon icon={ArtificialIntelligence01Icon} className="h-4 w-4 text-primary" />
       </div>
       <div className="max-w-[80%] rounded-lg bg-muted px-3 py-2 text-sm text-foreground leading-relaxed">
         {message.content}
@@ -91,7 +85,7 @@ function ToolUseCard({ message }: { message: ChatMessage }) {
         aria-expanded={expanded}
         aria-label={`${expanded ? 'Collapse' : 'Expand'} tool call: ${message.toolName ?? 'tool'}`}
       >
-        <ArrowRight01Icon
+        <HugeiconsIcon icon={ArrowRight01Icon}
           className={`h-3 w-3 shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
         />
         <span className="font-mono text-xs text-muted-foreground">{message.toolName ?? 'tool'}</span>
@@ -135,7 +129,7 @@ function ToolResultCard({ message }: { message: ChatMessage }) {
 function ThinkingBlock({ message }: { message: ChatMessage }) {
   return (
     <div className="flex gap-2 border-l-2 border-muted-foreground/30 pl-3 italic text-sm text-muted-foreground">
-      <Idea01Icon className="h-4 w-4 shrink-0 mt-0.5" aria-hidden="true" />
+      <HugeiconsIcon icon={Idea01Icon} className="h-4 w-4 shrink-0 mt-0.5" aria-hidden="true" />
       <span>{message.content}</span>
     </div>
   );
@@ -150,7 +144,7 @@ function SystemLine({ message }: { message: ChatMessage }) {
 function ErrorCard({ message }: { message: ChatMessage }) {
   return (
     <div className="flex gap-2 rounded-lg border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-      <Alert01Icon className="h-4 w-4 shrink-0 mt-0.5" aria-hidden="true" />
+      <HugeiconsIcon icon={Alert01Icon} className="h-4 w-4 shrink-0 mt-0.5" aria-hidden="true" />
       <span>{message.content}</span>
     </div>
   );
@@ -159,7 +153,7 @@ function ErrorCard({ message }: { message: ChatMessage }) {
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
-      <ArtificialIntelligence01Icon className="h-10 w-10 opacity-40" aria-hidden="true" />
+      <HugeiconsIcon icon={ArtificialIntelligence01Icon} className="h-10 w-10 opacity-40" aria-hidden="true" />
       <p className="text-sm">Start a conversation with your agent</p>
     </div>
   );
@@ -315,7 +309,7 @@ export function AgentChatPanel({
                 onClick={interrupt}
                 aria-label="Interrupt agent"
               >
-                <Cancel01Icon className="h-4 w-4 mr-1" />
+                <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4 mr-1" />
                 Interrupt
               </Button>
             )}
@@ -338,7 +332,7 @@ export function AgentChatPanel({
               aria-label="Send message"
               className="shrink-0"
             >
-              <SentIcon className="h-4 w-4" />
+              <HugeiconsIcon icon={SentIcon} className="h-4 w-4" />
             </Button>
           </div>
         </div>

--- a/web-ui/src/components/sessions/NewSessionModal.tsx
+++ b/web-ui/src/components/sessions/NewSessionModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon } from '@hugeicons/core-free-icons';
 import type { SessionCreateRequest } from '@/types';
 import {
   Dialog,
@@ -108,7 +109,7 @@ export function NewSessionModal({
             onClick={handleSubmit}
             disabled={isSubmitting}
           >
-            {isSubmitting && <Loading03Icon className="mr-2 h-4 w-4 animate-spin" />}
+            {isSubmitting && <HugeiconsIcon icon={Loading03Icon} className="mr-2 h-4 w-4 animate-spin" />}
             Start Session
           </Button>
         </DialogFooter>

--- a/web-ui/src/components/sessions/SessionCard.tsx
+++ b/web-ui/src/components/sessions/SessionCard.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
-import { Cancel01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Cancel01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -66,7 +67,7 @@ export function SessionCard({ session, onEnd }: SessionCardProps) {
                   variant="ghost"
                   className="h-7 gap-1 px-2 text-xs text-destructive"
                 >
-                  <Cancel01Icon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={Cancel01Icon} className="h-3.5 w-3.5" />
                   End
                 </Button>
               </AlertDialogTrigger>

--- a/web-ui/src/components/sessions/SessionListView.tsx
+++ b/web-ui/src/components/sessions/SessionListView.tsx
@@ -3,7 +3,8 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import useSWR from 'swr';
-import { Search01Icon, Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Search01Icon, Loading03Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { SessionCard } from './SessionCard';
@@ -115,7 +116,7 @@ export function SessionListView({ workspacePath }: SessionListViewProps) {
           </Button>
         </div>
         <div className="rounded-lg border bg-muted/50 p-8 text-center">
-          <Loading03Icon className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+          <HugeiconsIcon icon={Loading03Icon} className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
           <p className="text-sm font-medium text-foreground">No sessions yet</p>
           <p className="mt-1 text-xs text-muted-foreground">
             Start a new session to begin working with an AI agent.
@@ -143,7 +144,7 @@ export function SessionListView({ workspacePath }: SessionListViewProps) {
 
       {/* Search */}
       <div className="relative">
-        <Search01Icon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <HugeiconsIcon icon={Search01Icon} className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           placeholder="Search sessions..."
           value={search}

--- a/web-ui/src/components/sessions/SplitPane.tsx
+++ b/web-ui/src/components/sessions/SplitPane.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRef, useEffect, useState, useCallback } from 'react';
-import { ArrowLeft01Icon, ArrowRight01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowLeft01Icon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
 import { cn } from '@/lib/utils';
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -298,9 +299,9 @@ export function SplitPane({
           aria-label={isLeftCollapsed ? 'Expand left pane' : 'Collapse left pane'}
         >
           {isLeftCollapsed ? (
-            <ArrowRight01Icon className="h-3 w-3" />
+            <HugeiconsIcon icon={ArrowRight01Icon} className="h-3 w-3" />
           ) : (
-            <ArrowLeft01Icon className="h-3 w-3" />
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="h-3 w-3" />
           )}
         </button>
 
@@ -319,9 +320,9 @@ export function SplitPane({
           aria-label={isRightCollapsed ? 'Expand right pane' : 'Collapse right pane'}
         >
           {isRightCollapsed ? (
-            <ArrowLeft01Icon className="h-3 w-3" />
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="h-3 w-3" />
           ) : (
-            <ArrowRight01Icon className="h-3 w-3" />
+            <HugeiconsIcon icon={ArrowRight01Icon} className="h-3 w-3" />
           )}
         </button>
       </div>

--- a/web-ui/src/components/tasks/BatchActionsBar.tsx
+++ b/web-ui/src/components/tasks/BatchActionsBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { CheckListIcon, PlayCircleIcon, Loading03Icon, Cancel01Icon, ArrowTurnBackwardIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CheckListIcon, PlayCircleIcon, Loading03Icon, Cancel01Icon, ArrowTurnBackwardIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -55,7 +56,7 @@ export function BatchActionsBar({
         onClick={onToggleSelectionMode}
         className="gap-1.5"
       >
-        <CheckListIcon className="h-4 w-4" />
+        <HugeiconsIcon icon={CheckListIcon} className="h-4 w-4" />
         {selectionMode ? 'Cancel' : 'Batch'}
       </Button>
 
@@ -92,9 +93,9 @@ export function BatchActionsBar({
               className="gap-1.5"
             >
               {isExecuting ? (
-                <Loading03Icon className="h-3.5 w-3.5 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="h-3.5 w-3.5 animate-spin" />
               ) : (
-                <PlayCircleIcon className="h-3.5 w-3.5" />
+                <HugeiconsIcon icon={PlayCircleIcon} className="h-3.5 w-3.5" />
               )}
               Execute {readyCount}
             </Button>
@@ -110,9 +111,9 @@ export function BatchActionsBar({
               className="gap-1.5"
             >
               {isStoppingBatch ? (
-                <Loading03Icon className="h-3.5 w-3.5 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="h-3.5 w-3.5 animate-spin" />
               ) : (
-                <Cancel01Icon className="h-3.5 w-3.5" />
+                <HugeiconsIcon icon={Cancel01Icon} className="h-3.5 w-3.5" />
               )}
               Stop {inProgressCount}
             </Button>
@@ -128,9 +129,9 @@ export function BatchActionsBar({
               className="gap-1.5"
             >
               {isResettingBatch ? (
-                <Loading03Icon className="h-3.5 w-3.5 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="h-3.5 w-3.5 animate-spin" />
               ) : (
-                <ArrowTurnBackwardIcon className="h-3.5 w-3.5" />
+                <HugeiconsIcon icon={ArrowTurnBackwardIcon} className="h-3.5 w-3.5" />
               )}
               Reset {failedCount}
             </Button>

--- a/web-ui/src/components/tasks/BulkActionConfirmDialog.tsx
+++ b/web-ui/src/components/tasks/BulkActionConfirmDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Loading03Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Loading03Icon } from '@hugeicons/core-free-icons';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -69,7 +70,7 @@ export function BulkActionConfirmDialog({
             disabled={isLoading}
             className={config.destructive ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90' : ''}
           >
-            {isLoading && <Loading03Icon className="mr-2 h-4 w-4 animate-spin" />}
+            {isLoading && <HugeiconsIcon icon={Loading03Icon} className="mr-2 h-4 w-4 animate-spin" />}
             Confirm
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/web-ui/src/components/tasks/GitHubIssueBadge.tsx
+++ b/web-ui/src/components/tasks/GitHubIssueBadge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { GithubIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { GithubIcon } from '@hugeicons/core-free-icons';
 
 interface GitHubIssueBadgeProps {
   issueNumber: number;
@@ -21,7 +22,7 @@ export function GitHubIssueBadge({ issueNumber, issueUrl }: GitHubIssueBadgeProp
       aria-label={`Imported from GitHub issue #${issueNumber}`}
       className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-[3px] focus-visible:ring-ring"
     >
-      <GithubIcon className="h-3.5 w-3.5 shrink-0" />
+      <HugeiconsIcon icon={GithubIcon} className="h-3.5 w-3.5 shrink-0" />
       Imported from GitHub #{issueNumber}
     </a>
   );

--- a/web-ui/src/components/tasks/GitHubIssueImportModal.tsx
+++ b/web-ui/src/components/tasks/GitHubIssueImportModal.tsx
@@ -3,14 +3,8 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import useSWR from 'swr';
 import { formatDistanceToNowStrict } from 'date-fns';
-import {
-  Search01Icon,
-  ArrowLeft01Icon,
-  ArrowRight01Icon,
-  Cancel01Icon,
-  Loading03Icon,
-  Alert02Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Search01Icon, ArrowLeft01Icon, ArrowRight01Icon, Cancel01Icon, Loading03Icon, Alert02Icon } from '@hugeicons/core-free-icons';
 import {
   Dialog,
   DialogContent,
@@ -151,14 +145,14 @@ export function GitHubIssueImportModal({
             aria-label="Close"
             className="rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-[3px] focus-visible:ring-ring"
           >
-            <Cancel01Icon className="h-4 w-4" />
+            <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" />
           </button>
         </DialogHeader>
 
         {/* Filters */}
         <div className="flex flex-wrap items-center gap-3 border-b px-6 py-3">
           <div className="relative flex-1 min-w-[200px]">
-            <Search01Icon className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <HugeiconsIcon icon={Search01Icon} className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
@@ -219,7 +213,7 @@ export function GitHubIssueImportModal({
               role="alert"
               className="flex items-center gap-2 rounded-md border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive"
             >
-              <Alert02Icon className="h-4 w-4 shrink-0" />
+              <HugeiconsIcon icon={Alert02Icon} className="h-4 w-4 shrink-0" />
               <span>{error.detail || 'Failed to load issues.'}</span>
             </div>
           )}
@@ -278,7 +272,7 @@ export function GitHubIssueImportModal({
             role="alert"
             className="flex items-center gap-2 border-t border-destructive/40 bg-destructive/10 px-6 py-2.5 text-sm text-destructive"
           >
-            <Alert02Icon className="h-4 w-4 shrink-0" />
+            <HugeiconsIcon icon={Alert02Icon} className="h-4 w-4 shrink-0" />
             <span>{importError}</span>
           </div>
         )}
@@ -293,7 +287,7 @@ export function GitHubIssueImportModal({
               disabled={page <= 1 || isLoading}
               aria-label="Previous page"
             >
-              <ArrowLeft01Icon className="h-4 w-4" />
+              <HugeiconsIcon icon={ArrowLeft01Icon} className="h-4 w-4" />
             </Button>
             <span>
               Page {page} of {totalPages}
@@ -305,7 +299,7 @@ export function GitHubIssueImportModal({
               disabled={page >= totalPages || isLoading}
               aria-label="Next page"
             >
-              <ArrowRight01Icon className="h-4 w-4" />
+              <HugeiconsIcon icon={ArrowRight01Icon} className="h-4 w-4" />
             </Button>
           </div>
           <div className="flex items-center gap-2">
@@ -317,7 +311,7 @@ export function GitHubIssueImportModal({
               disabled={selected.size === 0 || importing}
             >
               {(isLoading || importing) && (
-                <Loading03Icon className="mr-1.5 h-4 w-4 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-4 w-4 animate-spin" />
               )}
               {importing
                 ? `Importing ${selected.size} issue${selected.size !== 1 ? 's' : ''}…`

--- a/web-ui/src/components/tasks/TaskBoardView.tsx
+++ b/web-ui/src/components/tasks/TaskBoardView.tsx
@@ -10,7 +10,8 @@ import { TaskFilters } from './TaskFilters';
 import { BatchActionsBar } from './BatchActionsBar';
 import { BulkActionConfirmDialog, type BulkActionType } from './BulkActionConfirmDialog';
 import { GitHubIssueImportModal } from './GitHubIssueImportModal';
-import { Cancel01Icon, Task01Icon, GithubIcon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Cancel01Icon, Task01Icon, GithubIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { tasksApi, prdApi, costsApi, integrationsApi } from '@/lib/api';
 import { useRequirementsLookup } from '@/hooks/useRequirementsLookup';
@@ -410,7 +411,7 @@ export function TaskBoardView({ workspacePath }: TaskBoardViewProps) {
             variant="outline"
             onClick={() => setImportModalOpen(true)}
           >
-            <GithubIcon className="mr-2 h-4 w-4" />
+            <HugeiconsIcon icon={GithubIcon} className="mr-2 h-4 w-4" />
             Import from GitHub
           </Button>
         )}
@@ -453,7 +454,7 @@ export function TaskBoardView({ workspacePath }: TaskBoardViewProps) {
             aria-label="Dismiss import summary"
             className="ml-2 rounded p-0.5 hover:opacity-70 focus-visible:outline-hidden focus-visible:ring-[3px] focus-visible:ring-ring"
           >
-            <Cancel01Icon className="h-4 w-4" />
+            <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" />
           </button>
         </div>
       )}
@@ -467,7 +468,7 @@ export function TaskBoardView({ workspacePath }: TaskBoardViewProps) {
             aria-label="Dismiss error"
             className="ml-2 rounded p-0.5 text-destructive hover:text-destructive/80 focus-visible:outline-hidden focus-visible:ring-[3px] focus-visible:ring-ring"
           >
-            <Cancel01Icon className="h-4 w-4" />
+            <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" />
           </button>
         </div>
       )}
@@ -475,7 +476,7 @@ export function TaskBoardView({ workspacePath }: TaskBoardViewProps) {
       {/* Empty state — shown when no tasks exist after loading completes */}
       {tasks.length === 0 && (
         <div className="flex flex-col items-center justify-center rounded-lg border bg-muted/30 py-16 text-center">
-          <Task01Icon className="mb-4 h-10 w-10 text-muted-foreground/50" />
+          <HugeiconsIcon icon={Task01Icon} className="mb-4 h-10 w-10 text-muted-foreground/50" />
           <h2 className="text-base font-semibold text-foreground">No tasks yet</h2>
           <p className="mt-1 max-w-sm text-sm text-muted-foreground">
             Generate tasks from your PRD or create them manually to start building.

--- a/web-ui/src/components/tasks/TaskCard.tsx
+++ b/web-ui/src/components/tasks/TaskCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { PlayCircleIcon, CheckmarkCircle01Icon, LinkCircleIcon, Cancel01Icon, ArrowTurnBackwardIcon, Loading03Icon, BookOpen01Icon, MoneyBag02Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { PlayCircleIcon, CheckmarkCircle01Icon, LinkCircleIcon, Cancel01Icon, ArrowTurnBackwardIcon, Loading03Icon, BookOpen01Icon, MoneyBag02Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -145,7 +146,7 @@ export function TaskCard({
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="flex cursor-default items-center gap-1 text-xs text-muted-foreground">
-                  <LinkCircleIcon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={LinkCircleIcon} className="h-3.5 w-3.5" />
                   {task.depends_on.length}
                 </span>
               </TooltipTrigger>
@@ -173,7 +174,7 @@ export function TaskCard({
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >
-            <BookOpen01Icon className="h-3 w-3 shrink-0 text-muted-foreground" />
+            <HugeiconsIcon icon={BookOpen01Icon} className="h-3 w-3 shrink-0 text-muted-foreground" />
             <Link href={`/proof/${encodeURIComponent(reqIds[0])}`}>
               <Badge variant="outline" className="h-5 cursor-pointer gap-1 px-1.5 text-[10px] hover:bg-accent">
                 <span className="font-mono">{reqIds[0].slice(0, 10)}</span>
@@ -202,7 +203,7 @@ export function TaskCard({
                   variant="outline"
                   className="h-5 gap-1 px-1.5 text-[10px]"
                 >
-                  <MoneyBag02Icon className="h-3 w-3" />
+                  <HugeiconsIcon icon={MoneyBag02Icon} className="h-3 w-3" />
                   <span className="tabular-nums">{formatBadgeCost(costEntry.total_cost_usd)}</span>
                 </Badge>
               </TooltipTrigger>
@@ -222,7 +223,7 @@ export function TaskCard({
           <div className="mt-2 flex gap-1">
             {isLoading ? (
               <span role="status" aria-label="Loading">
-                <Loading03Icon className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                <HugeiconsIcon icon={Loading03Icon} className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
               </span>
             ) : (
               <>
@@ -236,7 +237,7 @@ export function TaskCard({
                       onExecute(task.id);
                     }}
                   >
-                    <PlayCircleIcon className="h-3.5 w-3.5" />
+                    <HugeiconsIcon icon={PlayCircleIcon} className="h-3.5 w-3.5" />
                     Execute
                   </Button>
                 )}
@@ -250,7 +251,7 @@ export function TaskCard({
                       onMarkReady(task.id);
                     }}
                   >
-                    <CheckmarkCircle01Icon className="h-3.5 w-3.5" />
+                    <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-3.5 w-3.5" />
                     Mark Ready
                   </Button>
                 )}
@@ -264,7 +265,7 @@ export function TaskCard({
                       onStop(task.id);
                     }}
                   >
-                    <Cancel01Icon className="h-3.5 w-3.5" />
+                    <HugeiconsIcon icon={Cancel01Icon} className="h-3.5 w-3.5" />
                     Stop
                   </Button>
                 )}
@@ -278,7 +279,7 @@ export function TaskCard({
                       onReset(task.id);
                     }}
                   >
-                    <ArrowTurnBackwardIcon className="h-3.5 w-3.5" />
+                    <HugeiconsIcon icon={ArrowTurnBackwardIcon} className="h-3.5 w-3.5" />
                     Reset
                   </Button>
                 )}

--- a/web-ui/src/components/tasks/TaskDetailModal.tsx
+++ b/web-ui/src/components/tasks/TaskDetailModal.tsx
@@ -3,18 +3,8 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  PlayCircleIcon,
-  CheckmarkCircle01Icon,
-  LinkCircleIcon,
-  Loading03Icon,
-  Time01Icon,
-  ViewIcon,
-  BookOpen01Icon,
-  Alert02Icon,
-  CheckListIcon,
-  InformationCircleIcon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { PlayCircleIcon, CheckmarkCircle01Icon, LinkCircleIcon, Loading03Icon, Time01Icon, ViewIcon, BookOpen01Icon, Alert02Icon, CheckListIcon, InformationCircleIcon } from '@hugeicons/core-free-icons';
 import {
   Dialog,
   DialogContent,
@@ -158,7 +148,7 @@ export function TaskDetailModal({
 
         {isLoading && (
           <div className="flex items-center justify-center py-12">
-            <Loading03Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+            <HugeiconsIcon icon={Loading03Icon} className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
         )}
 
@@ -214,13 +204,13 @@ export function TaskDetailModal({
             <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
               {task.estimated_hours != null && (
                 <span className="flex items-center gap-1">
-                  <Time01Icon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={Time01Icon} className="h-3.5 w-3.5" />
                   {task.estimated_hours}h estimated
                 </span>
               )}
               {task.updated_at && (
                 <span className="flex items-center gap-1">
-                  <Time01Icon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={Time01Icon} className="h-3.5 w-3.5" />
                   Last changed: {new Date(task.updated_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
                 </span>
               )}
@@ -248,7 +238,7 @@ export function TaskDetailModal({
             {task.depends_on.length > 0 && (
               <div className="space-y-1.5">
                 <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-                  <LinkCircleIcon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={LinkCircleIcon} className="h-3.5 w-3.5" />
                   Dependencies ({task.depends_on.length})
                 </div>
                 <ul className="space-y-1">
@@ -285,11 +275,11 @@ export function TaskDetailModal({
             {(task.requirement_ids ?? []).length > 0 && (
               <div className="space-y-1.5">
                 <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-                  <BookOpen01Icon className="h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={BookOpen01Icon} className="h-3.5 w-3.5" />
                   Requirements
                 </div>
                 {reqsLoading ? (
-                  <Loading03Icon className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                  <HugeiconsIcon icon={Loading03Icon} className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                 ) : (
                   <ul className="space-y-1">
                     {(task.requirement_ids ?? []).map((reqId) => {
@@ -321,7 +311,7 @@ export function TaskDetailModal({
             {task.status === 'FAILED' && (
               <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5" data-testid="status-next-step">
                 <div className="flex items-start gap-2">
-                  <Alert02Icon className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                  <HugeiconsIcon icon={Alert02Icon} className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
                   <div className="space-y-0.5">
                     <p className="text-xs font-medium text-destructive">Task failed during execution</p>
                     <p className="text-xs text-muted-foreground">
@@ -336,7 +326,7 @@ export function TaskDetailModal({
             {(task.status === 'DONE' || task.status === 'BLOCKED' || task.status === 'MERGED') && (
               <div className="rounded-md border bg-muted/40 px-3 py-2.5" data-testid="status-next-step">
                 <div className="flex items-start gap-2">
-                  <InformationCircleIcon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <HugeiconsIcon icon={InformationCircleIcon} className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                   <div className="space-y-0.5">
                     <p className="text-xs font-medium text-foreground">What&apos;s next?</p>
                     <p className="text-xs text-muted-foreground">{STATUS_INFO[task.status].nextSteps}</p>
@@ -354,9 +344,9 @@ export function TaskDetailModal({
                   onClick={handleMarkReady}
                 >
                   {isUpdating ? (
-                    <Loading03Icon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                   ) : (
-                    <CheckmarkCircle01Icon className="mr-1.5 h-3.5 w-3.5" />
+                    <HugeiconsIcon icon={CheckmarkCircle01Icon} className="mr-1.5 h-3.5 w-3.5" />
                   )}
                   Mark Ready
                 </Button>
@@ -369,7 +359,7 @@ export function TaskDetailModal({
                     router.push(`/execution/${task.id}`);
                   }}
                 >
-                  <ViewIcon className="mr-1.5 h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={ViewIcon} className="mr-1.5 h-3.5 w-3.5" />
                   View Execution
                 </Button>
               )}
@@ -378,7 +368,7 @@ export function TaskDetailModal({
                   size="sm"
                   onClick={() => onExecute(task.id)}
                 >
-                  <PlayCircleIcon className="mr-1.5 h-3.5 w-3.5" />
+                  <HugeiconsIcon icon={PlayCircleIcon} className="mr-1.5 h-3.5 w-3.5" />
                   Execute
                 </Button>
               )}
@@ -399,9 +389,9 @@ export function TaskDetailModal({
                       onClick={handleMarkReady}
                     >
                       {isUpdating ? (
-                        <Loading03Icon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        <HugeiconsIcon icon={Loading03Icon} className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                       ) : (
-                        <CheckmarkCircle01Icon className="mr-1.5 h-3.5 w-3.5" />
+                        <HugeiconsIcon icon={CheckmarkCircle01Icon} className="mr-1.5 h-3.5 w-3.5" />
                       )}
                       Reset to Ready
                     </Button>
@@ -412,7 +402,7 @@ export function TaskDetailModal({
                         router.push(proofLink);
                       }}
                     >
-                      <CheckListIcon className="mr-1.5 h-3.5 w-3.5" />
+                      <HugeiconsIcon icon={CheckListIcon} className="mr-1.5 h-3.5 w-3.5" />
                       View PROOF9 Gates
                     </Button>
                   </>

--- a/web-ui/src/components/tasks/TaskFilters.tsx
+++ b/web-ui/src/components/tasks/TaskFilters.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRef, useEffect, useState } from 'react';
-import { Search01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Search01Icon } from '@hugeicons/core-free-icons';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
@@ -49,7 +50,7 @@ export function TaskFilters({
     <div className="flex flex-wrap items-center gap-3">
       {/* Search input */}
       <div className="relative w-56">
-        <Search01Icon className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <HugeiconsIcon icon={Search01Icon} className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           value={localQuery}
           onChange={(e) => setLocalQuery(e.target.value)}

--- a/web-ui/src/components/workspace/OnboardingCard.tsx
+++ b/web-ui/src/components/workspace/OnboardingCard.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { Cancel01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Cancel01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { getOnboardingDismissed, setOnboardingDismissed } from '@/lib/workspace-storage';
@@ -58,7 +59,7 @@ export function OnboardingCard({ workspacePath }: OnboardingCardProps) {
           aria-label="Dismiss onboarding"
           className="ml-4 rounded p-1 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
         >
-          <Cancel01Icon className="h-4 w-4" />
+          <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" />
         </button>
       </CardHeader>
       <CardContent>

--- a/web-ui/src/components/workspace/QuickActions.tsx
+++ b/web-ui/src/components/workspace/QuickActions.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  FileEditIcon,
-  FileAddIcon,
-  Task01Icon,
-  GitBranchIcon,
-  PlayCircleIcon,
-  CheckListIcon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { FileEditIcon, FileAddIcon, Task01Icon, GitBranchIcon, PlayCircleIcon, CheckListIcon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import type { QuickActionsProps } from '@/types';
 
@@ -35,13 +29,13 @@ export function QuickActions({ taskCounts }: QuickActionsProps) {
           <>
             <Button asChild>
               <Link href="/prd">
-                <FileEditIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={FileEditIcon} className="mr-2 h-4 w-4" />
                 Create PRD
               </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href="/prd">
-                <FileAddIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={FileAddIcon} className="mr-2 h-4 w-4" />
                 Import PRD
               </Link>
             </Button>
@@ -52,13 +46,13 @@ export function QuickActions({ taskCounts }: QuickActionsProps) {
           <>
             <Button asChild>
               <Link href="/tasks">
-                <PlayCircleIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={PlayCircleIcon} className="mr-2 h-4 w-4" />
                 Execute Tasks
               </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href="/tasks">
-                <Task01Icon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={Task01Icon} className="mr-2 h-4 w-4" />
                 Manage Tasks
               </Link>
             </Button>
@@ -69,13 +63,13 @@ export function QuickActions({ taskCounts }: QuickActionsProps) {
           <>
             <Button asChild>
               <Link href="/tasks">
-                <PlayCircleIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={PlayCircleIcon} className="mr-2 h-4 w-4" />
                 View Running Tasks
               </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href="/tasks">
-                <Task01Icon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={Task01Icon} className="mr-2 h-4 w-4" />
                 Manage Tasks
               </Link>
             </Button>
@@ -86,13 +80,13 @@ export function QuickActions({ taskCounts }: QuickActionsProps) {
           <>
             <Button asChild>
               <Link href="/proof">
-                <CheckListIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={CheckListIcon} className="mr-2 h-4 w-4" />
                 View Proof Gates
               </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href="/review">
-                <GitBranchIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={GitBranchIcon} className="mr-2 h-4 w-4" />
                 Review Changes
               </Link>
             </Button>
@@ -103,19 +97,19 @@ export function QuickActions({ taskCounts }: QuickActionsProps) {
           <>
             <Button variant="outline" asChild>
               <Link href="/prd">
-                <FileEditIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={FileEditIcon} className="mr-2 h-4 w-4" />
                 View PRD
               </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href="/tasks">
-                <Task01Icon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={Task01Icon} className="mr-2 h-4 w-4" />
                 Manage Tasks
               </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href="/review">
-                <GitBranchIcon className="mr-2 h-4 w-4" />
+                <HugeiconsIcon icon={GitBranchIcon} className="mr-2 h-4 w-4" />
                 Review Changes
               </Link>
             </Button>

--- a/web-ui/src/components/workspace/RecentActivityFeed.tsx
+++ b/web-ui/src/components/workspace/RecentActivityFeed.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import type { IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Time01Icon,
   CheckmarkCircle01Icon,
   PlayIcon,
   Alert02Icon,
   Folder01Icon,
-} from '@hugeicons/react';
+} from '@hugeicons/core-free-icons';
 import { formatDistanceToNow } from 'date-fns';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { ActivityItem, ActivityType } from '@/types';
@@ -17,7 +19,7 @@ interface RecentActivityFeedProps {
 
 const MAX_ITEMS = 5;
 
-const activityIcons: Record<ActivityType, React.ElementType> = {
+const activityIcons: Record<ActivityType, IconSvgElement> = {
   task_completed: CheckmarkCircle01Icon,
   run_started: PlayIcon,
   blocker_raised: Alert02Icon,
@@ -40,7 +42,7 @@ export function RecentActivityFeed({ activities }: RecentActivityFeedProps) {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
         <CardTitle className="flex items-center gap-2 text-base font-semibold">
-          <Time01Icon className="h-5 w-5" />
+          <HugeiconsIcon icon={Time01Icon} className="h-5 w-5" />
           Recent Activity
         </CardTitle>
       </CardHeader>
@@ -50,7 +52,7 @@ export function RecentActivityFeed({ activities }: RecentActivityFeedProps) {
         ) : (
           <div className="space-y-4">
             {displayedActivities.map((activity, index) => {
-              const Icon = activityIcons[activity.type];
+              const icon = activityIcons[activity.type];
               const colorClass = activityColors[activity.type];
 
               return (
@@ -58,7 +60,7 @@ export function RecentActivityFeed({ activities }: RecentActivityFeedProps) {
                   {/* Timeline connector */}
                   <div className="flex flex-col items-center">
                     <div className={`rounded-full p-1.5 ${colorClass}`}>
-                      <Icon className="h-4 w-4" />
+                      <HugeiconsIcon icon={icon} className="h-4 w-4" />
                     </div>
                     {index < displayedActivities.length - 1 && (
                       <div className="mt-1 h-full w-px bg-border" />

--- a/web-ui/src/components/workspace/WorkspaceHeader.tsx
+++ b/web-ui/src/components/workspace/WorkspaceHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Folder01Icon, Loading03Icon, CheckmarkCircle01Icon, Alert01Icon } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Folder01Icon, Loading03Icon, CheckmarkCircle01Icon, Alert01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import type { WorkspaceResponse } from '@/types';
 
@@ -27,7 +28,7 @@ export function WorkspaceHeader({
             <>
               <span className="text-muted-foreground">/</span>
               <div className="flex items-center gap-2 text-muted-foreground">
-                <Folder01Icon className="h-5 w-5" />
+                <HugeiconsIcon icon={Folder01Icon} className="h-5 w-5" />
                 <span className="font-medium">{repoName}</span>
               </div>
               {workspace.tech_stack ? (
@@ -35,7 +36,7 @@ export function WorkspaceHeader({
                   data-testid="tech-stack-detected"
                   className="flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800"
                 >
-                  <CheckmarkCircle01Icon className="h-3 w-3" />
+                  <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-3 w-3" />
                   Tech stack detected
                 </div>
               ) : (
@@ -43,7 +44,7 @@ export function WorkspaceHeader({
                   data-testid="tech-stack-missing"
                   className="flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
                 >
-                  <Alert01Icon className="h-3 w-3" />
+                  <HugeiconsIcon icon={Alert01Icon} className="h-3 w-3" />
                   No tech stack
                 </div>
               )}
@@ -64,7 +65,7 @@ export function WorkspaceHeader({
             <Button onClick={onInitialize} disabled={isLoading}>
               {isLoading ? (
                 <>
-                  <Loading03Icon className="mr-2 h-4 w-4 animate-spin" />
+                  <HugeiconsIcon icon={Loading03Icon} className="mr-2 h-4 w-4 animate-spin" />
                   Initializing...
                 </>
               ) : (

--- a/web-ui/src/components/workspace/WorkspaceSelector.tsx
+++ b/web-ui/src/components/workspace/WorkspaceSelector.tsx
@@ -1,13 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Folder01Icon,
-  Time01Icon,
-  Cancel01Icon,
-  Loading03Icon,
-  Alert02Icon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Folder01Icon, Time01Icon, Cancel01Icon, Loading03Icon, Alert02Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
@@ -74,7 +69,7 @@ export function WorkspaceSelector({
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg">
-              <Folder01Icon className="h-5 w-5" />
+              <HugeiconsIcon icon={Folder01Icon} className="h-5 w-5" />
               Open Project
             </CardTitle>
           </CardHeader>
@@ -110,7 +105,7 @@ export function WorkspaceSelector({
               <Button type="submit" disabled={isLoading || !inputPath.trim()}>
                 {isLoading ? (
                   <>
-                    <Loading03Icon className="mr-2 h-4 w-4 animate-spin" />
+                    <HugeiconsIcon icon={Loading03Icon} className="mr-2 h-4 w-4 animate-spin" />
                     Opening...
                   </>
                 ) : (
@@ -125,7 +120,7 @@ export function WorkspaceSelector({
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg">
-              <Time01Icon className="h-5 w-5" />
+              <HugeiconsIcon icon={Time01Icon} className="h-5 w-5" />
               Recent Projects
             </CardTitle>
           </CardHeader>
@@ -135,7 +130,7 @@ export function WorkspaceSelector({
                 data-testid="workspaces-loading"
                 className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
               >
-                <Loading03Icon className="h-4 w-4 animate-spin" />
+                <HugeiconsIcon icon={Loading03Icon} className="h-4 w-4 animate-spin" />
                 Loading projects…
               </div>
             ) : recentWorkspaces.length === 0 ? (
@@ -167,7 +162,7 @@ export function WorkspaceSelector({
                       aria-disabled={isLoading}
                     >
                       <div className="flex items-center gap-3 min-w-0">
-                        <Folder01Icon className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
+                        <HugeiconsIcon icon={Folder01Icon} className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
                         <div className="min-w-0">
                           <p className="font-medium truncate flex items-center gap-1.5">
                             {displayName}
@@ -176,7 +171,7 @@ export function WorkspaceSelector({
                                 className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground"
                                 title="This path no longer exists on disk"
                               >
-                                <Alert02Icon className="h-3 w-3" />
+                                <HugeiconsIcon icon={Alert02Icon} className="h-3 w-3" />
                                 Missing
                               </span>
                             )}
@@ -204,7 +199,7 @@ export function WorkspaceSelector({
                           title="Remove from recent"
                           aria-label={`Remove ${displayName} from recent projects`}
                         >
-                          <Cancel01Icon className="h-4 w-4" />
+                          <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4" />
                         </button>
                       </div>
                     </div>

--- a/web-ui/src/components/workspace/WorkspaceStatsCards.tsx
+++ b/web-ui/src/components/workspace/WorkspaceStatsCards.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  CodeIcon,
-  Task01Icon,
-  PlayIcon,
-} from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { CodeIcon, Task01Icon, PlayIcon } from '@hugeicons/core-free-icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -33,7 +30,7 @@ export function WorkspaceStatsCards({
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">Tech Stack</CardTitle>
-          <CodeIcon className="h-4 w-4 text-muted-foreground" />
+          <HugeiconsIcon icon={CodeIcon} className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           {techStack ? (
@@ -59,7 +56,7 @@ export function WorkspaceStatsCards({
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">Tasks</CardTitle>
-          <Task01Icon className="h-4 w-4 text-muted-foreground" />
+          <HugeiconsIcon icon={Task01Icon} className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <div className="flex flex-wrap gap-2">
@@ -120,7 +117,7 @@ export function WorkspaceStatsCards({
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">Active Runs</CardTitle>
-          <PlayIcon className="h-4 w-4 text-muted-foreground" />
+          <HugeiconsIcon icon={PlayIcon} className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <p

--- a/web-ui/src/lib/eventStyles.ts
+++ b/web-ui/src/lib/eventStyles.ts
@@ -4,7 +4,7 @@
  * Used by EventItem, ExecutionHeader, and other execution monitor components
  * to ensure consistent badge colors and icons across the UI.
  */
-import type { ComponentType } from 'react';
+import type { IconSvgElement } from '@hugeicons/react';
 import type { UIAgentState } from '@/types';
 import type {
   ExecutionEvent,
@@ -23,7 +23,7 @@ import {
   Loading03Icon,
   WifiDisconnected01Icon,
   FileEditIcon,
-} from '@hugeicons/react';
+} from '@hugeicons/core-free-icons';
 
 // ── Agent state derivation ─────────────────────────────────────────────
 
@@ -100,11 +100,8 @@ export const agentStateLabels: Record<UIAgentState, string> = {
 
 // ── Icon mapping ───────────────────────────────────────────────────────
 
-// Hugeicons icon props type (size + className are the commonly used ones)
-type IconProps = { size?: number; className?: string };
-
-/** Icon component for each agent state. */
-export const agentStateIcons: Record<UIAgentState, ComponentType<IconProps>> = {
+/** Icon data for each agent state (rendered via `<HugeiconsIcon icon={...} />`). */
+export const agentStateIcons: Record<UIAgentState, IconSvgElement> = {
   CONNECTING: Loading03Icon,
   PLANNING: Idea01Icon,
   EXECUTING: PlayIcon,
@@ -117,7 +114,7 @@ export const agentStateIcons: Record<UIAgentState, ComponentType<IconProps>> = {
 };
 
 /**
- * Icon for specific event sub-types used inside event detail renderers
+ * Icon data for specific event sub-types used inside event detail renderers
  * (e.g. shell output uses a terminal icon, errors use a diamond alert).
  */
 export const eventDetailIcons = {


### PR DESCRIPTION
## Summary
Implements #869: Migrate `@hugeicons/react` 0.3.4 → 1.x (61 files import removed icon exports).

`@hugeicons/react` 1.x split the icon **data** (now in `@hugeicons/core-free-icons`) from the **renderer** (`@hugeicons/react` now exports only `HugeiconsIcon`). The prior Dependabot bump (#850) was closed because the named icon exports (`Add01Icon`, `Alert01Icon`, etc.) were removed in 1.x, producing 388 Turbopack errors.

What this PR does:
- Bumps `@hugeicons/react` to `^1.1.9` and adds `@hugeicons/core-free-icons@^4.2.2` to `web-ui/package.json`.
- Rewrites all 61 source files that imported from `@hugeicons/react`:
  - Imports `HugeiconsIcon` from `@hugeicons/react` and the icon **data** from `@hugeicons/core-free-icons`.
  - Wraps every `<XxxNNIcon ... />` JSX usage in `<HugeiconsIcon icon={XxxNNIcon} ... />`.
- Migrates 7 "value-typed" icon maps from `ComponentType<...>` / `ElementType` / `typeof XxxIcon` annotations to the new `IconSvgElement` data type, with consumer call sites updated:
  - `web-ui/src/lib/eventStyles.ts` (`agentStateIcons`, `eventDetailIcons`) + consumer `ExecutionHeader.tsx`
  - `web-ui/src/components/workspace/RecentActivityFeed.tsx` (`activityIcons`)
  - `web-ui/src/components/review/FileTreePanel.tsx` (`changeTypeIcon`)
  - `web-ui/src/components/blockers/BlockerCard.tsx` (`ORIGIN_CONFIG`)
  - `web-ui/src/components/layout/AppSidebar.tsx` (`NAV_ITEMS`)
  - `web-ui/src/components/layout/NotificationCenter.tsx` (`iconForNotification`)
  - `web-ui/src/components/execution/BatchExecutionMonitor.tsx` (`statusConfig`)
  - `web-ui/src/components/execution/VerificationEvent.tsx` (inline ternary)
- Updates the Jest mocks:
  - `web-ui/__mocks__/@hugeicons/react.js` now exports `HugeiconsIcon` (renders `<svg data-testid="icon-<Name>" />` from the sentinel).
  - New `web-ui/__mocks__/@hugeicons/core-free-icons.js` returns a stable `{__iconName: <Name>}` sentinel per property via a Proxy, so existing tests that assert on `data-testid="icon-<Name>"` continue to work.
  - `jest.config.js` adds a `moduleNameMapper` entry for the new package.

All 56 unique icon names used in the app exist 1:1 in `@hugeicons/core-free-icons@4.2.2` — **no renames were needed.** Free-tier (MIT) icons only; no Pro packs introduced.

## Acceptance Criteria

- [x] **Review the 1.x export surface / migration guide and map every icon import currently used (the 0.3.4 names) to its 1.x equivalent.** All 56 unique icon names verified to exist 1:1 in `@hugeicons/core-free-icons@4.2.2` by parsing the installed package's ESM export list (`node_modules/@hugeicons/core-free-icons/dist/esm/`). Mapping table is in `tasks/todo.md` (dev-only artifact).
- [x] **Update imports across the 61 files.** All 61 source files now use the split import structure. `rg "from '@hugeicons/react'" web-ui/src` returns 65 hits, all of which are either `HugeiconsIcon` or `import type IconSvgElement`.
- [x] **Bump the package to the latest 1.x in `web-ui/package.json`.** `@hugeicons/react` is now `^1.1.9` (was `^0.3.0`); `@hugeicons/core-free-icons` `^4.2.2` added.
- [x] **Verify: `npm run build` (Turbopack) green.** ✓ Compiled successfully in ~10s; all 16 routes generated. The 388-error failure from #850 is resolved.
- [x] **Verify: frontend unit tests green.** 95/95 suites, 1052/1052 tests pass (`cd web-ui && npm test`).
- [x] **Verify: E2E Browser Smoke green.** Verified by CI: [E2E Browser Smoke (Chromium)](https://github.com/frankbria/codeframe/actions/runs/29800485282/job/88540556782) pass (1m36s). Runs real Chromium against the production build with real `@hugeicons/core-free-icons` data.

## Test Plan

- [x] **Unit tests written (TDD approach).** Pure refactor — no new test code needed. Existing tests already cover the migrated components; the mock layer was updated to preserve `data-testid="icon-<Name>"` semantics so every icon assertion still resolves.
- [x] **All tests passing.** 1052/1052.
- [x] **Diff coverage ≥85% on changed lines (Phase 7a-1).** No-op for this PR: the change is a pure refactor (no new executable lines in production code) plus two mock files that are exercised by every component test. The 26 pre-existing `tsc` errors are all in `__tests__/`/`e2e/` fixtures and are unrelated to hugeicons.
- [x] **Linting clean.** `cd web-ui && npm run lint` (eslint `--max-warnings 0`) passes.
- [x] **Internal code review (advisory).** Skipped as a stand-alone pass — the diff is mechanical and uniform; the cross-family review (below) independently verified contract fulfillment.
- [x] **Cross-family review pass: opencode (GLM/z.ai).** Verdict: **APROVE.** No Critical/Major findings. Three Suggestions (libc lockfile churn, `eventDetailIcons` dead code, Proxy `then` guard) and two Nitpicks — all triaged below in Known Limitations or skipped per severity policy.
- [x] **Test mutation sanity check (Phase 7d).** Confirmed: when `__iconName` is broken in the `HugeiconsIcon` mock, 3 tests that assert on specific icon testids fail (`PipelineProgressBar`, `DiscoveryTranscript`, `NotificationCenter`). Tests exercise the mock behaviorally; they are not placeholders.

## Known Limitations / Intentionally Deferred

- **E2E Browser Smoke not yet run locally.** Deferred to the Phase 11 demo gate before merge (requires dev server + browser binaries). Acceptance criterion 4c will be evidenced there.
- **Lockfile libc-metadata churn.** Regenerating `package-lock.json` on this glibc host dropped `"libc": ["glibc"]` constraints from `@esbuild/*` / `@rollup/*` optional deps. This is npm's default behavior when the host doesn't match an optional dep's libc. On Alpine/musl deploy hosts `npm ci` will re-resolve correctly per-host (the libc field is informational for the resolver). Flagged by opencode; not caused by the migration logic.
- **`eventDetailIcons` in `web-ui/src/lib/eventStyles.ts` is exported but has zero consumers.** Pre-existing dead code, untouched by this migration (kept to minimize diff scope). Worth a follow-up cleanup ticket.
- **Proxy `then` / `default` / `Symbol.*` access in `__mocks__/@hugeicons/core-free-icons.js`.** The mock returns a sentinel for ANY string property access. No current call site does `import('...').then(...)` or `Promise.resolve(Icons)` on the mock, but a defensive allowlist (or excluding `then`) would harden it. Out of scope (YAGNI — fix when a real call site needs it).
- **Single-platform mock verification.** Mocks verified under Node + jsdom (jest). Not verified under Turbopack's runtime (which uses real `@hugeicons/core-free-icons` data, not the mock) — but the production build passing is the verification there.

## Implementation Notes

- **No icon renames.** All 56 unique icon names (`Add01Icon`, `Alert01Icon`, ..., `ZzzIcon`-style names) exist 1:1 in `@hugeicons/core-free-icons@4.2.2`. The 1.x release only split the package; the icon data and naming are unchanged.
- **Migration approach chosen over a wrapper module.** A local `lib/icons.tsx` that re-exports wrapped components was considered and rejected — it would add surface area (violates YAGNI) without behavioral benefit. The per-file mechanical rewrite matches Hugeicons' official migration guide.
- **Value-typed maps required both type and call-site changes.** Eight sites stored icons under `ComponentType<...>` / `ElementType` / `typeof XxxIcon` annotations and rendered them dynamically via `<Icon ... />`. In 1.x, icons are no longer components — they're plain data (`IconSvgElement` = `readonly [tag, attrs][]`). Each map's type annotation was changed to `IconSvgElement` and each consumer was updated to render via `<HugeiconsIcon icon={...} />`.
- **Mutation check evidence.** Breaking the mock's `__iconName` lookup (renaming to `__BROKEN__`) caused 3 specific tests to fail (`PipelineProgressBar`, `DiscoveryTranscript`, `NotificationCenter`), proving the new mock chain is behaviorally exercised, not just structurally present.

Closes #869
