### PR TITLE
fix(security): close credential-handling windows (#772)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,19 @@ REDIS_URL=redis://localhost:6379
 
 CODEFRAME_API_KEY_SECRET=<secret>     # API key hashing
 
+# Credential-file confidentiality (#772 — opt-in)
+CODEFRAME_CREDENTIAL_SECRET=<secret>  # Mixed into the PBKDF2 KDF for the
+                                      # encrypted-file credential fallback
+                                      # (codeframe/core/credentials.py). Unset =
+                                      # key derived from the (non-secret)
+                                      # machine-id alone — obfuscation-at-rest,
+                                      # not confidentiality vs a local reader.
+                                      # Set it for real confidentiality; prefer
+                                      # the OS keyring where available. WARNING:
+                                      # adding/changing this rekeys the store, so
+                                      # previously stored credentials become
+                                      # undecryptable and must be re-entered.
+
 # Session token lifetime (#657 — defense-in-depth)
 JWT_LIFETIME_SECONDS=86400            # JWT validity window; default 24h (was 7d).
                                       # Shorter window limits exposure of the

--- a/codeframe/cli/api_client.py
+++ b/codeframe/cli/api_client.py
@@ -51,6 +51,25 @@ def get_api_base_url() -> str:
     return url.rstrip("/")
 
 
+# Hosts for which plain http:// is acceptable (traffic never leaves the machine).
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def is_insecure_transport(url: str) -> bool:
+    """Return True if sending credentials to ``url`` would cross the network in
+    the clear — i.e. an ``http://`` URL to a non-loopback host (#772).
+
+    Loopback http is fine (self-hosted local server); https is always fine.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme != "http":
+        return False
+    host = (parsed.hostname or "").lower()
+    return host not in _LOOPBACK_HOSTS
+
+
 class APIClient:
     """HTTP client for CodeFRAME API with authentication.
 
@@ -72,6 +91,14 @@ class APIClient:
         self.token = token if token is not None else get_token()
         self.max_retries = max_retries
         self.timeout = timeout
+
+        # Warn before sending a bearer token over cleartext to a remote host.
+        if self.token and is_insecure_transport(self.base_url):
+            logger.warning(
+                "Sending credentials over insecure http:// to non-loopback host %s. "
+                "Use https:// to protect your token in transit.",
+                self.base_url,
+            )
 
     def _get_headers(self) -> dict[str, str]:
         """Get HTTP headers including auth token.

--- a/codeframe/cli/auth.py
+++ b/codeframe/cli/auth.py
@@ -15,6 +15,7 @@ Security considerations:
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -40,18 +41,31 @@ def store_token(token: str) -> None:
     """
     creds_path = get_credentials_path()
 
-    # Create parent directories if needed
+    # Create parent directory owner-only. mkdir's mode is masked by umask and
+    # only applies on creation, so chmod unconditionally to guarantee 0o700.
     creds_path.parent.mkdir(parents=True, exist_ok=True)
+    creds_path.parent.chmod(0o700)
 
-    # Write token with restricted permissions
     credentials = {"access_token": token}
 
-    # Write to file
-    with open(creds_path, "w") as f:
-        json.dump(credentials, f, indent=2)
-
-    # Set secure permissions (owner read/write only)
-    creds_path.chmod(0o600)
+    # Write to a fresh temp file (mkstemp creates it 0o600 with O_EXCL) and
+    # atomically replace the target. The token is thus only ever written to a
+    # born-owner-only file, closing the open()+chmod TOCTOU window even when a
+    # credentials file already exists with looser permissions (#772).
+    fd, tmp_path = tempfile.mkstemp(
+        dir=creds_path.parent, prefix=".credentials-", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(credentials, f, indent=2)
+        os.replace(tmp_path, creds_path)
+    except BaseException:
+        # Never leave a stray temp file holding the token behind.
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
     logger.debug(f"Token stored in {creds_path}")
 

--- a/codeframe/cli/auth_commands.py
+++ b/codeframe/cli/auth_commands.py
@@ -8,6 +8,15 @@ This module provides commands for:
 - Managing API credentials (setup, list, validate, rotate, remove)
 - Managing API keys (create, list, revoke, rotate)
 
+Note on api-key-* commands (local-admin only):
+    The api-key-* commands operate directly on the local CodeFRAME database
+    (get_db_for_cli) with no server-side authorization. Whoever can run them
+    already has filesystem access to that database, so the --user-id option is a
+    target selector, not an authorization boundary — it does not grant any
+    privilege the caller lacks. Restrict these commands to the machine's admin by
+    protecting the database file. For remote/authenticated key management, use
+    the authenticated server API instead.
+
 Usage:
     codeframe auth login --email user@example.com --password secret
     codeframe auth logout
@@ -33,7 +42,12 @@ import typer
 from rich.table import Table
 
 from codeframe.cli.auth import store_token, clear_token, is_authenticated
-from codeframe.cli.api_client import APIClient, AuthenticationError, get_api_base_url
+from codeframe.cli.api_client import (
+    APIClient,
+    AuthenticationError,
+    get_api_base_url,
+    is_insecure_transport,
+)
 from codeframe.cli.helpers import console
 from codeframe.core.credentials import (
     CredentialManager,
@@ -270,6 +284,11 @@ def login(
 
     # Call login API
     base_url = get_api_base_url()
+    if is_insecure_transport(base_url):
+        console.print(
+            f"[yellow]Warning:[/yellow] Sending your password over insecure http:// to "
+            f"{base_url}. Your credentials are not encrypted in transit. Use https://."
+        )
     login_url = f"{base_url}/auth/jwt/login"
 
     try:
@@ -363,6 +382,11 @@ def register(
 
     # Call register API
     base_url = get_api_base_url()
+    if is_insecure_transport(base_url):
+        console.print(
+            f"[yellow]Warning:[/yellow] Sending your password over insecure http:// to "
+            f"{base_url}. Your credentials are not encrypted in transit. Use https://."
+        )
     register_url = f"{base_url}/auth/register"
 
     try:
@@ -783,7 +807,7 @@ def remove_credential(
 @auth_app.command("api-key-create")
 def api_key_create(
     name: str = typer.Option(..., "--name", "-n", help="Human-readable name for the key"),
-    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID to create key for"),
+    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID to create key for (local-admin only; not an auth boundary)"),
     scopes: Optional[str] = typer.Option(
         None, "--scopes", "-s", help="Comma-separated scopes (default: read,write)"
     ),
@@ -839,7 +863,7 @@ def api_key_create(
 
 @auth_app.command("api-key-list")
 def api_key_list(
-    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID to list keys for"),
+    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID to list keys for (local-admin only; not an auth boundary)"),
 ):
     """List all API keys for a user.
 
@@ -892,7 +916,7 @@ def api_key_list(
 @auth_app.command("api-key-revoke")
 def api_key_revoke(
     key_id: str = typer.Argument(..., help="API key ID to revoke"),
-    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID (must own the key)"),
+    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID (local-admin only; not an auth boundary)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ):
     """Revoke an API key.
@@ -928,7 +952,7 @@ def api_key_revoke(
 @auth_app.command("api-key-rotate")
 def api_key_rotate(
     key_id: str = typer.Argument(..., help="API key ID to rotate"),
-    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID (must own the key)"),
+    user_id: int = typer.Option(..., "--user-id", "-u", help="User ID (local-admin only; not an auth boundary)"),
 ):
     """Rotate an API key.
 

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -12,6 +12,18 @@ Security features:
 - Machine-specific encryption keys
 - Audit logging for credential operations
 
+Threat model — file-fallback confidentiality (#772):
+    The encrypted-file fallback derives its key from a machine-specific
+    identifier (e.g. /etc/machine-id). That identifier is NOT a secret: a local
+    attacker who can read the ciphertext file can typically also read the
+    machine-id and re-derive the key. So this layer is obfuscation-at-rest that
+    stops casual disk/backup snooping — it is NOT confidentiality against a
+    local attacker with your file access. For real confidentiality either (a)
+    rely on the OS keyring (the primary, preferred backend), or (b) set the
+    CODEFRAME_CREDENTIAL_SECRET environment variable, which mixes a real secret
+    into the KDF. Changing/adding that secret rekeys the store, so previously
+    stored credentials become undecryptable and must be re-entered.
+
 Usage:
     from codeframe.core.credentials import CredentialManager, CredentialProvider
 
@@ -236,6 +248,13 @@ def derive_encryption_key(salt_file: Path) -> bytes:
     Uses PBKDF2 with machine ID and a persistent salt to create
     a Fernet-compatible encryption key.
 
+    The machine ID is not secret, so on its own this only obfuscates the file
+    at rest (see the module docstring "Threat model"). When the
+    CODEFRAME_CREDENTIAL_SECRET environment variable is set, its value is mixed
+    into the KDF input to provide real confidentiality. Note: adding or changing
+    that secret changes the derived key, rendering any previously stored
+    credentials undecryptable (they must be re-entered).
+
     Args:
         salt_file: Path to store/retrieve the salt
 
@@ -261,8 +280,16 @@ def derive_encryption_key(salt_file: Path) -> bytes:
         # Secure permissions
         salt_file.chmod(0o600)
 
-    # Get machine-specific identifier
+    # Get machine-specific identifier; optionally mix in a real user secret so
+    # the key isn't recoverable from the (non-secret) machine ID alone (#772).
     machine_id = _get_machine_id()
+    user_secret = os.environ.get("CODEFRAME_CREDENTIAL_SECRET")
+    # When no secret is set, key material stays exactly machine_id (unchanged
+    # from prior versions) so existing stored credentials remain decryptable.
+    if user_secret:
+        key_material = f"{machine_id}\0{user_secret}".encode()
+    else:
+        key_material = machine_id.encode()
 
     # Derive key using PBKDF2
     kdf = PBKDF2HMAC(
@@ -271,7 +298,7 @@ def derive_encryption_key(salt_file: Path) -> bytes:
         salt=salt,
         iterations=480000,
     )
-    key = base64.urlsafe_b64encode(kdf.derive(machine_id.encode()))
+    key = base64.urlsafe_b64encode(kdf.derive(key_material))
 
     return key
 

--- a/tests/cli/test_api_client.py
+++ b/tests/cli/test_api_client.py
@@ -15,7 +15,24 @@ from codeframe.cli.api_client import (
     APIError,
     AuthenticationError,
     get_api_base_url,
+    is_insecure_transport,
 )
+
+
+class TestIsInsecureTransport:
+    """Tests for is_insecure_transport (credential-leaking transport guard)."""
+
+    def test_https_is_secure(self):
+        assert is_insecure_transport("https://api.example.com") is False
+
+    def test_http_loopback_is_ok(self):
+        assert is_insecure_transport("http://localhost:8080") is False
+        assert is_insecure_transport("http://127.0.0.1:8080") is False
+        assert is_insecure_transport("http://[::1]:8080") is False
+
+    def test_http_remote_is_insecure(self):
+        assert is_insecure_transport("http://api.example.com") is True
+        assert is_insecure_transport("http://192.168.1.50:8080") is True
 
 
 class TestGetApiBaseUrl:

--- a/tests/cli/test_auth_module.py
+++ b/tests/cli/test_auth_module.py
@@ -105,6 +105,63 @@ class TestStoreToken:
         mode = creds_path.stat().st_mode & 0o777
         assert mode == 0o600
 
+    def test_store_token_directory_permissions(self, tmp_path):
+        """The .codeframe directory should be owner-only (0o700)."""
+        creds_path = tmp_path / ".codeframe" / "credentials.json"
+
+        with patch("codeframe.cli.auth.get_credentials_path", return_value=creds_path):
+            store_token("secret-token")
+
+        dir_mode = creds_path.parent.stat().st_mode & 0o777
+        assert dir_mode == 0o700
+
+    def test_store_token_no_world_readable_window(self, tmp_path):
+        """The file must never exist world/group-readable, even mid-write.
+
+        Regression for the TOCTOU where open()+chmod left a window in which the
+        JWT was 0o644. Under a permissive umask the file must still be born
+        0o600. We inspect the on-disk mode at the moment content is written.
+        """
+        creds_path = tmp_path / ".codeframe" / "credentials.json"
+        observed = {}
+
+        real_dump = json.dump
+
+        def spy_dump(obj, fp, *args, **kwargs):
+            # Inspect the exact file the token bytes are being written into.
+            observed["mode"] = os.stat(fp.fileno()).st_mode & 0o777
+            return real_dump(obj, fp, *args, **kwargs)
+
+        old_umask = os.umask(0o000)
+        try:
+            with patch("codeframe.cli.auth.get_credentials_path", return_value=creds_path), patch(
+                "codeframe.cli.auth.json.dump", side_effect=spy_dump
+            ):
+                store_token("secret-token")
+        finally:
+            os.umask(old_umask)
+
+        assert observed["mode"] == 0o600
+
+    def test_store_token_replaces_loose_preexisting_file(self, tmp_path):
+        """A pre-existing world-readable credentials file must not receive the
+        new token; the final file is 0o600 with the new content.
+
+        Regression: os.open(O_CREAT|O_TRUNC) would keep a pre-existing file's
+        loose perms while writing the token. The atomic temp+replace closes it.
+        """
+        creds_dir = tmp_path / ".codeframe"
+        creds_dir.mkdir()
+        creds_path = creds_dir / "credentials.json"
+        creds_path.write_text('{"access_token": "old"}')
+        creds_path.chmod(0o644)
+
+        with patch("codeframe.cli.auth.get_credentials_path", return_value=creds_path):
+            store_token("new-token")
+
+        assert creds_path.stat().st_mode & 0o777 == 0o600
+        assert json.loads(creds_path.read_text())["access_token"] == "new-token"
+
 
 class TestGetToken:
     """Tests for get_token function."""

--- a/tests/core/test_credentials.py
+++ b/tests/core/test_credentials.py
@@ -623,3 +623,32 @@ class TestValidation:
 
         # Invalid - too short
         assert validate_credential_format(CredentialProvider.LLM_OPENAI, "sk-short") is False
+
+
+class TestEncryptionKeyDerivation:
+    """Tests for derive_encryption_key (machine-id KDF + optional secret)."""
+
+    def test_key_is_deterministic_without_secret(self, tmp_path):
+        """Same machine + same salt -> same key when no secret is set."""
+        from codeframe.core.credentials import derive_encryption_key
+
+        salt_file = tmp_path / "salt"
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CODEFRAME_CREDENTIAL_SECRET", None)
+            key1 = derive_encryption_key(salt_file)
+            key2 = derive_encryption_key(salt_file)
+        assert key1 == key2
+
+    def test_credential_secret_changes_derived_key(self, tmp_path):
+        """Mixing CODEFRAME_CREDENTIAL_SECRET must change the derived key."""
+        from codeframe.core.credentials import derive_encryption_key
+
+        salt_file = tmp_path / "salt"
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CODEFRAME_CREDENTIAL_SECRET", None)
+            base_key = derive_encryption_key(salt_file)
+
+        with patch.dict(os.environ, {"CODEFRAME_CREDENTIAL_SECRET": "hunter2"}):
+            secret_key = derive_encryption_key(salt_file)
+
+        assert secret_key != base_key


### PR DESCRIPTION
## Summary
Batch fix for the four low-severity, local-attacker credential windows in #772.

| AC | Fix |
|----|-----|
| **JWT atomic `0o600` (dir `0o700`)** | `store_token` now writes to a `tempfile.mkstemp` file (born `0o600`, `O_EXCL`) and `os.replace`s it into place. Closes the `open()`+`chmod` TOCTOU **even when a loose credentials file already exists**. Parent dir forced to `0o700`. |
| **Credential-file confidentiality** | Documented in module + `derive_encryption_key` docstrings that the machine-id KDF is obfuscation-at-rest, *not* confidentiality against a local reader (the machine-id isn't secret). Added opt-in `CODEFRAME_CREDENTIAL_SECRET` mixed into PBKDF2 for real confidentiality. Backward-compatible: unset → identical key to before, so existing stored credentials still decrypt. |
| **Non-loopback `http://` warning** | New pure helper `is_insecure_transport(url)`. Prominent console warning in `login`/`register` (password) and `logger.warning` in `APIClient` when a bearer token is attached to a cleartext remote URL. Warns rather than hard-refuses so LAN self-hosted `http://` stays usable. |
| **api-key commands local-admin-only** | Documented in the module docstring and every `--user-id` help string that these run directly against the local DB with no server authz — `--user-id` is a target selector, not an authorization boundary. |

## Tests (TDD)
- `test_auth_module`: dir `0o700`; token only ever written to a `0o600` file (spied under permissive umask); pre-existing `0o644` file is atomically replaced, never written into.
- `test_credentials`: `CODEFRAME_CREDENTIAL_SECRET` changes the derived key; unset stays deterministic (backward compat).
- `test_api_client`: `is_insecure_transport` truth table (https / http-loopback safe; http-remote insecure).

All touched suites green; `ruff` + strict `mypy` clean.

## Review
Cross-family security review via opencode (GLM): **sound against all 4 goals, no Critical/Major**. Its one substantive observation — the pre-existing-loose-file window under `os.open` — is fixed here via the temp+atomic-replace upgrade.

## Known limitations
- `CODEFRAME_CREDENTIAL_SECRET` rekeys the store: adding/changing it makes previously stored credentials undecryptable (documented; they must be re-entered).
- Insecure-transport is a **warning**, not a refusal (intentional, for LAN self-hosting).
- `0.0.0.0` / empty host now treated as insecure (conservative).

Closes #772