### PR TITLE
test(test-trust): re-enable stale-skipped suites & fix no-op assertions (#773)

### DIFF
--- a/tests/blockers/test_blocker_expiration_minimal.py
+++ b/tests/blockers/test_blocker_expiration_minimal.py
@@ -1,7 +1,7 @@
 """Minimal tests for blocker expiration to isolate timeout issues."""
 
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def test_expire_stale_blockers_direct_sql():
@@ -64,8 +64,10 @@ def test_expire_stale_blockers_direct_sql():
         (1, 1, "Test Task", "Test", "pending", 0),
     )
 
-    # Create stale blocker (25 hours old)
-    stale_time = (datetime.now() - timedelta(hours=25)).isoformat()
+    # Create stale blocker (25 hours old). Use UTC — the expiry SQL compares
+    # against datetime('now'), which SQLite evaluates in UTC. A naive local
+    # datetime.now() makes this test pass/fail by the runner's timezone offset.
+    stale_time = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
     conn.execute(
         """
         INSERT INTO blockers (agent_id, task_id, blocker_type, question, status, created_at)

--- a/tests/cli/test_serve_command.py
+++ b/tests/cli/test_serve_command.py
@@ -1,200 +1,90 @@
-"""Tests for the serve CLI command.
+"""Tests for the `cf serve` CLI command.
 
-These tests are skipped during v2 refactor as the serve command is an optional
-adapter layer (not part of Golden Path). The current serve command is a stub.
-These tests will be enabled when the server adapter is implemented.
+`serve` is a thin, optional adapter that starts uvicorn on the FastAPI app — it
+is NOT part of the Golden Path (the CLI works with no server running). These
+tests mock ``uvicorn.run`` so nothing binds a socket, and assert the command
+wires host/port/reload through correctly and prints the startup banner.
+
+The command's real signature is ``serve(--port/-p, --host, --reload)`` calling
+``uvicorn.run("codeframe.ui.server:app", host=, port=, reload=)`` directly. It
+does NOT shell out via subprocess, do pre-flight port checks, open a browser, or
+take ``--no-browser`` — the pre-v2 stub these tests used to mock never shipped.
 """
 
-import subprocess
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
-# Skip all tests in this module - serve command is stub during v2 refactor
-pytestmark = pytest.mark.skip(
-    reason="serve command is stub - server adapter not yet implemented (v2 Golden Path)"
-)
+from codeframe.cli.app import app
 
-# Tests for serve command following TDD approach
+pytestmark = pytest.mark.v2
+
 runner = CliRunner()
 
 
-class TestServeBasicFunctionality:
-    """Test basic serve command functionality (User Story 1)."""
+class TestServeCommand:
+    """`cf serve` wires uvicorn with the requested host/port/reload."""
 
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_default_port(self, mock_port_check, mock_run):
-        """Test that serve command uses default port 8080."""
-        from codeframe.cli.app import app
+    def test_default_host_port_and_app(self):
+        """No flags → uvicorn.run on the v2 app at 0.0.0.0:8080, reload off."""
+        with patch("uvicorn.run") as mock_run:
+            result = runner.invoke(app, ["serve"])
 
-        # Mock port as available
-        mock_port_check.return_value = (True, "")
-        # Mock subprocess to avoid actually starting server
-        mock_run.return_value = Mock(returncode=0)
-
-        # Run command
-        runner.invoke(app, ["serve", "--no-browser"])
-
-        # Verify uvicorn was called with port 8080
+        assert result.exit_code == 0
         assert mock_run.called
-        call_args = mock_run.call_args[0][0]  # Get the command list
-        assert "uvicorn" in call_args
-        assert "--port" in call_args
-        port_index = call_args.index("--port") + 1
-        assert call_args[port_index] == "8080"
+        args, kwargs = mock_run.call_args
+        # The app import string is passed positionally to uvicorn.run.
+        assert args[0] == "codeframe.ui.server:app"
+        assert kwargs["host"] == "0.0.0.0"
+        assert kwargs["port"] == 8080
+        assert kwargs["reload"] is False
 
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_keyboard_interrupt(self, mock_port_check, mock_run):
-        """Test graceful shutdown on Ctrl+C."""
-        from codeframe.cli.app import app
+    def test_custom_port(self):
+        """--port overrides the default and is passed as an int."""
+        with patch("uvicorn.run") as mock_run:
+            result = runner.invoke(app, ["serve", "--port", "3000"])
 
-        # Mock port as available
-        mock_port_check.return_value = (True, "")
-        # Mock subprocess to raise KeyboardInterrupt (simulating Ctrl+C)
-        mock_run.side_effect = KeyboardInterrupt()
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["port"] == 3000
 
-        # Run command - should handle KeyboardInterrupt gracefully
-        result = runner.invoke(app, ["serve", "--no-browser"])
+    def test_custom_port_short_flag(self):
+        """-p is the short form of --port."""
+        with patch("uvicorn.run") as mock_run:
+            result = runner.invoke(app, ["serve", "-p", "4567"])
 
-        # Should have attempted to start server
-        assert mock_run.called
-        # Should show shutdown message
-        assert "Server stopped" in result.stdout
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["port"] == 4567
 
+    def test_custom_host(self):
+        """--host binds the requested interface."""
+        with patch("uvicorn.run") as mock_run:
+            result = runner.invoke(app, ["serve", "--host", "127.0.0.1"])
 
-class TestServeCustomPort:
-    """Test custom port configuration (User Story 2)."""
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["host"] == "127.0.0.1"
 
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_custom_port(self, mock_port_check, mock_run):
-        """Test that --port flag sets custom port."""
-        from codeframe.cli.app import app
+    def test_reload_flag_enables_reload(self):
+        """--reload turns on uvicorn auto-reload."""
+        with patch("uvicorn.run") as mock_run:
+            result = runner.invoke(app, ["serve", "--reload"])
 
-        # Mock port as available
-        mock_port_check.return_value = (True, "")
-        mock_run.return_value = Mock(returncode=0)
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["reload"] is True
 
-        # Run command with custom port
-        runner.invoke(app, ["serve", "--port", "3000", "--no-browser"])
+    def test_prints_startup_banner_with_port(self):
+        """The banner surfaces the docs URL for the chosen port before serving."""
+        with patch("uvicorn.run"):
+            result = runner.invoke(app, ["serve", "--port", "9123"])
 
-        # Verify uvicorn was called with port 3000
-        assert mock_run.called
-        call_args = mock_run.call_args[0][0]
-        assert "--port" in call_args
-        port_index = call_args.index("--port") + 1
-        assert call_args[port_index] == "3000"
+        assert result.exit_code == 0
+        assert "9123" in result.stdout
+        assert "/docs" in result.stdout
 
-    def test_serve_port_validation(self):
-        """Test that port <1024 is rejected with helpful error."""
-        from codeframe.cli.app import app
+    def test_uvicorn_not_started_on_bad_option(self):
+        """An unknown option is a usage error — uvicorn is never invoked."""
+        with patch("uvicorn.run") as mock_run:
+            result = runner.invoke(app, ["serve", "--definitely-not-a-flag"])
 
-        # Attempt to use privileged port should fail
-        result = runner.invoke(app, ["serve", "--port", "80"])
         assert result.exit_code != 0
-        assert "elevated privileges" in result.stdout
-
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_port_in_use(self, mock_port_check, mock_run):
-        """Test helpful error when port is already in use."""
-        from codeframe.cli.app import app
-
-        # Simulate port already in use
-        mock_port_check.return_value = (False, "Port 8080 is already in use")
-
-        # Run command
-        result = runner.invoke(app, ["serve"])
-
-        # Should exit with error
-        assert result.exit_code != 0
-        # Should not attempt to start server
         assert not mock_run.called
-
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_subprocess_failure(self, mock_port_check, mock_run):
-        """Test error handling when server subprocess fails to start."""
-        from codeframe.cli.app import app
-
-        # Port check passes
-        mock_port_check.return_value = (True, "")
-
-        # But subprocess fails (e.g., port conflict, permission error, etc.)
-        mock_run.side_effect = subprocess.CalledProcessError(1, "uvicorn")
-
-        # Run command
-        result = runner.invoke(app, ["serve", "--no-browser"])
-
-        # Should exit with error
-        assert result.exit_code != 0
-        # Should show helpful troubleshooting message
-        assert "failed to start" in result.stdout.lower()
-        assert "common issues" in result.stdout.lower()
-
-
-class TestServeBrowserOpening:
-    """Test browser auto-open functionality (User Story 3)."""
-
-    @patch("codeframe.cli.threading.Thread")
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_browser_opens(self, mock_port_check, mock_run, mock_thread):
-        """Test that browser opens automatically by default."""
-        from codeframe.cli.app import app
-
-        # Mock port as available
-        mock_port_check.return_value = (True, "")
-        mock_run.return_value = Mock(returncode=0)
-        mock_thread_instance = Mock()
-        mock_thread.return_value = mock_thread_instance
-
-        # Run command with default (browser enabled)
-        runner.invoke(app, ["serve"])
-
-        # Verify background thread was created for browser opening
-        assert mock_thread.called
-        # Verify thread was started
-        assert mock_thread_instance.start.called
-
-    @patch("codeframe.cli.threading.Thread")
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_no_browser(self, mock_port_check, mock_run, mock_thread):
-        """Test that --no-browser flag prevents browser opening."""
-        from codeframe.cli.app import app
-
-        # Mock port as available
-        mock_port_check.return_value = (True, "")
-        mock_run.return_value = Mock(returncode=0)
-
-        # Run command with --no-browser
-        runner.invoke(app, ["serve", "--no-browser"])
-
-        # Browser thread should NOT be created
-        assert not mock_thread.called
-
-
-class TestServeReloadFlag:
-    """Test development reload functionality (User Story 4)."""
-
-    @patch("codeframe.cli.subprocess.run")
-    @patch("codeframe.cli.check_port_availability")
-    def test_serve_reload_flag(self, mock_port_check, mock_run):
-        """Test that --reload flag is passed to uvicorn."""
-        from codeframe.cli.app import app
-
-        # Mock port as available
-        mock_port_check.return_value = (True, "")
-        mock_run.return_value = Mock(returncode=0)
-
-        # Run command with --reload
-        runner.invoke(app, ["serve", "--reload", "--no-browser"])
-
-        # Verify --reload was passed to uvicorn
-        assert mock_run.called
-        call_args = mock_run.call_args[0][0]
-        assert "--reload" in call_args

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -1512,19 +1512,33 @@ class TestParallelExecution:
     """Tests for parallel batch execution."""
 
     def test_parallel_independent_tasks_run_concurrently(self, workspace_with_tasks):
-        """Independent tasks should run in parallel."""
-        workspace, task_list = workspace_with_tasks
-        task_ids = [t.id for t in task_list]  # 3 independent tasks
+        """Independent tasks must actually run concurrently — not merely complete.
 
-        execution_order = []
+        Deterministic concurrency proof via a Barrier: every task body blocks
+        until all N are simultaneously in-flight. A serial executor can never get
+        N task bodies to the barrier at once, so it trips the timeout and raises
+        BrokenBarrierError → the test fails. The old version asserted only
+        completion and would pass green even if execution were fully serial
+        (the exact no-op-assertion this batch targets, #773). Sleep-based overlap
+        detection is avoided on purpose: per-task bookkeeping is serialized, so a
+        short sleep makes overlap timing-dependent and flaky.
+        """
         import threading
 
+        workspace, task_list = workspace_with_tasks
+        task_ids = [t.id for t in task_list]  # 3 independent tasks
+        n = len(task_ids)
+
+        barrier = threading.Barrier(n, timeout=15)
+        threads_seen: set[str] = set()
+        seen_lock = threading.Lock()
+
         def mock_execute(ws, tid, batch_id=None, **kwargs):
-            # Record when each task starts
-            execution_order.append(("start", tid, threading.current_thread().name))
-            import time
-            time.sleep(0.05)  # Small delay to allow overlap detection
-            execution_order.append(("end", tid, threading.current_thread().name))
+            with seen_lock:
+                threads_seen.add(threading.current_thread().name)
+            # Blocks until all N task bodies reach here at the same time. Serial
+            # execution never reaches N concurrently → BrokenBarrierError on timeout.
+            barrier.wait()
             return "COMPLETED"
 
         with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_execute):
@@ -1532,13 +1546,14 @@ class TestParallelExecution:
                 workspace,
                 task_ids,
                 strategy="parallel",
-                max_parallel=3,
+                max_parallel=n,
             )
 
         assert batch.status == BatchStatus.COMPLETED
-        # All tasks should be complete
         for tid in task_ids:
             assert batch.results[tid] == "COMPLETED"
+        # All N task bodies were in-flight simultaneously on distinct workers.
+        assert len(threads_seen) == n
 
     def test_parallel_respects_max_parallel(self, workspace_with_tasks):
         """max_parallel should limit concurrent execution."""

--- a/tests/lifecycle/test_cli_lifecycle.py
+++ b/tests/lifecycle/test_cli_lifecycle.py
@@ -7,7 +7,6 @@ not just that API calls succeed.
 Runtime: 10–30 minutes. Cost: ~$0.50–2.00 per run (haiku/sonnet).
 """
 
-import json
 import pytest
 
 from tests.lifecycle.sample_project.acceptance import run_acceptance_checks
@@ -71,20 +70,21 @@ class TestCLILifecycle:
             timeout=1800,
         )
 
-        result = cf("tasks", "list", "--output", "json")
-        if result.returncode != 0:
-            pytest.skip("tasks list --output json not supported, skipping status check")
+        # Query IN_PROGRESS tasks via a supported Golden-Path command. A failure
+        # of the command itself must FAIL the test, not silently skip it — a
+        # broken `cf tasks list` is exactly the kind of Golden-Path regression
+        # this lifecycle test exists to catch (#773). ``cf tasks list --output
+        # json`` does not exist; ``--status`` filtering does.
+        result = cf("tasks", "list", "--status", "IN_PROGRESS")
+        assert result.returncode == 0, (
+            f"`cf tasks list --status IN_PROGRESS` failed (exit {result.returncode}) — "
+            f"a Golden-Path command must not fail.\n"
+            f"stdout:\n{result.stdout[-1000:]}\nstderr:\n{result.stderr[-500:]}"
+        )
 
-        try:
-            tasks = json.loads(result.stdout)
-        except (json.JSONDecodeError, ValueError):
-            pytest.skip("Could not parse tasks JSON, skipping status check")
-
-        stuck = [
-            t for t in tasks
-            if t.get("status") == "IN_PROGRESS"
-        ]
-        assert not stuck, (
-            f"{len(stuck)} task(s) still IN_PROGRESS after batch run: "
-            + ", ".join(t.get("id", "?") for t in stuck)
+        # With no IN_PROGRESS tasks the CLI prints the sentinel; any stuck task
+        # instead renders in the tasks table, so the sentinel is absent.
+        assert "No tasks with status IN_PROGRESS" in result.stdout, (
+            "One or more tasks are still IN_PROGRESS after the batch run "
+            f"(none should be):\n{result.stdout}"
         )

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -21,13 +21,16 @@ import pytest
 import requests
 import shutil
 
-# Two legacy WebSocket tests are still in transition. They reference live
-# managers but use the v1 get_db/get_db_websocket plumbing; until they are
-# rewritten on the v2 dependencies, keep them excluded from collection.
-collect_ignore = [
-    "test_websocket_integration.py",
-    "test_websocket_subscriptions.py",
-]
+# Both legacy WebSocket suites are now collected normally instead of being hidden
+# here:
+#   * test_websocket_subscriptions.py is a pure unit suite (WebSocketSubscription
+#     manager / ConnectionManager with mock sockets — no server, no get_db) and
+#     passes as-is.
+#   * test_websocket_integration.py targets the removed v1 `/ws` project-
+#     subscription protocol (no such route or subscribe handler exists on the v2
+#     server), so it carries a truthful module-level skip until it is rewritten
+#     against the v2 workspace-scoped streaming API — not the false "server is a
+#     stub" reason it used to hide behind.
 
 from codeframe.platform_store.database import Database  # noqa: E402
 

--- a/tests/ui/test_proof_v2.py
+++ b/tests/ui/test_proof_v2.py
@@ -320,9 +320,15 @@ class TestRunProof:
         assert response.status_code == 422
 
     def test_run_results_shape(self, test_client):
-        """results is a dict mapping req_id to list of gate results."""
+        """results maps req_id → a NON-EMPTY list of executed gate results.
+
+        Asserts real gate execution, not just JSON shape: a captured requirement
+        must produce obligations that actually run and yield gate outcomes. The
+        old version asserted only isinstance(dict), so it stayed green even if no
+        gate ever executed — the shape-only no-op this batch targets (#773).
+        """
         # Capture a requirement first so there's something to run
-        test_client.post(
+        capture = test_client.post(
             "/api/v2/proof/requirements",
             json={
                 "title": "Run test req",
@@ -332,9 +338,18 @@ class TestRunProof:
                 "source": "qa",
             },
         )
+        assert capture.status_code == 201
         response = test_client.post("/api/v2/proof/run", json={"full": True})
         data = response.json()
         assert isinstance(data["results"], dict)
+        # The captured requirement was evaluated → at least one req_id with gates.
+        assert data["results"], "expected the captured requirement to be evaluated"
+        gate_results = [gr for reqs in data["results"].values() for gr in reqs]
+        assert gate_results, "expected at least one gate to actually execute"
+        # Each executed gate carries the real result contract (not just any dict).
+        for gr in gate_results:
+            assert set(gr) >= {"gate", "satisfied", "status"}
+            assert gr["status"] in ("passed", "failed", "unverifiable")
 
     def test_run_results_carry_status(self, test_client):
         """Each gate result carries a tri-state status alongside satisfied."""

--- a/tests/ui/test_terminal_ws.py
+++ b/tests/ui/test_terminal_ws.py
@@ -49,24 +49,27 @@ def _reset_tickets():
 
 class TestTerminalWsAuth:
     def test_missing_ticket_closes_4001(self, monkeypatch):
+        """No ticket in auth mode → closed with 4001 (auth failure), not just 'raised'.
+        Asserting the exact code is what makes a silent auth bypass fail this test."""
         monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         app = _make_app()
         client = TestClient(app)
-        with pytest.raises(Exception):
-            # No ticket → closed before accepting; TestClient raises on non-101
+        with pytest.raises(WebSocketDisconnect) as exc:
             with client.websocket_connect("/ws/sessions/s1/terminal"):
                 pass
+        assert exc.value.code == 4001
 
     def test_unknown_ticket_closes_4001(self, monkeypatch):
         monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         app = _make_app()
         client = TestClient(app)
-        with pytest.raises(Exception):
+        with pytest.raises(WebSocketDisconnect) as exc:
             with client.websocket_connect("/ws/sessions/s1/terminal?ticket=not-a-real-ticket"):
                 pass
+        assert exc.value.code == 4001
 
     def test_valid_ticket_session_not_found(self):
-        """Valid ticket but session does not exist → closed."""
+        """Valid ticket but session does not exist → closed 4004."""
         app = _make_app(session_data=None)
         client = TestClient(app)
 
@@ -75,12 +78,13 @@ class TestTerminalWsAuth:
             "codeframe.ui.routers.terminal_ws._authenticate_websocket",
             new=AsyncMock(return_value=(True, 1)),
         ):
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as exc:
                 with client.websocket_connect("/ws/sessions/missing/terminal?ticket=x"):
                     pass
+            assert exc.value.code == 4004
 
     def test_valid_ticket_ended_session(self):
-        """Valid ticket but session is ended → closed."""
+        """Valid ticket but session is ended → closed 4004."""
         app = _make_app(session_data={"state": "ended", "workspace_path": "/tmp"})
         client = TestClient(app)
 
@@ -88,12 +92,14 @@ class TestTerminalWsAuth:
             "codeframe.ui.routers.terminal_ws._authenticate_websocket",
             new=AsyncMock(return_value=(True, 1)),
         ):
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as exc:
                 with client.websocket_connect("/ws/sessions/s1/terminal?ticket=x"):
                     pass
+            assert exc.value.code == 4004
 
     def test_ownership_mismatch_closes(self):
-        """Ticket user_id does not match session user_id → closed."""
+        """Ticket user_id does not match session user_id → closed 4003 (forbidden).
+        A bypass that let the connection through would fail this exact-code assert."""
         app = _make_app(
             session_data={"state": "active", "workspace_path": "/tmp", "user_id": 999}
         )
@@ -103,9 +109,10 @@ class TestTerminalWsAuth:
             "codeframe.ui.routers.terminal_ws._authenticate_websocket",
             new=AsyncMock(return_value=(True, 1)),
         ):
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as exc:
                 with client.websocket_connect("/ws/sessions/s1/terminal?ticket=x"):
                     pass
+            assert exc.value.code == 4003
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_websocket_integration.py
+++ b/tests/ui/test_websocket_integration.py
@@ -12,9 +12,15 @@ This test suite validates the complete WebSocket subscription lifecycle includin
 The tests use real WebSocket connections via the `websockets` library to
 validate message routing correctness against a running FastAPI server.
 
-NOTE: These tests are skipped during v2 refactor. They require a running FastAPI
-server with full WebSocket support, but the v2 serve command is a stub.
-The server adapter will be implemented post-Golden Path.
+NOTE: These tests target the *removed* v1 `/ws` project-subscription protocol
+(``{"type": "subscribe", "project_id": N}`` → filtered broadcasts via
+``/test/broadcast``). The v2 server exposes no `/ws` route and no such subscribe
+handler — streaming is now workspace-scoped via streaming_v2.py — so this suite
+cannot pass without a full rewrite against the v2 streaming API. The unit-level
+behaviour of the subscription/connection managers is already covered by
+test_websocket_subscriptions.py. This module is collected (not hidden in
+conftest) but skipped with a truthful reason rather than the old, false
+"serve command is a stub" claim.
 """
 
 import asyncio
@@ -23,11 +29,13 @@ import pytest
 import requests
 import websockets
 
-# Skip tests that require running_server fixture - server is stub in v2
-# Tests using WebSocketSubscriptionManager directly (no server) will still run
-pytestmark = pytest.mark.skipif(
-    True,  # Skip all by default, individual tests override if needed
-    reason="WebSocket integration tests require full server - serve command is stub in v2"
+# Truthful skip: the v1 /ws project-subscription protocol these tests drive was
+# removed in the v2 refactor. Rewrite against the v2 workspace-scoped streaming
+# API to revive them.
+pytestmark = pytest.mark.skip(
+    reason="Targets removed v1 /ws project-subscription protocol; needs rewrite "
+    "against the v2 workspace-scoped streaming API (see test_websocket_subscriptions.py "
+    "for the current unit-level coverage)."
 )
 
 


### PR DESCRIPTION
Closes #773 — **[P3.2] Test-trust cleanup** batch. Every change makes a previously-vacuous test able to **fail on the regression it names**. Tests only; **no production code changed**.

## What & why

| Area | Before (green-but-vacuous) | After |
|------|----------------------------|-------|
| `tests/blockers/test_blocker_expiration_minimal.py` | naive `datetime.now()` vs SQLite `datetime('now')` (UTC) → pass/fail by runner TZ | `datetime.now(timezone.utc)` — **verified under `TZ=UTC+14`** (would fail pre-fix) |
| `tests/ui/test_terminal_ws.py` | auth/ownership tests asserted only `pytest.raises(Exception)` — a full bypass would pass | assert exact `WebSocketDisconnect.code` (**4001** auth / **4004** session / **4003** ownership) |
| `tests/ui/test_proof_v2.py` | `test_run_results_shape` asserted only `isinstance(dict)` — stayed green even if no gate ran (hid #728) | asserts obligations **actually execute** and yield real gate results (`gate`/`satisfied`/`status`) |
| `tests/core/test_conductor.py` | "run concurrently" recorded start/end order but **never asserted** it | `threading.Barrier(N)` that only trips under genuine concurrency — **mutation-checked** to fail under serial exec |
| `tests/cli/test_serve_command.py` | whole module `skip`; tests mocked a pre-v2 **stub design** (`subprocess`/`check_port`/`threading`/`--no-browser`) that never shipped | rewritten against the real impl (`uvicorn.run` wiring); **7 pass** |
| `tests/ui/test_websocket_subscriptions.py` | `collect_ignore`d behind a **false** "v1 get_db plumbing" reason | re-enabled — pure unit suite, **40 pass** |
| `tests/lifecycle/test_cli_lifecycle.py` | `pytest.skip` on CLI failure via unsupported `tasks list --output json` | **fails, not skips**, on Golden-Path failure via supported `--status IN_PROGRESS` |

## Acceptance criteria (all met)
- ✅ Passing WS/serve suites re-collected — subscriptions (40) + serve (7)
- ✅ Security tests assert exact close codes
- ✅ Proof-run tests assert real gate execution
- ✅ Parallel test asserts interleaving (barrier; mutation-verified)
- ✅ Blocker test uses UTC
- ✅ Lifecycle test fails (not skips) on Golden-Path command failure

## Known limitation
`tests/ui/test_websocket_integration.py` targets the **removed v1 `/ws` project-subscription protocol** (no `/ws` route or `subscribe` handler exists on the v2 workspace-scoped streaming server). It cannot pass without a full rewrite against the v2 streaming API, so instead of the old **false** "server is a stub" skip it now carries a **truthful** skip naming the real blocker, and is no longer hidden in `conftest`. Its unit-level coverage lives in the re-enabled `test_websocket_subscriptions.py`. Reviving it end-to-end is a separate follow-up.

## Verification
- `ruff check` clean on all touched files
- terminal_ws **11 pass**, TestRunProof **8 pass**, conductor parallel **3 pass** (×3, non-flaky), subscriptions **40 pass**, serve **7 pass**, blocker **1 pass** (TZ=UTC+14), integration **30 collected+skipped** (truthful reason)
- Dep #728 (blocking) is **CLOSED**

_Dependency note: dependent on #728 [P1.1], which is merged/closed._