### PR TITLE
fix(web-ui): remove placeholder "View Diff" from execution stream (#775)

### DIFF
--- a/web-ui/src/__tests__/components/execution/FileChangeEvent.test.tsx
+++ b/web-ui/src/__tests__/components/execution/FileChangeEvent.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { FileChangeEvent } from '@/components/execution/FileChangeEvent';
+import type { ProgressEvent } from '@/hooks/useTaskStream';
+
+function makeEvent(message: string): ProgressEvent {
+  return {
+    event_type: 'progress',
+    task_id: 'task-1',
+    timestamp: '2026-02-06T10:00:00Z',
+    phase: 'execution',
+    step: 2,
+    total_steps: 5,
+    message,
+  };
+}
+
+describe('FileChangeEvent', () => {
+  it('renders the extracted file path, not the raw message', () => {
+    render(<FileChangeEvent event={makeEvent('Creating file: src/main.py')} />);
+    expect(screen.getByText('src/main.py')).toBeInTheDocument();
+    expect(screen.queryByText('Creating file: src/main.py')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the raw message when the pattern does not match', () => {
+    render(<FileChangeEvent event={makeEvent('some other message')} />);
+    expect(screen.getByText('some other message')).toBeInTheDocument();
+  });
+
+  // Regression guard for #775: the "View Diff" toggle only expanded to a
+  // placeholder (the event message), never a real diff, so it was removed.
+  it('does not render a View Diff affordance', () => {
+    render(<FileChangeEvent event={makeEvent('Editing file: src/app.py')} />);
+    expect(screen.queryByText(/view diff/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/execution/FileChangeEvent.tsx
+++ b/web-ui/src/components/execution/FileChangeEvent.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { FileEditIcon } from '@hugeicons/core-free-icons';
-import { Button } from '@/components/ui/button';
 import type { ProgressEvent } from '@/hooks/useTaskStream';
 
 interface FileChangeEventProps {
@@ -11,40 +9,25 @@ interface FileChangeEventProps {
 }
 
 /**
- * Renders a file change event with a collapsible diff preview.
+ * Renders a file change event as a single file-path line.
  *
  * The message from the backend typically looks like:
  *   "Creating file: src/auth/middleware.py"
  *   "Editing file: src/auth/middleware.py"
+ *
+ * ponytail: no inline diff here. The stream is a live activity log; the real
+ * per-file diff lives on the /review page (DiffViewer). A previous "View Diff"
+ * toggle only expanded to the event message — a placeholder, not a diff — so it
+ * was removed (#775) rather than duplicate /review with a worse mini-viewer.
  */
 export function FileChangeEvent({ event }: FileChangeEventProps) {
-  const [expanded, setExpanded] = useState(false);
-
   // Extract file path from message (pattern: "Creating/Editing file: <path>")
   const filePath = event.message?.replace(/^(Creating|Editing|Deleting) file:\s*/i, '') ?? '';
 
   return (
-    <div className="text-sm">
-      <div className="flex items-center gap-2">
-        <HugeiconsIcon icon={FileEditIcon} className="h-4 w-4 shrink-0 text-green-600" />
-        <span className="truncate font-mono text-xs">{filePath || event.message}</span>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="ml-auto h-5 px-1.5 text-[10px] text-muted-foreground"
-          onClick={() => setExpanded(!expanded)}
-          aria-expanded={expanded}
-        >
-          {expanded ? 'Hide' : 'View Diff'}
-        </Button>
-      </div>
-      {expanded && (
-        <pre className="mt-1.5 max-h-48 overflow-auto rounded bg-muted/50 p-2 font-mono text-[11px] leading-relaxed">
-          {/* Diff content will come from OutputEvents following this ProgressEvent.
-              For now, show the event message as placeholder context. */}
-          {event.message}
-        </pre>
-      )}
+    <div className="flex items-center gap-2 text-sm">
+      <HugeiconsIcon icon={FileEditIcon} className="h-4 w-4 shrink-0 text-green-600" />
+      <span className="truncate font-mono text-xs">{filePath || event.message}</span>
     </div>
   );
 }


### PR DESCRIPTION
Closes #775

## Problem
The execution stream's `FileChangeEvent` rendered a **View Diff** button that expanded only to the one-line `event.message` placeholder (self-marked in a code comment) — never an actual diff. It advertised a capability it could not deliver.

## Why remove rather than wire it
No *correlatable per-event* diff source reaches the browser:
- The editor **does** compute a real unified diff (`core/editor.py`), but it's sent only to the LLM and run logs — the SSE `AGENT_TOOL_RESULT` event carries just metadata (`is_error`, `has_lint_errors`), not the diff text.
- The only browser-reachable diff (`GET /api/v2/review/diff` → `git diff`) **omits untracked, newly-created files** — and `FileChangeEvent` fires on "Creating file:" too, so wiring it would silently show nothing for the most common case.
- The canonical diff surface **already exists** at `/review` (`DiffViewer` + `FileTreePanel`), with per-file hunks and task context. An inline `max-h-48` mini-diff in a live log row would be a strictly worse duplicate — and mid-execution the file is still changing, so any inline diff is stale on render.

The execution stream's job is an honest live activity log; diffs belong on `/review`. Per the issue's own fallback ("remove the button until the data source exists"), the toggle + placeholder panel are removed and the file-path line is kept.

## Changes
- `FileChangeEvent.tsx`: drop `useState`/`Button`/expand + placeholder `<pre>`; render the extracted file path only. Documented with a `ponytail:` comment pointing at `/review`.
- New `FileChangeEvent.test.tsx`: asserts path extraction, raw-message fallback, and a **regression guard** that no "View Diff" button/affordance renders.

## Verification
- `npx jest .../execution/FileChangeEvent.test.tsx .../execution/EventItem.test.tsx` → 16 passed
- `npm run build` → success
- eslint on changed files → clean

## Known limitations / follow-ups (not this PR)
- If per-execution diffs are wanted in-stream later, the right move is to surface the editor's already-computed unified diff into a correlatable SSE event — a small backend feature, out of scope for this atomic UX fix.
- A lighter enhancement: deep-link the file path to `/review` filtered to that file. Deferred (YAGNI) until requested.