### PR TITLE
fix(tui): run dashboard refresh in a thread worker with a single shared connection (#776)

### DIFF
--- a/codeframe/core/blockers.py
+++ b/codeframe/core/blockers.py
@@ -6,6 +6,7 @@ until answered by a human.
 This module is headless - no FastAPI or HTTP dependencies.
 """
 
+import sqlite3
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -244,16 +245,19 @@ def get(workspace: Workspace, blocker_id: str) -> Optional[Blocker]:
     return _row_to_blocker(row)
 
 
-def list_open(workspace: Workspace) -> list[Blocker]:
+def list_open(
+    workspace: Workspace, conn: Optional[sqlite3.Connection] = None
+) -> list[Blocker]:
     """List open blockers.
 
     Args:
         workspace: Workspace to query
+        conn: Optional borrowed connection (caller keeps ownership; not closed)
 
     Returns:
         List of open Blockers, oldest first
     """
-    return list_all(workspace, status=BlockerStatus.OPEN)
+    return list_all(workspace, status=BlockerStatus.OPEN, conn=conn)
 
 
 def list_all(
@@ -261,6 +265,7 @@ def list_all(
     status: Optional[BlockerStatus] = None,
     task_id: Optional[str] = None,
     limit: int = 100,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> list[Blocker]:
     """List blockers with optional filters.
 
@@ -269,11 +274,14 @@ def list_all(
         status: Optional status filter
         task_id: Optional task filter
         limit: Maximum blockers to return
+        conn: Optional borrowed connection (caller keeps ownership; not closed)
 
     Returns:
         List of Blockers, oldest first
     """
-    conn = get_db_connection(workspace)
+    own_conn = conn is None
+    if own_conn:
+        conn = get_db_connection(workspace)
     cursor = conn.cursor()
 
     query = """
@@ -297,7 +305,8 @@ def list_all(
 
     cursor.execute(query, params)
     rows = cursor.fetchall()
-    conn.close()
+    if own_conn:
+        conn.close()
 
     return [_row_to_blocker(row) for row in rows]
 

--- a/codeframe/core/blockers.py
+++ b/codeframe/core/blockers.py
@@ -282,31 +282,33 @@ def list_all(
     own_conn = conn is None
     if own_conn:
         conn = get_db_connection(workspace)
-    cursor = conn.cursor()
+    try:
+        cursor = conn.cursor()
 
-    query = """
-        SELECT id, workspace_id, task_id, question, answer, status, created_at, answered_at,
-               COALESCE(created_by, 'human') as created_by
-        FROM blockers
-        WHERE workspace_id = ?
-    """
-    params: list = [workspace.id]
+        query = """
+            SELECT id, workspace_id, task_id, question, answer, status, created_at, answered_at,
+                   COALESCE(created_by, 'human') as created_by
+            FROM blockers
+            WHERE workspace_id = ?
+        """
+        params: list = [workspace.id]
 
-    if status:
-        query += " AND status = ?"
-        params.append(status.value)
+        if status:
+            query += " AND status = ?"
+            params.append(status.value)
 
-    if task_id:
-        query += " AND task_id = ?"
-        params.append(task_id)
+        if task_id:
+            query += " AND task_id = ?"
+            params.append(task_id)
 
-    query += " ORDER BY created_at ASC LIMIT ?"
-    params.append(limit)
+        query += " ORDER BY created_at ASC LIMIT ?"
+        params.append(limit)
 
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    if own_conn:
-        conn.close()
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+    finally:
+        if own_conn:
+            conn.close()
 
     return [_row_to_blocker(row) for row in rows]
 

--- a/codeframe/core/events.py
+++ b/codeframe/core/events.py
@@ -9,6 +9,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import json
+import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -251,6 +252,7 @@ def list_recent(
     workspace: Workspace,
     limit: int = 20,
     since_id: Optional[int] = None,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> list[Event]:
     """List recent events for a workspace.
 
@@ -258,11 +260,14 @@ def list_recent(
         workspace: Workspace to query
         limit: Maximum number of events to return
         since_id: Only return events after this ID (for pagination)
+        conn: Optional borrowed connection (caller keeps ownership; not closed)
 
     Returns:
         List of Event objects, newest first
     """
-    conn = get_db_connection(workspace)
+    own_conn = conn is None
+    if own_conn:
+        conn = get_db_connection(workspace)
     try:
         cursor = conn.cursor()
 
@@ -291,7 +296,8 @@ def list_recent(
 
         rows = cursor.fetchall()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
     return [
         Event(

--- a/codeframe/core/proof/ledger.py
+++ b/codeframe/core/proof/ledger.py
@@ -352,28 +352,30 @@ def list_requirements(
     _ensure_tables(workspace, conn=conn)
     if own_conn:
         conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-    if status:
-        cursor.execute(
-            """SELECT id, title, description, severity, source, scope, obligations,
-                      evidence_rules, status, waiver, created_at, satisfied_at,
-                      created_by, source_issue, related_reqs, glitch_type
-               FROM proof_requirements WHERE workspace_id = ? AND status = ?
-               ORDER BY created_at DESC""",
-            (workspace.id, status.value),
-        )
-    else:
-        cursor.execute(
-            """SELECT id, title, description, severity, source, scope, obligations,
-                      evidence_rules, status, waiver, created_at, satisfied_at,
-                      created_by, source_issue, related_reqs, glitch_type
-               FROM proof_requirements WHERE workspace_id = ?
-               ORDER BY created_at DESC""",
-            (workspace.id,),
-        )
-    rows = cursor.fetchall()
-    if own_conn:
-        conn.close()
+    try:
+        cursor = conn.cursor()
+        if status:
+            cursor.execute(
+                """SELECT id, title, description, severity, source, scope, obligations,
+                          evidence_rules, status, waiver, created_at, satisfied_at,
+                          created_by, source_issue, related_reqs, glitch_type
+                   FROM proof_requirements WHERE workspace_id = ? AND status = ?
+                   ORDER BY created_at DESC""",
+                (workspace.id, status.value),
+            )
+        else:
+            cursor.execute(
+                """SELECT id, title, description, severity, source, scope, obligations,
+                          evidence_rules, status, waiver, created_at, satisfied_at,
+                          created_by, source_issue, related_reqs, glitch_type
+                   FROM proof_requirements WHERE workspace_id = ?
+                   ORDER BY created_at DESC""",
+                (workspace.id,),
+            )
+        rows = cursor.fetchall()
+    finally:
+        if own_conn:
+            conn.close()
     return [_row_to_requirement(r) for r in rows]
 
 

--- a/codeframe/core/proof/ledger.py
+++ b/codeframe/core/proof/ledger.py
@@ -114,9 +114,17 @@ def init_proof_tables(workspace: Workspace) -> None:
     conn.close()
 
 
-def _ensure_tables(workspace: Workspace) -> None:
-    """Lazily init tables on first access."""
-    conn = get_db_connection(workspace)
+def _ensure_tables(
+    workspace: Workspace, conn: Optional[sqlite3.Connection] = None
+) -> None:
+    """Lazily init tables on first access.
+
+    A borrowed ``conn`` is used for the existence checks only (and not closed);
+    the one-time init/migration paths manage their own connections.
+    """
+    own_conn = conn is None
+    if own_conn:
+        conn = get_db_connection(workspace)
     cursor = conn.cursor()
     cursor.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='proof_requirements'"
@@ -137,7 +145,8 @@ def _ensure_tables(workspace: Workspace) -> None:
             "SELECT name FROM sqlite_master WHERE type='table' AND name='pr_merge_overrides'"
         )
         missing = not cursor.fetchone()
-    conn.close()
+    if own_conn:
+        conn.close()
     if missing:
         init_proof_tables(workspace)
     _migrate_evidence_status_column(workspace)
@@ -331,11 +340,18 @@ def get_requirement(workspace: Workspace, req_id: str) -> Optional[Requirement]:
 
 
 def list_requirements(
-    workspace: Workspace, status: Optional[ReqStatus] = None
+    workspace: Workspace,
+    status: Optional[ReqStatus] = None,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> list[Requirement]:
-    """List all requirements, optionally filtered by status."""
-    _ensure_tables(workspace)
-    conn = get_db_connection(workspace)
+    """List all requirements, optionally filtered by status.
+
+    ``conn``: optional borrowed connection (caller keeps ownership; not closed).
+    """
+    own_conn = conn is None
+    _ensure_tables(workspace, conn=conn)
+    if own_conn:
+        conn = get_db_connection(workspace)
     cursor = conn.cursor()
     if status:
         cursor.execute(
@@ -356,7 +372,8 @@ def list_requirements(
             (workspace.id,),
         )
     rows = cursor.fetchall()
-    conn.close()
+    if own_conn:
+        conn.close()
     return [_row_to_requirement(r) for r in rows]
 
 

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -7,6 +7,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 
 import asyncio
 import json
+import sqlite3
 import logging
 import re
 import threading
@@ -353,6 +354,7 @@ def list_tasks(
     workspace: Workspace,
     status: Optional[TaskStatus] = None,
     limit: Optional[int] = 100,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> list[Task]:
     """List tasks in a workspace.
 
@@ -361,6 +363,8 @@ def list_tasks(
         status: Optional status filter
         limit: Maximum tasks to return. ``None`` returns every task (uncapped)
             so listing/bulk ops can address tasks beyond the default cap (#743).
+        conn: Optional borrowed connection (caller keeps ownership; not closed
+            here). Lets callers batch several reads on one connection (#776).
 
     Returns:
         List of Tasks
@@ -369,7 +373,9 @@ def list_tasks(
     # it); pass limit=None to opt into an uncapped list.
     limit_clause = "" if limit is None else "LIMIT ?"
 
-    conn = get_db_connection(workspace)
+    own_conn = conn is None
+    if own_conn:
+        conn = get_db_connection(workspace)
     try:
         cursor = conn.cursor()
 
@@ -404,7 +410,8 @@ def list_tasks(
 
         rows = cursor.fetchall()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
     return [_row_to_task(row) for row in rows]
 

--- a/codeframe/tui/app.py
+++ b/codeframe/tui/app.py
@@ -163,8 +163,9 @@ class DashboardApp(App):
         """Load fresh data off the event loop, then apply it on the UI thread.
 
         The 5 SQLite queries run in a thread worker so they never block input
-        or rendering (#776). ``exclusive=True`` cancels a still-running load
-        when the next tick fires instead of piling up stale refreshes.
+        or rendering (#776). ``exclusive=True`` marks a still-running load
+        cancelled when the next tick fires; the ``is_cancelled`` guard below
+        then drops its stale snapshot instead of applying it.
         """
         if not self.workspace:
             return

--- a/codeframe/tui/app.py
+++ b/codeframe/tui/app.py
@@ -11,6 +11,8 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.widgets import DataTable, Footer, Header, RichLog, Static
+from textual.worker import get_current_worker
+from textual import work
 
 from codeframe.core.workspace import Workspace
 from codeframe.tui.data_service import DashboardData, load_dashboard_data
@@ -156,12 +158,23 @@ class DashboardApp(App):
         # Auto-refresh
         self.set_interval(self.refresh_interval, self._refresh_data)
 
+    @work(thread=True, exclusive=True, group="refresh")
     def _refresh_data(self) -> None:
-        """Load fresh data from the workspace and update all widgets."""
+        """Load fresh data off the event loop, then apply it on the UI thread.
+
+        The 5 SQLite queries run in a thread worker so they never block input
+        or rendering (#776). ``exclusive=True`` cancels a still-running load
+        when the next tick fires instead of piling up stale refreshes.
+        """
         if not self.workspace:
             return
 
         data = load_dashboard_data(self.workspace)
+        if not get_current_worker().is_cancelled:
+            self.call_from_thread(self._apply_data, data)
+
+    def _apply_data(self, data: DashboardData) -> None:
+        """Update all widgets from a data snapshot (UI thread only)."""
         self.data = data
 
         self._update_status_bar(data)

--- a/codeframe/tui/app.py
+++ b/codeframe/tui/app.py
@@ -11,7 +11,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.widgets import DataTable, Footer, Header, RichLog, Static
-from textual.worker import get_current_worker
+from textual.worker import Worker, get_current_worker
 from textual import work
 
 from codeframe.core.workspace import Workspace
@@ -153,10 +153,21 @@ class DashboardApp(App):
         table.cursor_type = "row"
 
         # Initial data load
-        self._refresh_data()
+        self._maybe_refresh()
 
         # Auto-refresh
-        self.set_interval(self.refresh_interval, self._refresh_data)
+        self.set_interval(self.refresh_interval, self._maybe_refresh)
+
+    def _maybe_refresh(self) -> None:
+        """Start a refresh unless one is already in flight.
+
+        Thread workers can't be interrupted mid-query, so without this gate a
+        load slower than the refresh interval would stack cancelled-but-still-
+        running loads (one per tick).
+        """
+        if any(w.group == "refresh" and not w.is_finished for w in self.workers):
+            return
+        self._refresh_data()
 
     @work(thread=True, exclusive=True, group="refresh")
     def _refresh_data(self) -> None:
@@ -170,12 +181,20 @@ class DashboardApp(App):
         if not self.workspace:
             return
 
+        worker = get_current_worker()
         data = load_dashboard_data(self.workspace)
-        if not get_current_worker().is_cancelled:
-            self.call_from_thread(self._apply_data, data)
+        if not worker.is_cancelled:
+            self.call_from_thread(self._apply_data, data, worker)
 
-    def _apply_data(self, data: DashboardData) -> None:
-        """Update all widgets from a data snapshot (UI thread only)."""
+    def _apply_data(self, data: DashboardData, worker: Optional[Worker] = None) -> None:
+        """Update all widgets from a data snapshot (UI thread only).
+
+        Re-checks the producing worker's cancellation here: cancellation
+        happens on this (loop) thread, so this check is race-free where the
+        worker-side one is best-effort.
+        """
+        if worker is not None and worker.is_cancelled:
+            return
         self.data = data
 
         self._update_status_bar(data)
@@ -267,5 +286,5 @@ class DashboardApp(App):
 
     def action_refresh(self) -> None:
         """Manual refresh via 'r' key."""
-        self._refresh_data()
+        self._maybe_refresh()
         self.notify("Refreshed")

--- a/codeframe/tui/data_service.py
+++ b/codeframe/tui/data_service.py
@@ -6,7 +6,7 @@ Loads all dashboard data in a single call to minimize DB access.
 from dataclasses import dataclass, field
 from typing import Optional
 
-from codeframe.core.workspace import Workspace
+from codeframe.core.workspace import Workspace, get_db_connection
 
 
 @dataclass
@@ -51,53 +51,63 @@ def load_dashboard_data(
         tech_stack=workspace.tech_stack or "",
     )
 
+    # One connection shared by all queries (#776) — opened here, closed here.
     try:
-        from codeframe.core import tasks as task_module
-
-        all_tasks = task_module.list_tasks(workspace)
-        data.tasks = all_tasks
-
-        counts: dict[str, int] = {}
-        for t in all_tasks:
-            status_name = t.status.value if hasattr(t.status, "value") else str(t.status)
-            counts[status_name] = counts.get(status_name, 0) + 1
-        data.task_counts = counts
+        conn = get_db_connection(workspace)
     except Exception as exc:
-        data.error = f"Tasks: {exc}"
+        data.error = f"DB: {exc}"
+        return data
 
     try:
-        from codeframe.core import blockers
-        data.blockers = blockers.list_open(workspace)
-        data.blocker_count = len(data.blockers)
-    except Exception as exc:
-        if not data.error:
-            data.error = f"Blockers: {exc}"
+        try:
+            from codeframe.core import tasks as task_module
 
-    try:
-        from codeframe.core.events import list_recent
-        data.events = list_recent(workspace, limit=event_limit)
-    except Exception as exc:
-        if not data.error:
-            data.error = f"Events: {exc}"
+            all_tasks = task_module.list_tasks(workspace, conn=conn)
+            data.tasks = all_tasks
 
-    try:
-        from datetime import date
-        from codeframe.core.proof.ledger import list_requirements
-        from codeframe.core.proof.models import ReqStatus
+            counts: dict[str, int] = {}
+            for t in all_tasks:
+                status_name = t.status.value if hasattr(t.status, "value") else str(t.status)
+                counts[status_name] = counts.get(status_name, 0) + 1
+            data.task_counts = counts
+        except Exception as exc:
+            data.error = f"Tasks: {exc}"
 
-        open_reqs = list_requirements(workspace, status=ReqStatus.OPEN)
-        data.open_requirements = open_reqs
-        data.open_obligation_count = len(open_reqs)
+        try:
+            from codeframe.core import blockers
+            data.blockers = blockers.list_open(workspace, conn=conn)
+            data.blocker_count = len(data.blockers)
+        except Exception as exc:
+            if not data.error:
+                data.error = f"Blockers: {exc}"
 
-        waived = list_requirements(workspace, status=ReqStatus.WAIVED)
-        today = date.today()
-        data.expiring_waivers = [
-            req for req in waived
-            if req.waiver and req.waiver.expires is not None
-            and 0 <= (req.waiver.expires - today).days <= 7
-        ]
-    except Exception as exc:
-        if not data.error:
-            data.error = f"Proof: {exc}"
+        try:
+            from codeframe.core.events import list_recent
+            data.events = list_recent(workspace, limit=event_limit, conn=conn)
+        except Exception as exc:
+            if not data.error:
+                data.error = f"Events: {exc}"
+
+        try:
+            from datetime import date
+            from codeframe.core.proof.ledger import list_requirements
+            from codeframe.core.proof.models import ReqStatus
+
+            open_reqs = list_requirements(workspace, status=ReqStatus.OPEN, conn=conn)
+            data.open_requirements = open_reqs
+            data.open_obligation_count = len(open_reqs)
+
+            waived = list_requirements(workspace, status=ReqStatus.WAIVED, conn=conn)
+            today = date.today()
+            data.expiring_waivers = [
+                req for req in waived
+                if req.waiver and req.waiver.expires is not None
+                and 0 <= (req.waiver.expires - today).days <= 7
+            ]
+        except Exception as exc:
+            if not data.error:
+                data.error = f"Proof: {exc}"
+    finally:
+        conn.close()
 
     return data

--- a/tests/core/test_tui_dashboard.py
+++ b/tests/core/test_tui_dashboard.py
@@ -117,15 +117,14 @@ class TestDashboardApp:
 
 
 class TestSingleConnection:
-    def test_steady_state_refresh_opens_one_connection(self, workspace, monkeypatch):
-        """After warm-up (table init), a dashboard load opens exactly ONE connection."""
+    def test_refresh_connection_counts(self, workspace, monkeypatch):
+        """Cold load opens 3 (shared read + one-time proof DDL/migration);
+        every steady-state load after that opens exactly ONE."""
         import codeframe.tui.data_service as ds
         from codeframe.core import blockers, events
         from codeframe.core import tasks as task_module
         from codeframe.core.proof import ledger
         from codeframe.core.workspace import get_db_connection
-
-        ds.load_dashboard_data(workspace)  # warm-up: proof table init + migration
 
         opens: list[int] = []
 
@@ -136,7 +135,12 @@ class TestSingleConnection:
         for module in (ds, task_module, blockers, events, ledger):
             monkeypatch.setattr(module, "get_db_connection", counting)
 
-        data = ds.load_dashboard_data(workspace)
+        data = ds.load_dashboard_data(workspace)  # cold: proof tables absent
+        assert data.error is None
+        assert len(opens) == 3
+
+        opens.clear()
+        data = ds.load_dashboard_data(workspace)  # steady state (the every-2s path)
         assert data.error is None
         assert len(opens) == 1
 
@@ -223,6 +227,34 @@ class TestThreadWorkerRefresh:
 
         assert seen, "refresh never ran"
         assert all(t is not threading.main_thread() for t in seen)
+
+    @pytest.mark.asyncio
+    async def test_refresh_skipped_while_one_in_flight(self, workspace, monkeypatch):
+        """A new refresh is not started while a slow one is still running."""
+        import time as _time
+
+        import codeframe.tui.app as app_module
+        from codeframe.tui.app import DashboardApp
+
+        real = app_module.load_dashboard_data
+        calls: list[int] = []
+
+        def slow(ws):
+            calls.append(1)
+            _time.sleep(0.3)
+            return real(ws)
+
+        monkeypatch.setattr(app_module, "load_dashboard_data", slow)
+
+        app = DashboardApp(workspace=workspace, refresh_interval=60)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.workers.wait_for_complete()  # initial load
+            app.action_refresh()
+            await pilot.pause(0.05)
+            app.action_refresh()  # in-flight -> skipped
+            await app.workers.wait_for_complete()
+
+        assert len(calls) == 2  # mount + first manual; second manual skipped
 
     @pytest.mark.asyncio
     async def test_worker_refresh_updates_widgets(self, workspace):

--- a/tests/core/test_tui_dashboard.py
+++ b/tests/core/test_tui_dashboard.py
@@ -158,8 +158,45 @@ class TestSingleConnection:
             assert ledger.list_requirements(workspace, conn=conn) == []
             # still usable — borrowed conn was not closed by any reader
             conn.execute("SELECT 1")
+
+            # default (no conn) still works: each reader owns its connection
+            assert len(task_module.list_tasks(workspace)) == 1
+            assert blockers.list_open(workspace) == []
+            assert len(events.list_recent(workspace)) == len(
+                events.list_recent(workspace, conn=conn)
+            )
+            assert ledger.list_requirements(workspace) == []
         finally:
             conn.close()
+
+    def test_db_open_failure_sets_error(self, workspace, monkeypatch):
+        import codeframe.tui.data_service as ds
+
+        def boom(ws):
+            raise RuntimeError("no db")
+
+        monkeypatch.setattr(ds, "get_db_connection", boom)
+        data = ds.load_dashboard_data(workspace)
+        assert data.error is not None and data.error.startswith("DB:")
+
+    def test_section_failures_are_isolated(self, workspace, monkeypatch):
+        """A failing section sets error (first wins) without killing the others."""
+        import codeframe.tui.data_service as ds
+        from codeframe.core import blockers, events
+        from codeframe.core import tasks as task_module
+        from codeframe.core.proof import ledger
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(task_module, "list_tasks", boom)
+        monkeypatch.setattr(blockers, "list_open", boom)
+        monkeypatch.setattr(events, "list_recent", boom)
+        monkeypatch.setattr(ledger, "list_requirements", boom)
+
+        data = ds.load_dashboard_data(workspace)
+        assert data.error == "Tasks: boom"  # first failure wins
+        assert data.tasks == [] and data.blockers == [] and data.events == []
 
 
 class TestThreadWorkerRefresh:

--- a/tests/core/test_tui_dashboard.py
+++ b/tests/core/test_tui_dashboard.py
@@ -113,6 +113,98 @@ class TestDashboardApp:
             await pilot.press("q")
 
 
+# --- Issue #776: thread-worker refresh + single connection ---
+
+
+class TestSingleConnection:
+    def test_steady_state_refresh_opens_one_connection(self, workspace, monkeypatch):
+        """After warm-up (table init), a dashboard load opens exactly ONE connection."""
+        import codeframe.tui.data_service as ds
+        from codeframe.core import blockers, events
+        from codeframe.core import tasks as task_module
+        from codeframe.core.proof import ledger
+        from codeframe.core.workspace import get_db_connection
+
+        ds.load_dashboard_data(workspace)  # warm-up: proof table init + migration
+
+        opens: list[int] = []
+
+        def counting(ws):
+            opens.append(1)
+            return get_db_connection(ws)
+
+        for module in (ds, task_module, blockers, events, ledger):
+            monkeypatch.setattr(module, "get_db_connection", counting)
+
+        data = ds.load_dashboard_data(workspace)
+        assert data.error is None
+        assert len(opens) == 1
+
+    def test_core_readers_accept_borrowed_connection(self, workspace):
+        """Passing conn= must not close the borrowed connection."""
+        from codeframe.core import blockers, events
+        from codeframe.core import tasks as task_module
+        from codeframe.core.events import EventType, emit_for_workspace
+        from codeframe.core.proof import ledger
+        from codeframe.core.workspace import get_db_connection
+
+        task_module.create(workspace, title="T1", description="d")
+        emit_for_workspace(workspace, EventType.WORKSPACE_INIT, {}, print_event=False)
+        conn = get_db_connection(workspace)
+        try:
+            assert len(task_module.list_tasks(workspace, conn=conn)) == 1
+            assert blockers.list_open(workspace, conn=conn) == []
+            assert events.list_recent(workspace, conn=conn) != []
+            assert ledger.list_requirements(workspace, conn=conn) == []
+            # still usable — borrowed conn was not closed by any reader
+            conn.execute("SELECT 1")
+        finally:
+            conn.close()
+
+
+class TestThreadWorkerRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_offloads_db_load_to_thread(self, workspace, monkeypatch):
+        """load_dashboard_data must run off the event-loop thread."""
+        import threading
+
+        import codeframe.tui.app as app_module
+        from codeframe.tui.app import DashboardApp
+
+        real = app_module.load_dashboard_data
+        seen: list[threading.Thread] = []
+
+        def spy(ws):
+            seen.append(threading.current_thread())
+            return real(ws)
+
+        monkeypatch.setattr(app_module, "load_dashboard_data", spy)
+
+        app = DashboardApp(workspace=workspace)
+        async with app.run_test(size=(120, 40)):
+            await app.workers.wait_for_complete()
+
+        assert seen, "refresh never ran"
+        assert all(t is not threading.main_thread() for t in seen)
+
+    @pytest.mark.asyncio
+    async def test_worker_refresh_updates_widgets(self, workspace):
+        """Results are posted back to the UI thread and rendered."""
+        from textual.widgets import DataTable
+
+        from codeframe.core import tasks as task_module
+        from codeframe.tui.app import DashboardApp
+
+        task_module.create(workspace, title="Worker task", description="d")
+
+        app = DashboardApp(workspace=workspace)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            table = app.query_one("#task-table", DataTable)
+            assert table.row_count == 1
+
+
 # --- Proof Panel Tests ---
 
 
@@ -273,6 +365,9 @@ class TestDashboardAppProof:
 
         app = DashboardApp(workspace=workspace)
         async with app.run_test(size=(120, 40)) as pilot:
+            # refresh runs in a thread worker (#776) — wait for it to apply
+            await app.workers.wait_for_complete()
+            await pilot.pause()
             log = app.query_one("#proof-log", RichLog)
             # RichLog.lines returns Strip objects; str() gives plain text
             content = "\n".join(str(line) for line in log.lines)


### PR DESCRIPTION
## Summary
Implements #776: the TUI dashboard's `_refresh_data` ran 5 synchronous SQLite queries (each opening its own connection) directly on Textual's event loop — on mount, every 2s via `set_interval`, and on `r` — freezing input and rendering on larger workspaces.

- `_refresh_data` is now `@work(thread=True, exclusive=True)`; widget updates are posted back with `call_from_thread(self._apply_data, data)`, guarded by `get_current_worker().is_cancelled` so a superseded load drops its stale snapshot
- `load_dashboard_data` opens **one** connection shared by all five queries; the four core readers (`tasks.list_tasks`, `blockers.list_open`/`list_all`, `events.list_recent`, `proof.ledger.list_requirements`) gained an optional borrowed `conn=` parameter (borrow → never closed; own → always closed, now in `finally`)
- The connection is per-refresh, **not** persistent across refreshes: sqlite3 connections are thread-bound and Textual's worker pool doesn't guarantee thread affinity, so a held connection would intermittently raise `ProgrammingError`

## Acceptance Criteria
- [x] Refresh runs in a thread worker (`@work(thread=True)`)
- [x] Results posted back to the UI thread
- [x] Single connection reused (5 opens/tick → 1)

## Test Plan
- [x] Unit tests written first (TDD); 26 pass in `tests/core/test_tui_dashboard.py`
- [x] 536 tests across the touched core modules (tasks/blockers/events/proof) pass
- [x] Diff coverage 96% on changed lines (gate ≥85%, diff-cover vs origin/main)
- [x] ruff clean; strict mypy clean on full `codeframe/`
- [x] Internal code review (advisory): no Critical/Major; leak-on-exception suggestion applied
- [x] Cross-family review pass: **opencode (GLM)** — verdict APPROVE, no Critical findings
- [x] Mutation sanity (Phase 7d): 4 mutations (decorator removed, post-back dropped, shared conn bypassed, skip-gate disabled) — each killed by its target test

## Review-feedback fixes (post-open)
- **Overlapping refreshes gated** (CodeRabbit Major): `_maybe_refresh` skips a tick while a refresh worker is in flight — thread workers can't be interrupted mid-query, so slow loads previously stacked one cancelled-but-running load per tick. Covered by `test_refresh_skipped_while_one_in_flight` (mutation-verified).
- **Stale-snapshot TOCTOU closed** (CodeRabbit Major / opencode Suggestion): `_apply_data` re-checks the producing worker's cancellation on the loop thread, where cancellation happens — race-free where the worker-side check is best-effort.
- **Cold path now asserted, not warmed past** (opencode post-PR Major): the connection-count test asserts first load == 3 (shared read + one-time proof DDL + migration) and steady state == 1.

## Known Limitations / Intentionally Deferred
- **First load per process opens 3 connections**, not 1: `_ensure_tables` one-time proof-table init and the cached `#728` column migration manage their own connections. Steady state (the every-2s path this issue targets) is exactly 1. Both counts are pinned by `test_refresh_connection_counts`. (Cross-family finding — accepted as designed, now test-asserted.)
- The thread test observes the mount-triggered load; interval ticks invoke the same decorated method, so a decorator regression is caught, but a deliberate split of the two paths would not be.

Closes #776
