### PR TITLE
fix(cli): resolve cf stats DB via cwd walk-up and DATABASE_PATH (#777)

### DIFF
--- a/codeframe/cli/stats_commands.py
+++ b/codeframe/cli/stats_commands.py
@@ -52,9 +52,9 @@ def _get_db():
     env_path = os.getenv("DATABASE_PATH")
     if env_path:
         db_path = Path(env_path)
-        if not db_path.exists():
+        if not db_path.is_file():
             console.print(
-                f"[red]Error:[/red] DATABASE_PATH points to a non-existent database: {db_path}"
+                f"[red]Error:[/red] DATABASE_PATH does not point to a database file: {db_path}"
             )
             raise typer.Exit(1)
     else:
@@ -62,7 +62,7 @@ def _get_db():
         db_path = None
         for p in (cwd, *cwd.parents):
             candidate = p / ".codeframe" / "state.db"
-            if candidate.exists():
+            if candidate.is_file():
                 db_path = candidate
                 break
         if db_path is None:

--- a/codeframe/cli/stats_commands.py
+++ b/codeframe/cli/stats_commands.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
@@ -35,9 +36,10 @@ stats_app = typer.Typer(
 
 
 def _get_db():
-    """Get database from current workspace.
+    """Get database from the enclosing workspace.
 
-    Looks for .codeframe/state.db relative to the current directory.
+    Honors the DATABASE_PATH environment variable; otherwise walks up from
+    the current directory looking for .codeframe/state.db (issue #777).
 
     Returns:
         Initialized Database instance.
@@ -47,10 +49,25 @@ def _get_db():
     """
     from codeframe.platform_store.database import Database
 
-    db_path = Path(".codeframe/state.db")
-    if not db_path.exists():
-        console.print("[red]Error:[/red] No workspace found. Run 'cf init' first.")
-        raise typer.Exit(1)
+    env_path = os.getenv("DATABASE_PATH")
+    if env_path:
+        db_path = Path(env_path)
+        if not db_path.exists():
+            console.print(
+                f"[red]Error:[/red] DATABASE_PATH points to a non-existent database: {db_path}"
+            )
+            raise typer.Exit(1)
+    else:
+        cwd = Path.cwd()
+        db_path = None
+        for p in (cwd, *cwd.parents):
+            candidate = p / ".codeframe" / "state.db"
+            if candidate.exists():
+                db_path = candidate
+                break
+        if db_path is None:
+            console.print("[red]Error:[/red] No workspace found. Run 'cf init' first.")
+            raise typer.Exit(1)
     db = Database(db_path)
     db.initialize()
     return db

--- a/tests/cli/test_stats_db_resolution.py
+++ b/tests/cli/test_stats_db_resolution.py
@@ -1,0 +1,101 @@
+"""Regression tests for `cf stats` DB resolution (issue #777 / P3.6).
+
+Before the fix, `stats_commands._get_db()` hardcoded `.codeframe/state.db`
+relative to the current directory, so `cf stats` failed from any subdirectory
+of a workspace and ignored the `DATABASE_PATH` env var honored elsewhere
+(e.g. `core/config.py`). These tests lock in the walk-up from cwd and the
+`DATABASE_PATH` override.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.stats_commands import stats_app
+from codeframe.core.models import CallType, TokenUsage
+from codeframe.core.workspace import create_or_load_workspace
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+def _make_workspace_with_row(repo: Path) -> Path:
+    """Create a workspace at ``repo`` with one token_usage row; return db path."""
+    ws = create_or_load_workspace(repo)
+    db = Database(str(ws.db_path))
+    db.initialize()
+    try:
+        db.save_token_usage(
+            TokenUsage(
+                task_id="task-1",
+                agent_id="react-agent",
+                project_id=0,
+                model_name="claude-sonnet-4-5",
+                input_tokens=1000,
+                output_tokens=500,
+                estimated_cost_usd=0.0105,
+                call_type=CallType.TASK_EXECUTION,
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+    finally:
+        db.close()
+    return ws.db_path
+
+
+def test_stats_tokens_walks_up_from_subdirectory(tmp_path: Path, monkeypatch):
+    """`cf stats tokens` finds the workspace DB from a nested subdirectory."""
+    monkeypatch.delenv("DATABASE_PATH", raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _make_workspace_with_row(repo)
+
+    subdir = repo / "src" / "pkg"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    result = CliRunner().invoke(stats_app, ["tokens"])
+    assert result.exit_code == 0, result.output
+    assert "1,500" in result.output
+
+
+def test_stats_tokens_honors_database_path_env(tmp_path: Path, monkeypatch):
+    """DATABASE_PATH points at the DB directly, regardless of cwd."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    db_path = _make_workspace_with_row(repo)
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
+
+    result = CliRunner().invoke(stats_app, ["tokens"])
+    assert result.exit_code == 0, result.output
+    assert "1,500" in result.output
+
+
+def test_stats_tokens_errors_when_no_workspace(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("DATABASE_PATH", raising=False)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    # The walk-up is unbounded; guard against a stray DB above tmp_path.
+    if any((p / ".codeframe" / "state.db").exists() for p in (empty, *empty.parents)):
+        pytest.skip("stray .codeframe/state.db above tmp_path")
+    monkeypatch.chdir(empty)
+
+    result = CliRunner().invoke(stats_app, ["tokens"])
+    assert result.exit_code == 1
+    assert "No workspace found" in result.output
+
+
+def test_stats_tokens_errors_when_database_path_missing(tmp_path: Path, monkeypatch):
+    """DATABASE_PATH pointing at a missing file errors without falling back."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "nope.db"))
+
+    result = CliRunner().invoke(stats_app, ["tokens"])
+    assert result.exit_code == 1
+    assert "DATABASE_PATH points to a non-existent database" in result.output

--- a/tests/cli/test_stats_db_resolution.py
+++ b/tests/cli/test_stats_db_resolution.py
@@ -91,11 +91,14 @@ def test_stats_tokens_errors_when_no_workspace(tmp_path: Path, monkeypatch):
     assert "No workspace found" in result.output
 
 
-def test_stats_tokens_errors_when_database_path_missing(tmp_path: Path, monkeypatch):
-    """DATABASE_PATH pointing at a missing file errors without falling back."""
+@pytest.mark.parametrize("target", ["nope.db", "."])
+def test_stats_tokens_errors_when_database_path_invalid(
+    tmp_path: Path, monkeypatch, target: str
+):
+    """DATABASE_PATH pointing at a missing file or a directory errors out."""
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "nope.db"))
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / target))
 
     result = CliRunner().invoke(stats_app, ["tokens"])
     assert result.exit_code == 1
-    assert "DATABASE_PATH points to a non-existent database" in result.output
+    assert "DATABASE_PATH does not point to a database file" in result.output


### PR DESCRIPTION
Closes #777.

## Problem
`stats_commands._get_db()` hardcoded `Path(".codeframe/state.db")` relative to cwd, so `cf stats` failed from any subdirectory of a workspace and ignored `DATABASE_PATH`.

## Fix
- `DATABASE_PATH` env var takes precedence (matching `core/config.py` / `auth_commands.get_db_for_cli()`), with a distinct error when it points at a missing file.
- Otherwise walk up from cwd (`cwd` + parents) looking for `.codeframe/state.db`.

**Note on the acceptance criterion**: the issue asked for resolution "via `get_workspace(Path.cwd())` walk-up", but `get_workspace` has no walk-up — it only checks the given path. The walk-up is therefore implemented in `_get_db()` directly; behavior matches the criterion's intent (works from subdirectories, honors `DATABASE_PATH`).

## Tests
`tests/cli/test_stats_db_resolution.py` (5 tests): walk-up from nested subdir, `DATABASE_PATH` override from unrelated cwd, `DATABASE_PATH`→missing-file error, no-workspace error. Plus existing `test_stats_task_uuid.py` still green.

## Demo (real CLI, real workspace)
- From `repo/src/deep`: `cf stats tokens` → renders summary (3,000 tokens, $0.0210) ✅
- From unrelated dir with `DATABASE_PATH=<repo>/.codeframe/state.db` → same summary ✅
- No workspace, no env → `Error: No workspace found. Run 'cf init' first.`, exit 1 ✅

## Review
Cross-family review (opencode/GLM) done pre-PR. Applied: distinct missing-`DATABASE_PATH` error message, extra test for it, deterministic negative test, clearer walk-up loop. Declined: extracting a shared resolver also covering `cf auth` — behavior change outside this atomic issue's scope.

## Known Limitations
- `cf auth` (`get_db_for_cli()`) still resolves cwd-only; consistent walk-up across all CLI commands would be a follow-up.