### PR TITLE
fix(llm): honor base_url on the Anthropic provider path (#780)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,12 +294,12 @@ CODEFRAME_ENABLE_TEST_ENDPOINTS=1     # Registers the integration-test-only
 CODEFRAME_LLM_PROVIDER=anthropic      # Provider: anthropic (default), openai, ollama, vllm, compatible
 CODEFRAME_LLM_MODEL=gpt-4o            # Model override (used with openai/ollama/vllm/compatible)
 OPENAI_API_KEY=sk-...                 # Required for openai provider; not needed for local providers
-OPENAI_BASE_URL=http://localhost:11434/v1  # Base URL override (for ollama, vllm, or custom endpoints)
+OPENAI_BASE_URL=http://localhost:11434/v1  # Base URL override (OpenAI-compatible providers only, #780)
 # Per-workspace config: .codeframe/config.yaml supports llm: block
 # llm:
 #   provider: openai
 #   model: qwen2.5-coder:7b
-#   base_url: http://localhost:11434/v1   # optional, for local models
+#   base_url: http://localhost:11434/v1   # optional; local models, or an API proxy/gateway (any provider incl. anthropic, #780)
 
 # Optional — Rate limiting
 RATE_LIMIT_ENABLED=true

--- a/codeframe/adapters/llm/__init__.py
+++ b/codeframe/adapters/llm/__init__.py
@@ -51,7 +51,9 @@ __all__ = [
     "get_provider",
 ]
 
-_OPENAI_COMPATIBLE = {"openai", "ollama", "vllm", "compatible"}
+# Provider types routed to OpenAIProvider; also gates the OPENAI_BASE_URL
+# env fallback in core.llm_resolution (#780).
+OPENAI_COMPATIBLE_PROVIDERS = {"openai", "ollama", "vllm", "compatible"}
 
 
 def get_provider(provider_type: str = "anthropic", **kwargs) -> LLMProvider:
@@ -73,7 +75,7 @@ def get_provider(provider_type: str = "anthropic", **kwargs) -> LLMProvider:
     Raises:
         ValueError: If provider type is unknown
     """
-    if provider_type in _OPENAI_COMPATIBLE:
+    if provider_type in OPENAI_COMPATIBLE_PROVIDERS:
         api_key = kwargs.get("api_key") or os.environ.get("OPENAI_API_KEY")
         if not api_key and provider_type != "openai":
             # Local providers (ollama, vllm, compatible) don't need real auth;
@@ -98,7 +100,9 @@ def get_provider(provider_type: str = "anthropic", **kwargs) -> LLMProvider:
                 supervision_model=model,
             )
         return AnthropicProvider(
-            api_key=kwargs.get("api_key"), model_selector=model_selector
+            api_key=kwargs.get("api_key"),
+            model_selector=model_selector,
+            base_url=kwargs.get("base_url"),
         )
     elif provider_type == "mock":
         return MockProvider()

--- a/codeframe/adapters/llm/anthropic.py
+++ b/codeframe/adapters/llm/anthropic.py
@@ -33,6 +33,7 @@ class AnthropicProvider(LLMProvider):
         api_key: Optional[str] = None,
         model_selector: Optional[ModelSelector] = None,
         credential_manager: Optional["CredentialManager"] = None,
+        base_url: Optional[str] = None,
     ):
         """Initialize the Anthropic provider.
 
@@ -40,6 +41,8 @@ class AnthropicProvider(LLMProvider):
             api_key: Anthropic API key (defaults to ANTHROPIC_API_KEY env var)
             model_selector: Custom model selector
             credential_manager: Optional credential manager for secure key retrieval
+            base_url: Custom API endpoint (proxy/gateway); None uses the
+                SDK default (#780)
 
         Raises:
             ValueError: If no API key is available
@@ -65,6 +68,7 @@ class AnthropicProvider(LLMProvider):
                 "Set the environment variable, pass api_key parameter, "
                 "or configure via 'codeframe auth setup --provider anthropic'."
             )
+        self.base_url = base_url
         self._client = None
         self._async_client = None
 
@@ -74,7 +78,7 @@ class AnthropicProvider(LLMProvider):
         if self._client is None:
             from anthropic import Anthropic
 
-            self._client = Anthropic(api_key=self.api_key)
+            self._client = Anthropic(api_key=self.api_key, base_url=self.base_url)
         return self._client
 
     def complete(
@@ -151,7 +155,9 @@ class AnthropicProvider(LLMProvider):
         )
 
         if self._async_client is None:
-            self._async_client = AsyncAnthropic(api_key=self.api_key)
+            self._async_client = AsyncAnthropic(
+                api_key=self.api_key, base_url=self.base_url
+            )
 
         model = self.get_model(purpose)
         kwargs: dict = {
@@ -205,7 +211,9 @@ class AnthropicProvider(LLMProvider):
         from anthropic import AsyncAnthropic
 
         if self._async_client is None:
-            self._async_client = AsyncAnthropic(api_key=self.api_key)
+            self._async_client = AsyncAnthropic(
+                api_key=self.api_key, base_url=self.base_url
+            )
 
         # Convert messages to Anthropic API format (handles tool_calls/tool_results)
         converted = self._convert_messages(messages)

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -56,7 +56,8 @@ def resolve_llm_settings(
 
     Provider: flag → CODEFRAME_LLM_PROVIDER → config → "anthropic".
     Model: flag → CODEFRAME_LLM_MODEL → config.
-    Base URL: config → OPENAI_BASE_URL.
+    Base URL: config → OPENAI_BASE_URL (env tier applies to
+    OpenAI-compatible providers only, #780).
 
     Args:
         repo_path: Workspace repo path for ``.codeframe/config.yaml``
@@ -82,9 +83,14 @@ def resolve_llm_settings(
         or os.getenv("CODEFRAME_LLM_MODEL")
         or (llm_cfg.model if llm_cfg else None)
     )
-    base_url = (llm_cfg.base_url if llm_cfg else None) or os.getenv(
-        "OPENAI_BASE_URL"
-    )
+    # Explicit config base_url applies to any provider (anthropic proxies
+    # included, #780); the OPENAI_BASE_URL env fallback is OpenAI-compatible
+    # only, so an ambient value can't redirect Anthropic traffic.
+    from codeframe.adapters.llm import OPENAI_COMPATIBLE_PROVIDERS
+
+    base_url = llm_cfg.base_url if llm_cfg else None
+    if not base_url and provider_type in OPENAI_COMPATIBLE_PROVIDERS:
+        base_url = os.getenv("OPENAI_BASE_URL")
     return LLMSettings(provider_type=provider_type, model=model, base_url=base_url)
 
 

--- a/demo-pr552.md
+++ b/demo-pr552.md
@@ -50,8 +50,8 @@ src = inspect.getsource(get_provider)
 # Check default branch
 assert \"anthropic\" in src
 # Verify OpenAI-compatible set covers expected providers
-from codeframe.adapters.llm import _OPENAI_COMPATIBLE
-print(\"OpenAI-compatible providers:\", sorted(_OPENAI_COMPATIBLE))
+from codeframe.adapters.llm import OPENAI_COMPATIBLE_PROVIDERS
+print(\"OpenAI-compatible providers:\", sorted(OPENAI_COMPATIBLE_PROVIDERS))
 print(\"Default: anthropic -> AnthropicProvider\")
 print(\"openai/ollama/vllm/compatible -> OpenAIProvider\")
 print(\"Factory routes correctly.\")

--- a/demo-pr888.md
+++ b/demo-pr888.md
@@ -1,0 +1,68 @@
+# Demo PR #888 — honor base_url on the Anthropic provider path (#780)
+
+*2026-07-24T00:14:34Z by Showboat 0.6.1*
+<!-- showboat-id: 96a4f409-5a95-4701-93fe-6a00e88b6cd4 -->
+
+Criterion 1: get_provider('anthropic', base_url=...) must reach the Anthropic SDK client — previously it was silently dropped. Evidence: the constructed client's base_url is the override, not api.anthropic.com.
+
+```bash
+uv run python - <<'EOF'
+import os
+os.environ['ANTHROPIC_API_KEY'] = 'sk-ant-demo-key'
+from codeframe.adapters.llm import get_provider
+
+p = get_provider('anthropic', base_url='http://litellm-proxy:4000')
+print('provider.base_url =', p.base_url)
+print('SDK client.base_url =', p.client.base_url)
+
+default = get_provider('anthropic')
+print('no override -> SDK default =', default.client.base_url)
+EOF
+```
+
+```output
+provider.base_url = http://litellm-proxy:4000
+SDK client.base_url = http://litellm-proxy:4000
+no override -> SDK default = https://api.anthropic.com
+```
+
+Criterion 2: an ambient OPENAI_BASE_URL (e.g. set for occasional ollama use) must NOT redirect Anthropic traffic — the env fallback is gated to OpenAI-compatible providers. Explicit config llm.base_url still applies to anthropic (proxy deployments).
+
+```bash
+uv run python - <<'EOF'
+import os, tempfile
+from pathlib import Path
+from codeframe.core.llm_resolution import resolve_llm_settings
+
+os.environ['OPENAI_BASE_URL'] = 'http://ollama-box:11434/v1'
+repo = Path(tempfile.mkdtemp())
+
+s = resolve_llm_settings(repo)
+print('anthropic + ambient OPENAI_BASE_URL -> base_url =', s.base_url)
+
+s = resolve_llm_settings(repo, provider_flag='ollama')
+print('ollama    + ambient OPENAI_BASE_URL -> base_url =', s.base_url)
+
+(repo / '.codeframe').mkdir()
+(repo / '.codeframe' / 'config.yaml').write_text('llm:\n  provider: anthropic\n  base_url: http://corp-gateway:8080\n')
+s = resolve_llm_settings(repo)
+print('anthropic + explicit config llm.base_url -> base_url =', s.base_url)
+EOF
+```
+
+```output
+anthropic + ambient OPENAI_BASE_URL -> base_url = None
+ollama    + ambient OPENAI_BASE_URL -> base_url = http://ollama-box:11434/v1
+anthropic + explicit config llm.base_url -> base_url = http://corp-gateway:8080
+```
+
+Criterion 3: regression tests lock the behavior in (silent re-drop would fail the suite).
+
+```bash
+uv run pytest tests/core/test_llm_resolution.py -q 2>&1 | tail -2
+```
+
+```output
+(8 durations < 0.005s hidden.  Use -vv to show these durations.)
+============================== 22 passed in 1.36s ==============================
+```

--- a/tests/core/test_llm_resolution.py
+++ b/tests/core/test_llm_resolution.py
@@ -75,6 +75,31 @@ class TestModelAndBaseUrl:
         monkeypatch.setenv("OPENAI_BASE_URL", "http://env:8000/v1")
         assert resolve_llm_settings(tmp_path).base_url == "http://cfg:11434/v1"
 
+    def test_openai_base_url_env_does_not_leak_to_anthropic(
+        self, tmp_path, monkeypatch
+    ):
+        """OPENAI_BASE_URL is OpenAI-compatible-only; it must not redirect
+        Anthropic traffic now that the anthropic path honors base_url (#780)."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://env:8000/v1")
+        settings = resolve_llm_settings(tmp_path)
+        assert settings.provider_type == "anthropic"
+        assert settings.base_url is None
+
+    def test_openai_base_url_env_applies_to_openai_compatible(
+        self, tmp_path, monkeypatch
+    ):
+        _write_llm_config(tmp_path, provider="ollama")
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://env:8000/v1")
+        assert resolve_llm_settings(tmp_path).base_url == "http://env:8000/v1"
+
+    def test_config_base_url_applies_to_anthropic(self, tmp_path):
+        """An explicit llm.base_url in config is honored for anthropic
+        (proxy/gateway deployments, #780)."""
+        _write_llm_config(
+            tmp_path, provider="anthropic", base_url="http://proxy:8080"
+        )
+        assert resolve_llm_settings(tmp_path).base_url == "http://proxy:8080"
+
     def test_provider_kwargs_only_includes_set_values(self, tmp_path):
         settings = resolve_llm_settings(tmp_path)
         assert settings.provider_kwargs() == {}
@@ -121,6 +146,16 @@ class TestCreateProvider:
         assert selector.planning_model == "claude-test-model"
         assert selector.execution_model == "claude-test-model"
         assert selector.generation_model == "claude-test-model"
+
+    def test_anthropic_base_url_override_is_honored(self, monkeypatch):
+        """A resolved base_url must reach the Anthropic SDK client, not be
+        silently dropped (#780)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+        provider = create_provider(
+            LLMSettings(provider_type="anthropic", base_url="http://proxy:8080")
+        )
+        assert provider.base_url == "http://proxy:8080"
+        assert str(provider.client.base_url).rstrip("/") == "http://proxy:8080"
 
     def test_creates_openai_compatible_for_ollama(self, monkeypatch):
         from codeframe.adapters.llm import OpenAIProvider


### PR DESCRIPTION
Closes #780 (remaining scope after #860 fixed the model override).

## Problem
`get_provider("anthropic", base_url=...)` silently dropped `base_url`, so a configured `llm.base_url` (proxy/gateway deployments) never reached the Anthropic SDK.

## Change
- `AnthropicProvider` accepts `base_url` and passes it to all three SDK client construction sites (sync `Anthropic`, both `AsyncAnthropic` paths).
- `get_provider("anthropic", ...)` forwards `base_url` instead of dropping it.
- **Env-leak guard**: `resolve_llm_settings` previously fell back to the ambient `OPENAI_BASE_URL` env var for *every* provider — harmless only because the anthropic branch dropped it. Now that `base_url` is honored, that fallback is gated to OpenAI-compatible providers (`openai`, `ollama`, `vllm`, `compatible`) so an ambient `OPENAI_BASE_URL` cannot silently redirect Anthropic traffic. An explicit `llm.base_url` in `.codeframe/config.yaml` still applies to any provider.
- Renamed `_OPENAI_COMPATIBLE` → `OPENAI_COMPATIBLE_PROVIDERS` (now shared with `core.llm_resolution`); updated the one demo-doc reference.

## Tests
`tests/core/test_llm_resolution.py`:
- `test_anthropic_base_url_override_is_honored` — asserts the value reaches the SDK client itself, guarding against a silent re-drop
- `test_openai_base_url_env_does_not_leak_to_anthropic`
- `test_config_base_url_applies_to_anthropic`
- `test_openai_base_url_env_applies_to_openai_compatible` (regression)

## Third-party review (pre-PR)
opencode (GLM) reviewed the diff: no Critical/Major findings. Both Minor findings (dangling `_OPENAI_COMPATIBLE` reference in `demo-pr552.md`, stale docstring in `llm_resolution.py`) are fixed in this PR.

## Known limitations
Pre-existing call sites that bypass `resolve_llm_settings` still won't pick up a configured `base_url` (deliberate defaults, out of scope here): `core/tasks.py` `get_provider()` fallback, `ui/routers/session_chat_ws.py`, and the legacy `api_key` branches in `prd_discovery.py` / `streaming_chat.py`. Candidate follow-up under the #861 migration pattern.