### PR TITLE
fix(cli): APIClient retry wraps non-connection errors and preserves cause (#781)

### DIFF
--- a/codeframe/cli/api_client.py
+++ b/codeframe/cli/api_client.py
@@ -207,6 +207,7 @@ class APIClient:
         """
         url = self._make_url(endpoint)
         headers = self._get_headers()
+        last_exc: requests.RequestException | None = None
 
         for attempt in range(self.max_retries):
             try:
@@ -220,6 +221,7 @@ class APIClient:
                 return self._handle_response(response)
 
             except requests.ConnectionError as e:
+                last_exc = e
                 logger.warning(f"Connection error (attempt {attempt + 1}/{self.max_retries}): {e}")
 
                 if attempt < self.max_retries - 1:
@@ -229,18 +231,23 @@ class APIClient:
                 continue
 
             except requests.Timeout as e:
+                last_exc = e
                 logger.warning(f"Request timeout (attempt {attempt + 1}/{self.max_retries}): {e}")
 
                 if attempt < self.max_retries - 1:
                     time.sleep(2 ** attempt)
                 continue
 
+            except requests.RequestException as e:
+                # Non-transient (bad URL, redirect loop, ...): no point retrying
+                raise APIError(f"Request failed: {e}", status_code=None) from e
+
         # All retries exhausted
         raise APIError(
             f"Connection error: Unable to connect to {self.base_url}. "
             "Please check the server is running and try again.",
             status_code=None,
-        )
+        ) from last_exc
 
     def get(self, endpoint: str, params: dict | None = None) -> Any:
         """Make GET request.

--- a/tests/cli/test_api_client.py
+++ b/tests/cli/test_api_client.py
@@ -318,6 +318,34 @@ class TestAPIClientRetry:
 
             assert "Connection error" in str(exc_info.value)
 
+    def test_max_retries_exceeded_preserves_cause(self):
+        """Exhausted retries should chain the last underlying exception."""
+        last_error = requests.Timeout("timed out")
+        with patch("requests.request", side_effect=[
+            requests.ConnectionError("Connection refused"),
+            last_error,
+        ]), patch("time.sleep"):
+            client = APIClient(token="test-token", max_retries=2)
+
+            with pytest.raises(APIError) as exc_info:
+                client.get("/api/projects")
+
+        assert exc_info.value.__cause__ is last_error
+
+    def test_non_connection_request_error_wrapped(self):
+        """Other RequestException types should be wrapped in APIError, not propagate raw."""
+        redirect_error = requests.TooManyRedirects("too many redirects")
+        with patch("requests.request", side_effect=redirect_error) as mock_request:
+            client = APIClient(token="test-token", max_retries=3)
+
+            with pytest.raises(APIError) as exc_info:
+                client.get("/api/projects")
+
+        # Non-transient: raised immediately, no retries
+        assert mock_request.call_count == 1
+        assert exc_info.value.__cause__ is redirect_error
+        assert "too many redirects" in str(exc_info.value)
+
 
 class TestAPIClientErrorMessages:
     """Tests for user-friendly error messages."""


### PR DESCRIPTION
Closes #781

## Problem
`_request_with_retry` in `codeframe/cli/api_client.py` only caught `ConnectionError`/`Timeout`. Any other `requests.RequestException` (bad URL, redirect loop, …) propagated unwrapped past the `APIError` contract, and the exhausted-retries `APIError` discarded the real exception (`__cause__` was `None`).

## Fix
- Track `last_exc` in the `ConnectionError`/`Timeout` handlers; the exhaustion raise is now `raise APIError(...) from last_exc`.
- New `except requests.RequestException` fallback wraps in `APIError` and raises immediately (`from e`) — these errors are non-transient, so no retry.

## Acceptance criteria
- [x] Catch `RequestException` as fallback, wrap in `APIError`
- [x] `raise ... from last_exc` (cause preserved on retry exhaustion)

## Evidence
- TDD red→green: `test_max_retries_exceeded_preserves_cause`, `test_non_connection_request_error_wrapped`
- Mutation check: dropping `from last_exc` and dropping `from e` each made its test fail
- Diff coverage: 100% of changed lines (diff-cover vs origin/main)
- `tests/cli/`: 483 passed; `ruff check .` clean; `mypy codeframe/` clean (195 files)
- Cross-family review (opencode/GLM): APPROVE, 0 Critical/Major
- Internal review: APPROVE, 0 Critical/Major

## Known limitations
- `max_retries=0` (degenerate config) exhausts with no attempt, so the raise is `from None` — pre-existing behavior, no request was made so there is genuinely no cause; left untested deliberately.
- Log/error messages interpolate `str(e)` which can include the request URL — pre-existing pattern in the retry branches, unchanged.