### PR TITLE
fix(security): ignore every .env variant, not an enumeration (#895)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,11 @@ codeframe.db
 *.db.backup*
 
 # Environment
-.env
-.env.local
-.env.staging
+# Ignore every .env variant and re-include only the committed templates, so a
+# new variant (.env.production, .env.hosted, ...) is never committable by
+# default. Enumerating them instead failed open — see #895.
+.env*
+!.env*.example
 
 # Staging server private configuration
 .staging-server.conf

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -179,6 +179,8 @@ REAL_ENV_FILES = (
     ".env.hosted",
 )
 
+# These guards are necessarily CI/checkout-only: gitignore behaviour cannot be
+# tested without git. They do not run against an unpacked sdist.
 requires_git_checkout = pytest.mark.skipif(
     shutil.which("git") is None or not (REPO / ".git").exists(),
     reason="needs a git checkout (not available in an unpacked sdist)",
@@ -221,6 +223,24 @@ def test_env_examples_are_not_gitignored(name):
     assert not _is_ignored(name), (
         f"{name} is gitignored — the `!.env*.example` negation is missing or "
         f"ordered before the `.env*` rule that it must override."
+    )
+
+
+@requires_git_checkout
+@pytest.mark.parametrize("name", REAL_ENV_FILES)
+def test_real_env_files_are_not_tracked(name):
+    """.gitignore only governs *untracked* paths — a file already in the index
+    stays committable no matter what the rules say. Guard against a real env
+    file being force-added (`git add -f`) and quietly reopening the hole."""
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", name],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode != 0, (
+        f"{name} is TRACKED — it will be committed on every change regardless "
+        f"of .gitignore. Remove it from the index: git rm --cached {name}"
     )
 
 

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -150,3 +150,88 @@ def test_remote_setup_installs_proxy_and_binds_loopback_firewall():
     # The raw app ports must no longer be opened to the world.
     assert "ufw allow 14100/tcp" not in text
     assert "ufw allow 14200/tcp" not in text
+
+
+# --- .env ignore rules (#895 / P0.1) ----------------------------------------
+#
+# deploy.yml writes a real .env.production (ANTHROPIC_API_KEY + AUTH_SECRET)
+# into the production git checkout. The ignore list used to enumerate
+# .env/.env.local/.env.staging, so .env.production — and every future variant —
+# defaulted to committable. These guard the pattern-plus-negation that replaced
+# the enumeration.
+
+# Templates that must stay committed (they carry no real values).
+ENV_EXAMPLES = (
+    ".env.example",
+    ".env.production.example",
+    ".env.staging.example",
+    "web-ui/.env.example",
+)
+
+# Files that may hold live secrets and must never be committable. The last one
+# does not exist today on purpose: the rule has to fail closed for variants
+# nobody has thought of yet.
+REAL_ENV_FILES = (
+    ".env",
+    ".env.local",
+    ".env.staging",
+    ".env.production",
+    ".env.hosted",
+)
+
+requires_git_checkout = pytest.mark.skipif(
+    shutil.which("git") is None or not (REPO / ".git").exists(),
+    reason="needs a git checkout (not available in an unpacked sdist)",
+)
+
+
+def _is_ignored(path: str) -> bool:
+    """Ask git whether `path` is excluded, rather than re-implementing
+    .gitignore matching here.
+
+    `--no-index` makes this a pure test of the ignore rules: without it git
+    short-circuits and reports any *tracked* file as not-ignored, which would
+    make the ENV_EXAMPLES assertions pass even if the `!` negation were broken.
+    """
+    return (
+        subprocess.run(
+            ["git", "check-ignore", "-q", "--no-index", "--", path],
+            cwd=str(REPO),
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+@requires_git_checkout
+@pytest.mark.parametrize("name", REAL_ENV_FILES)
+def test_real_env_files_are_gitignored(name):
+    """Any file that can hold live credentials must be unstageable."""
+    assert _is_ignored(name), (
+        f"{name} is not gitignored — `git add -A` would publish live secrets "
+        f"to a public repo. Expected `.env*` to match it."
+    )
+
+
+@requires_git_checkout
+@pytest.mark.parametrize("name", ENV_EXAMPLES)
+def test_env_examples_are_not_gitignored(name):
+    """The `.env*` rule must be narrowed by `!.env*.example` so the templates
+    stay committable — otherwise operators lose the files they copy from."""
+    assert not _is_ignored(name), (
+        f"{name} is gitignored — the `!.env*.example` negation is missing or "
+        f"ordered before the `.env*` rule that it must override."
+    )
+
+
+@requires_git_checkout
+@pytest.mark.parametrize("name", ENV_EXAMPLES)
+def test_env_examples_are_still_tracked(name):
+    """Belt-and-braces: the templates are actually in the index."""
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", name],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, f"{name} is no longer tracked: {tracked.stderr.strip()}"


### PR DESCRIPTION
Closes #895.

## Problem

`.gitignore` **enumerated** env files — `.env`, `.env.local`, `.env.staging` — so anything not on the list was committable by default. `.env.production` was not on the list, while:

- `.env.production.example:2` tells operators to copy it and fill in `ANTHROPIC_API_KEY` + `AUTH_SECRET`
- `.github/workflows/deploy.yml:412` writes the real `.env.production` **inside the production git checkout**

So a single `git add -A` on the deploy host would publish live API keys and the JWT signing secret to a public AGPL repo, and `git clean -fd` would delete the live env file out from under the running service.

## Fix

Replace the enumeration with a pattern plus a negation:

```gitignore
.env*
!.env*.example
```

New variants now fail **closed** by default instead of open. This also fixes the second half of the issue: `git clean -fd` skips ignored files (only `-x` removes them), so the live env file survives a routine clean.

## History audit — clean, no rotation required

The third acceptance criterion asks whether a real env file was ever committed. It was not:

- `git log --all --full-history --diff-filter=A` — the only `.env*` paths ever added are the four templates (`.env.example`, `.env.production.example`, `.env.staging.example`, `web-ui/.env.example`)
- Pickaxe scans for `sk-ant-api03`, `AUTH_SECRET=`, `ANTHROPIC_API_KEY=sk` and `e2b_` return only source, doc and test-fixture placeholders (e.g. `"sk-ant-api03-" + "x" * 32`)

**No secret rotation is needed.** Recording this here so the audit is not repeated.

## Tests

`tests/test_deploy_config.py` (+18 parametrized guards, the existing home for repo-level deploy/env checks):

| Guard | Asserts |
|---|---|
| `test_real_env_files_are_gitignored` | `.env`, `.env.local`, `.env.staging`, `.env.production` **and `.env.hosted`** are ignored |
| `test_real_env_files_are_not_tracked` | none of them is in the index (gitignore does not protect a tracked file) |
| `test_env_examples_are_not_gitignored` | all four templates stay committable |
| `test_env_examples_are_still_tracked` | all four templates remain in the index |

Two deliberate details:

- **`git check-ignore --no-index`.** Without `--no-index`, git short-circuits and reports any *tracked* file as not-ignored — so the template assertions would pass even if `!.env*.example` were deleted. The flag makes them a real test of the negation rather than a tautology.
- **The `.env.hosted` canary.** It does not exist, on purpose. A one-line `.env.production` addition would fix the reported symptom and leave the enumeration that caused it; asserting on an unanticipated variant is what pins the fail-closed behaviour against regression.

## Review

Cross-family review by **opencode (GLM)** — verdict: no blocking issues; rule verified against git semantics, ordering correct, tests confirmed non-vacuous. One Minor was **applied**: assert real env files are untracked, since `.gitignore` cannot protect a file already in the index.

## Known limitations

- These guards are **checkout-only** (`requires_git_checkout`) — gitignore behaviour cannot be tested without git, so they do not run against an unpacked sdist.
- `web-ui/.gitignore` still uses the old enumeration style (`.env*.local` + `!.env.example`). Traced and confirmed compatible — the root rule already covers `web-ui/`, and any new `web-ui/.env.production` is caught by root `.env*`. Left alone as unrelated churn; worth simplifying separately to avoid drift.
- `.env*` is intentionally broad and also matches `.envrc` (direnv). Nothing tracked is affected (verified via `git ls-files -i -c --exclude-standard`); a legitimately committable `.env*` file would need explicit re-inclusion.

## Verification

- `uv run pytest tests/test_deploy_config.py` → **31 passed, 1 skipped** (skip is pre-existing: `caddy` not installed)
- `uv run ruff check .` → clean
- Full CI gate `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` → **4372 passed, 5 failed**; all 5 failures reproduce identically on clean `main` (`d696978`) and are **not** caused by this change. Detail below.

<details>
<summary>The 5 pre-existing failures</summary>

- `tests/core/test_conductor.py::TestParallelExecution::test_parallel_independent_tasks_run_concurrently` — timing-sensitive concurrency test; **passes in isolation**, flakes under a 4-hour loaded run.
- `tests/cli/.../test_pr_merge` + 3 × `tests/ui/test_v2_scope_enforcement.py` — fail with `OperationalError('no such table: workspace')` because a developer's repo-root `.codeframe/state.db` is picked up by the workspace walk-up. **All 10 pass once `.codeframe/` is moved aside.** CI has no `.codeframe/`, and `Test Suite (Unit + E2E)` is green on `main` at `d696978`.

Worth tracking separately: tests reading the developer's ambient workspace is a real isolation gap, but out of scope here.
</details>
