### PR TITLE
test(isolation): guard tests against the developer's ambient .codeframe/ (#975)

### DIFF
--- a/tests/cli/test_v2_cli_integration.py
+++ b/tests/cli/test_v2_cli_integration.py
@@ -1184,8 +1184,11 @@ class TestPRCommands:
         assert result.exit_code == 0
         assert "42" in result.output or "created" in result.output.lower()
 
-    def test_pr_merge(self, mock_github_env, mock_pr_details, monkeypatch):
+    def test_pr_merge(self, mock_github_env, mock_pr_details, tmp_path, monkeypatch):
         """PR merge command merges a PR."""
+        # CliRunner does not change cwd, so the PROOF9 merge gate would resolve
+        # the developer's own repo-root workspace (issue #975).
+        monkeypatch.chdir(tmp_path)
         from unittest.mock import AsyncMock
         from codeframe.git.github_integration import MergeResult
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,108 @@ os.environ.setdefault("CODEFRAME_TELEMETRY", "off")
 collect_ignore: list[str] = []
 
 
+# --------------------------------------------------------------------------
+# Ambient-workspace guard (issue #975)
+#
+# Several CLI and API code paths resolve a workspace from the process cwd
+# (``cli/pr_commands.py`` merge gate, ``ui/dependencies.py:get_v2_workspace``).
+# Neither ``CliRunner`` nor ``TestClient`` changes cwd, so under pytest that cwd
+# is the repo root — which on a developer machine holds a real ``.codeframe/``
+# left over from ``codeframe serve`` or dogfooding. Tests then read the
+# developer's own state instead of an isolated one: they fail locally while CI,
+# which has no ``.codeframe/``, stays green.
+#
+# The guard below wraps ``_get_state_dir`` — the chokepoint for every
+# ``core.workspace`` resolution (``get_workspace``, ``create_or_load_workspace``,
+# ``workspace_exists``, ``update_workspace_tech_stack``) — and turns an ambient
+# read into a loud, self-explaining error. It hooks the private helper rather
+# than ``get_workspace`` because callers like ``ui/dependencies.py`` bind
+# ``get_workspace`` by name at import time and would bypass a patch on it;
+# ``_get_state_dir`` is looked up through module globals on every call, so
+# wrapping it covers every import style.
+#
+# SCOPE — what this guard does NOT cover. Several call sites build a
+# ``.codeframe`` path from cwd directly and never reach ``_get_state_dir``:
+#
+#   codeframe/ui/server.py:385,393       WORKSPACE_ROOT / DATABASE_PATH defaults
+#   codeframe/auth/manager.py:90         platform_store DB fallback
+#   codeframe/auth/dependencies.py:291   platform_store DB fallback
+#   codeframe/auth/api_key_router.py:121 platform_store DB fallback
+#   codeframe/cli/auth_commands.py:79    platform_store DB fallback
+#   codeframe/core/config.py:466,712     per-workspace config dir
+#
+# Those are the paths that *wrote* the ambient state.db in the first place.
+# A test exercising one of them without an isolated cwd still reads ambient
+# state and this guard stays silent — so do not treat a green run as proof of
+# isolation for them. They need an explicit env override (DATABASE_PATH,
+# WORKSPACE_ROOT) or `monkeypatch.chdir`.
+# --------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Imported here rather than at the top of the file so the environment defaults
+# set above are already in place — importing core pulls in config, which reads
+# the environment at import time. (E402: deliberate, not an oversight.)
+from codeframe.core import workspace as _workspace_module  # noqa: E402
+
+_REAL_GET_STATE_DIR = _workspace_module._get_state_dir
+
+# Populated by ``pytest_configure`` when --basetemp puts pytest's tmp dirs
+# somewhere the OS does not consider temporary.
+_EXTRA_ISOLATED_ROOTS: list[Path] = []
+
+
+class AmbientWorkspaceError(RuntimeError):
+    """A test tried to resolve a workspace outside an isolated temp directory."""
+
+
+def _isolated_roots() -> list[Path]:
+    """Directories whose contents are per-run scratch space, not real state."""
+    roots = {Path(tempfile.gettempdir()).resolve()}
+    for var in ("TMPDIR", "TEMP", "TMP"):
+        value = os.environ.get(var)
+        if value:
+            roots.add(Path(value).resolve())
+    return [*roots, *_EXTRA_ISOLATED_ROOTS]
+
+
+def _is_isolated(path: Path) -> bool:
+    """True when ``path`` lives under a temp root (``tmp_path``, mkdtemp, ...)."""
+    resolved = Path(path).resolve()
+    return any(resolved.is_relative_to(root) for root in _isolated_roots())
+
+
+@pytest.fixture(autouse=True)
+def forbid_ambient_workspace(monkeypatch):
+    """Fail loudly when a test resolves a workspace outside an isolated dir.
+
+    Only fires when the ``.codeframe/`` directory actually exists — probing a
+    path that has none reads nothing and raises ``FileNotFoundError`` on its own,
+    which is legitimate test behaviour.
+
+    Being function-scoped, this does not cover a *session*- or *module*-scoped
+    fixture that resolves a workspace during its own setup: pytest builds those
+    before any function-scoped fixture. No such fixture exists in the non-e2e
+    suite today. If one is added, guard it there too rather than assuming this
+    covers it.
+    """
+
+    def guarded_get_state_dir(repo_path: Path) -> Path:
+        state_dir = _REAL_GET_STATE_DIR(repo_path)
+        if state_dir.exists() and not _is_isolated(state_dir):
+            raise AmbientWorkspaceError(
+                f"Test resolved the ambient workspace at {state_dir}.\n"
+                "Tests must never read the developer's real .codeframe/ state — "
+                "it makes the suite pass on CI and fail locally (issue #975).\n"
+                "Fix: run the test from an isolated cwd with "
+                "`monkeypatch.chdir(tmp_path)`, or pass an explicit workspace "
+                "path (repo_path=/workspace_path=) instead of relying on cwd."
+            )
+        return state_dir
+
+    monkeypatch.setattr(_workspace_module, "_get_state_dir", guarded_get_state_dir)
+
+
 def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     """Create a JWT token for testing.
 
@@ -194,6 +296,10 @@ def openai_api_key(mock_env) -> str:
 # Markers for test organization
 def pytest_configure(config):
     """Configure pytest with custom markers."""
+    # --basetemp can point tmp_path outside the OS temp root; still isolated.
+    if config.option.basetemp:
+        _EXTRA_ISOLATED_ROOTS.append(Path(config.option.basetemp).resolve())
+
     config.addinivalue_line("markers", "unit: mark test as a unit test")
     config.addinivalue_line("markers", "integration: mark test as an integration test")
     config.addinivalue_line("markers", "slow: mark test as slow running")

--- a/tests/test_ambient_workspace_guard.py
+++ b/tests/test_ambient_workspace_guard.py
@@ -1,0 +1,100 @@
+"""The ambient-workspace guard itself (issue #975).
+
+Four tests used to fail on a pristine ``main`` purely because the developer's
+repo-root ``.codeframe/`` existed: CLI and API code paths fall back to
+``Path.cwd()`` to resolve a workspace, ``CliRunner``/``TestClient`` do not change
+cwd, and the repo-root ``.codeframe/state.db`` is a *platform_store* DB with no
+``workspace`` table — so the resolution blew up instead of finding nothing.
+
+``tests/conftest.py`` installs an autouse guard that turns any such ambient
+resolution into a loud, self-explaining failure. These tests prove the guard
+fires where it should and stays out of the way where it shouldn't.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codeframe.core import workspace as workspace_module
+from codeframe.core.workspace import create_or_load_workspace, get_workspace, workspace_exists
+
+from .conftest import _REAL_GET_STATE_DIR, REPO_ROOT, AmbientWorkspaceError, _is_isolated
+
+pytestmark = pytest.mark.v2
+
+# The guard defines "ambient" as "outside a temp root". If the checkout itself
+# lives under /tmp (some ephemeral CI runners), no path near the repo is ambient
+# and these tests have nothing real to assert against.
+needs_ambient_location = pytest.mark.skipif(
+    _is_isolated(REPO_ROOT),
+    reason="repo is checked out under a temp root, so no ambient path exists here",
+)
+
+
+@pytest.fixture
+def ambient_repo():
+    """A real directory outside any temp root holding a ``.codeframe/``.
+
+    Stands in for the developer's own checkout — created next to the repo rather
+    than under ``tmp_path`` precisely so the guard sees it as non-isolated.
+    """
+    path = Path(tempfile.mkdtemp(dir=REPO_ROOT, prefix=".ambient-probe-"))
+    (path / ".codeframe").mkdir()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def test_guard_is_installed():
+    """The autouse fixture wraps the real resolver for every test."""
+    assert workspace_module._get_state_dir is not _REAL_GET_STATE_DIR
+
+
+@needs_ambient_location
+def test_guard_fires_on_a_real_ambient_workspace(ambient_repo):
+    """Resolving a workspace outside a temp root is an error, not a surprise."""
+    with pytest.raises(AmbientWorkspaceError, match="ambient"):
+        workspace_exists(ambient_repo)
+
+
+@needs_ambient_location
+def test_guard_message_names_the_path_and_the_fix(ambient_repo):
+    """A loud failure is only useful if it says what to do about it."""
+    with pytest.raises(AmbientWorkspaceError) as exc:
+        get_workspace(ambient_repo)
+
+    message = str(exc.value)
+    assert str(ambient_repo / ".codeframe") in message
+    assert "tmp_path" in message
+
+
+def test_guard_allows_workspaces_under_tmp_path(tmp_path):
+    """The normal case — an isolated workspace — is untouched."""
+    workspace = create_or_load_workspace(tmp_path, tech_stack="python")
+
+    assert workspace_exists(tmp_path)
+    assert get_workspace(tmp_path).id == workspace.id
+
+
+def test_guard_ignores_paths_with_no_state_dir():
+    """Probing a path that has no ``.codeframe/`` reads nothing, so it is allowed.
+
+    ``workspace_exists`` is a legitimate read-only probe; only a resolution that
+    would actually open ambient state is a defect.
+    """
+    assert workspace_exists(REPO_ROOT / "codeframe" / "core") is False
+
+
+@needs_ambient_location
+def test_repo_root_is_not_treated_as_isolated():
+    """Sanity-check the isolation predicate the guard is built on."""
+    assert _is_isolated(REPO_ROOT / ".codeframe") is False
+    assert _is_isolated(Path.home() / ".codeframe") is False
+
+
+def test_tmp_path_is_treated_as_isolated(tmp_path):
+    """The other half of the predicate — temp dirs must read as isolated."""
+    assert _is_isolated(tmp_path / ".codeframe") is True

--- a/tests/ui/test_v2_scope_enforcement.py
+++ b/tests/ui/test_v2_scope_enforcement.py
@@ -13,6 +13,7 @@ this only constrains scoped API keys.
 """
 
 import importlib
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -28,6 +29,11 @@ pytestmark = pytest.mark.v2
 @pytest.fixture
 def scoped_app(tmp_path, monkeypatch):
     """Real server app with auth ON and three API keys (read/write/admin)."""
+    # TestClient does not change cwd, so routes that resolve a workspace from
+    # Path.cwd() (get_v2_workspace) would read the developer's own repo-root
+    # .codeframe/ (issue #975). Chdir before the server reload below so the
+    # module's cwd-derived defaults are isolated too.
+    monkeypatch.chdir(tmp_path)
     db_path = tmp_path / "state.db"
     monkeypatch.setenv("DATABASE_PATH", str(db_path))
     monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
@@ -55,6 +61,13 @@ def scoped_app(tmp_path, monkeypatch):
 
     from codeframe.ui import server
 
+    # server.py re-reads Path.cwd() at module eval for the WORKSPACE_ROOT and
+    # DATABASE_PATH defaults. DATABASE_PATH is overridden above, but
+    # WORKSPACE_ROOT is not — so the chdir MUST still be in effect here or
+    # app.state.workspace_manager binds to the developer's real workspaces dir.
+    # The conftest guard does not cover that path (it bypasses _get_state_dir),
+    # so assert the ordering rather than trusting it.
+    assert Path.cwd() == tmp_path
     importlib.reload(server)
 
     # Isolate the credential store: with auth ON, requests carry user_id=1 and


### PR DESCRIPTION
Closes #975.

## Problem

Four tests failed on **any** branch — including a pristine `main` — purely because the developer's repo-root `.codeframe/` directory existed.

The mechanism, confirmed locally: `codeframe serve` defaults `DATABASE_PATH` to `Path.cwd()/.codeframe/state.db` (`ui/server.py:393`), so dogfooding leaves a **platform_store** DB (`users`, `api_keys`, `sessions`) at the repo root. That DB has no `workspace` table. Two cwd fallbacks then read it as if it were a workspace:

- `cli/pr_commands.py:413` — `get_workspace(Path.cwd())` in the PROOF9 merge gate
- `ui/dependencies.py:160,174` — `get_v2_workspace` falls back to `Path.cwd()`

`workspace_exists()` only checks that the file exists → `True`; `get_workspace()` then raises `OperationalError('no such table: workspace')`. The CLI gate correctly failed closed (`exit_code == 1`) and the API path 500'd out of `TestClient`. Neither `CliRunner` nor `TestClient` changes cwd, so under pytest cwd is always the repo root.

CI has no `.codeframe/`, so it stayed green while the same commit was red locally — the inverse of the usual ambient-env trap.

## Fix

**No production code is touched.** The defect is that tests read the developer's ambient workspace; fail-closed-on-a-broken-ledger is correct behaviour and is unchanged.

| Change | File |
|---|---|
| Autouse guard: raises a self-explaining `AmbientWorkspaceError` when a test resolves a `.codeframe/` outside a temp root | `tests/conftest.py` |
| Coverage for the guard itself | `tests/test_ambient_workspace_guard.py` (new) |
| `monkeypatch.chdir(tmp_path)` on the merge test | `tests/cli/test_v2_cli_integration.py` |
| `monkeypatch.chdir(tmp_path)` + a cwd assertion in `scoped_app` | `tests/ui/test_v2_scope_enforcement.py` |

The chdir approach reuses the pattern already established at `tests/cli/test_pr_commands.py:295` rather than introducing a resolver-injection abstraction.

### Why the guard hooks a private helper

It wraps `core.workspace._get_state_dir`, not `get_workspace`. `ui/dependencies.py:19` binds `get_workspace` **at import time**, so patching the public name would silently miss the entire API surface — 3 of the 4 reported failures. `_get_state_dir` is resolved through module globals on every call, so wrapping it covers every import style.

The trade-off: renaming `_get_state_dir` in production would break the guard. `test_guard_is_installed` fails loudly if that happens rather than silently disarming.

### Guard trip condition

Fires when the resolved `.codeframe/` **exists** *and* is **outside a temp root** — rather than the issue's literal "outside `tmp_path`". The suite legitimately uses both `tmp_path` and `tempfile.TemporaryDirectory()` (both isolated), and requiring the directory to actually exist means tests that deliberately probe non-existent paths keep their normal `FileNotFoundError` instead of a spurious guard failure. Validated across ~4,400 tests with zero false positives.

## Verification

- **The four named tests pass with a real `.codeframe/` present** at the repo root (the reproduction condition).
- **Full non-e2e suite green with `.codeframe/` present.** Run in three chunks on a machine that has the ambient workspace (4,421 collected):
  - adapters → most of core: 0 failures through 89%
  - rest of core + debug/integration/lib/notifications/planning/platform_store/scripts: **396 passed, 3 skipped**
  - ui/unit/workspace/contract: **697 passed, 30 skipped**, zero guard hits
- **Mutation check**: disabling the guard's condition fails exactly the two firing tests and no others — they detect the defect rather than asserting plumbing.
- `uv run ruff check .` clean; pre-commit hooks pass.
- **Third-party review**: opencode (GLM). Its central finding — that the "single chokepoint" claim in my comment was false — was verified and corrected (see below).

## Known limitations

1. **The guard does not cover every ambient `.codeframe/` read.** Six production sites build the path from cwd directly and never reach `_get_state_dir`: `ui/server.py:385,393`, `auth/manager.py:90`, `auth/dependencies.py:291`, `auth/api_key_router.py:121`, `cli/auth_commands.py:79`, `core/config.py:466,712`. These are the paths that *wrote* the ambient `state.db` in the first place. A test exercising one of them without an isolated cwd still reads ambient state and the guard stays silent. This is now enumerated in the conftest comment so a green run is not mistaken for proof of isolation there — those need an explicit `DATABASE_PATH`/`WORKSPACE_ROOT` override or a chdir.

2. **`scoped_app`'s `WORKSPACE_ROOT` isolation rests on ordering, not the guard.** `server.py:385` re-reads `Path.cwd()` at module eval, and the fixture overrides `DATABASE_PATH` but not `WORKSPACE_ROOT`. The chdir must precede `importlib.reload(server)`. Since the guard cannot backstop that path, the fixture now asserts `Path.cwd() == tmp_path` immediately before the reload.

3. **Function-scoped, so it does not cover session/module-scoped fixtures**, which pytest builds first. No such fixture resolves a workspace in the non-e2e suite today (verified); the docstring says to guard explicitly if one is added.

4. **`cli/app.py:37` captures `_cwd = Path.cwd()` at import** and loads a repo-root `.env` at collection time. Out of scope here, but it is ambient state this change does not address.

5. **Guard is inert if the checkout itself lives under a temp root** (some ephemeral CI runners). The tests that need a genuinely ambient path skip in that case rather than failing.
