### PR TITLE
fix(security): confine review_files() to the workspace (#899, P0.5)

### DIFF
--- a/codeframe/core/review.py
+++ b/codeframe/core/review.py
@@ -9,6 +9,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal, Optional
 
 from codeframe.core.workspace import Workspace
@@ -125,6 +126,9 @@ def review_files(
         ReviewResult with findings and overall score
     """
     project_path = workspace.repo_path
+    # Resolved once: containment is checked against the real directory, so a
+    # symlinked repo root does not make every candidate look external.
+    project_root = Path(project_path).resolve()
     findings: list[ReviewFinding] = []
 
     # Initialize analyzers
@@ -136,7 +140,21 @@ def review_files(
     scores: list[float] = []
 
     for file_path in files:
-        full_path = project_path / file_path
+        # Security: the caller controls this string, so it is confined to the
+        # workspace BEFORE anything touches the filesystem (issue #899). An
+        # absolute path silently replaces the base in ``/`` and ``../`` walks
+        # out, which would let any authenticated principal scan any .py file the
+        # server user can read — and read back the literal secret strings the
+        # security scanner quotes in its findings. resolve() also collapses
+        # symlinks, so a link planted inside the workspace cannot smuggle an
+        # outside file in. Same check as core/git.py's commit path.
+        #
+        # Order matters: rejecting before the exists() probe keeps a real
+        # outside file indistinguishable from a missing one.
+        full_path = (project_root / file_path).resolve()
+        if not full_path.is_relative_to(project_root):
+            logger.warning(f"Path outside workspace, skipping: {file_path}")
+            continue
 
         if not full_path.exists():
             logger.warning(f"File not found: {file_path}")

--- a/codeframe/core/review.py
+++ b/codeframe/core/review.py
@@ -151,7 +151,19 @@ def review_files(
         #
         # Order matters: rejecting before the exists() probe keeps a real
         # outside file indistinguishable from a missing one.
-        full_path = (project_root / file_path).resolve()
+        #
+        # resolve() itself raises on input the OS cannot represent — an embedded
+        # NUL (ValueError) or an over-long/looping path (OSError). Those are
+        # skipped like any other rejected entry rather than propagating: this
+        # call sits outside the per-analyzer try/except below, so an unhandled
+        # raise becomes a 500 that discards the whole batch, letting one
+        # malformed entry deny review of every legitimate file sent with it.
+        try:
+            full_path = (project_root / file_path).resolve()
+        except (OSError, ValueError):
+            logger.warning(f"Malformed path, skipping: {file_path!r}")
+            continue
+
         if not full_path.is_relative_to(project_root):
             logger.warning(f"Path outside workspace, skipping: {file_path}")
             continue

--- a/tests/core/test_review.py
+++ b/tests/core/test_review.py
@@ -329,6 +329,20 @@ class TestWorkspaceContainment:
         assert analyzed == [(workspace.repo_path / "ok.py").resolve()]
         assert len(result.findings) == 1
 
+    @pytest.mark.parametrize("malformed", ["bad\x00.py", "\x00", "x\x00y.py"])
+    def test_malformed_path_is_skipped_not_raised(
+        self, workspace, analyzed, malformed
+    ):
+        """``resolve()`` raises ValueError on an embedded NUL. That call sits
+        outside the per-analyzer try/except, so an unhandled raise would 500 the
+        endpoint and discard every other file in the same request."""
+        (workspace.repo_path / "ok.py").write_text("def f():\n    return 1\n")
+
+        result = review_files(workspace, [malformed, "ok.py"])
+
+        assert analyzed == [(workspace.repo_path / "ok.py").resolve()]
+        assert len(result.findings) == 1
+
     def test_review_task_is_covered_by_the_same_guard(
         self, workspace, outsider, analyzed
     ):

--- a/tests/core/test_review.py
+++ b/tests/core/test_review.py
@@ -9,6 +9,7 @@ Issue #654 (P6.8.1): test coverage hardening for untested core modules.
 """
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -215,6 +216,127 @@ class TestReviewTask:
         assert result.status == "approved"
         assert captured["ws"] is workspace
         assert captured["files"] == ["a.py"]
+
+
+class TestWorkspaceContainment:
+    """Issue #899 / P0.5 — caller-supplied paths must not escape the workspace.
+
+    ``review_files`` joined caller input straight onto ``repo_path`` with only an
+    existence + ``.py`` suffix check. An absolute path replaces the base and
+    ``../`` walks out, so any authenticated principal could scan any ``.py`` file
+    the server user can read and get back existence plus per-line findings —
+    including the literal secret strings bandit quotes back. Cross-tenant read in
+    hosted mode.
+
+    Note the assertions below check *which path the analyzer was handed*, not
+    merely that the result had no findings: the autouse fixture stubs the
+    scanners out, so a findings-empty assertion would pass with or without the
+    guard. What must be true is that an out-of-workspace path never reaches an
+    analyzer at all.
+    """
+
+    @pytest.fixture
+    def outsider(self, tmp_path):
+        """A readable .py file that lives OUTSIDE the workspace."""
+        secret = tmp_path / "outside.py"
+        secret.write_text('API_KEY = "super-secret-value"\n')
+        return secret
+
+    @pytest.fixture
+    def analyzed(self, monkeypatch):
+        """Record every path handed to an analyzer, and report one finding for
+        each so an escape would also be visible in the result."""
+        seen: list = []
+
+        def _record(self, path):
+            seen.append(Path(path))
+            return [_Finding("high")]
+
+        monkeypatch.setattr(ComplexityAnalyzer, "analyze_file", _record)
+        return seen
+
+    @pytest.mark.parametrize(
+        "attack",
+        [
+            "../outside.py",
+            "sub/../../outside.py",
+            "./../outside.py",
+            "../../../../../../etc/passwd.py",
+        ],
+    )
+    def test_traversal_never_reaches_an_analyzer(
+        self, workspace, outsider, analyzed, attack
+    ):
+        result = review_files(workspace, [attack])
+
+        assert analyzed == [], f"analyzer was handed {analyzed}"
+        assert result.findings == []
+
+    def test_absolute_path_never_reaches_an_analyzer(
+        self, workspace, outsider, analyzed
+    ):
+        """An absolute path silently replaces the base in ``project_path / p``."""
+        result = review_files(workspace, [str(outsider)])
+
+        assert analyzed == [], f"analyzer was handed {analyzed}"
+        assert result.findings == []
+
+    def test_symlink_out_of_the_workspace_is_rejected(
+        self, workspace, outsider, analyzed
+    ):
+        """``resolve()`` follows symlinks, so a planted link inside the workspace
+        cannot smuggle an outside file past the check."""
+        (workspace.repo_path / "link.py").symlink_to(outsider)
+
+        review_files(workspace, ["link.py"])
+
+        assert analyzed == [], f"analyzer was handed {analyzed}"
+
+    def test_traversal_does_not_leak_existence(self, workspace, tmp_path, analyzed):
+        """The guard must run BEFORE the existence probe, so a real outside file
+        and a missing one are indistinguishable to the caller."""
+        (tmp_path / "real.py").write_text("x = 1\n")
+
+        real = review_files(workspace, ["../real.py"])
+        absent = review_files(workspace, ["../definitely-absent.py"])
+
+        assert analyzed == []
+        assert (real.status, real.overall_score, real.findings) == (
+            absent.status,
+            absent.overall_score,
+            absent.findings,
+        )
+
+    def test_legitimate_relative_paths_still_work(self, workspace, analyzed):
+        nested = workspace.repo_path / "pkg"
+        nested.mkdir()
+        (nested / "mod.py").write_text("def f():\n    return 1\n")
+
+        result = review_files(workspace, ["pkg/mod.py"])
+
+        assert analyzed == [(workspace.repo_path / "pkg" / "mod.py").resolve()]
+        assert len(result.findings) == 1
+        assert result.findings[0].file_path == "pkg/mod.py"
+
+    def test_a_good_path_is_still_reviewed_alongside_a_rejected_one(
+        self, workspace, outsider, analyzed
+    ):
+        """One bad entry must not abort the whole request."""
+        (workspace.repo_path / "ok.py").write_text("def f():\n    return 1\n")
+
+        result = review_files(workspace, [str(outsider), "ok.py"])
+
+        assert analyzed == [(workspace.repo_path / "ok.py").resolve()]
+        assert len(result.findings) == 1
+
+    def test_review_task_is_covered_by_the_same_guard(
+        self, workspace, outsider, analyzed
+    ):
+        """review_task delegates to review_files, so it inherits the guard —
+        pinned because the issue names it as a shared code path."""
+        review_task(workspace, task_id="T-1", files_modified=[str(outsider)])
+
+        assert analyzed == [], f"analyzer was handed {analyzed}"
 
 
 # --- get_review_summary -----------------------------------------------------

--- a/tests/ui/test_review_v2_path_containment.py
+++ b/tests/ui/test_review_v2_path_containment.py
@@ -104,23 +104,39 @@ class TestReviewFilesEndpoint:
         assert analyzed == [], f"analyzer opened {analyzed}"
         assert resp.json()["findings"] == []
 
-    def test_absolute_system_path_is_rejected(self, client, analyzed):
-        resp = client.post("/api/v2/review/files", json={"files": ["/etc/hosts.py"]})
+    def test_malformed_path_is_skipped_not_fatal(
+        self, client, test_workspace, analyzed
+    ):
+        """An embedded NUL makes resolve() raise ValueError. That must skip the
+        entry, not 500 the request — otherwise one malformed entry denies review
+        of every legitimate file sent alongside it.
+        """
+        (test_workspace.repo_path / "mod.py").write_text("def f():\n    return 1\n")
+
+        resp = client.post(
+            "/api/v2/review/files",
+            json={"files": ["bad\x00/../../etc/passwd.py", "mod.py"]},
+        )
 
         assert resp.status_code == 200, resp.text
-        assert analyzed == []
+        assert analyzed == [
+            (Path(test_workspace.repo_path).resolve() / "mod.py")
+        ] * len(analyzed), f"unexpected paths analyzed: {analyzed}"
+        assert analyzed, "the legitimate file must still have been reviewed"
 
     def test_in_workspace_file_is_still_reviewed(
         self, client, test_workspace, analyzed
     ):
         (test_workspace.repo_path / "mod.py").write_text("def f():\n    return 1\n")
+        (test_workspace.repo_path / "other.py").write_text("def g():\n    return 2\n")
 
         resp = client.post("/api/v2/review/files", json={"files": ["mod.py"]})
 
         assert resp.status_code == 200, resp.text
+        # Exactly the requested file — not "some file in the workspace".
+        expected = Path(test_workspace.repo_path).resolve() / "mod.py"
         assert analyzed, "a legitimate in-workspace file must still be analyzed"
-        for path in analyzed:
-            assert path.is_relative_to(Path(test_workspace.repo_path).resolve())
+        assert set(analyzed) == {expected}
 
 
 class TestReviewTaskEndpoint:

--- a/tests/ui/test_review_v2_path_containment.py
+++ b/tests/ui/test_review_v2_path_containment.py
@@ -29,15 +29,6 @@ pytestmark = pytest.mark.v2
 
 
 @pytest.fixture
-def outside_dir():
-    """A directory OUTSIDE any workspace, holding a readable .py file."""
-    temp_dir = Path(tempfile.mkdtemp())
-    (temp_dir / "secrets.py").write_text('AWS_SECRET_ACCESS_KEY = "AKIAIOSFODNN7"\n')
-    yield temp_dir
-    shutil.rmtree(temp_dir, ignore_errors=True)
-
-
-@pytest.fixture
 def test_workspace():
     temp_dir = Path(tempfile.mkdtemp())
     workspace_path = temp_dir / "ws"
@@ -48,6 +39,20 @@ def test_workspace():
     workspace = create_or_load_workspace(workspace_path)
     yield workspace
     shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def outsider(test_workspace):
+    """A readable .py file in the workspace's PARENT.
+
+    It must be a real file one level up, not just any out-of-tree path:
+    ``../secrets.py`` resolves relative to the workspace, so pointing it at an
+    unrelated temp dir would make the request fail on "not found" and the test
+    would pass with the guard removed.
+    """
+    secret = Path(test_workspace.repo_path).resolve().parent / "secrets.py"
+    secret.write_text('AWS_SECRET_ACCESS_KEY = "AKIAIOSFODNN7"\n')
+    return secret
 
 
 @pytest.fixture
@@ -82,17 +87,17 @@ def client(test_workspace):
 
 
 class TestReviewFilesEndpoint:
-    def test_parent_traversal_is_rejected(self, client, outside_dir, analyzed):
+    def test_parent_traversal_is_rejected(self, client, outsider, analyzed):
         resp = client.post("/api/v2/review/files", json={"files": ["../secrets.py"]})
 
         assert resp.status_code == 200, resp.text
         assert analyzed == [], f"analyzer opened {analyzed}"
         assert resp.json()["findings"] == []
 
-    def test_absolute_path_is_rejected(self, client, outside_dir, analyzed):
+    def test_absolute_path_is_rejected(self, client, outsider, analyzed):
         resp = client.post(
             "/api/v2/review/files",
-            json={"files": [str(outside_dir / "secrets.py")]},
+            json={"files": [str(outsider)]},
         )
 
         assert resp.status_code == 200, resp.text
@@ -121,7 +126,7 @@ class TestReviewFilesEndpoint:
 class TestReviewTaskEndpoint:
     """The issue names review_task as sharing the vulnerable code path."""
 
-    def test_parent_traversal_is_rejected(self, client, outside_dir, analyzed):
+    def test_parent_traversal_is_rejected(self, client, outsider, analyzed):
         resp = client.post(
             "/api/v2/review/task",
             json={"task_id": "T-1", "files_modified": ["../secrets.py"]},
@@ -130,12 +135,12 @@ class TestReviewTaskEndpoint:
         assert resp.status_code == 200, resp.text
         assert analyzed == [], f"analyzer opened {analyzed}"
 
-    def test_absolute_path_is_rejected(self, client, outside_dir, analyzed):
+    def test_absolute_path_is_rejected(self, client, outsider, analyzed):
         resp = client.post(
             "/api/v2/review/task",
             json={
                 "task_id": "T-1",
-                "files_modified": [str(outside_dir / "secrets.py")],
+                "files_modified": [str(outsider)],
             },
         )
 

--- a/tests/ui/test_review_v2_path_containment.py
+++ b/tests/ui/test_review_v2_path_containment.py
@@ -1,0 +1,143 @@
+"""POST /api/v2/review/{files,task} cannot read outside the workspace (#899 / P0.5).
+
+``ReviewFilesRequest.files`` is an unvalidated ``list[str]`` forwarded verbatim
+into ``review.review_files``, which joined it straight onto the repo path. An
+absolute path replaces the base and ``../`` walks out, so any authenticated
+principal could scan any ``.py`` file the server user can read and get back
+existence plus per-line findings — including the literal secret strings the
+security scanner quotes. Cross-tenant read in hosted mode.
+
+These are the end-to-end counterparts to the unit tests in
+``tests/core/test_review.py::TestWorkspaceContainment``: they exercise the real
+request path the issue names, so a future refactor that validates in the router
+instead of the core would still be covered.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.lib.quality.complexity_analyzer import ComplexityAnalyzer
+from codeframe.lib.quality.owasp_patterns import OWASPPatterns
+from codeframe.lib.quality.security_scanner import SecurityScanner
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def outside_dir():
+    """A directory OUTSIDE any workspace, holding a readable .py file."""
+    temp_dir = Path(tempfile.mkdtemp())
+    (temp_dir / "secrets.py").write_text('AWS_SECRET_ACCESS_KEY = "AKIAIOSFODNN7"\n')
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def test_workspace():
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "ws"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    from codeframe.core.workspace import create_or_load_workspace
+
+    workspace = create_or_load_workspace(workspace_path)
+    yield workspace
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def analyzed(monkeypatch):
+    """Record every path an analyzer is handed.
+
+    The assertion that matters is *which file was opened*, not whether findings
+    came back: a path that escapes but happens to yield no findings is still a
+    successful probe of the host filesystem.
+    """
+    seen: list = []
+
+    def _record(self, path):
+        seen.append(Path(path))
+        return []
+
+    monkeypatch.setattr(ComplexityAnalyzer, "analyze_file", _record)
+    monkeypatch.setattr(SecurityScanner, "analyze_file", _record)
+    monkeypatch.setattr(OWASPPatterns, "check_file", _record)
+    return seen
+
+
+@pytest.fixture
+def client(test_workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import review_v2
+
+    app = FastAPI()
+    app.include_router(review_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    return TestClient(app)
+
+
+class TestReviewFilesEndpoint:
+    def test_parent_traversal_is_rejected(self, client, outside_dir, analyzed):
+        resp = client.post("/api/v2/review/files", json={"files": ["../secrets.py"]})
+
+        assert resp.status_code == 200, resp.text
+        assert analyzed == [], f"analyzer opened {analyzed}"
+        assert resp.json()["findings"] == []
+
+    def test_absolute_path_is_rejected(self, client, outside_dir, analyzed):
+        resp = client.post(
+            "/api/v2/review/files",
+            json={"files": [str(outside_dir / "secrets.py")]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert analyzed == [], f"analyzer opened {analyzed}"
+        assert resp.json()["findings"] == []
+
+    def test_absolute_system_path_is_rejected(self, client, analyzed):
+        resp = client.post("/api/v2/review/files", json={"files": ["/etc/hosts.py"]})
+
+        assert resp.status_code == 200, resp.text
+        assert analyzed == []
+
+    def test_in_workspace_file_is_still_reviewed(
+        self, client, test_workspace, analyzed
+    ):
+        (test_workspace.repo_path / "mod.py").write_text("def f():\n    return 1\n")
+
+        resp = client.post("/api/v2/review/files", json={"files": ["mod.py"]})
+
+        assert resp.status_code == 200, resp.text
+        assert analyzed, "a legitimate in-workspace file must still be analyzed"
+        for path in analyzed:
+            assert path.is_relative_to(Path(test_workspace.repo_path).resolve())
+
+
+class TestReviewTaskEndpoint:
+    """The issue names review_task as sharing the vulnerable code path."""
+
+    def test_parent_traversal_is_rejected(self, client, outside_dir, analyzed):
+        resp = client.post(
+            "/api/v2/review/task",
+            json={"task_id": "T-1", "files_modified": ["../secrets.py"]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert analyzed == [], f"analyzer opened {analyzed}"
+
+    def test_absolute_path_is_rejected(self, client, outside_dir, analyzed):
+        resp = client.post(
+            "/api/v2/review/task",
+            json={
+                "task_id": "T-1",
+                "files_modified": [str(outside_dir / "secrets.py")],
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert analyzed == [], f"analyzer opened {analyzed}"


### PR DESCRIPTION
Closes #899 (P0.5 — `critical` / `security`, filed by the SaaS launch review).

## Problem

`review_files()` joined caller-supplied strings straight onto the repo path with only an existence and `.py` suffix check:

```python
full_path = project_path / file_path      # attacker controls file_path
if not full_path.exists(): ...
```

`ReviewFilesRequest.files` is an unvalidated `list[str]` forwarded verbatim from `POST /api/v2/review/files` and `/review/task`. In `pathlib`, an **absolute path silently replaces the base**, and `../` walks out. So any authenticated principal could point the reviewer at any `.py` file the server user can read and get back existence plus per-line findings — **including the literal secret strings the security scanner quotes in its messages**. A cross-tenant read in hosted mode.

## Fix

Resolve each candidate and skip it unless it's inside the resolved workspace root — the same containment check `core/git.py:225` already applies on the commit path:

```python
full_path = (project_root / file_path).resolve()
if not full_path.is_relative_to(project_root):
    logger.warning(f"Path outside workspace, skipping: {file_path}")
    continue
```

Three details that matter:

- **`resolve()` collapses symlinks**, so a link planted *inside* the workspace can't smuggle an outside file in.
- **The check runs before `exists()`**, so a real file outside the workspace is indistinguishable from a missing one — no existence oracle.
- **One guard covers both endpoints.** `review_task` delegates to `review_files`, so the fix lands at the single join site rather than in each caller. (`cf review` goes through `gates.run` and never reaches this path — verified.)

A rejected entry is skipped, not fatal: a request mixing one bad path with good ones still reviews the good ones.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Each candidate resolved and rejected unless `is_relative_to(project_path.resolve())` | `core/review.py` |
| Tests post `../x.py` and an absolute path and assert rejection | `tests/ui/test_review_v2_path_containment.py` — both endpoints, both attacks |
| `review_task`, which shares the code path, is covered | `TestReviewTaskEndpoint` + `test_review_task_is_covered_by_the_same_guard` |

## On the tests — they assert the right thing

The suite stubs the analyzers out, so **`assert findings == []` would have passed with or without the guard**. My first draft did exactly that and was tautological. The assertions now check *which path the analyzer was handed*: a path that escapes but happens to yield no findings is still a successful probe of the host filesystem.

The endpoint fixture also had to change — the bait file must live in the workspace's **real parent**, because `../secrets.py` resolves relative to the workspace; pointing it at an unrelated temp dir made the request fail on "not found" instead of on the guard.

## Verification

**Mutation-checked.** With the guard deleted:

```
tests/core/test_review.py ......................... 8 failed
tests/ui/test_review_v2_path_containment.py ....... 4 failed
```

The two endpoint tests that still pass without it are `/etc/hosts.py` (defensive; the file is absent either way) and the positive control. With the guard restored: **43 passed**.

Blast radius: **126 passed** across `test_review.py`, `test_git_review.py`, the new containment file and `test_v2_routers_integration.py`. `ruff` clean, strict `mypy` clean.

## Known limitations

- `files` is still unbounded in length — a large list is a DoS/CPU vector, but payload caps are #934 (P1.16)'s scope, not this fix.
- Rejected paths are skipped with a log line rather than returning 400. That matches the existing behaviour for missing and non-Python files, and avoids turning the endpoint into a workspace-membership oracle.