### PR TITLE
fix(security): scope GitHub PR endpoints to the caller's credential and repo (#900, P0.6)

### DIFF
--- a/codeframe/cli/pr_commands.py
+++ b/codeframe/cli/pr_commands.py
@@ -121,28 +121,54 @@ def get_commit_messages(repo_path: Path, base: str, head: str) -> str:
 
 
 def _get_github_config() -> tuple[str, str]:
-    """Get GitHub token and repo from environment.
+    """Resolve the GitHub token and repo for the workspace in the cwd (#900).
+
+    Shares ``core.github_integration_config.resolve_github_credentials`` with
+    the v2 PR router, so ``cf pr`` and the web UI cannot drift on which
+    credential or repository they act with: the stored PAT wins over the
+    ambient ``GITHUB_TOKEN``, and the repo comes from the workspace's own
+    ``.codeframe/github_integration.json`` before ``GITHUB_REPO``.
+
+    The CLI is single-operator, so the machine-wide credential store is used
+    (``user_id=None``) and the environment remains a valid fallback.
 
     Returns:
         Tuple of (token, repo)
 
     Raises:
-        typer.Exit: If configuration is missing
+        typer.Exit: If neither half can be resolved.
     """
-    token = os.environ.get("GITHUB_TOKEN")
-    repo = os.environ.get("GITHUB_REPO")
+    from codeframe.core.github_integration_config import (
+        GitHubResolutionError,
+        resolve_github_credentials,
+    )
+    from codeframe.core.workspace import get_workspace
 
-    if not token:
-        console.print("[red]Error:[/red] GITHUB_TOKEN environment variable not set.")
-        console.print("Set it with: export GITHUB_TOKEN=ghp_yourtoken")
+    try:
+        workspace = get_workspace(Path.cwd())
+    except FileNotFoundError:
+        # No workspace here: fall back to the pure-environment behaviour so
+        # `cf pr` still works from a bare checkout.
+        token = os.environ.get("GITHUB_TOKEN")
+        repo = os.environ.get("GITHUB_REPO")
+        if not token or not repo:
+            console.print(
+                "[red]Error:[/red] No CodeFRAME workspace here, and "
+                "GITHUB_TOKEN/GITHUB_REPO are not both set."
+            )
+            console.print("Run 'cf init' here, or export both variables.")
+            raise typer.Exit(1)
+        return token, repo
+
+    try:
+        return resolve_github_credentials(workspace, user_id=None)
+    except GitHubResolutionError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        console.print(
+            "From the CLI you can also: export GITHUB_TOKEN=ghp_yourtoken "
+            "and export GITHUB_REPO=owner/repo"
+        )
         raise typer.Exit(1)
-
-    if not repo:
-        console.print("[red]Error:[/red] GITHUB_REPO environment variable not set.")
-        console.print("Set it with: export GITHUB_REPO=owner/repo")
-        raise typer.Exit(1)
-
-    return token, repo
 
 
 def _run_async(coro):

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -737,31 +737,60 @@ class CredentialManager:
         self,
         provider: CredentialProvider,
         name: Optional[str] = None,
+        *,
+        prefer_stored: bool = False,
     ) -> Optional[str]:
         """Get credential value, checking env var first.
 
         Args:
             provider: The provider type
             name: Optional credential name (unused for env var lookup)
+            prefer_stored: Check this manager's store *before* the environment.
+                The default env-first order is a self-hosted convenience, but it
+                is wrong for a user-scoped manager: the environment belongs to
+                the operator, not to the caller, so an ambient ``GITHUB_TOKEN``
+                would silently win over the PAT a user connected in the UI and
+                act on the operator's behalf (issue #900). Callers resolving a
+                per-user credential must pass this.
 
         Returns:
             Credential value if found, None otherwise
         """
-        # Check environment variable first
-        env_value = os.environ.get(provider.env_var)
-        if env_value:
-            logger.debug(f"Using {provider.env_var} from environment")
-            return env_value
-
-        # Fall back to store
-        credential = self._store.retrieve(provider)
-        if credential:
+        def _from_store() -> Optional[str]:
+            credential = self._store.retrieve(provider)
+            if credential is None:
+                return None
             if credential.is_expired:
                 logger.warning(f"Credential for {provider.name} has expired")
                 return None
             return credential.value
 
-        return None
+        def _from_env() -> Optional[str]:
+            env_value = os.environ.get(provider.env_var)
+            if env_value:
+                logger.debug(f"Using {provider.env_var} from environment")
+            return env_value or None
+
+        first, second = (_from_store, _from_env) if prefer_stored else (_from_env, _from_store)
+        return first() or second()
+
+    def get_stored_credential(
+        self,
+        provider: CredentialProvider,
+    ) -> Optional[str]:
+        """Get a credential from this manager's store only, never the environment.
+
+        For contexts where the process environment is not the caller's to use —
+        hosted/multi-tenant mode, where ``GITHUB_TOKEN`` is shared by every
+        tenant and falling back to it is the cross-tenant leak itself (#900).
+        """
+        credential = self._store.retrieve(provider)
+        if credential is None:
+            return None
+        if credential.is_expired:
+            logger.warning(f"Credential for {provider.name} has expired")
+            return None
+        return credential.value
 
     def get_credential_source(
         self,

--- a/codeframe/core/github_integration_config.py
+++ b/codeframe/core/github_integration_config.py
@@ -117,3 +117,92 @@ def clear_github_integration_config(workspace: Workspace) -> None:
         path.unlink(missing_ok=True)
     except OSError as e:
         logger.warning("Failed to remove github_integration.json: %s", e)
+
+
+class GitHubResolutionError(Exception):
+    """No usable GitHub credential/repo for this caller and workspace.
+
+    Carries a caller-facing ``message`` explaining which half is missing so the
+    HTTP and CLI layers can render it without re-deriving the reason.
+    """
+
+
+def resolve_github_repo(
+    workspace: Workspace,
+    *,
+    allow_env_fallback: bool = True,
+) -> Optional[str]:
+    """The repo GitHub operations should target for this workspace (issue #900).
+
+    The workspace's own connection wins. ``GITHUB_REPO`` is a self-hosted
+    convenience only: it is the operator's ambient setting, so it must never
+    silently redirect a connected workspace's PRs at another repository.
+    """
+    config = load_github_integration_config(workspace)
+    if config and config.get("repo"):
+        return config["repo"]
+    if allow_env_fallback:
+        return os.getenv("GITHUB_REPO") or None
+    return None
+
+
+def resolve_github_credentials(
+    workspace: Workspace,
+    user_id: Optional[int] = None,
+    *,
+    allow_env_fallback: bool = True,
+) -> tuple[str, str]:
+    """Resolve ``(token, repo)`` for GitHub operations, scoped to the caller.
+
+    The single resolution path shared by the v2 PR router and ``cf pr`` (issue
+    #900), so the server and the CLI cannot drift.
+
+    The token comes from the caller-scoped ``CredentialManager`` (#790). For an
+    **authenticated principal** the store is consulted before the environment:
+    the default env-first order would let the operator's ambient
+    ``GITHUB_TOKEN`` beat the PAT that user connected in the UI, so every PR
+    would be opened on the operator's behalf, unattributed — the defect this
+    resolves. For ``user_id=None`` (CLI / auth disabled) the caller *is* the
+    operator, so there is no one to protect the environment from and the
+    original env-first order stands — which also keeps ``cf pr`` from doing an
+    OS-keyring read on every invocation when ``GITHUB_TOKEN`` is set.
+
+    The repo always comes from the workspace's own
+    ``.codeframe/github_integration.json`` first.
+
+    Args:
+        workspace: Workspace whose GitHub connection to use.
+        user_id: Authenticated principal, or ``None`` for the machine-wide store
+            (auth disabled / CLI).
+        allow_env_fallback: Permit ``GITHUB_TOKEN``/``GITHUB_REPO`` when the
+            workspace/user has no connection of its own. Callers in hosted mode
+            must pass ``False`` — there the environment is shared by every
+            tenant, so falling back to it is precisely the cross-tenant leak.
+
+    Raises:
+        GitHubResolutionError: If either half cannot be resolved.
+    """
+    from codeframe.core.credentials import CredentialManager, CredentialProvider
+
+    manager = CredentialManager(user_id=user_id, migrate=False)
+    if not allow_env_fallback:
+        token = manager.get_stored_credential(CredentialProvider.GIT_GITHUB)
+    else:
+        token = manager.get_credential(
+            CredentialProvider.GIT_GITHUB,
+            prefer_stored=user_id is not None,
+        )
+
+    repo = resolve_github_repo(workspace, allow_env_fallback=allow_env_fallback)
+
+    if not token:
+        raise GitHubResolutionError(
+            "No GitHub credential for this account. Connect a repository in "
+            "Settings → Integrations, or run 'cf auth setup --provider github'."
+        )
+    if not repo:
+        raise GitHubResolutionError(
+            "No GitHub repository connected for this workspace. Connect one in "
+            "Settings → Integrations."
+        )
+    return token, repo

--- a/codeframe/ui/dependencies.py
+++ b/codeframe/ui/dependencies.py
@@ -174,7 +174,62 @@ def get_v2_workspace(
     return workspace
 
 
+def github_env_fallback_allowed(auth: Dict[str, Any]) -> bool:
+    """Whether this caller may fall back to the process-wide GitHub env vars (#900).
+
+    One rule, stated once: **the process environment belongs to the operator, so
+    only the operator may act with it.** ``GITHUB_TOKEN``/``GITHUB_REPO`` are the
+    machine's ambient configuration, not any particular user's credential, so
+    serving them to an ordinary principal opens PRs — and reads private repos —
+    on the operator's behalf, unattributed.
+
+    Gating this on *deployment mode* is not enough, and was the first cut's
+    mistake: the default deployment is self-hosted **with auth enabled**, so an
+    ordinary authenticated user with no PAT of their own would still have been
+    handed the operator's token there.
+
+    - auth disabled (``user_id is None``) — the caller *is* the local operator.
+    - authenticated operator — an ``admin``-scoped principal. Since #898 that
+      means an ``is_superuser`` account, and an admin-scoped API key is clamped
+      to a superuser owner on every request, so this is a real operator check
+      rather than a self-asserted one.
+    - anyone else — store-only. They get a clear "connect a repository" 400
+      rather than someone else's credential.
+    - hosted mode — never. There the environment is shared by every tenant, so
+      falling back to it is precisely the cross-tenant leak.
+    """
+    from codeframe.auth.api_keys import SCOPE_ADMIN
+    from codeframe.auth.scopes import has_scope
+    from codeframe.ui.server import is_hosted_mode
+
+    if is_hosted_mode():
+        return False
+    if auth.get("user_id") is None:
+        return True
+    return has_scope(auth, SCOPE_ADMIN)
+
+
+def resolve_github_pat(credential_manager, auth: Dict[str, Any]) -> Optional[str]:
+    """The GitHub PAT this caller may act with (#900).
+
+    Shared by the PR router and the Integrations router so the two cannot drift
+    on whose credential is used. ``get_credential`` is env-*first* by default,
+    so a plain call would let the operator's ambient ``GITHUB_TOKEN`` displace
+    the PAT a user connected in the UI.
+    """
+    from codeframe.core.credentials import CredentialProvider
+
+    if github_env_fallback_allowed(auth):
+        return credential_manager.get_credential(
+            CredentialProvider.GIT_GITHUB,
+            prefer_stored=auth.get("user_id") is not None,
+        )
+    return credential_manager.get_stored_credential(CredentialProvider.GIT_GITHUB)
+
+
 __all__ = [
     "get_v2_workspace",
     "enforce_workspace_allowlist",
+    "github_env_fallback_allowed",
+    "resolve_github_pat",
 ]

--- a/codeframe/ui/routers/github_integrations_v2.py
+++ b/codeframe/ui/routers/github_integrations_v2.py
@@ -47,7 +47,7 @@ from codeframe.core.github_integration_config import (
 from codeframe.core import tasks
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
-from codeframe.ui.dependencies import get_v2_workspace
+from codeframe.ui.dependencies import get_v2_workspace, resolve_github_pat
 from codeframe.ui.response_models import ErrorCodes, api_error
 
 logger = logging.getLogger(__name__)
@@ -190,6 +190,7 @@ async def get_status(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
     manager: CredentialManager = Depends(get_credential_manager_readonly),
+    auth: dict = Depends(require_auth),
 ) -> StatusResponse:
     """Report whether a GitHub repo is connected for this workspace.
 
@@ -197,7 +198,7 @@ async def get_status(
     calling user's GitHub PAT is present (env var or stored).
     """
     cfg = load_github_integration_config(workspace)
-    has_pat = manager.get_credential(CredentialProvider.GIT_GITHUB) is not None
+    has_pat = resolve_github_pat(manager, auth) is not None
     if cfg is None or not has_pat:
         return StatusResponse(connected=False)
     return StatusResponse(
@@ -270,7 +271,12 @@ async def connect(
     # The GIT_GITHUB slot is shared with the API Keys tab, so capture any
     # prior token first to restore it if the config write fails — never
     # blindly delete an unrelated, previously working credential.
-    prior_pat = manager.get_credential(CredentialProvider.GIT_GITHUB)
+    # Store-only, deliberately: get_credential is env-first, so in a
+    # deployment with GITHUB_TOKEN set this would capture the *operator's*
+    # ambient token and the rollback below would persist it into this user's
+    # store, where they could then use it (#900). Only a genuinely stored
+    # prior credential is worth restoring.
+    prior_pat = manager.get_stored_credential(CredentialProvider.GIT_GITHUB)
     try:
         manager.set_credential(CredentialProvider.GIT_GITHUB, body.pat)
     except Exception as e:
@@ -364,7 +370,7 @@ async def get_issues(
     The PAT is never returned.
     """
     cfg = load_github_integration_config(workspace)
-    pat = manager.get_credential(CredentialProvider.GIT_GITHUB)
+    pat = resolve_github_pat(manager, auth)
     if cfg is None or not pat:
         raise HTTPException(
             status_code=409,
@@ -430,7 +436,7 @@ async def get_issues(
 
 
 def _require_connection(
-    workspace: Workspace, manager: CredentialManager
+    workspace: Workspace, manager: CredentialManager, auth: dict
 ) -> tuple[str, str]:
     """Return ``(repo, pat)`` for a connected workspace, or raise 409.
 
@@ -438,7 +444,7 @@ def _require_connection(
     repo metadata AND a stored PAT must be present.
     """
     cfg = load_github_integration_config(workspace)
-    pat = manager.get_credential(CredentialProvider.GIT_GITHUB)
+    pat = resolve_github_pat(manager, auth)
     if cfg is None or not pat:
         raise HTTPException(
             status_code=409,
@@ -489,7 +495,7 @@ async def import_issues(
     issue fails the request cleanly without leaving a partial set of tasks
     behind (which would confuse a retry with phantom duplicates).
     """
-    repo, pat = _require_connection(workspace, manager)
+    repo, pat = _require_connection(workspace, manager, auth)
 
     skipped: list[int] = []
     to_create: list[tuple[int, dict]] = []

--- a/codeframe/ui/routers/pr_v2.py
+++ b/codeframe/ui/routers/pr_v2.py
@@ -1,7 +1,11 @@
 """V2 Pull Request router - delegates to git/github_integration module.
 
 This module provides v2-style API endpoints for GitHub PR management.
-Requires GITHUB_TOKEN and GITHUB_REPO environment variables.
+
+Credentials are scoped to the authenticated caller (#900): the PAT comes from
+the caller's CredentialManager and the repo from the workspace's own
+``.codeframe/github_integration.json``. ``GITHUB_TOKEN``/``GITHUB_REPO`` remain
+a self-hosted fallback only, and are ignored entirely in hosted mode.
 
 Routes:
     GET  /api/v2/pr             - List pull requests
@@ -13,7 +17,6 @@ Routes:
 
 import asyncio
 import logging
-import os
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -175,24 +178,71 @@ def _pr_to_response(pr: PRDetails) -> PRResponse:
     )
 
 
-def _get_github_client() -> GitHubIntegration:
-    """Get a GitHub integration client.
+def _get_github_client(workspace: Workspace, auth: dict) -> GitHubIntegration:
+    """Get a GitHub client scoped to the caller and the caller's workspace (#900).
 
-    Returns:
-        GitHubIntegration instance
+    This used to be ``GitHubIntegration()`` with no arguments, which took the
+    token from ``GITHUB_TOKEN`` and the repo from ``GITHUB_REPO`` — the
+    *operator's* ambient credentials — even though the Integrations router
+    deliberately stores a PAT per user. Two consequences: any principal with
+    write scope could open or close PRs on the operator's repo using the
+    operator's token, unattributed; and a user who connected GitHub in the UI
+    could not use Ship at all, because their PAT was never consulted.
+
+    Resolution now goes through the same core path as ``cf pr``: the caller's
+    stored PAT first (never displaced by the ambient env var), and the repo from
+    this workspace's own ``.codeframe/github_integration.json``.
+
+    In hosted mode the environment fallback is disabled outright — there
+    ``GITHUB_TOKEN`` is shared by every tenant, so falling back to it *is* the
+    cross-tenant leak.
 
     Raises:
-        HTTPException: If GitHub token or repo not configured
+        HTTPException: 400 if no credential/repo can be resolved for this caller.
     """
+    from codeframe.core.github_integration_config import (
+        GitHubResolutionError,
+        resolve_github_credentials,
+    )
+    from codeframe.ui.server import is_hosted_mode
+
     try:
-        return GitHubIntegration()
-    except ValueError as e:
+        token, repo = resolve_github_credentials(
+            workspace,
+            user_id=auth.get("user_id"),
+            allow_env_fallback=not is_hosted_mode(),
+        )
+        return GitHubIntegration(token=token, repo=repo)
+    except (GitHubResolutionError, ValueError) as e:
         raise HTTPException(
             status_code=400,
             detail=api_error(
                 "GitHub not configured",
                 ErrorCodes.INVALID_REQUEST,
                 str(e),
+            ),
+        )
+
+
+def _refuse_mutating_pr_in_hosted_mode() -> None:
+    """Block PR-mutating routes in hosted mode (issue #900).
+
+    Per-user credential scoping is in place, but a hosted deployment shares one
+    process and one workspace-root tree across tenants, so a mistake in path or
+    credential scoping there writes to somebody's real repository. Until hosted
+    multi-tenancy has its own review, creating/merging/closing PRs is
+    self-hosted only. Read paths stay available.
+    """
+    from codeframe.ui.server import is_hosted_mode
+
+    if is_hosted_mode():
+        raise HTTPException(
+            status_code=403,
+            detail=api_error(
+                "PR write operations are not available in hosted mode",
+                ErrorCodes.INVALID_STATE,
+                "Creating, merging and closing pull requests is currently "
+                "self-hosted only.",
             ),
         )
 
@@ -224,8 +274,11 @@ def _dispatch_pr_merged_webhook(workspace: Workspace, pr_number: int) -> None:
     """Best-effort outbound webhook for ``pr.merged`` (issue #560).
 
     Builds the canonical ``https://github.com/{owner}/{repo}/pull/{N}`` URL
-    from the ``GITHUB_REPO`` env var when set to a valid ``owner/repo`` slug;
-    sets ``pr_url`` to ``None`` otherwise.
+    from the repo this workspace is actually connected to, falling back to the
+    ``GITHUB_REPO`` env var; sets ``pr_url`` to ``None`` when neither yields a
+    valid ``owner/repo`` slug. Resolving the workspace first keeps the notified
+    URL pointing at the repo the merge really happened on (#900) rather than
+    whatever the operator's environment names.
     The always-present ``pr_number`` field lets consumers branch without
     parsing a URL.
     """
@@ -240,12 +293,14 @@ def _dispatch_pr_merged_webhook(workspace: Workspace, pr_number: int) -> None:
         if url is None:
             return
 
-        # Canonical github.com URL when GITHUB_REPO is configured, ``None``
+        # Canonical github.com URL when a repo is resolvable, ``None``
         # otherwise. The payload always carries ``pr_number`` so consumers
-        # can branch on it without parsing the URL. Read the env var directly
+        # can branch on it without parsing the URL. Resolve the slug directly
         # instead of constructing GitHubIntegration — the constructor eagerly
         # opens an httpx.AsyncClient that would leak here (#779).
-        repo = (os.getenv("GITHUB_REPO") or "").strip()
+        from codeframe.core.github_integration_config import resolve_github_repo
+
+        repo = (resolve_github_repo(workspace) or "").strip()
         parts = [part.strip() for part in repo.split("/")]
         pr_url: Optional[str] = (
             f"https://github.com/{parts[0]}/{parts[1]}/pull/{pr_number}"
@@ -272,6 +327,7 @@ async def get_pr_status(
     request: Request,
     pr_number: int = Query(..., description="PR number to poll"),
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> PRStatusResponse:
     """Get live PR status: CI checks, review status, and merge state.
 
@@ -288,7 +344,7 @@ async def get_pr_status(
     """
     # _get_github_client() raises HTTPException if GitHub isn't configured —
     # no client to close in that case, so call it before the try/finally.
-    client = _get_github_client()
+    client = _get_github_client(workspace, auth)
     try:
         # Single call to get PR state, URL, and head SHA.
         pr_raw = await client._make_request(
@@ -369,6 +425,7 @@ async def list_pull_requests(
     request: Request,
     state: str = Query("open", description="Filter by state: open, closed, all"),
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> PRListResponse:
     """List pull requests for the repository.
 
@@ -379,7 +436,7 @@ async def list_pull_requests(
     Returns:
         List of pull requests
     """
-    client = _get_github_client()
+    client = _get_github_client(workspace, auth)
     try:
         prs = await client.list_pull_requests(state=state)
 
@@ -408,6 +465,7 @@ async def get_pr_history(
     request: Request,
     limit: int = Query(10, ge=1, le=50),
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> PRHistoryResponse:
     """List recently merged PRs with proof snapshots.
 
@@ -423,7 +481,7 @@ async def get_pr_history(
     """
     from codeframe.core.proof.ledger import get_pr_merge_override, get_pr_proof_snapshot
 
-    client = _get_github_client()
+    client = _get_github_client(workspace, auth)
     try:
         prs = await client.list_pull_requests(state="closed")
 
@@ -484,6 +542,7 @@ async def get_pr_files(
     request: Request,
     pr_number: int,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> PRFilesResponse:
     """Get the list of files changed in a pull request.
 
@@ -494,7 +553,7 @@ async def get_pr_files(
     Returns:
         List of changed filenames
     """
-    client = _get_github_client()
+    client = _get_github_client(workspace, auth)
     try:
         files = await client.get_pr_files(pr_number)
         return PRFilesResponse(files=files)
@@ -523,6 +582,7 @@ async def get_pull_request(
     request: Request,
     pr_number: int,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> PRResponse:
     """Get details of a specific pull request.
 
@@ -533,7 +593,7 @@ async def get_pull_request(
     Returns:
         PR details
     """
-    client = _get_github_client()
+    client = _get_github_client(workspace, auth)
     try:
         pr = await client.get_pull_request(pr_number)
 
@@ -558,12 +618,19 @@ async def get_pull_request(
         await client.close()
 
 
-@router.post("", response_model=PRResponse, status_code=201)
+@router.post(
+    "",
+    response_model=PRResponse,
+    status_code=201,
+    # Opening a PR writes to the repo with the caller's PAT (#900).
+    dependencies=[Depends(require_scope(SCOPE_ADMIN))],
+)
 @rate_limit_standard()
 async def create_pull_request(
     request: Request,
     body: CreatePRRequest,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> PRResponse:
     """Create a new pull request.
 
@@ -575,7 +642,8 @@ async def create_pull_request(
     Returns:
         Created PR details
     """
-    client = _get_github_client()
+    _refuse_mutating_pr_in_hosted_mode()
+    client = _get_github_client(workspace, auth)
     try:
         pr = await client.create_pull_request(
             branch=body.branch,
@@ -664,6 +732,8 @@ async def merge_pull_request(
     Returns:
         Merge result
     """
+    _refuse_mutating_pr_in_hosted_mode()
+
     method = body.method if body else "squash"
     override = bool(body and body.override)
     override_reason = (body.override_reason or "").strip() if body else ""
@@ -709,7 +779,7 @@ async def merge_pull_request(
                 ),
             )
 
-    client = _get_github_client()
+    client = _get_github_client(workspace, auth)
     try:
         result = await client.merge_pull_request(pr_number, method=method)
 
@@ -772,12 +842,17 @@ async def merge_pull_request(
         await client.close()
 
 
-@router.post("/{pr_number}/close")
+@router.post(
+    "/{pr_number}/close",
+    # Closing someone's PR is a repo mutation (#900).
+    dependencies=[Depends(require_scope(SCOPE_ADMIN))],
+)
 @rate_limit_standard()
 async def close_pull_request(
     request: Request,
     pr_number: int,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> dict:
     """Close a pull request without merging.
 
@@ -788,7 +863,8 @@ async def close_pull_request(
     Returns:
         Close confirmation
     """
-    client = _get_github_client()
+    _refuse_mutating_pr_in_hosted_mode()
+    client = _get_github_client(workspace, auth)
     try:
         closed = await client.close_pull_request(pr_number)
 

--- a/codeframe/ui/routers/pr_v2.py
+++ b/codeframe/ui/routers/pr_v2.py
@@ -193,9 +193,11 @@ def _get_github_client(workspace: Workspace, auth: dict) -> GitHubIntegration:
     stored PAT first (never displaced by the ambient env var), and the repo from
     this workspace's own ``.codeframe/github_integration.json``.
 
-    In hosted mode the environment fallback is disabled outright — there
-    ``GITHUB_TOKEN`` is shared by every tenant, so falling back to it *is* the
-    cross-tenant leak.
+    The ``GITHUB_TOKEN``/``GITHUB_REPO`` fallback is gated on *who is calling*,
+    not on deployment mode — see ``github_env_fallback_allowed``. Gating it on
+    hosted mode alone would have left the default deployment (self-hosted with
+    auth enabled) still handing every ordinary authenticated user the operator's
+    token.
 
     Raises:
         HTTPException: 400 if no credential/repo can be resolved for this caller.
@@ -204,13 +206,13 @@ def _get_github_client(workspace: Workspace, auth: dict) -> GitHubIntegration:
         GitHubResolutionError,
         resolve_github_credentials,
     )
-    from codeframe.ui.server import is_hosted_mode
+    from codeframe.ui.dependencies import github_env_fallback_allowed
 
     try:
         token, repo = resolve_github_credentials(
             workspace,
             user_id=auth.get("user_id"),
-            allow_env_fallback=not is_hosted_mode(),
+            allow_env_fallback=github_env_fallback_allowed(auth),
         )
         return GitHubIntegration(token=token, repo=repo)
     except (GitHubResolutionError, ValueError) as e:

--- a/tests/cli/test_pr_commands.py
+++ b/tests/cli/test_pr_commands.py
@@ -19,8 +19,16 @@ runner = CliRunner()
 
 
 @pytest.fixture
-def mock_github_token(monkeypatch):
-    """Set up mock GitHub token for tests."""
+def mock_github_token(monkeypatch, tmp_path):
+    """Env-var-configured GitHub CLI, in an isolated cwd.
+
+    ``cf pr`` resolves the workspace in the cwd since #900 (the workspace's
+    connected repo and the caller's stored PAT win over the ambient env vars),
+    so these env-var tests must not run in the developer's own repo — the
+    conftest ambient-workspace guard rejects that. An empty tmp cwd has no
+    workspace, which is exactly the bare-checkout case these tests cover.
+    """
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_test_token_12345")
     monkeypatch.setenv("GITHUB_REPO", "testowner/testrepo")
 
@@ -99,10 +107,13 @@ class TestPRCreateCommand:
         call_args = mock_gh.create_pull_request.call_args
         assert call_args.kwargs.get("base") == "develop" or call_args[1].get("base") == "develop"
 
-    def test_create_pr_no_github_token_shows_error(self, monkeypatch):
+    def test_create_pr_no_github_token_shows_error(self, monkeypatch, tmp_path):
         """Create PR without GitHub token should show helpful error."""
         from codeframe.cli.pr_commands import pr_app
 
+        # Isolated cwd: `cf pr` resolves the workspace here since #900, and the
+        # conftest guard rejects resolving the developer's own repo.
+        monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_REPO", raising=False)
 
@@ -715,3 +726,66 @@ class TestErrorHandling:
 
         assert result.exit_code != 0
         assert "rate" in result.output.lower() or "limit" in result.output.lower() or "error" in result.output.lower()
+
+
+class TestCliUsesWorkspaceResolution:
+    """`cf pr` shares the v2 router's credential/repo resolution (#900 / P0.6).
+
+    Before this, the CLI read GITHUB_TOKEN/GITHUB_REPO and nothing else, so a
+    repository connected through the UI was invisible to it — the two halves of
+    the product disagreed about which repo Ship acts on.
+    """
+
+    def test_workspace_repo_wins_over_the_env_repo(self, monkeypatch, tmp_path):
+        from datetime import timezone
+
+        from codeframe.cli.pr_commands import pr_app
+        from codeframe.core.github_integration_config import (
+            save_github_integration_config,
+        )
+        from codeframe.core.workspace import create_or_load_workspace
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_env_token_12345")
+        monkeypatch.setenv("GITHUB_REPO", "operator/ambient-repo")
+
+        workspace = create_or_load_workspace(tmp_path)
+        save_github_integration_config(
+            workspace,
+            {
+                "repo": "connected/repo",
+                "owner_login": "connected",
+                "owner_avatar_url": "",
+                "connected_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+        with patch("codeframe.cli.pr_commands.GitHubIntegration") as MockGH:
+            mock_gh = AsyncMock()
+            mock_gh.list_pull_requests = AsyncMock(return_value=[])
+            mock_gh.close = AsyncMock()
+            MockGH.return_value = mock_gh
+
+            result = runner.invoke(pr_app, ["list"])
+
+        assert result.exit_code == 0, result.output
+        assert MockGH.call_args.kwargs["repo"] == "connected/repo"
+
+    def test_no_workspace_still_works_from_a_bare_checkout(self, monkeypatch, tmp_path):
+        """The CLI must not start requiring `cf init` just to list PRs."""
+        from codeframe.cli.pr_commands import pr_app
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_env_token_12345")
+        monkeypatch.setenv("GITHUB_REPO", "operator/ambient-repo")
+
+        with patch("codeframe.cli.pr_commands.GitHubIntegration") as MockGH:
+            mock_gh = AsyncMock()
+            mock_gh.list_pull_requests = AsyncMock(return_value=[])
+            mock_gh.close = AsyncMock()
+            MockGH.return_value = mock_gh
+
+            result = runner.invoke(pr_app, ["list"])
+
+        assert result.exit_code == 0, result.output
+        assert MockGH.call_args.kwargs["repo"] == "operator/ambient-repo"

--- a/tests/cli/test_v2_cli_integration.py
+++ b/tests/cli/test_v2_cli_integration.py
@@ -1076,8 +1076,16 @@ class TestPRCommands:
     """Tests for PR CLI commands with mocked GitHub API."""
 
     @pytest.fixture
-    def mock_github_env(self, monkeypatch):
-        """Set up mock GitHub environment variables."""
+    def mock_github_env(self, monkeypatch, tmp_path):
+        """Env-var-configured GitHub CLI, in an isolated cwd.
+
+        ``cf pr`` resolves the workspace in the cwd since #900 (the workspace's
+        connected repo and the caller's stored PAT win over the ambient env
+        vars), so these env-var tests must not run in the developer's own repo
+        — the conftest ambient-workspace guard rejects that. An empty tmp cwd
+        has no workspace, which is the bare-checkout case these tests cover.
+        """
+        monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test_token_12345")
         monkeypatch.setenv("GITHUB_REPO", "testowner/testrepo")
 
@@ -1247,8 +1255,11 @@ class TestPRCommands:
         assert result.exit_code == 0
         assert "42" in result.output or "open" in result.output.lower()
 
-    def test_pr_no_token_error(self, monkeypatch):
+    def test_pr_no_token_error(self, monkeypatch, tmp_path):
         """PR commands without GITHUB_TOKEN show helpful error."""
+        # Isolated cwd: `cf pr` resolves the workspace here since #900, and the
+        # conftest guard rejects resolving the developer's own repo (#975).
+        monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_REPO", raising=False)
 

--- a/tests/ui/test_pr_credential_scoping.py
+++ b/tests/ui/test_pr_credential_scoping.py
@@ -113,7 +113,7 @@ def env(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pr_v2, "GitHubIntegration", _FakeGitHub)
 
-    state = {"uid": 1}
+    state = {"uid": 1, "scopes": ["read", "write", "admin"]}
     app = FastAPI()
     app.include_router(pr_v2.router)
 
@@ -122,7 +122,7 @@ def env(tmp_path, monkeypatch):
     app.dependency_overrides[require_auth] = lambda: {
         "type": "jwt",
         "user_id": state["uid"],
-        "scopes": ["read", "write", "admin"],
+        "scopes": list(state["scopes"]),
     }
     app.dependency_overrides[get_v2_workspace] = lambda: workspaces[state["uid"]]
 
@@ -131,8 +131,9 @@ def env(tmp_path, monkeypatch):
         github_calls = calls
 
         @staticmethod
-        def as_user(uid):
+        def as_user(uid, scopes=("read", "write", "admin")):
             state["uid"] = uid
+            state["scopes"] = list(scopes)
 
         @staticmethod
         def workspace(uid):
@@ -184,25 +185,64 @@ class TestPerUserCredential:
         assert resp.status_code == 200, resp.text
         assert env.github_calls[-1]["repo"] == "tenant-a/project"
 
-    def test_unconnected_caller_gets_400_not_the_operator_token(self, env, monkeypatch):
-        """A principal with no stored PAT must be told to connect, not silently
-        handed the operator's credential."""
+    def test_unconnected_non_operator_never_gets_the_env_token(self, env, monkeypatch):
+        """The default deployment is self-hosted **with auth on**, so gating the
+        env fallback on hosted mode alone would still hand an ordinary
+        authenticated user the operator's token. Only the operator may use it.
+        """
         from codeframe.core.credentials import CredentialProvider
 
         monkeypatch.setenv("GITHUB_TOKEN", OPERATOR_PAT)
-        env.as_user(1)
-        # Drop user 1's stored PAT, leaving only the ambient env var.
-        mgr_calls_before = len(env.github_calls)
+        env.as_user(1, scopes=["read", "write"])  # not an operator
         env.manager(1).delete_credential(CredentialProvider.GIT_GITHUB)
 
         resp = env.client.get("/api/v2/pr")
 
-        # The env fallback is still permitted in self-hosted mode, so this is
-        # allowed to succeed — but it must never have used a *different user's*
-        # stored PAT.
-        used = [c["token"] for c in env.github_calls[mgr_calls_before:]]
-        assert PAT_B not in used
-        assert resp.status_code in (200, 400), resp.text
+        assert resp.status_code == 400, resp.text
+        assert OPERATOR_PAT not in [c["token"] for c in env.github_calls]
+
+    def test_unconnected_operator_may_use_the_env_token(self, env, monkeypatch):
+        """The environment is the operator's own configuration, so the operator
+        (admin scope → is_superuser since #898) may still act with it."""
+        from codeframe.core.credentials import CredentialProvider
+
+        monkeypatch.setenv("GITHUB_TOKEN", OPERATOR_PAT)
+        monkeypatch.setenv("GITHUB_REPO", "operator/infra")
+        env.as_user(1, scopes=["read", "write", "admin"])
+        env.manager(1).delete_credential(CredentialProvider.GIT_GITHUB)
+        (env.workspace(1).state_dir / "github_integration.json").unlink()
+
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 200, resp.text
+        assert env.github_calls[-1]["token"] == OPERATOR_PAT
+
+    def test_non_operator_with_own_pat_is_unaffected(self, env, monkeypatch):
+        """Tightening the fallback must not break a user who *has* connected."""
+        monkeypatch.setenv("GITHUB_TOKEN", OPERATOR_PAT)
+        env.as_user(1, scopes=["read", "write"])
+
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 200, resp.text
+        assert env.github_calls[-1]["token"] == PAT_A
+
+    def test_unconnected_caller_hosted_gets_400_not_the_operator_token(
+        self, env, monkeypatch
+    ):
+        """Hosted: the environment belongs to no tenant, so a caller with no
+        stored PAT is told to connect rather than handed the operator's."""
+        from codeframe.core.credentials import CredentialProvider
+
+        monkeypatch.setattr("codeframe.ui.server.is_hosted_mode", lambda: True)
+        monkeypatch.setenv("GITHUB_TOKEN", OPERATOR_PAT)
+        env.as_user(1)
+        env.manager(1).delete_credential(CredentialProvider.GIT_GITHUB)
+
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 400, resp.text
+        assert OPERATOR_PAT not in [c["token"] for c in env.github_calls]
 
 
 class TestHostedModeRefusesPrWrites:

--- a/tests/ui/test_pr_credential_scoping.py
+++ b/tests/ui/test_pr_credential_scoping.py
@@ -1,0 +1,234 @@
+"""PR endpoints act with the caller's credential and repo (#900 / P0.6).
+
+``_get_github_client()`` used to be ``GitHubIntegration()`` with no arguments,
+so the token came from ``GITHUB_TOKEN`` and the repo from ``GITHUB_REPO`` — the
+*operator's* ambient credentials — even though the Integrations router
+deliberately scopes the PAT per user. Any principal with write scope could open
+or close PRs on the operator's repo, using the operator's token, unattributed;
+and a user who connected GitHub in the UI could not use Ship at all, because
+their PAT was never consulted.
+
+These tests assert on the *token and repo actually handed to* ``GitHubIntegration``
+— not merely that a request succeeded — because that is the thing the defect got
+wrong.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core.credentials import (
+    CredentialManager as _RealCredentialManager,
+    CredentialStore as _RealCredentialStore,
+)
+
+pytestmark = pytest.mark.v2
+
+PAT_A = "ghp_tenantA" + "a" * 20
+PAT_B = "ghp_tenantB" + "b" * 20
+OPERATOR_PAT = "ghp_operator" + "o" * 18
+
+
+def _manager(storage_dir, user_id: Optional[int]):
+    """CredentialManager over an isolated per-user file store (no keyring).
+
+    Binds the real classes at import time, not per call: the fixture below
+    monkeypatches ``credentials.CredentialManager`` to route the resolver here,
+    so re-importing the name inside this helper would find that stand-in and
+    recurse.
+    """
+    store = _RealCredentialStore(storage_dir=storage_dir, user_id=user_id)
+    store._keyring_available = False
+    mgr = _RealCredentialManager.__new__(_RealCredentialManager)
+    mgr._store = store
+    return mgr
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Two tenants with their own PATs, workspaces and connected repos.
+
+    Returns a handle exposing ``as_user(uid)``, the recorded
+    ``GitHubIntegration(**kwargs)`` calls, and the client.
+    """
+    from codeframe.core.credentials import CredentialProvider
+    from codeframe.core.github_integration_config import save_github_integration_config
+    from codeframe.core.workspace import create_or_load_workspace
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import pr_v2
+
+    for provider in CredentialProvider:
+        monkeypatch.delenv(provider.env_var, raising=False)
+    monkeypatch.delenv("GITHUB_REPO", raising=False)
+
+    creds = tmp_path / "creds"
+    workspaces = {}
+    for uid, pat, repo in ((1, PAT_A, "tenant-a/project"), (2, PAT_B, "tenant-b/project")):
+        _manager(creds, uid).set_credential(CredentialProvider.GIT_GITHUB, pat)
+        ws_path = tmp_path / f"ws{uid}"
+        ws_path.mkdir()
+        ws = create_or_load_workspace(ws_path)
+        save_github_integration_config(
+            ws,
+            {
+                "repo": repo,
+                "owner_login": repo.split("/")[0],
+                "owner_avatar_url": "",
+                "connected_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        workspaces[uid] = ws
+
+    # resolve_github_credentials imports CredentialManager lazily from
+    # core.credentials, so patching it there covers the resolver without
+    # touching the developer's real ~/.codeframe store.
+    import codeframe.core.credentials as credentials_mod
+
+    monkeypatch.setattr(
+        credentials_mod,
+        "CredentialManager",
+        lambda user_id=None, migrate=False: _manager(creds, user_id),
+    )
+
+    # Record what GitHubIntegration is constructed with, and never open a socket.
+    calls: list[dict] = []
+
+    class _FakeGitHub:
+        def __init__(self, token=None, repo=None, credential_manager=None):
+            calls.append({"token": token, "repo": repo})
+            self.owner, self.repo_name = (repo or "x/y").split("/", 1)
+            self.repo = repo
+
+        async def list_pull_requests(self, state="open"):
+            return []
+
+        async def create_pull_request(self, **kw):
+            raise AssertionError("network call should not happen in this test")
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(pr_v2, "GitHubIntegration", _FakeGitHub)
+
+    state = {"uid": 1}
+    app = FastAPI()
+    app.include_router(pr_v2.router)
+
+    from codeframe.auth.dependencies import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "type": "jwt",
+        "user_id": state["uid"],
+        "scopes": ["read", "write", "admin"],
+    }
+    app.dependency_overrides[get_v2_workspace] = lambda: workspaces[state["uid"]]
+
+    class Handle:
+        client = TestClient(app, raise_server_exceptions=False)
+        github_calls = calls
+
+        @staticmethod
+        def as_user(uid):
+            state["uid"] = uid
+
+        @staticmethod
+        def workspace(uid):
+            return workspaces[uid]
+
+        @staticmethod
+        def manager(uid):
+            return _manager(creds, uid)
+
+    return Handle
+
+
+class TestPerUserCredential:
+    def test_user_a_acts_with_user_a_pat_and_repo(self, env):
+        env.as_user(1)
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 200, resp.text
+        assert env.github_calls[-1] == {"token": PAT_A, "repo": "tenant-a/project"}
+
+    def test_user_b_cannot_use_user_a_pat(self, env):
+        """The acceptance criterion: A's PAT must never serve B's request."""
+        env.as_user(2)
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 200, resp.text
+        assert env.github_calls[-1] == {"token": PAT_B, "repo": "tenant-b/project"}
+        assert PAT_A not in [c["token"] for c in env.github_calls]
+
+    def test_stored_pat_beats_the_operator_env_token(self, env, monkeypatch):
+        """CredentialManager checks env before its store by default, so without
+        prefer_stored the operator's ambient GITHUB_TOKEN silently wins and every
+        PR is opened on the operator's behalf."""
+        monkeypatch.setenv("GITHUB_TOKEN", OPERATOR_PAT)
+        env.as_user(1)
+
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 200, resp.text
+        assert env.github_calls[-1]["token"] == PAT_A
+        assert env.github_calls[-1]["token"] != OPERATOR_PAT
+
+    def test_workspace_repo_beats_the_operator_env_repo(self, env, monkeypatch):
+        monkeypatch.setenv("GITHUB_REPO", "operator/infra")
+        env.as_user(1)
+
+        resp = env.client.get("/api/v2/pr")
+
+        assert resp.status_code == 200, resp.text
+        assert env.github_calls[-1]["repo"] == "tenant-a/project"
+
+    def test_unconnected_caller_gets_400_not_the_operator_token(self, env, monkeypatch):
+        """A principal with no stored PAT must be told to connect, not silently
+        handed the operator's credential."""
+        from codeframe.core.credentials import CredentialProvider
+
+        monkeypatch.setenv("GITHUB_TOKEN", OPERATOR_PAT)
+        env.as_user(1)
+        # Drop user 1's stored PAT, leaving only the ambient env var.
+        mgr_calls_before = len(env.github_calls)
+        env.manager(1).delete_credential(CredentialProvider.GIT_GITHUB)
+
+        resp = env.client.get("/api/v2/pr")
+
+        # The env fallback is still permitted in self-hosted mode, so this is
+        # allowed to succeed — but it must never have used a *different user's*
+        # stored PAT.
+        used = [c["token"] for c in env.github_calls[mgr_calls_before:]]
+        assert PAT_B not in used
+        assert resp.status_code in (200, 400), resp.text
+
+
+class TestHostedModeRefusesPrWrites:
+    @pytest.fixture(autouse=True)
+    def hosted(self, monkeypatch):
+        monkeypatch.setattr("codeframe.ui.server.is_hosted_mode", lambda: True)
+
+    def test_create_is_refused(self, env):
+        env.as_user(1)
+        resp = env.client.post(
+            "/api/v2/pr",
+            json={"branch": "feat", "title": "t", "body": "", "base": "main"},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_close_is_refused(self, env):
+        env.as_user(1)
+        resp = env.client.post("/api/v2/pr/1/close")
+        assert resp.status_code == 403, resp.text
+
+    def test_merge_is_refused(self, env):
+        env.as_user(1)
+        resp = env.client.post("/api/v2/pr/1/merge", json={})
+        assert resp.status_code == 403, resp.text
+
+    def test_reads_still_work(self, env):
+        env.as_user(1)
+        resp = env.client.get("/api/v2/pr")
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
Closes #900 (P0.6 — `high` / `security`, filed by the SaaS launch review). Unblocked by #898.

## Problem

```python
def _get_github_client() -> GitHubIntegration:
    return GitHubIntegration()          # no arguments
```

With no arguments the token comes from `GITHUB_TOKEN` and the repo from `GITHUB_REPO` — the **operator's ambient credentials** — even though the Integrations router deliberately scopes the PAT per user (#790).

Two consequences, and the second is the one users actually hit:

1. Any principal with write scope could open or close PRs on the operator's repo, **using the operator's token, unattributed**.
2. A user who connected GitHub in the UI **could not use Ship at all** — their PAT was never consulted.

## Fix

One headless resolver, `core.github_integration_config.resolve_github_credentials`, shared by the v2 router and `cf pr` so the two halves of the product cannot disagree about which credential or repository Ship acts on:

- **token** from the caller-scoped `CredentialManager`; **repo** from the workspace's own `.codeframe/github_integration.json`;
- `GITHUB_TOKEN`/`GITHUB_REPO` demoted to a self-hosted fallback;
- the env fallback is gated on **who is calling**, not on deployment mode (corrected in `6854e9c` after review — see below).

**The rule, stated once** in `ui/dependencies.github_env_fallback_allowed`: *the process environment belongs to the operator, so only the operator may act with it.*

| Caller | Env fallback |
|---|---|
| auth disabled (`user_id is None`) | ✅ the caller **is** the local operator |
| authenticated with `admin` scope | ✅ the operator — since #898 that means `is_superuser`, and admin-scoped API keys are clamped to a superuser owner on every request |
| any other authenticated principal | ❌ store-only; clear "connect a repository" 400 |
| hosted mode | ❌ never |

My first cut gated this on `is_hosted_mode()`, which is the wrong axis: the **default deployment is self-hosted with auth enabled**, so an ordinary authenticated user with no PAT was still handed the operator's token. The corrected rule keeps the documented single-operator deployment working unchanged (the bootstrap account is a superuser) while closing the leak for everyone else.

The sibling **Integrations router** shares the same PAT slot and had the same env-first bug on `/issues`, `/import` and `/status` — plus a `connect` rollback that could persist the operator's PAT into a tenant's own store. It now routes through the same `resolve_github_pat`.

### The subtlety that would have silently undone it

`CredentialManager.get_credential` checks the **environment before its own store**. So passing a per-user manager is not enough: the operator's ambient `GITHUB_TOKEN` would still win, and every PR would still be opened on the operator's behalf.

It grows a `prefer_stored` flag, applied when — and only when — the caller is an authenticated principal:

```python
token = manager.get_credential(GIT_GITHUB, prefer_stored=user_id is not None)
```

For `user_id=None` (CLI, auth disabled) the caller **is** the operator, so there is nobody to protect the environment from and env-first correctly stands. That is not just semantics: forcing a store read there made `cf pr` do an OS-keyring lookup on every invocation, which hung a CLI test for 10 minutes. With the flag scoped correctly the CLI suite runs in 19s.

`get_stored_credential()` is the never-touch-the-environment accessor hosted mode uses.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `GitHubIntegration` built with a user-scoped `CredentialManager` + repo from the workspace's `github_integration.json` | `_get_github_client(workspace, auth)` → `resolve_github_credentials` |
| No PR route falls back to a process-wide `GITHUB_TOKEN` when a per-user credential exists; `cf pr` uses the same resolution | `prefer_stored`; `cli/pr_commands._get_github_config` calls the same resolver |
| Mutating PR routes require admin scope and are refused in hosted mode | `require_scope(SCOPE_ADMIN)` on create/close (merge already had it) + `_refuse_mutating_pr_in_hosted_mode()` |
| **Test: user A's PR call cannot use user B's stored PAT** | `test_user_b_cannot_use_user_a_pat` |

Also swept: the `pr.merged` webhook built its URL from the operator's `GITHUB_REPO`; it now uses the repo the merge actually happened on.

## On the tests

They assert on **the token and repo actually handed to `GitHubIntegration`**, not merely that a request returned 200 — that constructor argument is precisely what the defect got wrong, and a status-code assertion would pass either way.

```
test_user_a_acts_with_user_a_pat_and_repo      → {"token": PAT_A, "repo": "tenant-a/project"}
test_user_b_cannot_use_user_a_pat              → {"token": PAT_B, "repo": "tenant-b/project"}
test_stored_pat_beats_the_operator_env_token   → PAT_A, never OPERATOR_PAT
test_workspace_repo_beats_the_operator_env_repo→ "tenant-a/project", never "operator/infra"
```

## Test-fixture change, disclosed

The CLI PR tests now run in an isolated tmp cwd. `cf pr` resolves a workspace since this change, and the conftest ambient-workspace guard (#975) correctly refuses to resolve the developer's own repo. Their env-var premise is **unchanged** — an empty tmp cwd is exactly the bare-checkout case they cover, and two new tests cover the new behaviour (workspace repo wins; bare checkout still works).

## Known limitations

- Hosted mode refuses PR **writes** entirely rather than supporting them per-tenant. Per-user credentials are in place, but a hosted deployment shares one process and one workspace-root tree, so this stays closed until hosted multi-tenancy gets its own review. Reads work.
- `cf pr` uses the machine-wide credential store (`user_id=None`) — correct for a single-operator CLI, but it means the CLI cannot act as a specific web user.
- The broader question of whether `get_credential` should be store-first *everywhere* (it affects LLM API keys too) is deliberately not answered here; this change scopes the new ordering to the GitHub path.
