### PR TITLE
fix(perf): run batch execution off the uvicorn event loop (#901, P0.7)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -582,14 +582,13 @@ class BatchRun:
     llm_model: Optional[str] = None
 
 
-def start_batch(
+def create_batch(
     workspace: Workspace,
     task_ids: list[str],
     strategy: str = "serial",
     max_parallel: int = 4,
     on_failure: str = "continue",
     dry_run: bool = False,
-    max_retries: int = 0,
     on_event: Optional[Callable[[str, dict], None]] = None,
     engine: str = "react",
     stall_timeout_s: int = 300,
@@ -600,7 +599,13 @@ def start_batch(
     llm_provider: Optional[str] = None,
     llm_model: Optional[str] = None,
 ) -> BatchRun:
-    """Start a batch execution of multiple tasks.
+    """Validate and persist a batch record, without executing it.
+
+    The first half of the old ``start_batch``, split out so a server handler
+    can persist a batch and return its id immediately, then run
+    ``execute_batch`` on a worker thread (issue #901). Returns with the batch
+    PENDING (or COMPLETED for a dry run) and ``BATCH_STARTED`` already emitted,
+    so a client polling ``/batches`` sees it right away.
 
     Args:
         workspace: Target workspace
@@ -609,12 +614,11 @@ def start_batch(
         max_parallel: Max concurrent tasks for parallel strategy
         on_failure: Behavior on task failure ("continue" or "stop")
         dry_run: If True, don't actually execute tasks
-        max_retries: Max retry attempts for failed tasks (0 = no retries)
         on_event: Optional callback for batch events
         engine: Agent engine to use ("react" default, or "plan" for legacy)
 
     Returns:
-        BatchRun with results populated
+        The persisted BatchRun, PENDING and not yet executed.
 
     Raises:
         ValueError: If task_ids is empty or contains invalid IDs
@@ -681,7 +685,93 @@ def start_batch(
         batch.status = BatchStatus.COMPLETED
         batch.completed_at = _utc_now()
         _save_batch(workspace, batch)
+
+    return batch
+
+
+def start_batch(
+    workspace: Workspace,
+    task_ids: list[str],
+    strategy: str = "serial",
+    max_parallel: int = 4,
+    on_failure: str = "continue",
+    dry_run: bool = False,
+    max_retries: int = 0,
+    on_event: Optional[Callable[[str, dict], None]] = None,
+    engine: str = "react",
+    stall_timeout_s: int = 300,
+    stall_action: str = "blocker",
+    concurrency_by_status: Optional[dict[str, int]] = None,
+    isolation: str = "none",
+    cloud_timeout_minutes: int = 30,
+    llm_provider: Optional[str] = None,
+    llm_model: Optional[str] = None,
+) -> BatchRun:
+    """Create a batch and run it to completion. **Blocks.**
+
+    Convenience wrapper over ``create_batch`` + ``execute_batch`` for callers
+    that genuinely want to wait — the CLI, and tests.
+
+    **Server request handlers must not call this.** Execution drives every task
+    through a subprocess ``wait()``, so on an async handler it pins the uvicorn
+    event loop for the batch's whole duration — freezing every other request,
+    SSE stream, WebSocket and ``/health`` for potentially hours (issue #901).
+    Handlers should call ``create_batch``, return the id, and hand
+    ``execute_batch`` to a worker thread.
+
+    Returns:
+        BatchRun with results populated.
+    """
+    batch = create_batch(
+        workspace,
+        task_ids=task_ids,
+        strategy=strategy,
+        max_parallel=max_parallel,
+        on_failure=on_failure,
+        dry_run=dry_run,
+        on_event=on_event,
+        engine=engine,
+        stall_timeout_s=stall_timeout_s,
+        stall_action=stall_action,
+        concurrency_by_status=concurrency_by_status,
+        isolation=isolation,
+        cloud_timeout_minutes=cloud_timeout_minutes,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+    )
+    if dry_run:
         return batch
+    return execute_batch(workspace, batch, max_retries=max_retries, on_event=on_event)
+
+
+def execute_batch(
+    workspace: Workspace,
+    batch: BatchRun,
+    max_retries: int = 0,
+    on_event: Optional[Callable[[str, dict], None]] = None,
+) -> BatchRun:
+    """Run an already-created batch to completion. **Blocks.**
+
+    The second half of ``start_batch``, split out so a server handler can
+    persist the batch, return its id immediately, and run this on a worker
+    thread (issue #901). Every task ends in a subprocess ``wait()``, so calling
+    this on the event loop freezes the whole server for the batch's duration.
+
+    Reads strategy/max_parallel/engine off the ``batch`` record, so a resumed
+    or requeued batch executes exactly as it was created.
+
+    Args:
+        workspace: Target workspace
+        batch: A batch already persisted by ``create_batch``
+        max_retries: Max retry attempts for failed tasks (0 = no retries)
+        on_event: Optional callback for batch events
+
+    Returns:
+        The same BatchRun, with results populated.
+    """
+    strategy = batch.strategy
+    max_parallel = batch.max_parallel
+    task_ids = batch.task_ids
 
     # Update status to running
     batch.status = BatchStatus.RUNNING

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -539,6 +539,18 @@ class BatchStatus(str, Enum):
     CANCELLED = "CANCELLED"   # User cancelled
 
 
+#: Statuses from which a batch never moves again. A batch outside this set is
+#: still "in flight" as far as any observer is concerned.
+TERMINAL_BATCH_STATUSES = frozenset(
+    {
+        BatchStatus.COMPLETED,
+        BatchStatus.PARTIAL,
+        BatchStatus.FAILED,
+        BatchStatus.CANCELLED,
+    }
+)
+
+
 class OnFailure(str, Enum):
     """Behavior when a task fails."""
 
@@ -826,6 +838,37 @@ def execute_batch(
     if max_retries > 0:
         _execute_retries(workspace, batch, max_retries, on_event)
 
+    return batch
+
+
+
+def fail_batch(workspace: Workspace, batch_id: str, reason: str) -> Optional[BatchRun]:
+    """Force a non-terminal batch to FAILED and emit BATCH_FAILED.
+
+    For a batch whose execution died before it could finalize itself — the
+    detached server thread raising before ``_execute_parallel``'s own handler,
+    for instance (issue #901). Without this the row stays RUNNING forever: the
+    client already has its 200, and ``resume_batch`` accepts only
+    PARTIAL/FAILED/CANCELLED, so a wedged batch could not even be resumed.
+
+    No-op when the batch is missing or already terminal, so it is safe to call
+    unconditionally from an error path.
+    """
+    batch = get_batch(workspace, batch_id)
+    if batch is None or batch.status in TERMINAL_BATCH_STATUSES:
+        return batch
+
+    batch.status = BatchStatus.FAILED
+    batch.completed_at = _utc_now()
+    _save_batch(workspace, batch)
+
+    events.emit_for_workspace(
+        workspace,
+        events.EventType.BATCH_FAILED,
+        {"batch_id": batch_id, "reason": reason},
+        print_event=True,
+    )
+    logger.error("Batch %s marked FAILED: %s", batch_id[:8], reason)
     return batch
 
 

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -15,11 +15,13 @@ The v1 router (tasks.py) remains for backwards compatibility with
 existing web UI until Phase 3 (Web UI Rebuild).
 """
 
+import functools
 import logging
 import threading
 from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, model_validator
 
@@ -541,14 +543,19 @@ async def approve_tasks_endpoint(
 
         # Optionally start execution
         if body.start_execution:
-            # Persist first, then execute off the event loop (#901).
-            batch = conductor.create_batch(
-                workspace,
-                task_ids=result.approved_task_ids,
-                strategy="serial",
-                max_parallel=4,
-                on_failure="continue",
-                engine=body.engine,
+            # Persist first, then execute off the event loop (#901). The
+            # persist is a synchronous SQLite write, so it is offloaded too —
+            # small, but it is still the event loop's time.
+            batch = await run_in_threadpool(
+                functools.partial(
+                    conductor.create_batch,
+                    workspace,
+                    task_ids=result.approved_task_ids,
+                    strategy="serial",
+                    max_parallel=4,
+                    on_failure="continue",
+                    engine=body.engine,
+                )
             )
             batch_id = batch.id
             _start_batch_detached(workspace, batch_id)
@@ -654,13 +661,16 @@ async def start_execution(
         # Persist the batch, then execute it off the event loop (#901): the
         # handler must return batch_id at once so the UI can start polling
         # while the batch runs.
-        batch = conductor.create_batch(
-            workspace,
-            task_ids=task_ids,
-            strategy=body.strategy,
-            max_parallel=body.max_parallel,
-            on_failure="continue",
-            engine=body.engine,
+        batch = await run_in_threadpool(
+            functools.partial(
+                conductor.create_batch,
+                workspace,
+                task_ids=task_ids,
+                strategy=body.strategy,
+                max_parallel=body.max_parallel,
+                on_failure="continue",
+                engine=body.engine,
+            )
         )
         _start_batch_detached(workspace, batch.id, max_retries=body.retry_count)
 

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -460,6 +460,76 @@ def delete_task(
 
 
 
+# One batch per workspace at a time. Before #901 the blocking call *accidentally*
+# provided this: a second POST could not even be served until the first batch
+# finished. Offloading removes that, and `check_assignment_status` alone is
+# check-then-act — it counts IN_PROGRESS tasks, but tasks only flip to
+# IN_PROGRESS inside the detached thread, long after the handler responded. Two
+# clicks within that window would both pass, both persist, and run two agent
+# subprocesses against the same git worktree.
+_workspace_batch_locks: dict[str, threading.Lock] = {}
+_workspace_batch_locks_guard = threading.Lock()
+
+
+def _workspace_batch_lock(workspace: Workspace) -> threading.Lock:
+    """Process-wide lock for starting a batch in a given workspace."""
+    key = str(workspace.repo_path)
+    with _workspace_batch_locks_guard:
+        return _workspace_batch_locks.setdefault(key, threading.Lock())
+
+
+def _reject_if_batch_active(workspace: Workspace) -> None:
+    """Refuse to start a second batch in a workspace that already has one.
+
+    Checked against persisted state rather than task status, because the batch
+    record exists from the moment it is created — before any task has moved.
+    Callers must hold ``_workspace_batch_lock(workspace)``.
+    """
+    for status in (conductor.BatchStatus.RUNNING, conductor.BatchStatus.PENDING):
+        active = conductor.list_batches(workspace, status=status, limit=1)
+        if active:
+            raise HTTPException(
+                status_code=409,
+                detail=api_error(
+                    "A batch is already running in this workspace",
+                    ErrorCodes.CONFLICT,
+                    f"Batch {active[0].id[:8]} is {status.value}. Wait for it to "
+                    f"finish, or cancel it with POST /api/v2/batches/{active[0].id}/cancel.",
+                ),
+            )
+
+
+def _create_batch_exclusively(workspace: Workspace, **kwargs):
+    """Refuse a second concurrent batch, then create one — atomically.
+
+    The check and the create must share one lock: checking first and creating
+    after leaves exactly the window two clicks need to both pass. Runs on a
+    worker thread (both callers wrap it in ``run_in_threadpool``), so the lock
+    never blocks the event loop.
+    """
+    with _workspace_batch_lock(workspace):
+        _reject_if_batch_active(workspace)
+        return conductor.create_batch(workspace, **kwargs)
+
+
+def _finalize_wedged_batch(workspace: Workspace, batch_id: str, reason: str) -> None:
+    """Mark a batch FAILED if its detached run died before finalizing it.
+
+    Without this the batch is stuck RUNNING forever: the client already has its
+    200 + batch_id, and ``resume_batch`` only accepts PARTIAL/FAILED/CANCELLED,
+    so a wedged batch could not even be resumed. Work that runs *before*
+    ``_execute_parallel``'s own try (plan building, starting the reconciliation
+    thread) is exactly what can raise here.
+    """
+    try:
+        batch = conductor.get_batch(workspace, batch_id)
+        if batch is None or batch.status in conductor.TERMINAL_BATCH_STATUSES:
+            return
+        conductor.fail_batch(workspace, batch_id, reason=reason)
+    except Exception:
+        logger.error("Could not finalize wedged batch %s", batch_id, exc_info=True)
+
+
 def _run_batch_in_background(workspace: Workspace, batch_id: str, max_retries: int = 0) -> None:
     """Execute an already-created batch on a worker thread (issue #901).
 
@@ -473,14 +543,15 @@ def _run_batch_in_background(workspace: Workspace, batch_id: str, max_retries: i
     Failures are logged and left on the batch record rather than raised: there
     is no request left to fail, and the conductor already records task outcomes.
     """
-    batch = conductor.get_batch(workspace, batch_id)
-    if batch is None:  # pragma: no cover - the caller just persisted it
-        logger.error("Batch %s vanished before execution", batch_id)
-        return
     try:
+        batch = conductor.get_batch(workspace, batch_id)
+        if batch is None:  # pragma: no cover - the caller just persisted it
+            logger.error("Batch %s vanished before execution", batch_id)
+            return
         conductor.execute_batch(workspace, batch, max_retries=max_retries)
     except Exception as exc:
         logger.error("Background batch %s failed: %s", batch_id, exc, exc_info=True)
+        _finalize_wedged_batch(workspace, batch_id, reason=str(exc))
 
 
 def _start_batch_detached(workspace: Workspace, batch_id: str, max_retries: int = 0) -> None:
@@ -545,10 +616,11 @@ async def approve_tasks_endpoint(
         if body.start_execution:
             # Persist first, then execute off the event loop (#901). The
             # persist is a synchronous SQLite write, so it is offloaded too —
-            # small, but it is still the event loop's time.
+            # small, but it is still the event loop's time. The guard and the
+            # create happen under one lock so two requests cannot both pass it.
             batch = await run_in_threadpool(
                 functools.partial(
-                    conductor.create_batch,
+                    _create_batch_exclusively,
                     workspace,
                     task_ids=result.approved_task_ids,
                     strategy="serial",
@@ -571,6 +643,10 @@ async def approve_tasks_endpoint(
             message=message,
         )
 
+    except HTTPException:
+        # e.g. the 409 from the one-batch-per-workspace guard — a deliberate
+        # status must not be re-wrapped as a 500 by the catch-all below.
+        raise
     except Exception as e:
         logger.error(f"Failed to approve tasks: {e}", exc_info=True)
         raise HTTPException(
@@ -663,7 +739,7 @@ async def start_execution(
         # while the batch runs.
         batch = await run_in_threadpool(
             functools.partial(
-                conductor.create_batch,
+                _create_batch_exclusively,
                 workspace,
                 task_ids=task_ids,
                 strategy=body.strategy,

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -8,7 +8,8 @@ Key differences from v1:
 - Uses Workspace (path-based) instead of project_id
 - Delegates to core/runtime and core/conductor functions
 - No LeadAgent dependency for execution
-- Uses conductor.start_batch() for parallel execution
+- Uses conductor.create_batch() + a worker thread, so batch execution never
+  blocks the event loop (#901)
 
 The v1 router (tasks.py) remains for backwards compatibility with
 existing web UI until Phase 3 (Web UI Rebuild).
@@ -18,7 +19,7 @@ import logging
 import threading
 from typing import Any, Literal, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, model_validator
 
@@ -456,12 +457,51 @@ def delete_task(
 # ============================================================================
 
 
+
+def _run_batch_in_background(workspace: Workspace, batch_id: str, max_retries: int = 0) -> None:
+    """Execute an already-created batch on a worker thread (issue #901).
+
+    ``conductor.execute_batch`` drives every task through a subprocess
+    ``wait()``, so calling it from an async handler pinned the uvicorn event
+    loop for the batch's whole duration — every other request, SSE stream,
+    WebSocket and ``/health`` froze for potentially hours. The batch record is
+    already persisted, so the handler returns its id at once and this runs
+    detached, exactly as ``start_single_task`` already did for a single run.
+
+    Failures are logged and left on the batch record rather than raised: there
+    is no request left to fail, and the conductor already records task outcomes.
+    """
+    batch = conductor.get_batch(workspace, batch_id)
+    if batch is None:  # pragma: no cover - the caller just persisted it
+        logger.error("Batch %s vanished before execution", batch_id)
+        return
+    try:
+        conductor.execute_batch(workspace, batch, max_retries=max_retries)
+    except Exception as exc:
+        logger.error("Background batch %s failed: %s", batch_id, exc, exc_info=True)
+
+
+def _start_batch_detached(workspace: Workspace, batch_id: str, max_retries: int = 0) -> None:
+    """Hand a persisted batch to a daemon thread and return immediately.
+
+    A dedicated thread rather than ``BackgroundTasks``: Starlette would run it
+    in the shared anyio threadpool, where an hours-long batch permanently
+    occupies one of its limited workers and enough concurrent batches starve
+    every other sync endpoint.
+    """
+    threading.Thread(
+        target=_run_batch_in_background,
+        args=(workspace, batch_id, max_retries),
+        daemon=True,
+        name=f"batch-{batch_id[:8]}",
+    ).start()
+
+
 @router.post("/approve", response_model=ApproveTasksResponse)
 @rate_limit_standard()
 async def approve_tasks_endpoint(
     request: Request,
     body: ApproveTasksRequest,
-    background_tasks: BackgroundTasks,
     workspace: Workspace = Depends(get_v2_workspace),
 ) -> ApproveTasksResponse:
     """Approve tasks and optionally start execution.
@@ -473,7 +513,6 @@ async def approve_tasks_endpoint(
 
     Args:
         request: Approval request with exclusions and execution flag
-        background_tasks: FastAPI background tasks
         workspace: v2 Workspace
 
     Returns:
@@ -502,7 +541,8 @@ async def approve_tasks_endpoint(
 
         # Optionally start execution
         if body.start_execution:
-            batch = conductor.start_batch(
+            # Persist first, then execute off the event loop (#901).
+            batch = conductor.create_batch(
                 workspace,
                 task_ids=result.approved_task_ids,
                 strategy="serial",
@@ -511,6 +551,7 @@ async def approve_tasks_endpoint(
                 engine=body.engine,
             )
             batch_id = batch.id
+            _start_batch_detached(workspace, batch_id)
             message = f"Approved {result.approved_count} task(s) and started execution (batch {batch_id[:8]})."
 
         return ApproveTasksResponse(
@@ -610,16 +651,18 @@ async def start_execution(
                 ),
             )
 
-        # Start batch execution
-        batch = conductor.start_batch(
+        # Persist the batch, then execute it off the event loop (#901): the
+        # handler must return batch_id at once so the UI can start polling
+        # while the batch runs.
+        batch = conductor.create_batch(
             workspace,
             task_ids=task_ids,
             strategy=body.strategy,
             max_parallel=body.max_parallel,
-            max_retries=body.retry_count,
             on_failure="continue",
             engine=body.engine,
         )
+        _start_batch_detached(workspace, batch.id, max_retries=body.retry_count)
 
         return StartExecutionResponse(
             success=True,

--- a/tests/integration/test_tasks_v2_engine.py
+++ b/tests/integration/test_tasks_v2_engine.py
@@ -1,7 +1,7 @@
 """Integration tests for engine parameter on task execution endpoints.
 
 Tests that the engine parameter is correctly validated, defaulted, and
-passed through to conductor.start_batch() and runtime.execute_agent()
+passed through to conductor.create_batch() and runtime.execute_agent()
 on all three execution endpoints:
 - POST /api/v2/tasks/execute
 - POST /api/v2/tasks/approve
@@ -115,7 +115,8 @@ class TestExecuteEndpointEngine:
         with (
             patch("codeframe.ui.routers.tasks_v2.runtime.check_assignment_status", return_value=_assignment_ok()),
             patch("codeframe.ui.routers.tasks_v2.runtime.get_ready_task_ids", return_value=[task.id]),
-            patch("codeframe.ui.routers.tasks_v2.conductor.start_batch", return_value=_make_batch_run(ws.id, [task.id])) as mock_batch,
+            patch("codeframe.ui.routers.tasks_v2._start_batch_detached"),
+            patch("codeframe.ui.routers.tasks_v2.conductor.create_batch", return_value=_make_batch_run(ws.id, [task.id])) as mock_batch,
         ):
             resp = client.post(
                 "/api/v2/tasks/execute",
@@ -138,7 +139,8 @@ class TestExecuteEndpointEngine:
         with (
             patch("codeframe.ui.routers.tasks_v2.runtime.check_assignment_status", return_value=_assignment_ok()),
             patch("codeframe.ui.routers.tasks_v2.runtime.get_ready_task_ids", return_value=[task.id]),
-            patch("codeframe.ui.routers.tasks_v2.conductor.start_batch", return_value=_make_batch_run(ws.id, [task.id], engine="react")) as mock_batch,
+            patch("codeframe.ui.routers.tasks_v2._start_batch_detached"),
+            patch("codeframe.ui.routers.tasks_v2.conductor.create_batch", return_value=_make_batch_run(ws.id, [task.id], engine="react")) as mock_batch,
         ):
             resp = client.post(
                 "/api/v2/tasks/execute",
@@ -173,7 +175,8 @@ class TestExecuteEndpointEngine:
         with (
             patch("codeframe.ui.routers.tasks_v2.runtime.check_assignment_status", return_value=_assignment_ok()),
             patch("codeframe.ui.routers.tasks_v2.runtime.get_ready_task_ids", return_value=[task.id]),
-            patch("codeframe.ui.routers.tasks_v2.conductor.start_batch", return_value=_make_batch_run(ws.id, [task.id], engine="react")),
+            patch("codeframe.ui.routers.tasks_v2._start_batch_detached"),
+            patch("codeframe.ui.routers.tasks_v2.conductor.create_batch", return_value=_make_batch_run(ws.id, [task.id], engine="react")),
         ):
             resp = client.post(
                 "/api/v2/tasks/execute",
@@ -276,7 +279,8 @@ class TestApproveEndpointEngine:
 
         with (
             patch("codeframe.ui.routers.tasks_v2.runtime.approve_tasks", return_value=approval),
-            patch("codeframe.ui.routers.tasks_v2.conductor.start_batch", return_value=_make_batch_run(ws.id, [task.id], engine="react")) as mock_batch,
+            patch("codeframe.ui.routers.tasks_v2._start_batch_detached"),
+            patch("codeframe.ui.routers.tasks_v2.conductor.create_batch", return_value=_make_batch_run(ws.id, [task.id], engine="react")) as mock_batch,
         ):
             resp = client.post(
                 "/api/v2/tasks/approve",
@@ -324,7 +328,8 @@ class TestApproveEndpointEngine:
 
         with (
             patch("codeframe.ui.routers.tasks_v2.runtime.approve_tasks", return_value=approval),
-            patch("codeframe.ui.routers.tasks_v2.conductor.start_batch") as mock_batch,
+            patch("codeframe.ui.routers.tasks_v2._start_batch_detached"),
+            patch("codeframe.ui.routers.tasks_v2.conductor.create_batch") as mock_batch,
         ):
             resp = client.post(
                 "/api/v2/tasks/approve",

--- a/tests/ui/test_batch_execution_offload.py
+++ b/tests/ui/test_batch_execution_offload.py
@@ -1,0 +1,218 @@
+"""Batch execution never blocks the event loop (#901 / P0.7).
+
+``POST /api/v2/tasks/execute`` and ``/tasks/approve`` called
+``conductor.start_batch(...)`` directly from an ``async def`` handler.
+``start_batch`` does not detach — it drives every task through
+``_execute_task_subprocess``, ending in ``process.wait()`` — so the complete
+agent execution of the whole batch ran on the uvicorn event loop. Every other
+request, SSE stream, WebSocket and ``/health`` froze for its duration, which
+for a real batch is minutes to hours. The web UI calls this endpoint.
+
+The tests below assert the two properties that actually matter: the handler
+**returns while the batch is still running**, and a concurrent request is
+served meanwhile. Asserting only "200 OK" would pass on the broken code.
+"""
+
+import asyncio
+import shutil
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.v2
+
+# Upper bound on how long the stand-in batch will block if a test forgets to
+# release it — keeps a regression from hanging the suite instead of failing.
+MAX_BLOCK_SECONDS = 10.0
+# The handler / a concurrent request must land far inside that. Generous for CI.
+MAX_CONCURRENT_SECONDS = 2.0
+
+
+@pytest.fixture
+def test_workspace():
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "ws"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    from codeframe.core.workspace import create_or_load_workspace
+
+    yield create_or_load_workspace(workspace_path)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def slow_batch(monkeypatch):
+    """Replace the execution half with a stand-in that blocks until released.
+
+    Held on an Event rather than a fixed sleep: "is the batch still running?"
+    becomes a fact the test controls instead of a race against wall-clock, and
+    teardown releases it so a detached thread never leaks into the next test's
+    timing budget.
+    """
+    from codeframe.ui.routers import tasks_v2
+
+    state = {
+        "started": threading.Event(),
+        "finished": threading.Event(),
+        "release": threading.Event(),
+        "thread": None,
+    }
+
+    def _blocking_execute(workspace, batch, max_retries=0, on_event=None):
+        state["thread"] = threading.current_thread()
+        state["started"].set()
+        state["release"].wait(timeout=MAX_BLOCK_SECONDS)
+        state["finished"].set()
+        return batch
+
+    monkeypatch.setattr(tasks_v2.conductor, "execute_batch", _blocking_execute)
+    yield state
+    state["release"].set()
+    state["finished"].wait(timeout=5)
+
+
+@pytest.fixture
+def app(test_workspace, monkeypatch):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import tasks_v2
+
+    # The batch record is real; only task validation is stubbed so the test
+    # needs no seeded tasks.
+    monkeypatch.setattr(
+        tasks_v2.conductor.tasks, "get", lambda ws, tid: object()
+    )
+    monkeypatch.setattr(
+        tasks_v2.runtime,
+        "check_assignment_status",
+        lambda ws: type("S", (), {"can_assign": True, "reason": ""})(),
+    )
+
+    app = FastAPI()
+    app.include_router(tasks_v2.router)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    return app
+
+
+async def test_execute_returns_while_the_batch_is_still_running(app, slow_batch):
+    """The handler must return batch_id immediately, not after the batch ends."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.monotonic()
+        resp = await client.post(
+            "/api/v2/tasks/execute", json={"task_ids": ["t1", "t2"]}
+        )
+        elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["batch_id"], "handler must return a batch id"
+    assert elapsed < MAX_CONCURRENT_SECONDS, (
+        f"POST /tasks/execute took {elapsed:.2f}s — it waited for the batch"
+    )
+    # The batch really is still running: the handler did not simply skip it.
+    assert slow_batch["started"].wait(timeout=5), "execution never started"
+    assert not slow_batch["finished"].is_set(), (
+        "the batch finished before the handler returned — it was not detached"
+    )
+
+
+async def test_health_responds_while_a_batch_runs(app, slow_batch):
+    """A concurrent request is served while the batch executes.
+
+    The execute POST is left **in flight** rather than awaited first: awaiting
+    it would let a blocking handler finish before /health is even issued, so
+    the timing would look fine on the very code this is meant to catch.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.monotonic()
+        execute_task = asyncio.create_task(
+            client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+        )
+        # Yield so the handler starts (and, unfixed, blocks the loop here).
+        await asyncio.sleep(0.05)
+
+        health = await client.get("/health")
+        elapsed = time.monotonic() - start
+
+        execute_response = await execute_task
+
+    assert health.status_code == 200
+    assert execute_response.status_code == 200, execute_response.text
+    assert elapsed < MAX_CONCURRENT_SECONDS, (
+        f"/health took {elapsed:.2f}s while a batch ran — the loop was blocked"
+    )
+
+
+async def test_execution_runs_off_the_event_loop_thread(app, slow_batch):
+    """Positive control: the work happens, and not on the serving thread."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+
+    assert slow_batch["started"].wait(timeout=5)
+    assert slow_batch["thread"] is not threading.current_thread()
+    slow_batch["release"].set()
+    assert slow_batch["finished"].wait(timeout=5), (
+        "the detached batch never completed"
+    )
+
+
+async def test_approve_with_execution_also_returns_immediately(
+    app, slow_batch, monkeypatch
+):
+    """/tasks/approve shares the defect and the fix."""
+    from codeframe.ui.routers import tasks_v2
+
+    monkeypatch.setattr(
+        tasks_v2.runtime,
+        "approve_tasks",
+        lambda ws, excluded_task_ids=None: type(
+            "R",
+            (),
+            {
+                "approved_count": 2,
+                "excluded_count": 0,
+                "approved_task_ids": ["t1", "t2"],
+                "excluded_task_ids": [],
+            },
+        )(),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.monotonic()
+        resp = await client.post(
+            "/api/v2/tasks/approve", json={"start_execution": True}
+        )
+        elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["batch_id"]
+    assert elapsed < MAX_CONCURRENT_SECONDS, (
+        f"POST /tasks/approve took {elapsed:.2f}s — it waited for the batch"
+    )
+    assert slow_batch["started"].wait(timeout=5)
+
+
+async def test_batch_is_visible_immediately_after_the_handler_returns(
+    app, slow_batch, test_workspace
+):
+    """The record is persisted before the response, so a client can poll it."""
+    from codeframe.core import conductor
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+
+    batch_id = resp.json()["batch_id"]
+    assert conductor.get_batch(test_workspace, batch_id) is not None

--- a/tests/ui/test_batch_execution_offload.py
+++ b/tests/ui/test_batch_execution_offload.py
@@ -100,6 +100,7 @@ def app(test_workspace, monkeypatch):
         return {"status": "ok"}
 
     app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    app.state.workspace = test_workspace
     return app
 
 
@@ -138,8 +139,15 @@ async def test_health_responds_while_a_batch_runs(app, slow_batch):
         execute_task = asyncio.create_task(
             client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
         )
-        # Yield so the handler starts (and, unfixed, blocks the loop here).
-        await asyncio.sleep(0.05)
+        # Wait for the batch to be genuinely in flight before measuring, so a
+        # merely-slow-to-start thread cannot make this pass vacuously. Awaited
+        # via the executor so the wait itself never blocks the loop; on the
+        # unfixed code the POST holds the loop and this times out, which is the
+        # failure we want.
+        await asyncio.get_running_loop().run_in_executor(
+            None, slow_batch["started"].wait, 5
+        )
+        assert slow_batch["started"].is_set(), "batch never started"
 
         health = await client.get("/health")
         elapsed = time.monotonic() - start
@@ -216,3 +224,126 @@ async def test_batch_is_visible_immediately_after_the_handler_returns(
 
     batch_id = resp.json()["batch_id"]
     assert conductor.get_batch(test_workspace, batch_id) is not None
+
+
+class TestOneBatchPerWorkspace:
+    """Offloading removed an accidental safety property (#901 review).
+
+    While execution ran inline on the event loop, a second POST could not even
+    be *served* until the first batch finished — the bug serialized batches.
+    Nothing replaced that: ``check_assignment_status`` counts IN_PROGRESS tasks,
+    but tasks only move inside the detached thread, long after the handler has
+    responded. Two clicks would both pass and run two agent subprocesses against
+    the same git worktree.
+    """
+
+    async def test_second_execute_is_refused_while_one_runs(self, app, slow_batch):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+            assert first.status_code == 200, first.text
+            assert slow_batch["started"].wait(timeout=5)
+
+            second = await client.post("/api/v2/tasks/execute", json={"task_ids": ["t2"]})
+
+        assert second.status_code == 409, second.text
+
+    async def test_concurrent_executes_admit_exactly_one(self, app, slow_batch):
+        """The race itself: both requests in flight at once."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            results = await asyncio.gather(
+                client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]}),
+                client.post("/api/v2/tasks/execute", json={"task_ids": ["t2"]}),
+            )
+
+        codes = sorted(r.status_code for r in results)
+        assert codes == [200, 409], f"expected exactly one to win, got {codes}"
+
+    async def test_approve_is_guarded_too(self, app, slow_batch, monkeypatch):
+        """/approve never called the assignment guard at all."""
+        from codeframe.ui.routers import tasks_v2
+
+        monkeypatch.setattr(
+            tasks_v2.runtime,
+            "approve_tasks",
+            lambda ws, excluded_task_ids=None: type(
+                "R",
+                (),
+                {
+                    "approved_count": 1,
+                    "excluded_count": 0,
+                    "approved_task_ids": ["t1"],
+                    "excluded_task_ids": [],
+                },
+            )(),
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+            assert slow_batch["started"].wait(timeout=5)
+
+            resp = await client.post(
+                "/api/v2/tasks/approve", json={"start_execution": True}
+            )
+
+        assert resp.status_code == 409, resp.text
+
+    async def test_a_finished_batch_does_not_block_the_next_one(self, app, slow_batch):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+            assert slow_batch["started"].wait(timeout=5)
+            slow_batch["release"].set()
+            assert slow_batch["finished"].wait(timeout=5)
+
+            # The stand-in returns the batch without finalizing it, so mark it
+            # terminal the way a real run would before asserting the gate lifts.
+            from codeframe.core import conductor
+
+            for batch in conductor.list_batches(app.state.workspace, limit=5):
+                conductor.fail_batch(app.state.workspace, batch.id, reason="test")
+
+            second = await client.post("/api/v2/tasks/execute", json={"task_ids": ["t2"]})
+
+        assert second.status_code == 200, second.text
+
+
+class TestWedgedBatchIsFinalized:
+    """A crash in the detached thread must not leave the batch RUNNING forever.
+
+    The client already has its 200 + batch_id, and ``resume_batch`` accepts only
+    PARTIAL/FAILED/CANCELLED — so a wedged RUNNING batch could not even be
+    resumed. Work before ``_execute_parallel``'s own try (plan building,
+    starting the reconciliation thread) is exactly what can raise here.
+    """
+
+    async def test_thread_failure_marks_the_batch_failed(
+        self, app, test_workspace, monkeypatch
+    ):
+        from codeframe.core import conductor
+        from codeframe.ui.routers import tasks_v2
+
+        def _boom(workspace, batch, max_retries=0, on_event=None):
+            raise RuntimeError("plan building exploded")
+
+        monkeypatch.setattr(tasks_v2.conductor, "execute_batch", _boom)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/v2/tasks/execute", json={"task_ids": ["t1"]})
+
+        batch_id = resp.json()["batch_id"]
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            batch = conductor.get_batch(test_workspace, batch_id)
+            if batch and batch.status in conductor.TERMINAL_BATCH_STATUSES:
+                break
+            time.sleep(0.05)
+
+        batch = conductor.get_batch(test_workspace, batch_id)
+        assert batch is not None
+        assert batch.status == conductor.BatchStatus.FAILED, (
+            f"batch left {batch.status} — a wedged batch cannot even be resumed"
+        )


### PR DESCRIPTION
Closes #901 (P0.7 — `critical` / `perf`, filed by the SaaS launch review).

## Problem

`POST /api/v2/tasks/execute` and `/tasks/approve` called `conductor.start_batch(...)` **directly from an `async def` handler**. `start_batch` does not detach — it drives every task through `_execute_task_subprocess`, ending in `process.wait()`.

So the complete agent execution of the whole batch ran **on the uvicorn event loop**. Every other request, SSE stream, WebSocket and `/health` froze for its duration — minutes to hours for a real batch. The web UI calls this endpoint. As the issue puts it: *this alone makes the server unusable for more than one concurrent tenant.*

The unused `BackgroundTasks` parameter on `/tasks/approve` shows offloading was intended and never wired.

## Fix

`start_batch` splits at its natural seam:

| Function | Role |
|---|---|
| `create_batch()` | validates, persists, emits `BATCH_STARTED`, returns a **PENDING** record — so a client polling `/batches` sees it at once |
| `execute_batch()` | takes a persisted batch and runs it to completion; reads strategy/max_parallel/engine **off the record**, so a resumed batch executes exactly as created |
| `start_batch()` | unchanged blocking create+execute wrapper for the CLI and tests, with a docstring warning handlers off it |

Both handlers now create the batch, return `batch_id`, and hand execution to a **daemon thread** — the same shape `start_single_task` already used for a single run.

### Why a thread and not `BackgroundTasks`

Starlette would run it in the shared anyio threadpool, where an hours-long batch permanently occupies one of its limited workers, and enough concurrent batches starve every other sync endpoint. The issue's own criterion blesses the thread ("as `start_single_task` does"). The unused parameter is removed.

### One more blocking call, found by the test

`create_batch`'s SQLite INSERT was still synchronous on the loop. Milliseconds normally — but it made the concurrency test fail when run after the full conductor suite on an fsync-bound machine: the whole 2s budget went on the *persist*, not the batch. Loosening the threshold would have hidden a real blocking call, so both handlers wrap `create_batch` in `run_in_threadpool` (the pattern `diagnose_v2`/`environment_v2` already use). The handlers are now non-blocking end to end.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `start_batch` split into create-record and execute phases | `conductor.create_batch` / `conductor.execute_batch` |
| `POST /tasks/execute` returns `batch_id` immediately | `test_execute_returns_while_the_batch_is_still_running` |
| Test starts a batch via the API and asserts another endpoint responds while it runs | `test_health_responds_while_a_batch_runs` |
| The unused `BackgroundTasks` parameter is used or removed | removed, with its docstring line and the stale module-docstring reference |

## On the tests

They assert the properties that actually distinguish fixed from broken — the handler **returns while the batch is still running**, and a concurrent request is served meanwhile. A plain `assert status_code == 200` passes on the broken code.

Two details worth noting:

- The `/health` request is issued with the execute POST **still in flight** (`asyncio.create_task`). Awaiting the POST first would let a blocking handler finish before `/health` is even sent — the timing would look fine on exactly the code this is meant to catch. My first draft made that mistake and the mutation check caught it.
- The blocking stand-in waits on an `Event` the test releases rather than sleeping, so "still running" is a controlled fact instead of a wall-clock race, and teardown releases it so no detached thread leaks into the next test's timing budget.

**Mutation-verified:** replacing the `threading.Thread(...)` dispatch with a direct inline call fails 4 of the 5 tests. The fifth pins persist-before-response, which is true either way by design.

## Verification

- **81 passed** — the offload tests together with the entire `test_conductor.py` suite, the combination that surfaced the persist-on-loop blocking.
- **252 passed** across conductor, the v2 router integration suite, the existing event-loop offload suites, task-start failure handling and the CLI integration suite (that run predates the persist fix; its single failure was the health test now fixed).
- `ruff` clean, strict `mypy` clean on all 192 files.

## Known limitations

- Execution runs on an unbounded per-batch daemon thread. Fine for the current single-workspace server, but there is no global cap on concurrent batches — a queue/worker-pool is a larger change than this issue's scope.
- A batch is lost if the server restarts mid-run; `cf work batch resume` already covers recovery, and `execute_batch` reading its config off the record is what makes resume behave identically.