### PR TITLE
perf: offload the remaining blocking work off the FastAPI event loop (#902, P0.8)

### DIFF
--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -12,9 +12,12 @@ read+write always, admin only for ``is_superuser`` accounts (issue #898).
 import logging
 import os
 import re
+import threading
+import time
 from typing import Callable, Dict, Optional, Any, Tuple
 
 from fastapi import Depends, HTTPException, Request, Security, WebSocket, status
+from fastapi.concurrency import run_in_threadpool
 from fastapi.security import APIKeyHeader, HTTPBearer, HTTPAuthorizationCredentials
 
 from codeframe.auth.models import User
@@ -294,11 +297,40 @@ def _scopes_within_owner_grant(db: Any, key_record: Dict[str, Any]) -> list:
     return [s for s in scopes if s != SCOPE_ADMIN]
 
 
+# How long to suppress repeat ``last_used_at`` writes for the same key (#902).
+# Every API-key request used to do a bcrypt verify, a SELECT *and* an
+# UPDATE+COMMIT against a lock with busy_timeout=5000 — a write per request, on
+# the event loop, purely to refresh a timestamp nothing reads at that
+# resolution. Five minutes keeps the field useful for "is this key still in
+# use?" while removing almost all of the writes.
+_LAST_USED_COALESCE_SECONDS = 300.0
+
+# In-process only: each worker refreshes at most once per window per key, which
+# is the right trade for a usage hint. Bounded by the number of live keys.
+_last_used_writes: Dict[str, float] = {}
+_last_used_lock = threading.Lock()
+
+
+def _should_record_last_used(key_id: str) -> bool:
+    """Whether this key's ``last_used_at`` is due for a refresh."""
+    now = time.monotonic()
+    with _last_used_lock:
+        previous = _last_used_writes.get(key_id)
+        if previous is not None and (now - previous) < _LAST_USED_COALESCE_SECONDS:
+            return False
+        _last_used_writes[key_id] = now
+        return True
+
+
 async def get_api_key_auth(
     api_key: Optional[str] = Security(api_key_header),
     request: Request = None,
 ) -> Optional[Dict[str, Any]]:
     """Extract and validate API key from X-API-Key header.
+
+    The work is entirely synchronous — a bcrypt verify plus SQLite reads — so
+    it runs on a worker thread (#902). Inline, every API-key request blocked the
+    event loop on a lock with a 5s busy timeout.
 
     Args:
         api_key: API key from header (auto-extracted by FastAPI Security)
@@ -310,7 +342,11 @@ async def get_api_key_auth(
     """
     if not api_key:
         return None
+    return await run_in_threadpool(_resolve_api_key, api_key, request)
 
+
+def _resolve_api_key(api_key: str, request: Optional[Request]) -> Optional[Dict[str, Any]]:
+    """Blocking half of :func:`get_api_key_auth`. Runs on a worker thread."""
     fallback_db = None
     try:
         # Get database from app state (singleton) or request state
@@ -349,11 +385,14 @@ async def get_api_key_auth(
             logger.warning(f"API key auth failed: verification failed (prefix: {prefix[:4]}...)")
             return None
 
-        # Update last used timestamp (fire and forget)
-        try:
-            db.api_keys.update_last_used(key_record["id"])
-        except Exception as e:
-            logger.warning(f"Failed to update last_used_at: {e}")
+        # Refresh last_used_at at most once per key per window (#902) — this is
+        # an UPDATE+COMMIT, and doing it on every request made each
+        # authenticated call a database writer.
+        if _should_record_last_used(key_record["id"]):
+            try:
+                db.api_keys.update_last_used(key_record["id"])
+            except Exception as e:
+                logger.warning(f"Failed to update last_used_at: {e}")
 
         return {
             "type": "api_key",

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -306,7 +306,9 @@ def _scopes_within_owner_grant(db: Any, key_record: Dict[str, Any]) -> list:
 _LAST_USED_COALESCE_SECONDS = 300.0
 
 # In-process only: each worker refreshes at most once per window per key, which
-# is the right trade for a usage hint. Bounded by the number of live keys.
+# is the right trade for a usage hint. Entries older than the window are pruned
+# on access, so this tracks keys in *current* use rather than every key ever
+# authenticated — a revoked key's slot does not outlive the window.
 _last_used_writes: Dict[str, float] = {}
 _last_used_lock = threading.Lock()
 
@@ -315,11 +317,30 @@ def _should_record_last_used(key_id: str) -> bool:
     """Whether this key's ``last_used_at`` is due for a refresh."""
     now = time.monotonic()
     with _last_used_lock:
-        previous = _last_used_writes.get(key_id)
-        if previous is not None and (now - previous) < _LAST_USED_COALESCE_SECONDS:
+        # Prune first: an expired entry would be overwritten anyway, and this
+        # keeps the dict proportional to keys in active use.
+        for stale in [
+            k
+            for k, t in _last_used_writes.items()
+            if (now - t) >= _LAST_USED_COALESCE_SECONDS
+        ]:
+            del _last_used_writes[stale]
+
+        if key_id in _last_used_writes:
             return False
         _last_used_writes[key_id] = now
         return True
+
+
+def _release_last_used_claim(key_id: str) -> None:
+    """Undo a claim whose write failed, so the next request can retry.
+
+    The slot is claimed *before* the UPDATE (it is what makes the check atomic),
+    so a failed write must give it back rather than suppress refreshes for the
+    rest of the window.
+    """
+    with _last_used_lock:
+        _last_used_writes.pop(key_id, None)
 
 
 async def get_api_key_auth(
@@ -393,6 +414,7 @@ def _resolve_api_key(api_key: str, request: Optional[Request]) -> Optional[Dict[
                 db.api_keys.update_last_used(key_record["id"])
             except Exception as e:
                 logger.warning(f"Failed to update last_used_at: {e}")
+                _release_last_used_claim(key_record["id"])
 
         return {
             "type": "api_key",

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -962,6 +962,40 @@ def list_batches(
     return [_row_to_batch(row) for row in rows]
 
 
+
+def count_batches_by_status(workspace: Workspace) -> dict[str, int]:
+    """Count batches per status with one aggregate query (issue #902).
+
+    The batches list endpoint used to call ``list_batches(limit=1000)`` purely
+    to tally statuses — materializing up to a thousand ``BatchRun`` objects,
+    JSON-decoding each one's ``task_ids`` and ``results``, on every poll from
+    every open browser tab. A GROUP BY does the same job in the database and
+    returns a handful of integers.
+
+    Returns:
+        ``{status_value: count}``, omitting statuses with no rows.
+    """
+    conn = get_db_connection(workspace)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT status, COUNT(*) AS n
+            FROM batch_runs
+            WHERE workspace_id = ?
+            GROUP BY status
+            """,
+            (workspace.id,),
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    # Index access, not key access: this connection's row_factory is not
+    # guaranteed to be sqlite3.Row, and indices work for both.
+    return {row[0]: row[1] for row in rows}
+
+
 def find_batch_by_prefix(workspace: Workspace, prefix: str) -> list[BatchRun]:
     """Resolve batches whose id starts with ``prefix`` (SQL ``LIKE``, no cap).
 

--- a/codeframe/core/streaming.py
+++ b/codeframe/core/streaming.py
@@ -15,6 +15,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import asyncio
+import codecs
 import logging
 import os
 import threading
@@ -286,27 +287,59 @@ async def atail_run_output(
     # client — so a multi-MB agent log burned O(size) CPU and IO per tick on the
     # event loop, for every open tab. We now remember a byte offset and read
     # only what was appended since.
+    #
+    # Binary mode with a persistent incremental decoder, deliberately. Text mode
+    # would hand back an opaque tell() cookie (not comparable with st_size), and
+    # decoding each chunk independently mangles any multibyte character whose
+    # bytes straddle a poll: the partial sequence at EOF becomes U+FFFD and its
+    # remaining bytes are then orphaned. The decoder holds incomplete sequences
+    # until the rest arrives, so emoji/CJK output survives the boundary.
     offset = 0
-    pending = ""      # bytes read that do not yet end a line
+    pending = ""
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     skip_lines = max(since_line, 0)
-    started = False
+    reached_tail = skip_lines == 0
 
-    def _read_new() -> str:
-        """Return text appended since ``offset``, updating it. Never raises."""
-        nonlocal offset
+    # Last bytes we consumed, re-verified each poll to detect that the file was
+    # replaced underneath us. Inode identity is not enough on its own: a
+    # delete-then-recreate can reuse the inode number immediately, and file
+    # timestamps change on ordinary appends, so neither distinguishes "appended"
+    # from "replaced". Comparing the bytes we already read does, at the cost of
+    # one bounded extra read per poll.
+    _SIGNATURE_BYTES = 32
+    signature = b""
+
+    def _read_new() -> tuple[str, bool]:
+        """``(text_appended, was_reset)``. Never raises.
+
+        Returns ``was_reset`` rather than clearing ``pending`` itself: the
+        caller's ``pending += ...`` loads ``pending`` *before* evaluating this
+        call, so an assignment in here would be silently discarded.
+        """
+        nonlocal offset, decoder, signature
         try:
             size = log_path.stat().st_size
-            if size < offset:
-                # Truncated/rotated underneath us — start over rather than
-                # seeking past the end and yielding nothing forever.
+            reset = size < offset
+            if not reset and offset and signature:
+                with open(log_path, "rb") as f:
+                    f.seek(offset - len(signature))
+                    reset = f.read(len(signature)) != signature
+
+            if reset:
                 offset = 0
-            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                signature = b""
+                decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+
+            with open(log_path, "rb") as f:
                 f.seek(offset)
                 chunk = f.read()
                 offset = f.tell()
-            return chunk
+
+            if chunk:
+                signature = (signature + chunk)[-_SIGNATURE_BYTES:]
+            return decoder.decode(chunk), reset
         except Exception:
-            return ""  # File might be temporarily unavailable
+            return "", False  # File might be temporarily unavailable
 
     while True:
         if max_wait is not None and (time.monotonic() - start_time) >= max_wait:
@@ -316,7 +349,11 @@ async def atail_run_output(
             break
 
         if log_path.exists():
-            pending += _read_new()
+            appended, was_reset = _read_new()
+            if was_reset:
+                # Never weld a pre-rotation fragment onto the new file's head.
+                pending = ""
+            pending += appended
 
             # Only emit complete lines: a trailing fragment is a line the agent
             # is still writing. Holding it back until its newline arrives also
@@ -326,15 +363,20 @@ async def atail_run_output(
                 line, pending = pending.split("\n", 1)
                 if skip_lines:
                     skip_lines -= 1
+                    if skip_lines == 0:
+                        reached_tail = True
                     continue
-                started = True
+                reached_tail = True
                 yield line + "\n"
 
         await asyncio.sleep(poll_interval)
 
     # Flush a final unterminated line (a log whose last write had no newline),
-    # which would otherwise be lost when the stream closes.
-    if pending and not skip_lines and (started or since_line == 0):
+    # which would otherwise be lost when the stream closes. Gated on having
+    # reached the live tail rather than on having yielded anything: with
+    # since_line == the exact number of complete lines, every line is skipped
+    # and nothing is yielded, yet the trailing fragment is still the caller's.
+    if pending and reached_tail:
         yield pending
 
 

--- a/codeframe/core/streaming.py
+++ b/codeframe/core/streaming.py
@@ -279,8 +279,34 @@ async def atail_run_output(
         Lines from the log file as they appear
     """
     log_path = get_run_output_path(workspace, run_id)
-    current_line = since_line
     start_time = time.monotonic()
+
+    # Incremental tail (#902). The previous implementation re-read the whole
+    # file with readlines() on every poll — twice a second, per connected
+    # client — so a multi-MB agent log burned O(size) CPU and IO per tick on the
+    # event loop, for every open tab. We now remember a byte offset and read
+    # only what was appended since.
+    offset = 0
+    pending = ""      # bytes read that do not yet end a line
+    skip_lines = max(since_line, 0)
+    started = False
+
+    def _read_new() -> str:
+        """Return text appended since ``offset``, updating it. Never raises."""
+        nonlocal offset
+        try:
+            size = log_path.stat().st_size
+            if size < offset:
+                # Truncated/rotated underneath us — start over rather than
+                # seeking past the end and yielding nothing forever.
+                offset = 0
+            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                f.seek(offset)
+                chunk = f.read()
+                offset = f.tell()
+            return chunk
+        except Exception:
+            return ""  # File might be temporarily unavailable
 
     while True:
         if max_wait is not None and (time.monotonic() - start_time) >= max_wait:
@@ -289,20 +315,27 @@ async def atail_run_output(
         if should_stop is not None and await should_stop():
             break
 
-        # ponytail: full-file readlines each poll (same as the sync tailer);
-        # fine for agent logs. Switch to incremental seek reads if they grow large.
         if log_path.exists():
-            try:
-                with open(log_path, "r", encoding="utf-8") as f:
-                    all_lines = f.readlines()
+            pending += _read_new()
 
-                while current_line < len(all_lines):
-                    yield all_lines[current_line]
-                    current_line += 1
-            except Exception:
-                pass  # File might be temporarily unavailable
+            # Only emit complete lines: a trailing fragment is a line the agent
+            # is still writing. Holding it back until its newline arrives also
+            # fixes a latent bug in the old version, which could yield a partial
+            # line and then never emit its remainder.
+            while "\n" in pending:
+                line, pending = pending.split("\n", 1)
+                if skip_lines:
+                    skip_lines -= 1
+                    continue
+                started = True
+                yield line + "\n"
 
         await asyncio.sleep(poll_interval)
+
+    # Flush a final unterminated line (a log whose last write had no newline),
+    # which would otherwise be lost when the stream closes.
+    if pending and not skip_lines and (started or since_line == 0):
+        yield pending
 
 
 # =============================================================================

--- a/codeframe/ui/routers/batches_v2.py
+++ b/codeframe/ui/routers/batches_v2.py
@@ -165,7 +165,7 @@ async def get_batch(
     Raises:
         HTTPException: 404 if batch not found
     """
-    batch = conductor.get_batch(workspace, batch_id)
+    batch = await run_in_threadpool(conductor.get_batch, workspace, batch_id)
 
     if not batch:
         raise HTTPException(
@@ -211,7 +211,9 @@ async def stop_batch(
     force = body.force if body else False
 
     try:
-        batch = conductor.stop_batch(workspace, batch_id, force=force)
+        batch = await run_in_threadpool(
+            conductor.stop_batch, workspace, batch_id, force=force
+        )
         return _batch_to_response(batch)
 
     except ValueError as e:
@@ -254,7 +256,9 @@ async def resume_batch(
     force = body.force if body else False
 
     try:
-        batch = conductor.resume_batch(workspace, batch_id, force=force)
+        batch = await run_in_threadpool(
+            conductor.resume_batch, workspace, batch_id, force=force
+        )
         return _batch_to_response(batch)
 
     except ValueError as e:
@@ -301,7 +305,7 @@ async def cancel_batch(
             - 400: Batch not in cancellable state
     """
     try:
-        batch = conductor.cancel_batch(workspace, batch_id)
+        batch = await run_in_threadpool(conductor.cancel_batch, workspace, batch_id)
         return _batch_to_response(batch)
 
     except ValueError as e:

--- a/codeframe/ui/routers/batches_v2.py
+++ b/codeframe/ui/routers/batches_v2.py
@@ -14,6 +14,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -127,15 +128,16 @@ async def list_batches(
                 ),
             )
 
-    # Get batches
-    batch_list = conductor.list_batches(workspace, status=status_filter, limit=limit)
+    # Both reads are synchronous SQLite, so they run off the event loop (#902).
+    batch_list = await run_in_threadpool(
+        conductor.list_batches, workspace, status=status_filter, limit=limit
+    )
 
-    # Calculate counts by status
-    all_batches = conductor.list_batches(workspace, limit=1000)
-    status_counts: dict[str, int] = {}
-    for batch in all_batches:
-        status_val = batch.status.value
-        status_counts[status_val] = status_counts.get(status_val, 0) + 1
+    # Counts come from a GROUP BY rather than materializing up to 1000 batches
+    # on every poll from every open tab (#902).
+    status_counts = await run_in_threadpool(
+        conductor.count_batches_by_status, workspace
+    )
 
     return BatchListResponse(
         batches=[_batch_to_response(b) for b in batch_list],

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -129,7 +129,7 @@ async def start_discovery(
     """
     try:
         # Check for existing active session
-        existing = prd_discovery.get_active_session(workspace)
+        existing = await run_in_threadpool(prd_discovery.get_active_session, workspace)
         if existing and not existing.is_complete():
             raise HTTPException(
                 status_code=400,
@@ -142,7 +142,8 @@ async def start_discovery(
             )
 
         # Start new session
-        session = prd_discovery.start_discovery_session(workspace)
+        # LLM round trip: minutes, not milliseconds (#902).
+        session = await run_in_threadpool(prd_discovery.start_discovery_session, workspace)
         question = session.get_current_question()
 
         return StartDiscoveryResponse(
@@ -183,7 +184,8 @@ async def get_status(
     Returns:
         Discovery status including state, progress, and current question
     """
-    status = prd_discovery.get_discovery_status(
+    status = await run_in_threadpool(
+        prd_discovery.get_discovery_status,
         workspace,
         session_id=session_id,
     )
@@ -220,7 +222,9 @@ async def submit_answer(
             - 500: Processing error
     """
     try:
-        result = prd_discovery.process_discovery_answer(
+        # LLM round trip (#902).
+        result = await run_in_threadpool(
+            prd_discovery.process_discovery_answer,
             workspace,
             session_id,
             body.answer,
@@ -319,7 +323,9 @@ async def reset_discovery(
     Returns:
         Success status and message
     """
-    reset = prd_discovery.reset_discovery(workspace, session_id=session_id)
+    reset = await run_in_threadpool(
+        prd_discovery.reset_discovery, workspace, session_id=session_id
+    )
 
     if reset:
         return {
@@ -402,7 +408,9 @@ async def generate_tasks_from_prd(
             provider = create_provider(resolve_llm_settings(workspace.repo_path))
 
         # Generate tasks
-        generated_tasks = tasks.generate_from_prd(
+        # LLM decomposition of a whole PRD: minutes (#902).
+        generated_tasks = await run_in_threadpool(
+            tasks.generate_from_prd,
             workspace,
             prd_record,
             use_llm=use_llm,

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -381,14 +381,14 @@ async def generate_tasks_from_prd(
     try:
         # Get PRD
         if prd_id:
-            prd_record = prd.get_by_id(workspace, prd_id)
+            prd_record = await run_in_threadpool(prd.get_by_id, workspace, prd_id)
             if not prd_record:
                 raise HTTPException(
                     status_code=404,
                     detail=f"PRD not found: {prd_id}",
                 )
         else:
-            prd_record = prd.get_latest(workspace)
+            prd_record = await run_in_threadpool(prd.get_latest, workspace)
             if not prd_record:
                 raise HTTPException(
                     status_code=404,
@@ -405,7 +405,9 @@ async def generate_tasks_from_prd(
                 resolve_llm_settings,
             )
 
-            provider = create_provider(resolve_llm_settings(workspace.repo_path))
+            provider = await run_in_threadpool(
+                lambda: create_provider(resolve_llm_settings(workspace.repo_path))
+            )
 
         # Generate tasks
         # LLM decomposition of a whole PRD: minutes (#902).

--- a/codeframe/ui/routers/environment_v2.py
+++ b/codeframe/ui/routers/environment_v2.py
@@ -131,7 +131,9 @@ async def check_environment(
     """
     try:
         validator = EnvironmentValidator()
-        result = validator.validate_environment(workspace.repo_path)
+        result = await run_in_threadpool(
+            validator.validate_environment, workspace.repo_path
+        )
 
         return _result_to_response(result)
 
@@ -164,7 +166,8 @@ async def run_doctor(
         validator = EnvironmentValidator()
 
         # Doctor mode validates everything including optional tools
-        result = validator.validate_environment(
+        result = await run_in_threadpool(
+            validator.validate_environment,
             workspace.repo_path,
             # Include optional tools in the check
             optional_tools=["ruff", "black", "mypy", "pre-commit"],

--- a/codeframe/ui/routers/git_v2.py
+++ b/codeframe/ui/routers/git_v2.py
@@ -10,6 +10,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -97,7 +98,7 @@ async def get_git_status(
         GitStatusResponse with status information
     """
     try:
-        status = git.get_status(workspace)
+        status = await run_in_threadpool(git.get_status, workspace)
 
         return GitStatusResponse(
             current_branch=status.current_branch,
@@ -137,7 +138,9 @@ async def list_commits(
         raise HTTPException(status_code=400, detail="Limit must be between 1 and 100")
 
     try:
-        commits = git.list_commits(workspace, branch=branch, limit=limit)
+        commits = await run_in_threadpool(
+            git.list_commits, workspace, branch=branch, limit=limit
+        )
 
         return CommitListResponse(
             commits=[
@@ -180,7 +183,8 @@ async def create_commit(
         CommitResultResponse with commit details
     """
     try:
-        result = git.create_commit(
+        result = await run_in_threadpool(
+            git.create_commit,
             workspace,
             files=body.files,
             message=body.message,
@@ -217,7 +221,7 @@ async def get_diff(
         DiffResponse with diff content
     """
     try:
-        diff_content = git.get_diff(workspace, staged=staged)
+        diff_content = await run_in_threadpool(git.get_diff, workspace, staged=staged)
 
         return DiffResponse(
             diff=diff_content,
@@ -247,7 +251,7 @@ async def get_current_branch(
         Dict with branch name
     """
     try:
-        branch = git.get_current_branch(workspace)
+        branch = await run_in_threadpool(git.get_current_branch, workspace)
         return {"branch": branch}
 
     except ValueError as e:
@@ -273,7 +277,7 @@ async def check_clean(
         Dict with is_clean boolean
     """
     try:
-        is_clean = git.is_clean(workspace)
+        is_clean = await run_in_threadpool(git.is_clean, workspace)
         return {"is_clean": is_clean}
 
     except ValueError as e:

--- a/codeframe/ui/routers/review_v2.py
+++ b/codeframe/ui/routers/review_v2.py
@@ -10,6 +10,7 @@ import logging
 from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
@@ -129,7 +130,7 @@ async def review_files(
         ReviewResultResponse with findings and score
     """
     try:
-        result = review.review_files(workspace, body.files)
+        result = await run_in_threadpool(review.review_files, workspace, body.files)
 
         return ReviewResultResponse(
             status=result.status,
@@ -222,7 +223,7 @@ async def review_files_summary(
         ReviewSummaryResponse with aggregated metrics
     """
     try:
-        result = review.review_files(workspace, body.files)
+        result = await run_in_threadpool(review.review_files, workspace, body.files)
         summary = review.get_review_summary(result)
 
         return ReviewSummaryResponse(
@@ -265,7 +266,7 @@ async def get_review_diff(
         DiffStatsResponse with diff text and statistics
     """
     try:
-        stats = git.get_diff_stats(workspace, staged=staged)
+        stats = await run_in_threadpool(git.get_diff_stats, workspace, staged=staged)
 
         return DiffStatsResponse(
             diff=stats.diff,
@@ -311,8 +312,8 @@ async def get_review_patch(
         PatchResponse with patch content and suggested filename
     """
     try:
-        patch_content = git.get_patch(workspace, staged=staged)
-        branch = git.get_current_branch(workspace)
+        patch_content = await run_in_threadpool(git.get_patch, workspace, staged=staged)
+        branch = await run_in_threadpool(git.get_current_branch, workspace)
         filename = f"{branch.replace('/', '-')}.patch"
 
         return PatchResponse(
@@ -348,7 +349,9 @@ async def generate_commit_message(
         CommitMessageResponse with suggested message
     """
     try:
-        message = git.generate_commit_message(workspace, staged=staged)
+        message = await run_in_threadpool(
+            git.generate_commit_message, workspace, staged=staged
+        )
 
         return CommitMessageResponse(message=message)
 

--- a/codeframe/ui/routers/review_v2.py
+++ b/codeframe/ui/routers/review_v2.py
@@ -174,7 +174,8 @@ async def review_task(
         ReviewResultResponse with findings and score
     """
     try:
-        result = review.review_task(
+        result = await run_in_threadpool(
+            review.review_task,
             workspace,
             task_id=body.task_id,
             files_modified=body.files_modified,

--- a/tests/auth/test_api_key_last_used_coalescing.py
+++ b/tests/auth/test_api_key_last_used_coalescing.py
@@ -147,3 +147,40 @@ class TestResolutionIsOffloaded:
 
         assert auth is not None
         assert seen["thread"] is not loop_thread
+
+
+class TestClaimHousekeeping:
+    """Review findings on the coalescing (#902 round 2)."""
+
+    @pytest.mark.asyncio
+    async def test_a_failed_write_is_retried_next_request(
+        self, db_and_key, monkeypatch
+    ):
+        """The slot is claimed *before* the UPDATE, so a failed write must give
+        it back rather than suppress refreshes for the rest of the window."""
+        db, key = db_and_key
+        attempts = []
+
+        def _flaky(key_id):
+            attempts.append(key_id)
+            if len(attempts) == 1:
+                raise RuntimeError("database is locked")
+
+        monkeypatch.setattr(db.api_keys, "update_last_used", _flaky)
+
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+
+        assert len(attempts) == 2, "a failed write was not retried"
+
+    @pytest.mark.asyncio
+    async def test_stale_entries_are_pruned(self, db_and_key):
+        """Entries must not accumulate for every key ever authenticated."""
+        db, key = db_and_key
+
+        deps._last_used_writes["revoked-key-long-gone"] = (
+            0.0 - deps._LAST_USED_COALESCE_SECONDS
+        )
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+
+        assert "revoked-key-long-gone" not in deps._last_used_writes

--- a/tests/auth/test_api_key_last_used_coalescing.py
+++ b/tests/auth/test_api_key_last_used_coalescing.py
@@ -1,0 +1,149 @@
+"""API-key auth stops writing to the database on every request (#902 / P0.8).
+
+Every API-key request did a SELECT *and* an UPDATE+COMMIT of ``last_used_at``,
+against a lock with ``busy_timeout=5000`` — a database **writer** per
+authenticated call, on the event loop, purely to refresh a timestamp nothing
+reads at per-request resolution.
+
+Resolution now runs on a worker thread, and the timestamp refresh is coalesced
+to at most once per key per window.
+"""
+
+import pytest
+
+from codeframe.auth import dependencies as deps
+from codeframe.auth.api_keys import SCOPE_READ, SCOPE_WRITE
+from codeframe.core.api_key_service import ApiKeyService
+from codeframe.platform_store.database import Database
+from tests.conftest import setup_test_user
+
+pytestmark = pytest.mark.v2
+
+
+class _State:
+    pass
+
+
+class _App:
+    def __init__(self, db):
+        self.state = _State()
+        self.state.db = db
+
+
+class _Request:
+    def __init__(self, db):
+        self.app = _App(db)
+        self.state = _State()
+
+
+@pytest.fixture(autouse=True)
+def clean_coalesce_state():
+    deps._last_used_writes.clear()
+    yield
+    deps._last_used_writes.clear()
+
+
+@pytest.fixture
+def db_and_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "state.db"))
+    db = Database(tmp_path / "state.db")
+    db.initialize()
+    setup_test_user(db, user_id=1)
+    key = ApiKeyService(db).create_api_key(
+        user_id=1, name="k", scopes=[SCOPE_READ, SCOPE_WRITE]
+    )
+    yield db, key
+    db.close()
+
+
+class TestLastUsedCoalescing:
+    @pytest.mark.asyncio
+    async def test_repeat_requests_write_once(self, db_and_key, monkeypatch):
+        db, key = db_and_key
+        writes = []
+        real = db.api_keys.update_last_used
+        monkeypatch.setattr(
+            db.api_keys,
+            "update_last_used",
+            lambda key_id: (writes.append(key_id), real(key_id))[1],
+        )
+
+        for _ in range(5):
+            auth = await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+            assert auth is not None
+
+        assert len(writes) == 1, (
+            f"{len(writes)} database writes for 5 authenticated requests"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_window_expires(self, db_and_key, monkeypatch):
+        db, key = db_and_key
+        writes = []
+        real = db.api_keys.update_last_used
+        monkeypatch.setattr(
+            db.api_keys,
+            "update_last_used",
+            lambda key_id: (writes.append(key_id), real(key_id))[1],
+        )
+
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+        # Age the recorded write past the window rather than sleeping for it.
+        for key_id in list(deps._last_used_writes):
+            deps._last_used_writes[key_id] -= deps._LAST_USED_COALESCE_SECONDS + 1
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+
+        assert len(writes) == 2, "the timestamp must still refresh once per window"
+
+    @pytest.mark.asyncio
+    async def test_the_timestamp_is_still_recorded(self, db_and_key):
+        """Coalescing must not mean 'never write'."""
+        db, key = db_and_key
+
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+
+        assert db.api_keys.get_by_id(key.id)["last_used_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_distinct_keys_are_tracked_separately(self, db_and_key, monkeypatch):
+        db, key = db_and_key
+        second = ApiKeyService(db).create_api_key(
+            user_id=1, name="k2", scopes=[SCOPE_READ]
+        )
+        writes = []
+        real = db.api_keys.update_last_used
+        monkeypatch.setattr(
+            db.api_keys,
+            "update_last_used",
+            lambda key_id: (writes.append(key_id), real(key_id))[1],
+        )
+
+        await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+        await deps.get_api_key_auth(api_key=second.key, request=_Request(db))
+
+        assert sorted(writes) == sorted([key.id, second.id])
+
+
+class TestResolutionIsOffloaded:
+    @pytest.mark.asyncio
+    async def test_the_blocking_half_runs_on_a_worker_thread(
+        self, db_and_key, monkeypatch
+    ):
+        """The bcrypt verify plus SQLite reads must not sit on the event loop."""
+        import threading
+
+        db, key = db_and_key
+        seen = {}
+        real = deps._resolve_api_key
+
+        def _record(api_key, request):
+            seen["thread"] = threading.current_thread()
+            return real(api_key, request)
+
+        monkeypatch.setattr(deps, "_resolve_api_key", _record)
+
+        loop_thread = threading.current_thread()
+        auth = await deps.get_api_key_auth(api_key=key.key, request=_Request(db))
+
+        assert auth is not None
+        assert seen["thread"] is not loop_thread

--- a/tests/core/test_incremental_tail_902.py
+++ b/tests/core/test_incremental_tail_902.py
@@ -172,3 +172,82 @@ class TestIncrementalReads:
     async def test_missing_file_is_not_an_error(self, workspace):
         lines = await _collect(workspace, max_wait=0.15)
         assert lines == []
+
+
+class TestRotationAndEncoding:
+    """Review findings on the incremental rewrite (#902 round 2)."""
+
+    async def test_rotation_to_a_larger_file_is_detected(self, workspace, log):
+        """A size-only check misses the usual case: the replacement file grows
+        *past* the old offset, so the reader seeks into its middle and silently
+        drops the head."""
+        log.write_text("".join(f"old {i}\n" for i in range(20)))
+        collected: list[str] = []
+
+        async def _rotate():
+            await asyncio.sleep(0.12)
+            log.unlink()
+            log.write_text("".join(f"new {i}\n" for i in range(60)))
+
+        rotator = asyncio.create_task(_rotate())
+        collected = await _collect(workspace, max_wait=0.5)
+        await rotator
+
+        assert "new 0\n" in collected, (
+            "head of the rotated file was skipped — rotation not detected"
+        )
+
+    async def test_truncation_does_not_weld_the_old_fragment_on(
+        self, workspace, log
+    ):
+        """`pending` must reset with the offset, or the pre-rotation fragment is
+        concatenated onto the new file's first line."""
+        log.write_text("old partial")  # no newline: stays in `pending`
+
+        async def _replace():
+            await asyncio.sleep(0.12)
+            log.write_text("new line\n")
+
+        replacer = asyncio.create_task(_replace())
+        lines = await _collect(workspace, max_wait=0.45)
+        await replacer
+
+        assert "old partialnew line\n" not in lines, f"welded fragment: {lines}"
+        assert "new line\n" in lines
+
+    async def test_multibyte_split_across_polls_is_not_mangled(
+        self, workspace, log
+    ):
+        """A UTF-8 sequence straddling a poll must survive.
+
+        Decoding each chunk independently turns the partial sequence at EOF into
+        U+FFFD and orphans its remaining bytes — permanently mangling the
+        character and replaying the corruption to every client.
+        """
+        raw = "héllo wörld ✅ 日本語\n".encode("utf-8")
+        split = len(raw) - 6  # lands inside the multibyte tail
+        log.write_bytes(raw[:split])
+
+        async def _finish():
+            await asyncio.sleep(0.12)
+            with open(log, "ab") as f:
+                f.write(raw[split:])
+
+        finisher = asyncio.create_task(_finish())
+        lines = await _collect(workspace, max_wait=0.45)
+        await finisher
+
+        assert lines == ["héllo wörld ✅ 日本語\n"], lines
+        assert "\ufffd" not in "".join(lines)
+
+    async def test_trailing_fragment_survives_since_line_on_the_boundary(
+        self, workspace, log
+    ):
+        """since_line == the exact number of complete lines: every line is
+        skipped and nothing is yielded, but the trailing fragment is still the
+        caller's."""
+        log.write_text("a\nb\nc\npartial")
+
+        lines = await _collect(workspace, since_line=3, max_wait=0.15)
+
+        assert lines == ["partial"]

--- a/tests/core/test_incremental_tail_902.py
+++ b/tests/core/test_incremental_tail_902.py
@@ -1,0 +1,174 @@
+"""``atail_run_output`` reads incrementally from a saved offset (#902 / P0.8).
+
+It used to call ``readlines()`` on the whole file every poll — twice a second,
+per connected client — so a multi-MB agent log burned O(size) CPU and IO per
+tick on the event loop for every open tab.
+
+The tests assert *how much is read*, not just what is yielded: a correct-output
+assertion passes on the full-reread version too.
+"""
+
+import asyncio
+
+import pytest
+
+from codeframe.core.streaming import atail_run_output, get_run_output_path
+
+pytestmark = pytest.mark.v2
+
+RUN_ID = "run-902"
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_path = tmp_path / "ws"
+    ws_path.mkdir()
+    return create_or_load_workspace(ws_path)
+
+
+@pytest.fixture
+def log(workspace):
+    path = get_run_output_path(workspace, RUN_ID)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+    return path
+
+
+async def _collect(workspace, *, since_line=0, max_wait=0.35, poll=0.05):
+    return [
+        line
+        async for line in atail_run_output(
+            workspace, RUN_ID, since_line=since_line,
+            poll_interval=poll, max_wait=max_wait,
+        )
+    ]
+
+
+class TestIncrementalReads:
+    async def test_only_new_bytes_are_read_after_the_first_poll(
+        self, workspace, log, monkeypatch
+    ):
+        """The point of the fix: bytes read per poll must not scale with file size.
+
+        Measured by shadowing ``open`` in the streaming module only (Python
+        resolves the name through module globals before builtins), so nothing
+        else in the process is affected.
+        """
+        import builtins
+
+        from codeframe.core import streaming as streaming_mod
+
+        log.write_text("".join(f"line {i}\n" for i in range(500)))
+        assert log.stat().st_size > 4000
+
+        reads: list[int] = []
+        real_open = builtins.open
+
+        def tracking_open(path, *args, **kwargs):
+            handle = real_open(path, *args, **kwargs)
+            if str(path) != str(log):
+                return handle
+
+            class _Tracked:
+                def __enter__(self_inner):
+                    handle.__enter__()
+                    return self_inner
+
+                def __exit__(self_inner, *exc):
+                    return handle.__exit__(*exc)
+
+                def read(self_inner, *a, **kw):
+                    data = handle.read(*a, **kw)
+                    reads.append(len(data))
+                    return data
+
+                def __getattr__(self_inner, name):
+                    return getattr(handle, name)
+
+            return _Tracked()
+
+        monkeypatch.setattr(streaming_mod, "open", tracking_open, raising=False)
+
+        async def _appender():
+            for i in range(3):
+                await asyncio.sleep(0.08)
+                with real_open(log, "a") as f:
+                    f.write(f"appended {i}\n")
+
+        appender = asyncio.create_task(_appender())
+        lines = await _collect(workspace, max_wait=0.5, poll=0.05)
+        await appender
+
+        assert any(line.startswith("appended") for line in lines)
+        assert reads, "the tailer never read the log"
+        # First poll drains the backlog; every later read is only the append.
+        assert reads[0] > 4000
+        assert all(n < 200 for n in reads[1:]), (
+            f"log re-read in full after the first poll: {reads}"
+        )
+
+    async def test_yields_appended_lines(self, workspace, log):
+        log.write_text("a\nb\n")
+
+        async def _appender():
+            await asyncio.sleep(0.1)
+            with log.open("a") as f:
+                f.write("c\n")
+
+        appender = asyncio.create_task(_appender())
+        lines = await _collect(workspace, max_wait=0.35)
+        await appender
+
+        assert lines == ["a\n", "b\n", "c\n"]
+
+    async def test_since_line_skips_the_backlog(self, workspace, log):
+        log.write_text("a\nb\nc\n")
+
+        lines = await _collect(workspace, since_line=2, max_wait=0.2)
+
+        assert lines == ["c\n"]
+
+    async def test_a_partial_line_is_held_until_its_newline_arrives(
+        self, workspace, log
+    ):
+        """The old version could yield a half-written line and then never emit
+        its remainder, because the line count had already advanced."""
+        log.write_text("complete\npar")
+
+        async def _finisher():
+            await asyncio.sleep(0.1)
+            with log.open("a") as f:
+                f.write("tial\n")
+
+        finisher = asyncio.create_task(_finisher())
+        lines = await _collect(workspace, max_wait=0.35)
+        await finisher
+
+        assert lines == ["complete\n", "partial\n"]
+
+    async def test_final_unterminated_line_is_flushed_at_close(self, workspace, log):
+        log.write_text("done\nno trailing newline")
+
+        lines = await _collect(workspace, max_wait=0.15)
+
+        assert lines == ["done\n", "no trailing newline"]
+
+    async def test_truncation_restarts_rather_than_stalling(self, workspace, log):
+        """A rotated/truncated log must not leave the reader seeking past EOF."""
+        log.write_text("old line 1\nold line 2\n")
+
+        async def _truncate():
+            await asyncio.sleep(0.12)
+            log.write_text("fresh\n")
+
+        truncator = asyncio.create_task(_truncate())
+        lines = await _collect(workspace, max_wait=0.4)
+        await truncator
+
+        assert "fresh\n" in lines
+
+    async def test_missing_file_is_not_an_error(self, workspace):
+        lines = await _collect(workspace, max_wait=0.15)
+        assert lines == []

--- a/tests/ui/test_batches_status_counts_902.py
+++ b/tests/ui/test_batches_status_counts_902.py
@@ -1,0 +1,70 @@
+"""Batch status counts come from SQL, not from materializing 1000 batches (#902).
+
+``GET /api/v2/batches`` called ``list_batches(limit=1000)`` purely to tally
+statuses — building up to a thousand ``BatchRun`` objects and JSON-decoding each
+one's ``task_ids`` and ``results`` — on every poll, from every open tab.
+"""
+
+import pytest
+
+from codeframe.core import conductor
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_path = tmp_path / "ws"
+    ws_path.mkdir()
+    return create_or_load_workspace(ws_path)
+
+
+def _batch(workspace, task_id: str, status: conductor.BatchStatus):
+    from codeframe.core import tasks as tasks_mod
+
+    original = tasks_mod.get
+    tasks_mod.get = lambda ws, tid: object()
+    try:
+        batch = conductor.create_batch(workspace, task_ids=[task_id])
+    finally:
+        tasks_mod.get = original
+    batch.status = status
+    conductor._save_batch(workspace, batch)
+    return batch
+
+
+class TestCountBatchesByStatus:
+    def test_counts_match_the_rows(self, workspace):
+        _batch(workspace, "t1", conductor.BatchStatus.COMPLETED)
+        _batch(workspace, "t2", conductor.BatchStatus.COMPLETED)
+        _batch(workspace, "t3", conductor.BatchStatus.FAILED)
+
+        counts = conductor.count_batches_by_status(workspace)
+
+        assert counts == {"COMPLETED": 2, "FAILED": 1}
+
+    def test_empty_workspace_returns_empty(self, workspace):
+        assert conductor.count_batches_by_status(workspace) == {}
+
+    def test_counts_every_batch_not_just_a_page(self, workspace):
+        """The old tally was capped at limit=1000; this is a plain aggregate."""
+        for i in range(25):
+            _batch(workspace, f"t{i}", conductor.BatchStatus.COMPLETED)
+
+        counts = conductor.count_batches_by_status(workspace)
+
+        assert counts == {"COMPLETED": 25}
+
+    def test_does_not_materialize_batch_objects(self, workspace, monkeypatch):
+        """The regression this guards: tallying via list_batches."""
+        for i in range(5):
+            _batch(workspace, f"t{i}", conductor.BatchStatus.COMPLETED)
+
+        def _boom(*a, **kw):
+            raise AssertionError("count must not go through list_batches")
+
+        monkeypatch.setattr(conductor, "list_batches", _boom)
+
+        assert conductor.count_batches_by_status(workspace) == {"COMPLETED": 5}

--- a/tests/ui/test_blocking_handler_offload_902.py
+++ b/tests/ui/test_blocking_handler_offload_902.py
@@ -1,0 +1,220 @@
+"""The remaining hot paths no longer block the event loop (#902 / P0.8).
+
+Several `async def` handlers called synchronous core work inline, so one slow
+caller stalled every SSE stream, WebSocket terminal and concurrent request:
+review (tree-sitter/radon/bandit), all six git_v2 GitPython handlers, discovery
+LLM round trips, `/env/check` and `/env/doctor` (a subprocess per tool), and
+the API-key auth SELECT+UPDATE on every request.
+
+Each test holds the core function inside a worker thread and asserts `/health`
+is still served — the property that distinguishes offloaded from inline. A
+status-code assertion alone passes on the broken code.
+"""
+
+import asyncio
+import shutil
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.v2
+
+# A concurrent /health must land far inside the blocked window. Generous for CI.
+MAX_HEALTH_SECONDS = 2.0
+# Upper bound if a test forgets to release, so a regression fails rather than hangs.
+MAX_BLOCK_SECONDS = 10.0
+
+
+@pytest.fixture
+def test_workspace():
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "ws"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    from codeframe.core.workspace import create_or_load_workspace
+
+    yield create_or_load_workspace(workspace_path)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def blocker():
+    """A stand-in that blocks until released, recording that it was entered."""
+    state = {"started": threading.Event(), "release": threading.Event()}
+
+    def _block(*args, **kwargs):
+        state["started"].set()
+        state["release"].wait(timeout=MAX_BLOCK_SECONDS)
+        return state.get("result")
+
+    state["fn"] = _block
+    yield state
+    state["release"].set()
+
+
+def _app_with(router_module, test_workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    return app
+
+
+async def _assert_health_served_during(app, method, path, blocker, **kw):
+    """Fire the slow request, prove it is in flight, then time /health."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        slow = asyncio.create_task(getattr(client, method)(path, **kw))
+
+        # Prove the handler actually reached the blocking call before measuring,
+        # so a merely-slow-to-start request cannot make this pass vacuously.
+        await asyncio.get_running_loop().run_in_executor(
+            None, blocker["started"].wait, 5
+        )
+        assert blocker["started"].is_set(), "handler never reached the core call"
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        health = await client.get("/health")
+        elapsed = loop.time() - start
+
+        blocker["release"].set()
+        await slow
+
+    assert health.status_code == 200
+    assert elapsed < MAX_HEALTH_SECONDS, (
+        f"/health took {elapsed:.2f}s while {method.upper()} {path} ran — "
+        "the handler blocked the event loop"
+    )
+
+
+class TestReviewOffload:
+    async def test_health_responds_during_review_files(
+        self, test_workspace, blocker, monkeypatch
+    ):
+        from codeframe.ui.routers import review_v2
+
+        blocker["result"] = review_v2.review.ReviewResult("approved", 100.0, [], "ok")
+        monkeypatch.setattr(review_v2.review, "review_files", blocker["fn"])
+
+        await _assert_health_served_during(
+            _app_with(review_v2, test_workspace),
+            "post",
+            "/api/v2/review/files",
+            blocker,
+            json={"files": ["a.py"]},
+        )
+
+
+class TestGitOffload:
+    async def test_health_responds_during_git_status(
+        self, test_workspace, blocker, monkeypatch
+    ):
+        from codeframe.core.git import GitStatus
+        from codeframe.ui.routers import git_v2
+
+        blocker["result"] = GitStatus(
+            current_branch="main",
+            is_dirty=False,
+            modified_files=[],
+            untracked_files=[],
+            staged_files=[],
+        )
+        monkeypatch.setattr(git_v2.git, "get_status", blocker["fn"])
+
+        await _assert_health_served_during(
+            _app_with(git_v2, test_workspace), "get", "/api/v2/git/status", blocker
+        )
+
+    async def test_health_responds_during_git_diff(
+        self, test_workspace, blocker, monkeypatch
+    ):
+        from codeframe.ui.routers import git_v2
+
+        blocker["result"] = "diff --git a/x b/x\n"
+        monkeypatch.setattr(git_v2.git, "get_diff", blocker["fn"])
+
+        await _assert_health_served_during(
+            _app_with(git_v2, test_workspace), "get", "/api/v2/git/diff", blocker
+        )
+
+
+class TestEnvironmentOffload:
+    async def test_health_responds_during_env_check(
+        self, test_workspace, blocker, monkeypatch
+    ):
+        from codeframe.ui.routers import environment_v2
+
+        monkeypatch.setattr(
+            environment_v2.EnvironmentValidator,
+            "validate_environment",
+            lambda self, *a, **kw: blocker["fn"](),
+        )
+        monkeypatch.setattr(
+            environment_v2,
+            "_result_to_response",
+            lambda result: environment_v2.ValidationResultResponse(
+                project_type="python",
+                detected_tools={},
+                missing_tools=[],
+                optional_missing=[],
+                health_score=1.0,
+                health_percent=100,
+                is_healthy=True,
+                recommendations=[],
+                warnings=[],
+                conflicts=[],
+            ),
+        )
+
+        await _assert_health_served_during(
+            _app_with(environment_v2, test_workspace),
+            "get",
+            "/api/v2/env/check",
+            blocker,
+        )
+
+
+class TestDiscoveryOffload:
+    async def test_health_responds_during_discovery_start(
+        self, test_workspace, blocker, monkeypatch
+    ):
+        from codeframe.ui.routers import discovery_v2
+
+        monkeypatch.setattr(
+            discovery_v2.prd_discovery, "get_active_session", lambda ws: None
+        )
+        monkeypatch.setattr(
+            discovery_v2.prd_discovery, "start_discovery_session", blocker["fn"]
+        )
+
+        transport = ASGITransport(app=_app_with(discovery_v2, test_workspace))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            slow = asyncio.create_task(client.post("/api/v2/discovery/start"))
+            await asyncio.get_running_loop().run_in_executor(
+                None, blocker["started"].wait, 5
+            )
+            assert blocker["started"].is_set()
+
+            loop = asyncio.get_running_loop()
+            start = loop.time()
+            health = await client.get("/health")
+            elapsed = loop.time() - start
+
+            blocker["release"].set()
+            await slow
+
+        assert health.status_code == 200
+        assert elapsed < MAX_HEALTH_SECONDS, (
+            f"/health took {elapsed:.2f}s during an LLM discovery call"
+        )


### PR DESCRIPTION
Closes #902 (P0.8 — `critical` / `perf`, filed by the SaaS launch review). Unblocked by #899 and #901.

## Problem

Multiple hot paths ran synchronous work inline in `async def` handlers, so **one slow caller stalled every SSE stream, WebSocket terminal and concurrent request**. The codebase already knew the rule — `proof_v2.py` uses `run_in_threadpool` with a `#732` comment — it just wasn't applied here.

## Changes, one per symptom

| Path | Was | Now |
|---|---|---|
| `discovery_v2` | LLM round trips + `tasks.generate_from_prd` (**minutes**) inline | `run_in_threadpool` |
| `review_v2` | tree-sitter / radon / bandit inline | `run_in_threadpool` |
| `git_v2` | all six GitPython handlers inline | `run_in_threadpool` |
| `environment_v2` | `/env/check`, `/env/doctor` — one subprocess per tool | `run_in_threadpool` |
| `atail_run_output` | `readlines()` on the whole file, twice a second, per client | incremental read from a byte offset |
| API-key auth | SELECT **+ UPDATE+COMMIT** per request, on the loop, against a lock with `busy_timeout=5000` | offloaded; `last_used_at` coalesced to once per key per 5 min |
| `GET /api/v2/batches` | `list_batches(limit=1000)` per poll, per tab, just to tally | `SELECT status, COUNT(*) … GROUP BY` |

### Two bugs found while fixing the tailer

- The old version could **yield a half-written line and never emit its remainder** — the line count had already advanced past it. Unterminated fragments are now held until their newline arrives, and flushed at stream close.
- A truncated/rotated log left the reader seeking past EOF; the offset now resets.

## Acceptance criteria

| Criterion | Where |
|---|---|
| No `async def` handler in discovery_v2/review_v2/git_v2/environment_v2 calls a synchronous core function inline | all call sites wrapped; verified by grep |
| `atail_run_output` reads incrementally from a saved offset | `core/streaming.py` |
| API-key auth DB access offloaded, `last_used_at` coalesced | `_resolve_api_key` + `_should_record_last_used` |
| `list_batches` computes status counts with SQL GROUP BY | `conductor.count_batches_by_status` |
| **A test asserts /health responds while a long review/git call is in flight** | `tests/ui/test_blocking_handler_offload_902.py` |

## On the tests

Each offload test holds the core function **inside a worker thread** and asserts `/health` is still served — the property that distinguishes offloaded from inline. It waits for the handler to actually reach the blocking call before measuring, so a merely-slow-to-start request can't make it pass vacuously.

The tailer tests assert **how many bytes each poll reads**, not just what is yielded — a correct-output assertion passes on the full-reread version too. Measured by shadowing `open` in the streaming module only (Python resolves the name through module globals before builtins), so nothing else in the process is affected:

```
assert reads[0] > 4000                    # first poll drains the backlog
assert all(n < 200 for n in reads[1:])    # every later poll reads only the append
```

Likewise the coalescing test asserts **5 authenticated requests produce 1 database write**, and `test_does_not_materialize_batch_objects` makes `list_batches` raise so the count provably doesn't route through it.

## Known limitations

- `last_used_at` coalescing is per process, so a multi-worker deployment refreshes at most once per window *per worker*. That's the right trade for a usage hint, and it's stated in the code.
- The threadpool is Starlette's shared anyio pool. These are all short-to-medium calls that release; the genuinely long-running case (batch execution) got its own dedicated thread in #901.
- `tail_run_output` (the sync CLI tailer) still re-reads in full. It has one reader on a terminal, not N browser tabs, so it isn't the symptom this issue names.