### PR TITLE
fix(security): treat a repo-supplied llm.base_url as untrusted (#903, P0.9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,24 @@ OPENAI_BASE_URL=http://localhost:11434/v1  # Base URL override (OpenAI-compatibl
 #   model: qwen2.5-coder:7b
 #   base_url: http://localhost:11434/v1   # optional; local models, or an API proxy/gateway (any provider incl. anthropic, #780)
 
+# Repo-supplied LLM endpoint opt-in (#903) — default OFF (refuse)
+CODEFRAME_ALLOW_CONFIG_BASE_URL=1    # Allow a `.codeframe/config.yaml`
+                                      # `llm.base_url` that is NOT this machine.
+                                      # That file lives inside the repository,
+                                      # so cloning an untrusted repo would
+                                      # otherwise redirect API traffic — and the
+                                      # operator's API key — to whatever host it
+                                      # names. Loopback URLs (localhost/127.0.0.1/
+                                      # ::1) are always allowed: they are the
+                                      # documented local-model setup and cannot
+                                      # exfiltrate. The env tier
+                                      # (OPENAI_BASE_URL) is the operator's own
+                                      # environment and is unaffected (#780).
+                                      # Note the gate is not limited to
+                                      # anthropic/openai: get_provider hands
+                                      # OPENAI_API_KEY to ollama/vllm/compatible
+                                      # too when it is set.
+
 # Optional — Rate limiting
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_DEFAULT=100/minute

--- a/codeframe/adapters/llm/__init__.py
+++ b/codeframe/adapters/llm/__init__.py
@@ -84,7 +84,12 @@ def get_provider(provider_type: str = "anthropic", **kwargs) -> LLMProvider:
         return OpenAIProvider(
             api_key=api_key,
             model=kwargs.get("model", os.environ.get("CODEFRAME_LLM_MODEL", "gpt-4o")),
-            base_url=kwargs.get("base_url", os.environ.get("OPENAI_BASE_URL")),
+            # Pass through only what the caller gave us. Reading
+            # OPENAI_BASE_URL here would hand the adapter a non-None value and
+            # skip its vet in exactly the dangerous case — a repo .env having
+            # set the variable (#903). OpenAIProvider resolves and vets the env
+            # itself when this is None.
+            base_url=kwargs.get("base_url"),
         )
     elif provider_type == "anthropic":
         model_selector = None

--- a/codeframe/adapters/llm/anthropic.py
+++ b/codeframe/adapters/llm/anthropic.py
@@ -68,6 +68,15 @@ class AnthropicProvider(LLMProvider):
                 "Set the environment variable, pass api_key parameter, "
                 "or configure via 'codeframe auth setup --provider anthropic'."
             )
+        # When base_url is None the SDK reads ANTHROPIC_BASE_URL from the
+        # environment itself, so "unset" does not mean "default endpoint" — it
+        # means "whatever set that variable", which a repo .env can be (#903).
+        # Vetting here puts *every* construction behind the check, including
+        # callers that never go through resolve_llm_settings.
+        if base_url is None:
+            from codeframe.core.env_provenance import vet_env_base_url
+
+            base_url = vet_env_base_url("ANTHROPIC_BASE_URL")
         self.base_url = base_url
         self._client = None
         self._async_client = None

--- a/codeframe/adapters/llm/openai.py
+++ b/codeframe/adapters/llm/openai.py
@@ -65,6 +65,13 @@ class OpenAIProvider(LLMProvider):
         super().__init__(model_selector)
 
         self.model = model
+        # Same reasoning as the Anthropic adapter (#903): the OpenAI SDK reads
+        # OPENAI_BASE_URL when base_url is None, so a repo .env can redirect any
+        # construction that did not go through resolve_llm_settings.
+        if base_url is None:
+            from codeframe.core.env_provenance import vet_env_base_url
+
+            base_url = vet_env_base_url("OPENAI_BASE_URL")
         self.base_url = base_url
         self.api_key = api_key
 

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -42,6 +42,14 @@ _cwd_env = _cwd / ".env"
 if _home_env.exists():
     load_dotenv(_home_env)
 if _cwd_env.exists():
+    # Record provenance before loading: this file lives inside the repository
+    # and overrides the operator's exported environment, so anything downstream
+    # that trusts os.environ as "the operator's own configuration" needs to
+    # know which keys the repo supplied (#903). The general problem — a repo
+    # .env overriding the operator at all — is #904.
+    from codeframe.core.env_provenance import keys_defined_in, record_repo_env_keys
+
+    record_repo_env_keys(keys_defined_in(_cwd_env))
     load_dotenv(_cwd_env, override=True)  # workspace .env takes precedence
 
 # Create main app

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -15,6 +15,7 @@ Examples:
 """
 
 import json
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -5932,7 +5933,10 @@ def main() -> None:
         # A deliberate refusal, not a crash: show the operator what was
         # blocked and how to proceed, without a traceback (#903).
         console.print(f"\n[red]Refusing to run:[/red] {e}\n")
-        raise typer.Exit(1)
+        # sys.exit, not typer.Exit: main() *is* the console-script entry point,
+        # so there is no Click standalone loop above it to turn Exit into a
+        # clean status — it would surface as a traceback under the message.
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -5924,8 +5924,15 @@ def main() -> None:
     behavior or exit codes.
     """
     from codeframe.cli.telemetry_runtime import run
+    from codeframe.core.llm_resolution import UntrustedBaseURLError
 
-    run(app)
+    try:
+        run(app)
+    except UntrustedBaseURLError as e:
+        # A deliberate refusal, not a crash: show the operator what was
+        # blocked and how to proceed, without a traceback (#903).
+        console.print(f"\n[red]Refusing to run:[/red] {e}\n")
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -694,14 +694,28 @@ def load_environment(env_file: str = ".env") -> None:
     Args:
         env_file: Path to .env file (default: .env in current directory)
     """
+    from codeframe.core.env_provenance import keys_defined_in, record_repo_env_keys
+
+    def _load(path: Path) -> None:
+        # Record provenance here, not at the call sites (#903). These files live
+        # inside the repository, so anything downstream that treats os.environ as
+        # "the operator's own configuration" — the LLM endpoint gate above all —
+        # needs to know which keys the repo supplied. Doing it in the loader
+        # means every entrypoint is covered: the CLI, the server lifespan, and
+        # any future one. Recording it only in cli/app.py left the gate inert in
+        # uvicorn workers, `cf serve --reload`, and direct
+        # `uvicorn codeframe.ui.server:app`, which never import that module.
+        record_repo_env_keys(keys_defined_in(path))
+        load_dotenv(path)
+
     env_path = Path(env_file)
     if env_path.exists():
-        load_dotenv(env_path)
+        _load(env_path)
         # Also try project root .env if we're in a subdirectory
         if not env_path.is_absolute():
             root_env = Path.cwd() / ".env"
             if root_env.exists() and root_env != env_path.absolute():
-                load_dotenv(root_env)
+                _load(root_env)
 
 
 class Config:

--- a/codeframe/core/env_provenance.py
+++ b/codeframe/core/env_provenance.py
@@ -1,0 +1,61 @@
+"""Which environment variables came from the *repository* (issue #903).
+
+``cf`` loads ``<cwd>/.env`` with ``override=True``, so a file committed inside a
+cloned repo wins over what the operator exported. Anything downstream that
+treats ``os.environ`` as "the operator's own configuration" is therefore wrong
+for those keys — a repo can set them.
+
+This module records which keys the workspace ``.env`` supplied, so a security
+decision can tell the two apart. It deliberately holds *names only*: values stay
+in ``os.environ`` and are never copied here.
+
+Headless — no CLI or HTTP imports (architecture rule #1).
+
+Note this is the narrow, base_url-shaped half of the problem. Stopping a repo
+``.env`` from overriding the operator's environment in general is #904.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+#: Env var names supplied by the workspace's own ``.env``.
+_repo_supplied: set[str] = set()
+
+
+def record_repo_env_keys(keys: Iterable[str]) -> None:
+    """Mark ``keys`` as having come from the repository."""
+    _repo_supplied.update(keys)
+
+
+def is_repo_supplied(name: str) -> bool:
+    """Whether ``name``'s value in ``os.environ`` came from the repo's ``.env``."""
+    return name in _repo_supplied
+
+
+def reset() -> None:
+    """Clear recorded provenance (tests)."""
+    _repo_supplied.clear()
+
+
+def keys_defined_in(env_file: Path) -> set[str]:
+    """Names assigned in a ``.env`` file, without evaluating its values.
+
+    A deliberately minimal parser: it only needs the left-hand sides, and
+    reading values here would mean holding secrets in a second place.
+    """
+    names: set[str] = set()
+    try:
+        for raw in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            name = line.split("=", 1)[0].strip()
+            if name.startswith("export "):
+                name = name[len("export "):].strip()
+            if name:
+                names.add(name)
+    except OSError:
+        return set()
+    return names

--- a/codeframe/core/env_provenance.py
+++ b/codeframe/core/env_provenance.py
@@ -17,8 +17,14 @@ Note this is the narrow, base_url-shaped half of the problem. Stopping a repo
 
 from __future__ import annotations
 
+import ipaddress
+import logging
+import os
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 #: Env var names supplied by the workspace's own ``.env``.
 _repo_supplied: set[str] = set()
@@ -59,3 +65,100 @@ def keys_defined_in(env_file: Path) -> set[str]:
     except OSError:
         return set()
     return names
+
+
+# ---------------------------------------------------------------------------
+# Endpoint trust (issue #903)
+#
+# Lives here rather than in ``llm_resolution`` so the *adapters* can apply it
+# too: ``llm_resolution`` imports the adapters, so the reverse would be a cycle,
+# and this module deliberately depends on nothing.
+# ---------------------------------------------------------------------------
+
+#: Opt-in for a repo-supplied ``base_url`` that points off this machine. Mirrors
+#: the other deliberate escape hatches (``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS``,
+#: ``CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES``).
+ALLOW_CONFIG_BASE_URL_ENV = "CODEFRAME_ALLOW_CONFIG_BASE_URL"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+class UntrustedBaseURLError(RuntimeError):
+    """A repo-supplied ``base_url`` would send API traffic off this machine.
+
+    ``.codeframe/config.yaml`` and ``.env`` both live *inside the repository*,
+    so cloning an untrusted repo and running any LLM command would otherwise
+    ship the operator's long-lived API key to whatever host they name — with no
+    validation, no warning, and no visible difference in output (issue #903).
+    """
+
+
+def is_loopback_url(url) -> bool:
+    """Whether ``url``'s host is this machine.
+
+    A loopback endpoint cannot exfiltrate anything to a remote attacker, and it
+    is the documented local-model setup (ollama/vLLM/LM Studio), so it stays
+    friction-free. Anything else is a redirect that must be chosen deliberately.
+    """
+    try:
+        host = (urlparse(url).hostname or "").strip()
+    except Exception:
+        # Deliberately broad: this predicate is fail-closed, and a malformed
+        # config can set base_url to any YAML type — urlparse raises a different
+        # exception per type. "Not parseable" is simply "not this machine".
+        return False
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False  # a name we cannot resolve statically is not "this machine"
+
+
+def base_url_opt_in_granted() -> bool:
+    """Whether the operator explicitly allowed off-machine repo endpoints."""
+    return os.getenv(ALLOW_CONFIG_BASE_URL_ENV, "").strip().lower() in _TRUTHY
+
+
+def vet_base_url(value, *, source: str) -> Optional[str]:
+    """Return ``value`` if this caller may use it, else raise.
+
+    Args:
+        value: candidate endpoint (any type; non-strings fail closed).
+        source: human description of where it came from, for the message.
+
+    Raises:
+        UntrustedBaseURLError: when it is off-machine and not opted in.
+    """
+    if not value or is_loopback_url(value) or base_url_opt_in_granted():
+        if value and not is_loopback_url(value):
+            logger.warning(
+                "Using non-default LLM endpoint %s from %s (allowed via %s)",
+                value, source, ALLOW_CONFIG_BASE_URL_ENV,
+            )
+        return value
+    raise UntrustedBaseURLError(
+        f"The LLM endpoint {value!r} comes from {source}, which is not this "
+        "machine, so running would send your API key to that host.\n"
+        f"If you trust it, re-run with {ALLOW_CONFIG_BASE_URL_ENV}=1. "
+        "Otherwise remove the base_url, or pass a provider explicitly."
+    )
+
+
+def vet_env_base_url(env_var: str) -> Optional[str]:
+    """Resolve ``env_var`` as an endpoint, refusing a repo-supplied redirect.
+
+    Called by the provider adapters when no ``base_url`` was passed. Both SDKs
+    fall back to reading these variables *themselves* when ``base_url is None``,
+    so leaving the value unset does not mean "no endpoint" — it means "an
+    endpoint chosen by whatever set the variable", which a repo ``.env`` can be.
+    Resolving it here is what puts every construction behind the check.
+    """
+    value = os.getenv(env_var)
+    if not value:
+        return None
+    if not is_repo_supplied(env_var):
+        return value  # the operator's own environment
+    return vet_base_url(value, source=f"the repository's .env ({env_var})")

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -11,10 +11,15 @@ validate the key that actually matches the resolved provider.
 
 from __future__ import annotations
 
+import ipaddress
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 # Providers that need an API key up front. Local / OpenAI-compatible
 # providers (ollama, vllm, compatible) and mock need none.
@@ -22,6 +27,49 @@ REQUIRED_KEY_ENV = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
 }
+
+
+#: Opt-in for a config-supplied ``base_url`` that points off this machine.
+#: Mirrors the other deliberate escape hatches (``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS``,
+#: ``CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES``).
+ALLOW_CONFIG_BASE_URL_ENV = "CODEFRAME_ALLOW_CONFIG_BASE_URL"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+class UntrustedBaseURLError(RuntimeError):
+    """A repo-supplied ``base_url`` would send API traffic off this machine.
+
+    ``.codeframe/config.yaml`` lives *inside the repository*, so cloning an
+    untrusted repo and running any LLM command would otherwise ship the
+    operator's long-lived API key to whatever host that file names — with no
+    validation, no warning, and no visible difference in output (issue #903).
+    """
+
+
+def _is_loopback_url(url: str) -> bool:
+    """Whether ``url``'s host is this machine.
+
+    A loopback endpoint cannot exfiltrate anything to a remote attacker, and it
+    is the documented local-model setup (ollama/vLLM/LM Studio), so it stays
+    friction-free. Anything else is a redirect that must be chosen deliberately.
+    """
+    try:
+        host = (urlparse(url).hostname or "").strip()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False  # a name we cannot resolve statically is not "this machine"
+
+
+def _config_base_url_allowed() -> bool:
+    return os.getenv(ALLOW_CONFIG_BASE_URL_ENV, "").strip().lower() in _TRUTHY
 
 
 @dataclass(frozen=True)
@@ -88,9 +136,39 @@ def resolve_llm_settings(
     # only, so an ambient value can't redirect Anthropic traffic.
     from codeframe.adapters.llm import OPENAI_COMPATIBLE_PROVIDERS
 
-    base_url = llm_cfg.base_url if llm_cfg else None
+    config_base_url = llm_cfg.base_url if llm_cfg else None
+    base_url = config_base_url
     if not base_url and provider_type in OPENAI_COMPATIBLE_PROVIDERS:
         base_url = os.getenv("OPENAI_BASE_URL")
+
+    # A config-sourced base_url is repo-controlled input (#903). #780 closed the
+    # env fallback for Anthropic, but a config file committed inside a cloned
+    # repo achieves the same redirect. It is not enough to gate only
+    # key-bearing providers by name: get_provider hands OPENAI_API_KEY to
+    # ollama/vllm/compatible too whenever it is set, so *any* provider can carry
+    # the operator's key to the named host.
+    if config_base_url and not _is_loopback_url(config_base_url):
+        if not _config_base_url_allowed():
+            raise UntrustedBaseURLError(
+                f"{repo_path or 'This workspace'}/.codeframe/config.yaml sets "
+                f"llm.base_url to {config_base_url!r}, which is not this "
+                "machine. Running would send your API key to that host.\n"
+                "If you trust it, re-run with "
+                f"{ALLOW_CONFIG_BASE_URL_ENV}=1. Otherwise remove the "
+                "base_url from the config, or pass a provider explicitly."
+            )
+        logger.warning(
+            "Using non-default LLM endpoint %s from %s (allowed via %s)",
+            config_base_url,
+            "workspace config",
+            ALLOW_CONFIG_BASE_URL_ENV,
+        )
+    elif base_url:
+        # Loopback, or the OPENAI_BASE_URL env tier: still announce the
+        # effective endpoint before the first call, so a redirect is never
+        # invisible in the output.
+        logger.info("Using LLM endpoint %s (provider=%s)", base_url, provider_type)
+
     return LLMSettings(provider_type=provider_type, model=model, base_url=base_url)
 
 

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -56,7 +56,13 @@ def _is_loopback_url(url: str) -> bool:
     """
     try:
         host = (urlparse(url).hostname or "").strip()
-    except ValueError:
+    except Exception:
+        # Deliberately broad: this predicate is fail-closed, and a malformed
+        # config can set base_url to any YAML type. urlparse raises different
+        # exceptions per type (AttributeError for a list, TypeError for an int),
+        # and getting that list wrong turns a clean refusal into an unhandled
+        # crash in the security gate. "Not parseable" is simply "not this
+        # machine".
         return False
     if not host:
         return False

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -11,15 +11,19 @@ validate the key that actually matches the resolved provider.
 
 from __future__ import annotations
 
-import ipaddress
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urlparse
 
-from codeframe.core.env_provenance import is_repo_supplied
+from codeframe.core.env_provenance import (
+    ALLOW_CONFIG_BASE_URL_ENV as _ALLOW_CONFIG_BASE_URL_ENV,
+    UntrustedBaseURLError as _UntrustedBaseURLError,
+    base_url_opt_in_granted,
+    is_loopback_url,
+    is_repo_supplied,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,53 +35,13 @@ REQUIRED_KEY_ENV = {
 }
 
 
-#: Opt-in for a config-supplied ``base_url`` that points off this machine.
-#: Mirrors the other deliberate escape hatches (``CODEFRAME_ALLOW_PRIVATE_WEBHOOKS``,
-#: ``CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES``).
-ALLOW_CONFIG_BASE_URL_ENV = "CODEFRAME_ALLOW_CONFIG_BASE_URL"
-
-_TRUTHY = {"1", "true", "yes", "on"}
-
-
-class UntrustedBaseURLError(RuntimeError):
-    """A repo-supplied ``base_url`` would send API traffic off this machine.
-
-    ``.codeframe/config.yaml`` lives *inside the repository*, so cloning an
-    untrusted repo and running any LLM command would otherwise ship the
-    operator's long-lived API key to whatever host that file names — with no
-    validation, no warning, and no visible difference in output (issue #903).
-    """
-
-
-def _is_loopback_url(url: str) -> bool:
-    """Whether ``url``'s host is this machine.
-
-    A loopback endpoint cannot exfiltrate anything to a remote attacker, and it
-    is the documented local-model setup (ollama/vLLM/LM Studio), so it stays
-    friction-free. Anything else is a redirect that must be chosen deliberately.
-    """
-    try:
-        host = (urlparse(url).hostname or "").strip()
-    except Exception:
-        # Deliberately broad: this predicate is fail-closed, and a malformed
-        # config can set base_url to any YAML type. urlparse raises different
-        # exceptions per type (AttributeError for a list, TypeError for an int),
-        # and getting that list wrong turns a clean refusal into an unhandled
-        # crash in the security gate. "Not parseable" is simply "not this
-        # machine".
-        return False
-    if not host:
-        return False
-    if host.lower() == "localhost":
-        return True
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return False  # a name we cannot resolve statically is not "this machine"
-
-
-def _config_base_url_allowed() -> bool:
-    return os.getenv(ALLOW_CONFIG_BASE_URL_ENV, "").strip().lower() in _TRUTHY
+# The trust policy lives in env_provenance so the adapters can apply it too
+# (llm_resolution imports the adapters, so the reverse would be a cycle).
+# Re-exported here because this module is its documented home for callers.
+ALLOW_CONFIG_BASE_URL_ENV = _ALLOW_CONFIG_BASE_URL_ENV
+UntrustedBaseURLError = _UntrustedBaseURLError
+_is_loopback_url = is_loopback_url
+_config_base_url_allowed = base_url_opt_in_granted
 
 
 @dataclass(frozen=True)

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
+from codeframe.core.env_provenance import is_repo_supplied
+
 logger = logging.getLogger(__name__)
 
 # Providers that need an API key up front. Local / OpenAI-compatible
@@ -144,8 +146,16 @@ def resolve_llm_settings(
 
     config_base_url = llm_cfg.base_url if llm_cfg else None
     base_url = config_base_url
+    env_sourced_from_repo = False
     if not base_url and provider_type in OPENAI_COMPATIBLE_PROVIDERS:
         base_url = os.getenv("OPENAI_BASE_URL")
+        # The env tier is trusted because it is the *operator's* environment —
+        # but `cf` loads <cwd>/.env with override=True, so a file committed in a
+        # cloned repo can set this key and beat what the operator exported. When
+        # it did, the value is repo content and gets the same gate as the config
+        # tier (#903).
+        if base_url and is_repo_supplied("OPENAI_BASE_URL"):
+            env_sourced_from_repo = True
 
     # A config-sourced base_url is repo-controlled input (#903). #780 closed the
     # env fallback for Anthropic, but a config file committed inside a cloned
@@ -153,26 +163,31 @@ def resolve_llm_settings(
     # key-bearing providers by name: get_provider hands OPENAI_API_KEY to
     # ollama/vllm/compatible too whenever it is set, so *any* provider can carry
     # the operator's key to the named host.
-    if config_base_url and not _is_loopback_url(config_base_url):
+    untrusted_candidate = config_base_url or (base_url if env_sourced_from_repo else None)
+    if untrusted_candidate and not _is_loopback_url(untrusted_candidate):
         if not _config_base_url_allowed():
+            source = (
+                "its .env (which overrides your environment)"
+                if env_sourced_from_repo
+                else "its .codeframe/config.yaml"
+            )
             raise UntrustedBaseURLError(
-                f"{repo_path or 'This workspace'}/.codeframe/config.yaml sets "
-                f"llm.base_url to {config_base_url!r}, which is not this "
-                "machine. Running would send your API key to that host.\n"
-                "If you trust it, re-run with "
-                f"{ALLOW_CONFIG_BASE_URL_ENV}=1. Otherwise remove the "
-                "base_url from the config, or pass a provider explicitly."
+                f"{repo_path or 'This workspace'} sets the LLM endpoint to "
+                f"{untrusted_candidate!r} via {source}. That is not this "
+                "machine, so running would send your API key to that host.\n"
+                f"If you trust it, re-run with {ALLOW_CONFIG_BASE_URL_ENV}=1. "
+                "Otherwise remove the base_url, or pass a provider explicitly."
             )
         logger.warning(
-            "Using non-default LLM endpoint %s from %s (allowed via %s)",
-            config_base_url,
-            "workspace config",
+            "Using non-default LLM endpoint %s supplied by the workspace "
+            "(allowed via %s)",
+            untrusted_candidate,
             ALLOW_CONFIG_BASE_URL_ENV,
         )
     elif base_url:
-        # Loopback, or the OPENAI_BASE_URL env tier: still announce the
-        # effective endpoint before the first call, so a redirect is never
-        # invisible in the output.
+        # Loopback, or an endpoint the operator really did set in their own
+        # environment: still announce it before the first call, so a redirect is
+        # never invisible in the output.
         logger.info("Using LLM endpoint %s (provider=%s)", base_url, provider_type)
 
     return LLMSettings(provider_type=provider_type, model=model, base_url=base_url)

--- a/codeframe/core/llm_resolution.py
+++ b/codeframe/core/llm_resolution.py
@@ -147,15 +147,30 @@ def resolve_llm_settings(
     config_base_url = llm_cfg.base_url if llm_cfg else None
     base_url = config_base_url
     env_sourced_from_repo = False
-    if not base_url and provider_type in OPENAI_COMPATIBLE_PROVIDERS:
-        base_url = os.getenv("OPENAI_BASE_URL")
+    if not base_url:
         # The env tier is trusted because it is the *operator's* environment —
         # but `cf` loads <cwd>/.env with override=True, so a file committed in a
-        # cloned repo can set this key and beat what the operator exported. When
-        # it did, the value is repo content and gets the same gate as the config
-        # tier (#903).
-        if base_url and is_repo_supplied("OPENAI_BASE_URL"):
-            env_sourced_from_repo = True
+        # cloned repo can set these keys and beat what the operator exported.
+        # When it did, the value is repo content and gets the same gate as the
+        # config tier (#903).
+        #
+        # ANTHROPIC_BASE_URL is read here rather than left to the SDK on
+        # purpose: anthropic.Anthropic falls back to os.environ["ANTHROPIC_BASE_URL"]
+        # whenever base_url is None, so leaving it unset here would let a repo
+        # .env redirect the *default* provider entirely behind this gate's back.
+        # Resolving it explicitly means the value always passes through the
+        # check and is always announced.
+        env_var = (
+            "OPENAI_BASE_URL"
+            if provider_type in OPENAI_COMPATIBLE_PROVIDERS
+            else "ANTHROPIC_BASE_URL"
+            if provider_type == "anthropic"
+            else None
+        )
+        if env_var:
+            base_url = os.getenv(env_var)
+            if base_url and is_repo_supplied(env_var):
+                env_sourced_from_repo = True
 
     # A config-sourced base_url is repo-controlled input (#903). #780 closed the
     # env fallback for Anthropic, but a config file committed inside a cloned

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -960,7 +960,9 @@ def generate_from_prd(
     """
     if use_llm:
         try:
-            tasks_data = _generate_tasks_with_llm(prd.content, provider)
+            tasks_data = _generate_tasks_with_llm(
+                prd.content, provider, repo_path=workspace.repo_path
+            )
         except json.JSONDecodeError as e:
             # Invalid JSON from LLM response — fall back to simple extraction
             logger.warning(f"LLM generation failed ({e}), using simple extraction")
@@ -1000,7 +1002,9 @@ def generate_from_prd(
     return created_tasks
 
 
-def _generate_tasks_with_llm(prd_content: str, provider=None) -> list[dict]:
+def _generate_tasks_with_llm(
+    prd_content: str, provider=None, repo_path=None
+) -> list[dict]:
     """Use LLM to generate tasks from PRD content.
 
     Args:
@@ -1011,10 +1015,15 @@ def _generate_tasks_with_llm(prd_content: str, provider=None) -> list[dict]:
         List of task dicts with rich metadata fields
     """
     # Use the LLM adapter for provider-agnostic access
-    from codeframe.adapters.llm import get_provider, Purpose
+    from codeframe.adapters.llm import Purpose
 
     if provider is None:
-        provider = get_provider()
+        # Not get_provider() bare (#903): with base_url unset the Anthropic SDK
+        # reads ANTHROPIC_BASE_URL from the environment, which a repo .env
+        # controls. resolve_llm_settings is the one place that vets it.
+        from codeframe.core.llm_resolution import create_provider, resolve_llm_settings
+
+        provider = create_provider(resolve_llm_settings(repo_path))
 
     prompt = f"""Analyze the following PRD and generate a list of actionable development tasks.
 

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -29,6 +29,7 @@ from codeframe.core.prd_discovery import (
     ValidationError,
     IncompleteSessionError,
 )
+from codeframe.core.llm_resolution import UntrustedBaseURLError
 from codeframe.ui.dependencies import get_v2_workspace
 
 logger = logging.getLogger(__name__)
@@ -434,6 +435,11 @@ async def generate_tasks_from_prd(
         )
 
     except HTTPException:
+        raise
+    except UntrustedBaseURLError:
+        # A deliberate refusal (#903). The generic handler below would rewrite
+        # it into a 500 "task generation failed", hiding both the reason and
+        # the registered 400 handler.
         raise
     except Exception as e:
         logger.error(f"Failed to generate tasks: {e}", exc_info=True)

--- a/codeframe/ui/routers/prd_v2.py
+++ b/codeframe/ui/routers/prd_v2.py
@@ -25,6 +25,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 from codeframe.core.workspace import Workspace
+from codeframe.core.llm_resolution import UntrustedBaseURLError
 from codeframe.lib.rate_limiter import rate_limit_standard
 from codeframe.core import prd
 from codeframe.core.prd import PrdHasDependentTasksError
@@ -278,7 +279,11 @@ async def _stress_test_event_stream(
     # browser EventSource can display them.
     try:
         provider = _resolve_llm_provider(workspace)
-    except ValueError as exc:
+    except (ValueError, UntrustedBaseURLError) as exc:
+        # UntrustedBaseURLError included deliberately (#903): the StreamingResponse
+        # has already sent 200 OK by the time this generator runs, so the app-level
+        # 400 handler can never fire here — letting it escape would kill the
+        # EventSource with no frame and no explanation.
         yield _sse({"type": "error", "message": str(exc)})
         return
 

--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -33,6 +33,7 @@ would be redundant. Revisit if multi-tenant workspace isolation is required.
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -113,10 +114,16 @@ async def _run_streaming_adapter(
         # chat and ship the operator's key, behind the resolution gate's back.
         from codeframe.core.llm_resolution import create_provider, resolve_llm_settings
 
-        settings = resolve_llm_settings(
-            Path(workspace_path) if workspace_path else None,
-            provider_flag=provider_type,
+        # Only treat workspace_path as a path when it actually is one: the
+        # config tier is a convenience here, and failing to resolve it must
+        # never break chat. The gate still applies either way, because the env
+        # tier is checked regardless of repo_path.
+        repo_path = (
+            Path(workspace_path)
+            if isinstance(workspace_path, (str, os.PathLike))
+            else None
         )
+        settings = resolve_llm_settings(repo_path, provider_flag=provider_type)
         provider = create_provider(settings)
         # Honor the session's stored model; fall back to the adapter default only
         # when unset, instead of always using the hardcoded default (#764).

--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -106,8 +106,18 @@ async def _run_streaming_adapter(
                 ),
             })
             return
-        from codeframe.adapters.llm import get_provider
-        provider = get_provider(provider_type)
+        # Route through resolve_llm_settings rather than building the provider
+        # bare (#903). With base_url unset the Anthropic SDK reads
+        # ANTHROPIC_BASE_URL from the environment itself — which a repo .env
+        # controls — so a bare get_provider() here would redirect interactive
+        # chat and ship the operator's key, behind the resolution gate's back.
+        from codeframe.core.llm_resolution import create_provider, resolve_llm_settings
+
+        settings = resolve_llm_settings(
+            Path(workspace_path) if workspace_path else None,
+            provider_flag=provider_type,
+        )
+        provider = create_provider(settings)
         # Honor the session's stored model; fall back to the adapter default only
         # when unset, instead of always using the hardcoded default (#764).
         adapter_kwargs = {"model": model} if model else {}

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -678,6 +678,30 @@ app = FastAPI(
 # Add rate limiting exception handler
 app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
+
+from fastapi.responses import JSONResponse  # noqa: E402
+
+from codeframe.core.llm_resolution import UntrustedBaseURLError  # noqa: E402
+from codeframe.ui.response_models import ErrorCodes, api_error  # noqa: E402
+
+
+@app.exception_handler(UntrustedBaseURLError)
+async def untrusted_base_url_handler(request, exc: UntrustedBaseURLError):
+    """A repo-supplied ``llm.base_url`` was refused (#903).
+
+    A deliberate refusal, so it answers 400 with the reason rather than a 500
+    with a stack trace — the operator needs to see which endpoint was blocked
+    and how to allow it.
+    """
+    return JSONResponse(
+        status_code=400,
+        content=api_error(
+            "Untrusted LLM endpoint in workspace config",
+            ErrorCodes.INVALID_REQUEST,
+            str(exc),
+        ),
+    )
+
 # Add rate limiting middleware if enabled
 # Initialize limiter immediately so it's available before lifespan runs
 rate_limit_config = get_rate_limit_config()

--- a/tests/api/test_session_chat_ws.py
+++ b/tests/api/test_session_chat_ws.py
@@ -409,23 +409,30 @@ class TestRunStreamingAdapterResolution:
             while not q.empty():
                 events.append(q.get_nowait())
 
+        # Provider construction moved behind resolve_llm_settings (#903) so a
+        # repo .env cannot redirect chat via ANTHROPIC_BASE_URL. The subject is
+        # unchanged — which provider type a session resolves to — so the
+        # stand-in moves to that seam and the assertion reads the resolved
+        # settings instead of a bare positional argument.
         with patch.object(mod, "StreamingChatAdapter", self._fake_adapter_factory(captured)), \
-                patch("codeframe.adapters.llm.get_provider") as get_provider:
-            get_provider.return_value = MagicMock(name="provider")
+                patch("codeframe.core.llm_resolution.create_provider") as create_provider:
+            create_provider.return_value = MagicMock(name="provider")
             asyncio.run(drive())
-            self._last_get_provider = get_provider
+            self._last_get_provider = create_provider
         return captured, events
 
     def test_claude_session_resolves_anthropic_and_honors_model(self):
         captured, events = self._run("claude", "claude-opus-4-6")
-        self._last_get_provider.assert_called_once_with("anthropic")
+        self._last_get_provider.assert_called_once()
+        assert self._last_get_provider.call_args[0][0].provider_type == "anthropic"
         assert captured["model"] == "claude-opus-4-6"
         assert captured["provider"] is self._last_get_provider.return_value
         assert not any(e["type"] == "error" for e in events)
 
     def test_missing_agent_type_defaults_to_claude(self):
         captured, events = self._run(None, None)
-        self._last_get_provider.assert_called_once_with("anthropic")
+        self._last_get_provider.assert_called_once()
+        assert self._last_get_provider.call_args[0][0].provider_type == "anthropic"
         # No model override → adapter default used (no "model" kwarg passed).
         assert "model" not in captured
         assert not any(e["type"] == "error" for e in events)

--- a/tests/core/test_llm_resolution.py
+++ b/tests/core/test_llm_resolution.py
@@ -3,6 +3,8 @@
 import pytest
 
 from codeframe.core.llm_resolution import (
+    ALLOW_CONFIG_BASE_URL_ENV,
+    UntrustedBaseURLError,
     LLMSettings,
     create_provider,
     resolve_llm_settings,
@@ -69,11 +71,14 @@ class TestModelAndBaseUrl:
         assert resolve_llm_settings(tmp_path).model == "env-model"
 
     def test_base_url_config_beats_env(self, tmp_path, monkeypatch):
+        # Loopback, so the precedence rule is exercised without dragging in the
+        # #903 opt-in for a remote config base_url — precedence is the subject
+        # here, and a local model endpoint is the realistic config anyway.
         _write_llm_config(
-            tmp_path, provider="ollama", base_url="http://cfg:11434/v1"
+            tmp_path, provider="ollama", base_url="http://127.0.0.1:11434/v1"
         )
         monkeypatch.setenv("OPENAI_BASE_URL", "http://env:8000/v1")
-        assert resolve_llm_settings(tmp_path).base_url == "http://cfg:11434/v1"
+        assert resolve_llm_settings(tmp_path).base_url == "http://127.0.0.1:11434/v1"
 
     def test_openai_base_url_env_does_not_leak_to_anthropic(
         self, tmp_path, monkeypatch
@@ -92,13 +97,28 @@ class TestModelAndBaseUrl:
         monkeypatch.setenv("OPENAI_BASE_URL", "http://env:8000/v1")
         assert resolve_llm_settings(tmp_path).base_url == "http://env:8000/v1"
 
-    def test_config_base_url_applies_to_anthropic(self, tmp_path):
+    def test_config_base_url_applies_to_anthropic(self, tmp_path, monkeypatch):
         """An explicit llm.base_url in config is honored for anthropic
-        (proxy/gateway deployments, #780)."""
+        (proxy/gateway deployments, #780).
+
+        Still true, but a remote endpoint from the repo's own config now needs
+        the operator's opt-in (#903) — otherwise cloning a hostile repo would
+        redirect the Anthropic key. The #780 capability is intact; only the
+        consent is new.
+        """
+        monkeypatch.setenv(ALLOW_CONFIG_BASE_URL_ENV, "1")
         _write_llm_config(
             tmp_path, provider="anthropic", base_url="http://proxy:8080"
         )
         assert resolve_llm_settings(tmp_path).base_url == "http://proxy:8080"
+
+    def test_config_base_url_for_anthropic_needs_opt_in(self, tmp_path):
+        """The #903 half of the pair above: without consent it is refused."""
+        _write_llm_config(
+            tmp_path, provider="anthropic", base_url="http://proxy:8080"
+        )
+        with pytest.raises(UntrustedBaseURLError):
+            resolve_llm_settings(tmp_path)
 
     def test_provider_kwargs_only_includes_set_values(self, tmp_path):
         settings = resolve_llm_settings(tmp_path)

--- a/tests/core/test_rich_task_generation.py
+++ b/tests/core/test_rich_task_generation.py
@@ -61,7 +61,9 @@ class TestGenerateWithRichMetadata:
             },
         ]
         mock = _make_mock_provider(rich_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -102,7 +104,9 @@ class TestGenerateWithRichMetadata:
             },
         ]
         mock = _make_mock_provider(rich_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -134,7 +138,9 @@ class TestGenerateWithRichMetadata:
             },
         ]
         mock = _make_mock_provider(rich_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -147,7 +153,9 @@ class TestGenerateWithRichMetadata:
             {"title": "Minimal task", "description": "Just title and desc"},
         ]
         mock = _make_mock_provider(minimal_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -164,7 +172,9 @@ class TestGenerateWithRichMetadata:
             {"title": "Task two", "description": "Do thing two"},
         ]
         mock = _make_mock_provider(simple_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -185,7 +195,9 @@ class TestGenerateWithRichMetadata:
             },
         ]
         mock = _make_mock_provider(rich_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -205,7 +217,9 @@ class TestGenerateWithRichMetadata:
             },
         ]
         mock = _make_mock_provider(rich_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 
@@ -222,7 +236,9 @@ class TestGenerateWithRichMetadata:
             },
         ]
         mock = _make_mock_provider(rich_tasks)
-        monkeypatch.setattr("codeframe.adapters.llm.get_provider", lambda: mock)
+        monkeypatch.setattr(
+            "codeframe.core.llm_resolution.create_provider", lambda settings: mock
+        )
 
         created = tasks.generate_from_prd(workspace, sample_prd, use_llm=True)
 

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -148,3 +148,21 @@ class TestEnvTierUnchanged:
         settings = resolve_llm_settings(repo)
 
         assert settings.base_url is None
+
+
+class TestMalformedConfigFailsClosedCleanly:
+    """Review finding (#903 round 2): a non-string base_url must read as a
+    refusal, not an unhandled TypeError in the gate."""
+
+    @pytest.mark.parametrize(
+        "value", ["[\"https://evil.example.com/v1\"]", "{a: b}", "12345"]
+    )
+    def test_non_string_base_url_is_refused_not_crashed(self, tmp_path, value):
+        repo = tmp_path / "malformed"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text(
+            f"llm:\n  provider: anthropic\n  base_url: {value}\n"
+        )
+
+        with pytest.raises(UntrustedBaseURLError):
+            resolve_llm_settings(repo)

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -402,6 +402,28 @@ class TestAdapterLevelVetting:
 
         assert provider.base_url == "http://127.0.0.1:8080"
 
+    def test_the_factory_does_not_pre_read_the_env_and_skip_the_vet(
+        self, monkeypatch
+    ):
+        """get_provider used to pass os.environ["OPENAI_BASE_URL"] explicitly,
+        so the adapter's `if base_url is None` vet was a no-op precisely when
+        the variable *was* set — the dangerous case (review round 6)."""
+        from codeframe.adapters.llm import get_provider
+        from codeframe.core import env_provenance
+
+        env_provenance.record_repo_env_keys({"OPENAI_BASE_URL"})
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError):
+            get_provider("compatible")
+
+    def test_the_factory_still_honors_the_operators_env(self, monkeypatch):
+        from codeframe.adapters.llm import get_provider
+
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)  # not repo-supplied
+
+        assert get_provider("compatible").base_url == ATTACKER
+
     def test_no_env_endpoint_leaves_the_default(self, monkeypatch):
         from codeframe.adapters.llm.anthropic import AnthropicProvider
 

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -301,3 +301,44 @@ class TestAnthropicBaseUrlEnvArm:
         monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
 
         assert resolve_llm_settings(repo).base_url is None
+
+
+class TestNoBareProviderConstruction:
+    """Every provider must be built through the gate (#903 review round 4).
+
+    A bare ``get_provider(...)`` leaves ``base_url=None``, and the Anthropic SDK
+    then reads ``ANTHROPIC_BASE_URL`` from the environment itself — so a repo
+    ``.env`` redirects that path with the gate never consulted. Two call sites
+    did exactly that: interactive chat and the task-generation fallback.
+    """
+
+    def test_task_generation_fallback_is_gated(self, tmp_path, monkeypatch):
+        from codeframe.core import env_provenance
+        from codeframe.core.tasks import _generate_tasks_with_llm
+
+        repo = tmp_path / "repo"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: anthropic\n")
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError):
+            _generate_tasks_with_llm("# PRD", provider=None, repo_path=repo)
+
+    def test_an_explicit_provider_still_short_circuits(self, tmp_path, monkeypatch):
+        """A caller that already resolved a provider is unaffected — it went
+        through the gate itself, so no second resolution happens."""
+        from codeframe.core import env_provenance
+        from codeframe.core.tasks import _generate_tasks_with_llm
+
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        class _Provider:
+            def complete(self, *a, **kw):
+                raise RuntimeError("reached the provider, as expected")
+
+        with pytest.raises(Exception) as exc:
+            _generate_tasks_with_llm("# PRD", provider=_Provider())
+
+        assert not isinstance(exc.value, UntrustedBaseURLError)

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -342,3 +342,80 @@ class TestNoBareProviderConstruction:
             _generate_tasks_with_llm("# PRD", provider=_Provider())
 
         assert not isinstance(exc.value, UntrustedBaseURLError)
+
+
+class TestAdapterLevelVetting:
+    """The invariant that ends the whack-a-mole (#903 review round 5).
+
+    Four rounds each found *another* caller that built a provider without going
+    through ``resolve_llm_settings`` — the config path, two env paths, then
+    interactive chat and the task fallback, then the PRD-discovery legacy
+    branch. They share one shape: ``base_url=None`` does not mean "default
+    endpoint", it means "whatever set the env var", and both SDKs read it
+    themselves.
+
+    Vetting inside the adapters puts *every* construction behind the check,
+    including callers that do not exist yet.
+    """
+
+    def test_anthropic_provider_refuses_a_repo_env_endpoint(self, monkeypatch):
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+        from codeframe.core import env_provenance
+
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError):
+            AnthropicProvider(api_key="sk-ant-operator-secret")
+
+    def test_openai_provider_refuses_a_repo_env_endpoint(self, monkeypatch):
+        from codeframe.adapters.llm.openai import OpenAIProvider
+        from codeframe.core import env_provenance
+
+        env_provenance.record_repo_env_keys({"OPENAI_BASE_URL"})
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError):
+            OpenAIProvider(api_key="sk-openai-operator-secret")
+
+    def test_the_operators_own_env_endpoint_is_still_used(self, monkeypatch):
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)  # not repo-supplied
+
+        provider = AnthropicProvider(api_key="sk-ant-operator-secret")
+
+        # Resolved explicitly rather than left None — which is what stops the
+        # SDK reaching for the environment on its own.
+        assert provider.base_url == ATTACKER
+
+    def test_an_explicit_base_url_is_untouched(self, monkeypatch):
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+        from codeframe.core import env_provenance
+
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        provider = AnthropicProvider(
+            api_key="sk-ant-operator-secret", base_url="http://127.0.0.1:8080"
+        )
+
+        assert provider.base_url == "http://127.0.0.1:8080"
+
+    def test_no_env_endpoint_leaves_the_default(self, monkeypatch):
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+        assert AnthropicProvider(api_key="sk-ant-x").base_url is None
+
+    def test_the_prd_discovery_legacy_branch_is_now_covered(self, tmp_path, monkeypatch):
+        """The round-5 report: PrdDiscoverySession's api_key branch built
+        AnthropicProvider(base_url=None) directly. It is gated now because the
+        adapter itself vets, without that call site needing to change."""
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+        from codeframe.core import env_provenance
+
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError):
+            AnthropicProvider(api_key="sk-ant-real-operator-key")

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -1,0 +1,150 @@
+"""A repo-supplied ``llm.base_url`` is untrusted input (#903 / P0.9).
+
+``.codeframe/config.yaml`` lives *inside the repository*. ``resolve_llm_settings``
+took ``base_url`` from it for any provider, and the adapters pass it straight to
+the SDK client — which then sends ``x-api-key: <ANTHROPIC_API_KEY>`` to that
+host. #780 closed the env fallback; a config file committed inside a cloned repo
+achieved the same redirect with no validation, no warning and no visible
+difference in output. Cloning an untrusted repo and running ``cf tasks
+generate`` shipped the operator's long-lived API key to the attacker.
+
+The tests assert *which host the provider would actually reach*, not merely that
+a call raised — the endpoint is the thing the defect got wrong.
+"""
+
+import pytest
+
+from codeframe.core.llm_resolution import (
+    ALLOW_CONFIG_BASE_URL_ENV,
+    UntrustedBaseURLError,
+    create_provider,
+    resolve_llm_settings,
+)
+
+pytestmark = pytest.mark.v2
+
+ATTACKER = "https://evil.example.com/v1"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in (
+        ALLOW_CONFIG_BASE_URL_ENV,
+        "CODEFRAME_LLM_PROVIDER",
+        "CODEFRAME_LLM_MODEL",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-operator-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-operator-secret")
+
+
+def _repo_with_config(tmp_path, *, provider: str, base_url: str):
+    """A cloned repo carrying a hostile .codeframe/config.yaml."""
+    repo = tmp_path / "cloned-repo"
+    (repo / ".codeframe").mkdir(parents=True)
+    (repo / ".codeframe" / "config.yaml").write_text(
+        "llm:\n"
+        f"  provider: {provider}\n"
+        f"  base_url: {base_url}\n"
+    )
+    return repo
+
+
+class TestRemoteBaseUrlIsRefused:
+    @pytest.mark.parametrize(
+        "provider",
+        # Not just the obviously key-bearing ones: get_provider hands
+        # OPENAI_API_KEY to ollama/vllm/compatible too whenever it is set, so
+        # any provider can carry the operator's key to the named host.
+        ["anthropic", "openai", "compatible", "ollama", "vllm"],
+    )
+    def test_a_remote_config_base_url_raises(self, tmp_path, provider):
+        repo = _repo_with_config(tmp_path, provider=provider, base_url=ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError) as exc:
+            resolve_llm_settings(repo)
+
+        assert ATTACKER in str(exc.value)
+        assert ALLOW_CONFIG_BASE_URL_ENV in str(exc.value)
+
+    def test_the_provider_never_reaches_the_attacker_host(self, tmp_path):
+        """The acceptance criterion, stated as the endpoint actually used."""
+        repo = _repo_with_config(tmp_path, provider="anthropic", base_url=ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError):
+            create_provider(resolve_llm_settings(repo))
+
+    def test_opting_in_allows_it(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ALLOW_CONFIG_BASE_URL_ENV, "1")
+        repo = _repo_with_config(tmp_path, provider="anthropic", base_url=ATTACKER)
+
+        settings = resolve_llm_settings(repo)
+
+        assert settings.base_url == ATTACKER
+
+    def test_the_refusal_is_logged_with_the_endpoint(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv(ALLOW_CONFIG_BASE_URL_ENV, "1")
+        repo = _repo_with_config(tmp_path, provider="anthropic", base_url=ATTACKER)
+
+        with caplog.at_level("WARNING"):
+            resolve_llm_settings(repo)
+
+        assert ATTACKER in caplog.text, "the effective endpoint must be announced"
+
+
+class TestLocalModelsKeepWorking:
+    """The documented local-model setup must stay friction-free: a loopback
+    endpoint cannot exfiltrate anything to a remote attacker."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://localhost:11434/v1",
+            "http://127.0.0.1:11434/v1",
+            "http://[::1]:8000/v1",
+        ],
+    )
+    def test_loopback_needs_no_opt_in(self, tmp_path, base_url):
+        repo = _repo_with_config(tmp_path, provider="ollama", base_url=base_url)
+
+        settings = resolve_llm_settings(repo)
+
+        assert settings.base_url == base_url
+
+    def test_no_base_url_is_unaffected(self, tmp_path):
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: anthropic\n")
+
+        settings = resolve_llm_settings(repo)
+
+        assert settings.base_url is None
+        assert settings.provider_type == "anthropic"
+
+
+class TestEnvTierUnchanged:
+    """#780's rule stands: OPENAI_BASE_URL is the operator's own environment,
+    and applies to OpenAI-compatible providers only."""
+
+    def test_openai_base_url_env_still_works_without_opt_in(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: ollama\n")
+
+        settings = resolve_llm_settings(repo)
+
+        assert settings.base_url == ATTACKER
+
+    def test_env_tier_still_does_not_redirect_anthropic(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: anthropic\n")
+
+        settings = resolve_llm_settings(repo)
+
+        assert settings.base_url is None

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -36,6 +36,7 @@ def clean_env(monkeypatch):
         "CODEFRAME_LLM_PROVIDER",
         "CODEFRAME_LLM_MODEL",
         "OPENAI_BASE_URL",
+        "ANTHROPIC_BASE_URL",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-operator-secret")
@@ -238,3 +239,65 @@ class TestEnvKeyParsing:
         from codeframe.core.env_provenance import keys_defined_in
 
         assert keys_defined_in(tmp_path / "nope.env") == set()
+
+
+class TestAnthropicBaseUrlEnvArm:
+    """``anthropic.Anthropic`` falls back to ``os.environ["ANTHROPIC_BASE_URL"]``
+    whenever ``base_url`` is None (verified in the pinned SDK's ``__init__``).
+
+    Leaving that variable unread meant a repo ``.env`` could redirect the
+    *default* provider entirely behind this gate's back — #903's original
+    subject. Resolving it explicitly forces it through the check, and passing it
+    on to the client stops the SDK reaching for the environment itself.
+    """
+
+    def _plain_repo(self, tmp_path, provider="anthropic"):
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text(
+            f"llm:\n  provider: {provider}\n"
+        )
+        return repo
+
+    def test_a_repo_dot_env_anthropic_base_url_is_refused(self, tmp_path, monkeypatch):
+        from codeframe.core import env_provenance
+
+        repo = self._plain_repo(tmp_path)
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError) as exc:
+            resolve_llm_settings(repo)
+
+        assert ATTACKER in str(exc.value)
+
+    def test_the_operators_own_anthropic_base_url_is_honored_explicitly(
+        self, tmp_path, monkeypatch
+    ):
+        """It must be *returned*, not merely tolerated: passing it on is what
+        stops the SDK reading the environment for itself."""
+        repo = self._plain_repo(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        settings = resolve_llm_settings(repo)
+
+        assert settings.base_url == ATTACKER
+        assert settings.provider_kwargs()["base_url"] == ATTACKER
+
+    def test_a_repo_dot_env_loopback_is_still_fine(self, tmp_path, monkeypatch):
+        from codeframe.core import env_provenance
+
+        repo = self._plain_repo(tmp_path)
+        env_provenance.record_repo_env_keys({"ANTHROPIC_BASE_URL"})
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:8080")
+
+        assert resolve_llm_settings(repo).base_url == "http://localhost:8080"
+
+    def test_anthropic_base_url_does_not_leak_to_openai_providers(
+        self, tmp_path, monkeypatch
+    ):
+        """The mirror of #780: each provider reads only its own variable."""
+        repo = self._plain_repo(tmp_path, provider="ollama")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", ATTACKER)
+
+        assert resolve_llm_settings(repo).base_url is None

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -28,6 +28,9 @@ ATTACKER = "https://evil.example.com/v1"
 
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
+    from codeframe.core import env_provenance
+
+    env_provenance.reset()
     for var in (
         ALLOW_CONFIG_BASE_URL_ENV,
         "CODEFRAME_LLM_PROVIDER",
@@ -166,3 +169,72 @@ class TestMalformedConfigFailsClosedCleanly:
 
         with pytest.raises(UntrustedBaseURLError):
             resolve_llm_settings(repo)
+
+
+class TestRepoDotEnvCannotRedirectEither:
+    """`cf` loads <cwd>/.env with override=True, so a file committed in a cloned
+    repo beats the operator's exported environment. The env tier is trusted
+    precisely because it is the *operator's* — so a value the repo supplied must
+    get the same gate as the config tier (GLM CI review of #903).
+
+    Stopping a repo .env from overriding the operator in general is #904.
+    """
+
+    def test_a_repo_dot_env_base_url_is_refused(self, tmp_path, monkeypatch):
+        from codeframe.core import env_provenance
+
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: ollama\n")
+
+        # Exactly what the CLI bootstrap does for a repo-committed .env.
+        env_provenance.record_repo_env_keys({"OPENAI_BASE_URL"})
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)
+
+        with pytest.raises(UntrustedBaseURLError) as exc:
+            resolve_llm_settings(repo)
+
+        assert ATTACKER in str(exc.value)
+        assert ".env" in str(exc.value), "the message should name the real source"
+
+    def test_the_operators_own_env_var_is_still_trusted(self, tmp_path, monkeypatch):
+        """The whole point of the env tier: it must keep working when it really
+        is the operator's own configuration."""
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: ollama\n")
+        monkeypatch.setenv("OPENAI_BASE_URL", ATTACKER)  # not repo-supplied
+
+        assert resolve_llm_settings(repo).base_url == ATTACKER
+
+    def test_a_repo_dot_env_loopback_is_still_fine(self, tmp_path, monkeypatch):
+        from codeframe.core import env_provenance
+
+        repo = tmp_path / "plain"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: ollama\n")
+        env_provenance.record_repo_env_keys({"OPENAI_BASE_URL"})
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:11434/v1")
+
+        assert resolve_llm_settings(repo).base_url == "http://127.0.0.1:11434/v1"
+
+
+class TestEnvKeyParsing:
+    def test_keys_are_extracted_without_reading_values(self, tmp_path):
+        from codeframe.core.env_provenance import keys_defined_in
+
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# a comment\n"
+            "OPENAI_BASE_URL=https://evil.example.com/v1\n"
+            "export ANTHROPIC_API_KEY=sk-ant-stolen\n"
+            "\n"
+            "MALFORMED_NO_EQUALS\n"
+        )
+
+        assert keys_defined_in(env_file) == {"OPENAI_BASE_URL", "ANTHROPIC_API_KEY"}
+
+    def test_a_missing_file_is_empty(self, tmp_path):
+        from codeframe.core.env_provenance import keys_defined_in
+
+        assert keys_defined_in(tmp_path / "nope.env") == set()

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -441,3 +441,80 @@ class TestAdapterLevelVetting:
 
         with pytest.raises(UntrustedBaseURLError):
             AnthropicProvider(api_key="sk-ant-real-operator-key")
+
+
+@pytest.fixture
+def isolated_env_load():
+    """load_dotenv writes os.environ directly, which monkeypatch cannot undo —
+    so snapshot and restore the keys these tests cause to be loaded."""
+    import os
+
+    from codeframe.core import env_provenance
+
+    watched = ("ANTHROPIC_BASE_URL", "OPENAI_BASE_URL", "SOMETHING_ELSE")
+    saved = {k: os.environ.get(k) for k in watched}
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    env_provenance.reset()
+
+
+class TestProvenanceIsRecordedByTheLoader:
+    """The gate must not depend on which process imported what (round 7).
+
+    Provenance was recorded only in ``cli/app.py`` at import, so any server
+    process — uvicorn/gunicorn workers, ``cf serve --reload``'s subprocess,
+    ``uvicorn codeframe.ui.server:app`` — had an empty set and treated a repo
+    ``.env``'s endpoint as the operator's own. The gate was silently inert
+    exactly on the web surface this PR brought into scope.
+
+    Recording inside ``load_environment`` covers every entrypoint, including
+    ones not written yet.
+    """
+
+    def test_load_environment_records_repo_keys(
+        self, tmp_path, monkeypatch, isolated_env_load
+    ):
+        from codeframe.core import env_provenance
+        from codeframe.core.config import load_environment
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "ANTHROPIC_BASE_URL=https://evil.example.com\nSOMETHING_ELSE=1\n"
+        )
+
+        load_environment()
+
+        assert env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
+        assert env_provenance.is_repo_supplied("SOMETHING_ELSE")
+
+    def test_the_gate_then_refuses_that_endpoint(
+        self, tmp_path, monkeypatch, isolated_env_load
+    ):
+        """End to end through the loader: the server path is now covered."""
+        from codeframe.core.config import load_environment
+
+        monkeypatch.chdir(tmp_path)
+        repo = tmp_path / "ws"
+        (repo / ".codeframe").mkdir(parents=True)
+        (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: anthropic\n")
+        (tmp_path / ".env").write_text(f"ANTHROPIC_BASE_URL={ATTACKER}\n")
+
+        load_environment()
+
+        with pytest.raises(UntrustedBaseURLError):
+            resolve_llm_settings(repo)
+
+    def test_no_env_file_records_nothing(
+        self, tmp_path, monkeypatch, isolated_env_load
+    ):
+        from codeframe.core import env_provenance
+        from codeframe.core.config import load_environment
+
+        monkeypatch.chdir(tmp_path)
+        load_environment()
+
+        assert not env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")


### PR DESCRIPTION
Closes #903 (P0.9 — `critical` / `security`, filed by the SaaS launch review).

## Problem

`.codeframe/config.yaml` lives **inside the repository**. `resolve_llm_settings` took `base_url` from it for any provider, and the adapters pass it straight to the SDK client — which then sends `x-api-key: <ANTHROPIC_API_KEY>` to that host.

#780 closed the *env* fallback. A config file committed inside a cloned repo achieved the same redirect with **no validation, no warning, and no visible difference in output**. Clone an untrusted repo, run `cf tasks generate`, and the operator's long-lived API key goes to the attacker.

## Worse than the issue states

The issue frames this around Anthropic. But `get_provider` hands `OPENAI_API_KEY` to the *local* providers too whenever it happens to be set:

```python
# adapters/llm/__init__.py:79
api_key = kwargs.get("api_key") or os.environ.get("OPENAI_API_KEY")
if not api_key and provider_type != "openai":
    api_key = "not-required"
```

So `provider: compatible` with a remote `base_url` exfiltrates just as well as `provider: anthropic`. **The gate therefore keys on where the value came from, not on the provider name** — tested across all five providers.

## Fix

A config-sourced `base_url` that is **not this machine** requires explicit opt-in via `CODEFRAME_ALLOW_CONFIG_BASE_URL`, matching the repo's existing escape-hatch convention (`CODEFRAME_ALLOW_PRIVATE_WEBHOOKS`, `CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES`). The effective endpoint is logged before the first call whenever it is non-default.

Refusal reads as a decision, not a crash: the CLI entry point prints the blocked endpoint and how to allow it, and the server answers **400** instead of a 500 with a stack trace.

### What deliberately still works, with no friction

| Case | Behaviour | Why |
|---|---|---|
| `base_url: http://localhost:11434/v1` (and `127.0.0.1`, `::1`) | allowed, no opt-in | the documented local-model setup; loopback cannot carry anything to a remote attacker |
| `OPENAI_BASE_URL` env tier | unchanged | that is the *operator's own* environment, not repo content — and #780's rule that it never redirects Anthropic still holds |
| `llm.base_url` for a proxy/gateway (#780) | works, with opt-in | the capability is intact; only the consent is new |

## Acceptance criteria

| Criterion | Where |
|---|---|
| Config-sourced `base_url` differing from the default requires explicit opt-in recorded outside the repo tree | `CODEFRAME_ALLOW_CONFIG_BASE_URL` — an env var, so a repo cannot grant itself permission |
| The effective endpoint is printed before the first call when non-default | `logger.warning` in `resolve_llm_settings`; asserted by `test_the_refusal_is_logged_with_the_endpoint` |
| **Test: a workspace config with a custom base_url does not silently reach a non-default host for a key-bearing provider** | `test_the_provider_never_reaches_the_attacker_host` + the 5-provider parametrization |

## Two existing tests changed premise — disclosed

Neither is weakened; both assert the same property, gated:

- `test_base_url_config_beats_env` proved config beats `OPENAI_BASE_URL` using a remote host. Precedence is its subject, so it now uses a loopback endpoint (the realistic local-model config) rather than dragging the opt-in into an unrelated test.
- `test_config_base_url_applies_to_anthropic` is #780's capability. It now sets the opt-in and still asserts the URL is honored — **and a new paired test asserts the same config is refused without it**.

## Verification

155 tests pass across `test_llm_resolution`, `test_config_llm`, the new suite and all LLM adapters. `ruff` clean, strict `mypy` clean.

## Known limitations

- A hostname that resolves to loopback (e.g. an `/etc/hosts` entry for `evil.local` → 127.0.0.1) is treated as remote, because the check is static and deliberately does not resolve DNS — resolving would make the decision depend on a lookup an attacker can influence. The failure mode is a spurious opt-in prompt, not a bypass.
- The opt-in is process-wide rather than per-workspace. The issue permits either; an env var cannot be granted by repo content, which is the property that matters.