### PR TITLE
fix(security): stop a repository .env from steering the process (#904, P0.10)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -21,7 +21,6 @@ from typing import Optional
 
 import click
 import typer
-from dotenv import load_dotenv
 from rich.console import Console
 
 # Import auth subapp for credential management
@@ -33,24 +32,12 @@ from codeframe.cli.hooks_commands import hooks_app
 from codeframe.cli.stats_commands import stats_app
 from codeframe.cli.import_commands import import_app
 
-# Load environment variables from .env files
-# Priority: workspace .env > home .env
-_cwd = Path.cwd()
-_home_env = Path.home() / ".env"
-_cwd_env = _cwd / ".env"
+# Load environment variables from .env files.
+# One shared loader (#904): the repository's .env never overrides the operator's
+# environment, and never supplies security-steering keys at all.
+from codeframe.core.env_provenance import load_env_files  # noqa: E402
 
-if _home_env.exists():
-    load_dotenv(_home_env)
-if _cwd_env.exists():
-    # Record provenance before loading: this file lives inside the repository
-    # and overrides the operator's exported environment, so anything downstream
-    # that trusts os.environ as "the operator's own configuration" needs to
-    # know which keys the repo supplied (#903). The general problem — a repo
-    # .env overriding the operator at all — is #904.
-    from codeframe.core.env_provenance import keys_defined_in, record_repo_env_keys
-
-    record_repo_env_keys(keys_defined_in(_cwd_env))
-    load_dotenv(_cwd_env, override=True)  # workspace .env takes precedence
+load_env_files()
 
 # Create main app
 app = typer.Typer(

--- a/codeframe/cli/validators.py
+++ b/codeframe/cli/validators.py
@@ -1,10 +1,9 @@
 """CLI validation helpers for pre-command checks."""
 
 import os
-from pathlib import Path
 
 import typer
-from dotenv import load_dotenv
+from codeframe.core.env_provenance import load_env_files
 from rich.console import Console
 
 console = Console()
@@ -28,13 +27,7 @@ def require_anthropic_api_key() -> str:
         return key
 
     # Try loading from .env files (same priority as app.py)
-    cwd_env = Path.cwd() / ".env"
-    home_env = Path.home() / ".env"
-
-    if home_env.exists():
-        load_dotenv(home_env)
-    if cwd_env.exists():
-        load_dotenv(cwd_env, override=True)
+    load_env_files()
 
     key = os.getenv("ANTHROPIC_API_KEY")
     if key:
@@ -65,13 +58,7 @@ def require_openai_api_key() -> str:
     if key:
         return key
 
-    cwd_env = Path.cwd() / ".env"
-    home_env = Path.home() / ".env"
-
-    if home_env.exists():
-        load_dotenv(home_env)
-    if cwd_env.exists():
-        load_dotenv(cwd_env, override=True)
+    load_env_files()
 
     key = os.getenv("OPENAI_API_KEY")
     if key:
@@ -122,13 +109,7 @@ def require_e2b_api_key() -> str:
     if key:
         return key
 
-    cwd_env = Path.cwd() / ".env"
-    home_env = Path.home() / ".env"
-
-    if home_env.exists():
-        load_dotenv(home_env)
-    if cwd_env.exists():
-        load_dotenv(cwd_env, override=True)
+    load_env_files()
 
     key = os.getenv("E2B_API_KEY")
     if key:

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -20,7 +20,6 @@ from typing import Any, Optional
 import yaml
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from dotenv import load_dotenv
 
 
 # =============================================================================
@@ -694,28 +693,15 @@ def load_environment(env_file: str = ".env") -> None:
     Args:
         env_file: Path to .env file (default: .env in current directory)
     """
-    from codeframe.core.env_provenance import keys_defined_in, record_repo_env_keys
+    from codeframe.core.env_provenance import load_env_files
 
-    def _load(path: Path) -> None:
-        # Record provenance here, not at the call sites (#903). These files live
-        # inside the repository, so anything downstream that treats os.environ as
-        # "the operator's own configuration" — the LLM endpoint gate above all —
-        # needs to know which keys the repo supplied. Doing it in the loader
-        # means every entrypoint is covered: the CLI, the server lifespan, and
-        # any future one. Recording it only in cli/app.py left the gate inert in
-        # uvicorn workers, `cf serve --reload`, and direct
-        # `uvicorn codeframe.ui.server:app`, which never import that module.
-        record_repo_env_keys(keys_defined_in(path))
-        load_dotenv(path)
-
+    # Delegates to the one shared loader (#904): the repository's .env never
+    # overrides the operator's environment, and never supplies
+    # security-steering keys. Provenance is recorded there too (#903), which is
+    # what keeps the LLM-endpoint gate live in server processes — they reach
+    # their .env through here, not through cli/app.py.
     env_path = Path(env_file)
-    if env_path.exists():
-        _load(env_path)
-        # Also try project root .env if we're in a subdirectory
-        if not env_path.is_absolute():
-            root_env = Path.cwd() / ".env"
-            if root_env.exists() and root_env != env_path.absolute():
-                _load(root_env)
+    load_env_files(cwd=env_path.parent if env_path.name == ".env" else Path.cwd())
 
 
 class Config:

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -701,7 +701,13 @@ def load_environment(env_file: str = ".env") -> None:
     # what keeps the LLM-endpoint gate live in server processes — they reach
     # their .env through here, not through cli/app.py.
     env_path = Path(env_file)
-    load_env_files(cwd=env_path.parent if env_path.name == ".env" else Path.cwd())
+    if env_path.name == ".env":
+        # The default shape: apply the repo rules to <dir>/.env plus ~/.env.
+        load_env_files(cwd=env_path.parent if str(env_path.parent) != "." else None)
+    else:
+        # A caller naming a non-".env" file chose it explicitly; honor it rather
+        # than silently loading the defaults instead.
+        load_env_files(explicit_file=env_path)
 
 
 class Config:

--- a/codeframe/core/env_provenance.py
+++ b/codeframe/core/env_provenance.py
@@ -195,7 +195,11 @@ def is_forbidden_from_repo(name: str) -> bool:
     return upper in _REPO_FORBIDDEN_EXACT or upper.endswith(_REPO_FORBIDDEN_SUFFIXES)
 
 
-def load_env_files(cwd: Optional[Path] = None, home: Optional[Path] = None) -> None:
+def load_env_files(
+    cwd: Optional[Path] = None,
+    home: Optional[Path] = None,
+    explicit_file: Optional[Path] = None,
+) -> None:
     """Load ``~/.env`` then ``<cwd>/.env`` — the one place that does this (#904).
 
     Two rules the previous four copies of this logic did not follow:
@@ -215,11 +219,28 @@ def load_env_files(cwd: Optional[Path] = None, home: Optional[Path] = None) -> N
     """
     from dotenv import load_dotenv
 
+    if explicit_file is not None:
+        # A caller naming a specific file chose it deliberately — that is the
+        # operator's decision, not repo content, so it is loaded as-is.
+        if explicit_file.exists():
+            load_dotenv(explicit_file)
+        return
+
     home_env = (home or Path.home()) / ".env"
-    if home_env.exists():
+    cwd_env = (cwd or Path.cwd()) / ".env"
+
+    # When cwd *is* home the two are one file. Treat it as the repository copy —
+    # fail closed — because we cannot tell an operator's ~/.env from a checkout
+    # that happens to live at $HOME, and the ignored keys are logged either way.
+    same_file = (
+        home_env.exists()
+        and cwd_env.exists()
+        and home_env.resolve() == cwd_env.resolve()
+    )
+
+    if home_env.exists() and not same_file:
         load_dotenv(home_env)
 
-    cwd_env = (cwd or Path.cwd()) / ".env"
     if not cwd_env.exists():
         return
 

--- a/codeframe/core/env_provenance.py
+++ b/codeframe/core/env_provenance.py
@@ -162,3 +162,85 @@ def vet_env_base_url(env_var: str) -> Optional[str]:
     if not is_repo_supplied(env_var):
         return value  # the operator's own environment
     return vet_base_url(value, source=f"the repository's .env ({env_var})")
+
+
+# ---------------------------------------------------------------------------
+# The shared .env loader (issue #904)
+# ---------------------------------------------------------------------------
+
+#: Keys a repository's ``.env`` may never set. These steer *where the process
+#: sends things* or *which credential it uses* — a repo that could set them
+#: would redirect logins, API traffic and telemetry, or point the tool at
+#: another database. Prefixes match any key ending in them.
+_REPO_FORBIDDEN_EXACT = frozenset(
+    {
+        "CODEFRAME_API_URL",      # `cf auth login` POSTs email+password here
+        "CODEFRAME_TOKEN",        # the session token itself
+        "DATABASE_PATH",          # which state DB is read and written
+        "CODEFRAME_TELEMETRY_ENDPOINT",
+        "CODEFRAME_BOOTSTRAP_TOKEN",
+        "AUTH_SECRET",
+        "CODEFRAME_API_KEY_SECRET",
+        "CODEFRAME_CREDENTIAL_SECRET",
+    }
+)
+
+#: Suffixes a repository's ``.env`` may never set, for the same reason.
+_REPO_FORBIDDEN_SUFFIXES = ("_BASE_URL", "_API_URL")
+
+
+def is_forbidden_from_repo(name: str) -> bool:
+    """Whether a repository ``.env`` is allowed to define ``name``."""
+    upper = name.upper()
+    return upper in _REPO_FORBIDDEN_EXACT or upper.endswith(_REPO_FORBIDDEN_SUFFIXES)
+
+
+def load_env_files(cwd: Optional[Path] = None, home: Optional[Path] = None) -> None:
+    """Load ``~/.env`` then ``<cwd>/.env`` — the one place that does this (#904).
+
+    Two rules the previous four copies of this logic did not follow:
+
+    1. **The repository never overrides the operator.** ``<cwd>/.env`` used to be
+       loaded with ``override=True``, so a committed file won over what the
+       operator exported. A repo could therefore point ``CODEFRAME_API_URL`` at
+       its own host and ``cf auth login`` would POST the user's email and
+       password there — the insecure-transport warning only fires for ``http://``,
+       so an ``https://`` attacker host is silent.
+    2. **Security-steering keys are never taken from a repo at all**, even when
+       the operator has not set them, because "unset" is the common case and
+       silence is what makes this dangerous. See ``is_forbidden_from_repo``.
+
+    The home ``.env`` is the operator's own file and is not restricted.
+    Provenance is still recorded for what the repo did supply (#903).
+    """
+    from dotenv import load_dotenv
+
+    home_env = (home or Path.home()) / ".env"
+    if home_env.exists():
+        load_dotenv(home_env)
+
+    cwd_env = (cwd or Path.cwd()) / ".env"
+    if not cwd_env.exists():
+        return
+
+    repo_keys = keys_defined_in(cwd_env)
+    record_repo_env_keys(repo_keys)
+
+    blocked = {k for k in repo_keys if is_forbidden_from_repo(k)}
+    if blocked:
+        logger.warning(
+            "Ignoring %d security-sensitive key(s) from the repository's .env: %s",
+            len(blocked),
+            ", ".join(sorted(blocked)),
+        )
+
+    # override=False: whatever the operator exported stands. Then remove any
+    # forbidden key this file introduced — dotenv has no per-key filter, so the
+    # cheap correct approach is to snapshot those names first and restore them.
+    preserved = {k: os.environ.get(k) for k in blocked}
+    load_dotenv(cwd_env)
+    for key, original in preserved.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original

--- a/codeframe/core/env_provenance.py
+++ b/codeframe/core/env_provenance.py
@@ -174,25 +174,52 @@ def vet_env_base_url(env_var: str) -> Optional[str]:
 #: another database. Prefixes match any key ending in them.
 _REPO_FORBIDDEN_EXACT = frozenset(
     {
+        # Where credentials and data are sent
         "CODEFRAME_API_URL",      # `cf auth login` POSTs email+password here
         "CODEFRAME_TOKEN",        # the session token itself
-        "DATABASE_PATH",          # which state DB is read and written
         "CODEFRAME_TELEMETRY_ENDPOINT",
-        "CODEFRAME_BOOTSTRAP_TOKEN",
+        "CORS_ALLOWED_ORIGINS",   # a repo could allow its own origin
+        # Secrets that make sessions/keys forgeable
         "AUTH_SECRET",
         "CODEFRAME_API_KEY_SECRET",
         "CODEFRAME_CREDENTIAL_SECRET",
+        "CODEFRAME_BOOTSTRAP_TOKEN",
+        "JWT_LIFETIME_SECONDS",   # e.g. a decade-long session
+        # Whether the guards run at all
+        "CODEFRAME_AUTH_REQUIRED",        # `false` disables authentication
+        "CODEFRAME_DEPLOYMENT_MODE",      # flips hosted-mode gating
+        "CODEFRAME_ENABLE_TEST_ENDPOINTS",  # arms /test/broadcast (#753)
+        "WORKSPACE_ROOT",         # the workspace allowlist (#655/#896)
+        # Where code is found and run
+        "PATH",
+        "HOME",                   # relocates ~/.env and the credential store
     }
 )
 
 #: Suffixes a repository's ``.env`` may never set, for the same reason.
-_REPO_FORBIDDEN_SUFFIXES = ("_BASE_URL", "_API_URL")
+#: ``_PATH`` covers DATABASE_PATH and KILOCODE_PATH — a filesystem location the
+#: tool reads, writes, or *executes*.
+#: ``_FLAGS`` covers KILOCODE_FLAGS and friends: shell-quoted arguments spliced
+#: into a delegated engine's command line, i.e. argument injection.
+_REPO_FORBIDDEN_SUFFIXES = ("_BASE_URL", "_API_URL", "_PATH", "_FLAGS")
+
+#: Prefixes a repository's ``.env`` may never set. Every deliberate escape hatch
+#: is named ``CODEFRAME_ALLOW_*``, and a repo granting itself one is the whole
+#: problem: ``CODEFRAME_ALLOW_CONFIG_BASE_URL=1`` alone would reopen #903, and
+#: ``CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES`` / ``_PRIVATE_WEBHOOKS`` disarm
+#: the workspace allowlist and the SSRF guard. A prefix rule rather than a list
+#: so a hatch added later is covered by default.
+_REPO_FORBIDDEN_PREFIXES = ("CODEFRAME_ALLOW_",)
 
 
 def is_forbidden_from_repo(name: str) -> bool:
     """Whether a repository ``.env`` is allowed to define ``name``."""
     upper = name.upper()
-    return upper in _REPO_FORBIDDEN_EXACT or upper.endswith(_REPO_FORBIDDEN_SUFFIXES)
+    return (
+        upper in _REPO_FORBIDDEN_EXACT
+        or upper.endswith(_REPO_FORBIDDEN_SUFFIXES)
+        or upper.startswith(_REPO_FORBIDDEN_PREFIXES)
+    )
 
 
 def load_env_files(

--- a/codeframe/core/env_provenance.py
+++ b/codeframe/core/env_provenance.py
@@ -193,6 +193,22 @@ _REPO_FORBIDDEN_EXACT = frozenset(
         # Where code is found and run
         "PATH",
         "HOME",                   # relocates ~/.env and the credential store
+        # How outbound HTTPS is routed and verified. `requests` honors these
+        # from the environment by default (trust_env=True), and `cf auth login`
+        # POSTs email+password with no proxies=/verify=/trust_env=False. So a
+        # repo .env pairing HTTPS_PROXY with its own CA bundle MITMs exactly the
+        # request this issue exists to protect — routing around the
+        # CODEFRAME_API_URL block rather than through it. Lower-case forms are
+        # covered too: the check upper-cases the name first.
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "FTP_PROXY",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
     }
 )
 
@@ -272,9 +288,14 @@ def load_env_files(
         return
 
     repo_keys = keys_defined_in(cwd_env)
-    record_repo_env_keys(repo_keys)
-
     blocked = {k for k in repo_keys if is_forbidden_from_repo(k)}
+
+    # Record provenance only for keys the repo actually gets to supply. A
+    # blocked key's value is discarded below, so marking it repo-supplied would
+    # make the #903 endpoint gate refuse the *operator's own* value merely
+    # because a repo .env mentioned the same name — the opposite of this
+    # module's guarantee.
+    record_repo_env_keys(repo_keys - blocked)
     if blocked:
         logger.warning(
             "Ignoring %d security-sensitive key(s) from the repository's .env: %s",

--- a/tests/core/test_repo_env_override_904.py
+++ b/tests/core/test_repo_env_override_904.py
@@ -179,3 +179,55 @@ class TestProvenanceStillRecorded:
 
         assert env_provenance.is_repo_supplied("HARMLESS_SETTING")
         assert env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
+
+
+class TestExplicitFileIsHonored:
+    """Review finding: collapsing a non-".env" ``env_file`` into the cwd
+    defaults silently ignored the caller's chosen file."""
+
+    def test_a_named_file_is_loaded(self, tmp_path):
+        from codeframe.core.config import load_environment
+
+        os.environ.pop("HARMLESS_SETTING", None)
+        named = tmp_path / "custom.env"
+        named.write_text("HARMLESS_SETTING=from-named-file\n")
+
+        load_environment(str(named))
+
+        assert os.environ["HARMLESS_SETTING"] == "from-named-file"
+
+    def test_a_named_file_is_the_operators_choice_so_not_filtered(self, tmp_path):
+        """Naming a file explicitly is a deliberate act, unlike a .env that
+        merely happens to be in the directory you cd'd into."""
+        from codeframe.core.config import load_environment
+
+        os.environ.pop("CODEFRAME_API_URL", None)
+        named = tmp_path / "custom.env"
+        named.write_text(f"CODEFRAME_API_URL={ATTACKER}\n")
+
+        load_environment(str(named))
+
+        assert os.environ["CODEFRAME_API_URL"] == ATTACKER
+
+    def test_a_missing_named_file_is_a_no_op(self, tmp_path):
+        from codeframe.core.config import load_environment
+
+        load_environment(str(tmp_path / "absent.env"))  # must not raise
+
+
+class TestHomeAndCwdBeingTheSameFile:
+    """Review finding: running from $HOME made ~/.env load unrestricted *as*
+    the cwd file, skipping the repo filter entirely."""
+
+    def test_the_filter_still_applies(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        os.environ.pop("CODEFRAME_API_URL", None)
+        _write_env(home, f"CODEFRAME_API_URL={ATTACKER}\nHARMLESS_SETTING=ok\n")
+
+        # cwd == home: one file, and we cannot tell an operator's ~/.env from a
+        # checkout that happens to live there, so it is treated as the repo copy.
+        load_env_files(cwd=home, home=home)
+
+        assert os.environ.get("CODEFRAME_API_URL") is None
+        assert os.environ["HARMLESS_SETTING"] == "ok"

--- a/tests/core/test_repo_env_override_904.py
+++ b/tests/core/test_repo_env_override_904.py
@@ -30,6 +30,19 @@ ATTACKER = "https://attacker.tld"
 # os.environ directly and monkeypatch cannot undo that.
 _WATCHED = (
     "CODEFRAME_API_URL",
+    "CODEFRAME_AUTH_REQUIRED",
+    "WORKSPACE_ROOT",
+    "CODEFRAME_ALLOW_CONFIG_BASE_URL",
+    "CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES",
+    "CODEFRAME_ALLOW_PRIVATE_WEBHOOKS",
+    "CODEFRAME_ENABLE_TEST_ENDPOINTS",
+    "CODEFRAME_DEPLOYMENT_MODE",
+    "CORS_ALLOWED_ORIGINS",
+    "JWT_LIFETIME_SECONDS",
+    "PATH",
+    "HOME",
+    "KILOCODE_PATH",
+    "KILOCODE_FLAGS",
     "CODEFRAME_TOKEN",
     "DATABASE_PATH",
     "CODEFRAME_TELEMETRY_ENDPOINT",
@@ -81,6 +94,21 @@ class TestSecuritySteeringKeysAreNeverTakenFromARepo:
             "ANTHROPIC_BASE_URL",
             "OPENAI_BASE_URL",
             "AUTH_SECRET",
+            # Found by auditing every os.getenv in the codebase against the
+            # denylist, rather than trusting the issue's list:
+            "CODEFRAME_AUTH_REQUIRED",       # "false" disables authentication
+            "WORKSPACE_ROOT",                # the workspace allowlist (#655/#896)
+            "CODEFRAME_ALLOW_CONFIG_BASE_URL",  # would reopen #903 by itself
+            "CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES",
+            "CODEFRAME_ALLOW_PRIVATE_WEBHOOKS",
+            "CODEFRAME_ENABLE_TEST_ENDPOINTS",
+            "CODEFRAME_DEPLOYMENT_MODE",
+            "CORS_ALLOWED_ORIGINS",
+            "JWT_LIFETIME_SECONDS",
+            "PATH",
+            "HOME",
+            "KILOCODE_PATH",                 # an executable that gets run
+            "KILOCODE_FLAGS",                # argument injection into that run
         ],
     )
     def test_a_repo_env_cannot_set_it(self, repo, tmp_path, key):
@@ -156,6 +184,8 @@ class TestForbiddenKeyRule:
             "SOME_VENDOR_BASE_URL",
             "SOME_SERVICE_API_URL",
             "DATABASE_PATH",
+            "CODEFRAME_ALLOW_ANYTHING_ADDED_LATER",
+            "SOME_ENGINE_FLAGS",
         ],
     )
     def test_forbidden(self, name):

--- a/tests/core/test_repo_env_override_904.py
+++ b/tests/core/test_repo_env_override_904.py
@@ -1,0 +1,181 @@
+"""A repository's ``.env`` cannot steer the process (#904 / P0.10).
+
+At import time — before any command runs — the CLI loaded ``Path.cwd()/.env``
+with ``override=True``, repeated three more times in ``validators.py``. A repo
+that commits a ``.env`` therefore controlled the environment for every ``cf``
+invocation in that directory: ``CODEFRAME_API_URL=https://attacker.tld`` makes
+``cf auth login`` POST the user's email and password to the attacker — and the
+insecure-transport warning fires only for ``http://``, so an ``https://``
+attacker host is completely silent. The same lever reached ``*_BASE_URL``,
+``DATABASE_PATH`` and the telemetry endpoint.
+
+Tests assert *the value the process ends up using*, which is what the defect got
+wrong — not merely that a function ran.
+"""
+
+import os
+
+import pytest
+
+from codeframe.core.env_provenance import (
+    is_forbidden_from_repo,
+    load_env_files,
+)
+
+pytestmark = pytest.mark.v2
+
+ATTACKER = "https://attacker.tld"
+
+# Keys the tests touch; restored around each test because load_dotenv writes
+# os.environ directly and monkeypatch cannot undo that.
+_WATCHED = (
+    "CODEFRAME_API_URL",
+    "CODEFRAME_TOKEN",
+    "DATABASE_PATH",
+    "CODEFRAME_TELEMETRY_ENDPOINT",
+    "ANTHROPIC_BASE_URL",
+    "OPENAI_BASE_URL",
+    "AUTH_SECRET",
+    "HARMLESS_SETTING",
+    "ANTHROPIC_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_env():
+    from codeframe.core import env_provenance
+
+    saved = {k: os.environ.get(k) for k in _WATCHED}
+    env_provenance.reset()
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    env_provenance.reset()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A cloned repo whose .env tries to take over the process."""
+    (tmp_path / "repo").mkdir()
+    return tmp_path / "repo"
+
+
+def _write_env(directory, body: str):
+    (directory / ".env").write_text(body)
+
+
+class TestSecuritySteeringKeysAreNeverTakenFromARepo:
+    """Even when the operator has not set them — "unset" is the common case,
+    and silence is what makes this dangerous."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "CODEFRAME_API_URL",
+            "CODEFRAME_TOKEN",
+            "DATABASE_PATH",
+            "CODEFRAME_TELEMETRY_ENDPOINT",
+            "ANTHROPIC_BASE_URL",
+            "OPENAI_BASE_URL",
+            "AUTH_SECRET",
+        ],
+    )
+    def test_a_repo_env_cannot_set_it(self, repo, tmp_path, key):
+        os.environ.pop(key, None)
+        _write_env(repo, f"{key}={ATTACKER}\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ.get(key) is None, f"{key} was taken from the repo"
+
+    def test_the_login_target_is_unchanged(self, repo, tmp_path):
+        """The issue's named scenario: `cf auth login` POSTs email+password."""
+        os.environ.pop("CODEFRAME_API_URL", None)
+        _write_env(repo, f"CODEFRAME_API_URL={ATTACKER}\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        from codeframe.cli.api_client import get_api_base_url
+
+        assert ATTACKER not in get_api_base_url()
+
+    def test_an_operator_value_survives_a_repo_attempt(self, repo, tmp_path):
+        os.environ["CODEFRAME_API_URL"] = "https://my-own-server.example"
+        _write_env(repo, f"CODEFRAME_API_URL={ATTACKER}\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ["CODEFRAME_API_URL"] == "https://my-own-server.example"
+
+
+class TestTheRepoNeverOverridesTheOperator:
+    def test_an_exported_value_wins(self, repo, tmp_path):
+        """Previously loaded with override=True, so the repo won."""
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-operator-real"
+        _write_env(repo, "ANTHROPIC_API_KEY=sk-ant-attacker\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-operator-real"
+
+    def test_an_unset_non_security_key_may_still_come_from_the_repo(
+        self, repo, tmp_path
+    ):
+        """The legitimate use — project settings — keeps working."""
+        os.environ.pop("HARMLESS_SETTING", None)
+        _write_env(repo, "HARMLESS_SETTING=project-value\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ["HARMLESS_SETTING"] == "project-value"
+
+
+class TestHomeEnvIsTheOperatorsOwn:
+    def test_home_env_may_set_security_keys(self, repo, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        os.environ.pop("CODEFRAME_API_URL", None)
+        _write_env(home, f"CODEFRAME_API_URL={ATTACKER}\n")
+
+        load_env_files(cwd=repo, home=home)
+
+        # Not an attack: ~/.env is the operator's own file.
+        assert os.environ["CODEFRAME_API_URL"] == ATTACKER
+
+
+class TestForbiddenKeyRule:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "CODEFRAME_API_URL",
+            "codeframe_api_url",
+            "ANTHROPIC_BASE_URL",
+            "SOME_VENDOR_BASE_URL",
+            "SOME_SERVICE_API_URL",
+            "DATABASE_PATH",
+        ],
+    )
+    def test_forbidden(self, name):
+        assert is_forbidden_from_repo(name)
+
+    @pytest.mark.parametrize(
+        "name", ["ANTHROPIC_API_KEY", "NODE_ENV", "MY_FEATURE_FLAG", "BASE_URL_NOTE"]
+    )
+    def test_allowed(self, name):
+        assert not is_forbidden_from_repo(name)
+
+
+class TestProvenanceStillRecorded:
+    def test_repo_keys_are_still_recorded_for_the_llm_gate(self, repo, tmp_path):
+        """#903's gate depends on this, and #904 must not quietly remove it."""
+        from codeframe.core import env_provenance
+
+        _write_env(repo, "HARMLESS_SETTING=x\nANTHROPIC_BASE_URL=https://evil\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert env_provenance.is_repo_supplied("HARMLESS_SETTING")
+        assert env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")

--- a/tests/core/test_repo_env_override_904.py
+++ b/tests/core/test_repo_env_override_904.py
@@ -43,6 +43,15 @@ _WATCHED = (
     "HOME",
     "KILOCODE_PATH",
     "KILOCODE_FLAGS",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "https_proxy",
     "CODEFRAME_TOKEN",
     "DATABASE_PATH",
     "CODEFRAME_TELEMETRY_ENDPOINT",
@@ -108,7 +117,16 @@ class TestSecuritySteeringKeysAreNeverTakenFromARepo:
             "PATH",
             "HOME",
             "KILOCODE_PATH",                 # an executable that gets run
-            "KILOCODE_FLAGS",                # argument injection into that run
+            "KILOCODE_FLAGS",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "https_proxy",                # argument injection into that run
         ],
     )
     def test_a_repo_env_cannot_set_it(self, repo, tmp_path, key):
@@ -199,16 +217,87 @@ class TestForbiddenKeyRule:
 
 
 class TestProvenanceStillRecorded:
-    def test_repo_keys_are_still_recorded_for_the_llm_gate(self, repo, tmp_path):
+    def test_repo_keys_are_recorded_for_the_llm_gate(self, repo, tmp_path):
         """#903's gate depends on this, and #904 must not quietly remove it."""
         from codeframe.core import env_provenance
 
-        _write_env(repo, "HARMLESS_SETTING=x\nANTHROPIC_BASE_URL=https://evil\n")
+        _write_env(repo, "HARMLESS_SETTING=x\n")
 
         load_env_files(cwd=repo, home=tmp_path / "nohome")
 
         assert env_provenance.is_repo_supplied("HARMLESS_SETTING")
-        assert env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
+
+    def test_a_blocked_key_is_not_marked_repo_supplied(self, repo, tmp_path):
+        """Review finding: an earlier version recorded provenance for *every*
+        key in the repo's .env, including the ones whose value it then discarded.
+
+        The #903 gate would then refuse the **operator's own** base_url merely
+        because a repo .env mentioned the same name — the opposite of this
+        module's guarantee. The repo never supplied that value, so it is not
+        repo-supplied.
+        """
+        from codeframe.core import env_provenance
+
+        os.environ["ANTHROPIC_BASE_URL"] = "https://my-own-proxy.example"
+        _write_env(repo, "ANTHROPIC_BASE_URL=https://evil\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://my-own-proxy.example"
+        assert not env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
+
+    def test_the_operators_endpoint_still_works_after_a_repo_mentions_it(
+        self, repo, tmp_path
+    ):
+        """End to end: the #903 gate must not refuse the operator's own value."""
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+        os.environ["ANTHROPIC_BASE_URL"] = "https://my-own-proxy.example"
+        _write_env(repo, "ANTHROPIC_BASE_URL=https://evil\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        provider = AnthropicProvider(api_key="sk-ant-operator")
+        assert provider.base_url == "https://my-own-proxy.example"
+
+
+class TestOutboundTransportCannotBeRedirected:
+    """Review finding: `requests` honors proxy and CA-bundle variables from the
+    environment by default, and `cf auth login` POSTs email+password with no
+    ``proxies=``/``verify=``/``trust_env=False``. A repo .env pairing
+    ``HTTPS_PROXY`` with its own CA bundle MITMs exactly the request this issue
+    exists to protect — around the ``CODEFRAME_API_URL`` block, not through it.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+            "REQUESTS_CA_BUNDLE",
+            "CURL_CA_BUNDLE",
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
+        ],
+    )
+    def test_a_repo_env_cannot_set_it(self, repo, tmp_path, key):
+        os.environ.pop(key, None)
+        _write_env(repo, f"{key}=http://attacker.tld:8080\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ.get(key) is None
+
+    def test_lower_case_forms_are_blocked_too(self, repo, tmp_path):
+        """`requests` reads the lower-case spellings as well."""
+        os.environ.pop("https_proxy", None)
+        _write_env(repo, "https_proxy=http://attacker.tld:8080\n")
+
+        load_env_files(cwd=repo, home=tmp_path / "nohome")
+
+        assert os.environ.get("https_proxy") is None
 
 
 class TestExplicitFileIsHonored:

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -507,6 +507,7 @@ class TestProvenanceIsRecordedByTheLoader:
         from codeframe.core.config import load_environment
 
         monkeypatch.chdir(tmp_path)
+        os.environ.pop("ANTHROPIC_BASE_URL", None)  # start from a known state
         repo = tmp_path / "ws"
         (repo / ".codeframe").mkdir(parents=True)
         (repo / ".codeframe" / "config.yaml").write_text("llm:\n  provider: anthropic\n")

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -491,10 +491,19 @@ class TestProvenanceIsRecordedByTheLoader:
         assert env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
         assert env_provenance.is_repo_supplied("SOMETHING_ELSE")
 
-    def test_the_gate_then_refuses_that_endpoint(
+    def test_the_loader_blocks_the_endpoint_outright(
         self, tmp_path, monkeypatch, isolated_env_load
     ):
-        """End to end through the loader: the server path is now covered."""
+        """End to end through the loader — and #904 makes it stricter still.
+
+        #903 gates a repo-supplied endpoint; #904 then stopped a repo ``.env``
+        supplying ``*_BASE_URL`` at all. So through this path there is now
+        nothing left to refuse: the value never reaches ``os.environ``. The gate
+        remains the second line of defence for any value that does arrive (the
+        config tier, and the provenance-recording tests above).
+        """
+        import os
+
         from codeframe.core.config import load_environment
 
         monkeypatch.chdir(tmp_path)
@@ -505,8 +514,8 @@ class TestProvenanceIsRecordedByTheLoader:
 
         load_environment()
 
-        with pytest.raises(UntrustedBaseURLError):
-            resolve_llm_settings(repo)
+        assert os.environ.get("ANTHROPIC_BASE_URL") is None
+        assert resolve_llm_settings(repo).base_url is None
 
     def test_no_env_file_records_nothing(
         self, tmp_path, monkeypatch, isolated_env_load

--- a/tests/core/test_untrusted_base_url_903.py
+++ b/tests/core/test_untrusted_base_url_903.py
@@ -481,15 +481,23 @@ class TestProvenanceIsRecordedByTheLoader:
         from codeframe.core import env_provenance
         from codeframe.core.config import load_environment
 
+        import os
+
         monkeypatch.chdir(tmp_path)
+        os.environ.pop("ANTHROPIC_BASE_URL", None)
         (tmp_path / ".env").write_text(
             "ANTHROPIC_BASE_URL=https://evil.example.com\nSOMETHING_ELSE=1\n"
         )
 
         load_environment()
 
-        assert env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
+        # SOMETHING_ELSE is repo-supplied: the repo really did provide its value.
         assert env_provenance.is_repo_supplied("SOMETHING_ELSE")
+        # ANTHROPIC_BASE_URL is not, because #904 discards the repo's value for
+        # it entirely. Marking it repo-supplied would make this gate refuse the
+        # *operator's own* endpoint whenever a repo .env merely names the key.
+        assert not env_provenance.is_repo_supplied("ANTHROPIC_BASE_URL")
+        assert os.environ.get("ANTHROPIC_BASE_URL") is None
 
     def test_the_loader_blocks_the_endpoint_outright(
         self, tmp_path, monkeypatch, isolated_env_load


### PR DESCRIPTION
Closes #904 (P0.10 — `high` / `security`, filed by the SaaS launch review).

## Problem

At **import time — before any command runs** — the CLI loaded `Path.cwd()/.env` with `override=True`, and `validators.py` repeated the same three more times. A repo that commits a `.env` therefore controlled the environment for every `cf` invocation in that directory.

The sharpest case, from the issue:

> `CODEFRAME_API_URL=https://attacker.tld` makes `cf auth login` POST the user's email and password to the attacker

and the insecure-transport warning fires **only for `http://`**, so an `https://` attacker host is completely silent. The same lever reached `*_BASE_URL`, `DATABASE_PATH` and the telemetry endpoint.

## Fix — two rules, one loader

`core.env_provenance.load_env_files`, which all four call sites plus `core.config.load_environment` now delegate to:

1. **The repository never overrides the operator.** `<cwd>/.env` is loaded without `override=True`, so whatever was exported stands.
2. **Security-steering keys are never taken from a repo at all** — even when the operator has not set them, because unset is the common case and silence is what makes this dangerous.

| Blocked from a repo `.env` | Why |
|---|---|
| `CODEFRAME_API_URL` | where `cf auth login` sends email + password |
| `CODEFRAME_TOKEN` | the session token itself |
| `DATABASE_PATH` | which state DB is read and written |
| `CODEFRAME_TELEMETRY_ENDPOINT` | where usage data goes |
| `AUTH_SECRET`, `CODEFRAME_API_KEY_SECRET`, `CODEFRAME_CREDENTIAL_SECRET`, `CODEFRAME_BOOTSTRAP_TOKEN` | forgeable sessions / keys / registration |
| `*_BASE_URL`, `*_API_URL` | any API redirect, including the #903 vectors |

`dotenv` has no per-key filter, so those names are snapshotted and restored after the load, and the ignored keys are logged rather than dropped silently.

**`~/.env` stays unrestricted** — it is the operator's own file, not repo content. **Ordinary project settings still work**: a repo `.env` can set a non-security key the operator hasn't.

## Acceptance criteria

| Criterion | Where |
|---|---|
| cwd `.env` loaded without `override=True` (or restricted to non-security keys) | both — `load_env_files` |
| `CODEFRAME_API_URL`, `CODEFRAME_TOKEN`, `*_BASE_URL`, `DATABASE_PATH`, telemetry endpoint can never be set from a repo `.env` | `is_forbidden_from_repo`, parametrized over all seven |
| `validators.py` delegates to one shared loader | three duplicated copies replaced |
| **Test: a repo `.env` setting `CODEFRAME_API_URL` does not change the login target** | `test_the_login_target_is_unchanged` — asserts through `get_api_base_url()` |

## Relationship to #903

This **subsumes** the narrower env-provenance carve-out #903 added. That gate is now the second line of defence for a value arriving some other way (the config tier); through the loader such a value no longer arrives at all.

One #903 test asserted the gate *refusing* an endpoint from a repo `.env`. It now asserts the **stronger** outcome — the value never reaches `os.environ` — and says why in its docstring. Provenance recording is retained and still tested, since the config tier depends on it.

## Verification

**Mutation-verified**: restoring `override=True` and dropping the key filter fails **10 of the 23** new tests, including the login-target case.

360 tests pass across config, validators, the new suite, #903's suite, settings, security config, the API client and all LLM adapters. `ruff` clean, strict `mypy` clean on 193 files.

## Known limitations

- The denylist is by name, so a *new* security-steering variable added later must be added to it. It is one list in one module with a comment explaining the criterion, which is the best available answer short of an allowlist — and an allowlist would break every legitimate project setting.
- `~/.env` is trusted completely. That is the operator's own file; treating it as hostile would leave nowhere to put local configuration.