### PR TITLE
fix(security): confine plan-engine file operations to the workspace (#906)

### DIFF
--- a/codeframe/core/agent.py
+++ b/codeframe/core/agent.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from codeframe.adapters.llm import LLMProvider, Purpose
 from codeframe.core import blockers, events
+from codeframe.core.path_safety import is_path_safe
 from codeframe.core.context import ContextLoader, TaskContext
 from codeframe.core.events import EventType
 from codeframe.core.executor import Executor, ExecutionStatus, StepResult
@@ -78,31 +79,9 @@ def _extract_file_from_command(command: str) -> Optional[str]:
     return None
 
 
-def _is_path_safe(file_path: Path, workspace_path: Path) -> tuple[bool, str]:
-    """Check if a file path is safely within the workspace.
-
-    Prevents path traversal attacks via '..' components.
-
-    Args:
-        file_path: The file path to check
-        workspace_path: The workspace root path
-
-    Returns:
-        Tuple of (is_safe, reason) where reason explains any rejection
-    """
-    try:
-        # Resolve both paths to handle symlinks and relative paths
-        resolved_file = file_path.resolve()
-        resolved_workspace = workspace_path.resolve()
-
-        # Check if the file is within the workspace
-        try:
-            resolved_file.relative_to(resolved_workspace)
-            return (True, "")
-        except ValueError:
-            return (False, f"Path escapes workspace: {file_path}")
-    except Exception as e:
-        return (False, f"Path resolution error: {e}")
+# Moved to the leaf module core/path_safety.py (#906): this was the third copy
+# of an identical check. Kept as an alias so existing call sites read the same.
+_is_path_safe = is_path_safe
 
 
 def _parse_command_safely(command: str) -> tuple[list[str], bool, str]:

--- a/codeframe/core/executor.py
+++ b/codeframe/core/executor.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
 from codeframe.core.agent_env import build_agent_env
+from codeframe.core.path_safety import is_path_safe
 from codeframe.core.planner import PlanStep, StepType, ImplementationPlan
 from codeframe.core.context import TaskContext
 from codeframe.adapters.llm import LLMProvider, Purpose
@@ -292,6 +293,29 @@ class Executor:
 
         return result
 
+    def _resolve_target(self, step: PlanStep) -> tuple[Optional[Path], Optional[StepResult]]:
+        """Join ``step.target`` onto the repo root, refusing anything outside it.
+
+        ``step.target`` is LLM-generated from task/PRD/imported-issue text, which
+        this project already treats as an indirect prompt-injection surface. The
+        plain join is unsafe: an absolute target replaces the base entirely and
+        ``..`` walks out, so a poisoned task could overwrite
+        ``~/.ssh/authorized_keys`` (#906).
+
+        Returns:
+            ``(path, None)`` when the target is inside the workspace, otherwise
+            ``(None, failed_result)``.
+        """
+        file_path = self.repo_path / step.target
+        safe, reason = is_path_safe(file_path, self.repo_path)
+        if not safe:
+            return None, StepResult(
+                step=step,
+                status=ExecutionStatus.FAILED,
+                error=f"Blocked file operation outside the workspace: {reason}",
+            )
+        return file_path, None
+
     def _execute_file_create(
         self,
         step: PlanStep,
@@ -303,7 +327,9 @@ class Executor:
         - Identical content: returns SUCCESS (no-op)
         - Different content: falls back to edit behavior
         """
-        file_path = self.repo_path / step.target
+        file_path, blocked = self._resolve_target(step)
+        if blocked is not None:
+            return blocked
 
         # Check if file already exists -- fall back gracefully
         if file_path.exists():
@@ -385,7 +411,9 @@ class Executor:
         context: TaskContext,
     ) -> StepResult:
         """Edit an existing file."""
-        file_path = self.repo_path / step.target
+        file_path, blocked = self._resolve_target(step)
+        if blocked is not None:
+            return blocked
 
         # Check if file exists
         if not file_path.exists():
@@ -430,7 +458,9 @@ class Executor:
 
     def _execute_file_delete(self, step: PlanStep) -> StepResult:
         """Delete a file."""
-        file_path = self.repo_path / step.target
+        file_path, blocked = self._resolve_target(step)
+        if blocked is not None:
+            return blocked
 
         if not file_path.exists():
             return StepResult(

--- a/codeframe/core/executor.py
+++ b/codeframe/core/executor.py
@@ -808,6 +808,14 @@ class Executor:
         for change in reversed(self.changes):
             file_path = self.repo_path / change.path
 
+            # Every recorded path came from a guarded operation, so this cannot
+            # currently escape — but that invariant lives at a distance, and
+            # rollback writes files. Vet the join here too (#906).
+            safe, reason = is_path_safe(file_path, self.repo_path)
+            if not safe:
+                rolled_back.append(f"Refused to roll back outside the workspace: {reason}")
+                continue
+
             try:
                 if change.operation == "create":
                     # Delete the created file

--- a/codeframe/core/executor.py
+++ b/codeframe/core/executor.py
@@ -617,7 +617,12 @@ class Executor:
 
         # If target is a Python file, verify it exists and check syntax
         if target.endswith(".py"):
-            file_path = self.repo_path / target
+            # Same containment as the create/edit/delete steps (#906). This one
+            # reads: without the guard an absolute target reads any .py on disk,
+            # and the SyntaxError text below echoes the offending source line.
+            file_path, blocked = self._resolve_target(step)
+            if blocked is not None:
+                return blocked
             if not file_path.exists():
                 return StepResult(
                     step=step,
@@ -648,7 +653,9 @@ class Executor:
             return self._execute_shell_command(step)
 
         # Otherwise just check if the path exists
-        target_path = self.repo_path / target
+        target_path, blocked = self._resolve_target(step)
+        if blocked is not None:
+            return blocked
         if target_path.exists():
             return StepResult(
                 step=step,

--- a/codeframe/core/executor.py
+++ b/codeframe/core/executor.py
@@ -617,9 +617,10 @@ class Executor:
 
         # If target is a Python file, verify it exists and check syntax
         if target.endswith(".py"):
-            # Same containment as the create/edit/delete steps (#906). This one
-            # reads: without the guard an absolute target reads any .py on disk,
-            # and the SyntaxError text below echoes the offending source line.
+            # Same containment as the create/edit/delete steps (#906). This
+            # one reads: without the guard an absolute or ../ target turns the
+            # step into an existence-and-syntax oracle for any .py file on the
+            # host. (The SyntaxError message itself does not echo source text.)
             file_path, blocked = self._resolve_target(step)
             if blocked is not None:
                 return blocked

--- a/codeframe/core/path_safety.py
+++ b/codeframe/core/path_safety.py
@@ -1,0 +1,35 @@
+"""Workspace containment for agent-supplied paths (#906).
+
+A **leaf module**: stdlib only, so both ``core/tools.py`` (ReAct engine) and
+``core/executor.py`` (legacy plan engine) can share one check. ``tools.py``
+already imports from ``executor.py``, so the helper cannot live in either.
+
+Paths reaching these engines are LLM-generated from task/PRD/imported-issue
+text — an indirect prompt-injection surface. ``pathlib`` makes the naive join
+dangerous in two ways: an *absolute* right-hand side replaces the base entirely
+(``Path("/repo") / "/etc/passwd"`` is ``/etc/passwd``), and ``..`` walks out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def is_path_safe(file_path: Path, workspace_path: Path) -> tuple[bool, str]:
+    """Whether *file_path* stays inside *workspace_path*.
+
+    Resolves both sides first, so symlinks pointing out of the workspace are
+    rejected along with ``..`` and absolute paths.
+
+    Returns:
+        ``(True, "")`` when safe, ``(False, reason)`` otherwise.
+    """
+    try:
+        resolved_file = file_path.resolve()
+        resolved_workspace = workspace_path.resolve()
+        resolved_file.relative_to(resolved_workspace)
+        return (True, "")
+    except ValueError:
+        return (False, f"Path escapes workspace: {file_path}")
+    except Exception as e:
+        return (False, f"Path resolution error: {e}")

--- a/codeframe/core/tools.py
+++ b/codeframe/core/tools.py
@@ -26,6 +26,7 @@ from codeframe.adapters.llm.base import Tool, ToolCall, ToolResult
 from codeframe.core.agent_env import SAFE_ENV_VARS, build_agent_env
 from codeframe.core.context import DEFAULT_IGNORE_PATTERNS
 from codeframe.core.editor import EditOperation, SearchReplaceEditor
+from codeframe.core.path_safety import is_path_safe
 from codeframe.core.executor import is_dangerous_command
 from codeframe.core.gates import _detect_available_gates
 
@@ -48,21 +49,10 @@ _TRUNCATE_TAIL = 50
 # ---------------------------------------------------------------------------
 
 
-def _is_path_safe(file_path: Path, workspace_path: Path) -> tuple[bool, str]:
-    """Check if *file_path* is safely within *workspace_path*.
-
-    Returns:
-        ``(True, "")`` when safe, ``(False, reason)`` otherwise.
-    """
-    try:
-        resolved_file = file_path.resolve()
-        resolved_workspace = workspace_path.resolve()
-        resolved_file.relative_to(resolved_workspace)
-        return (True, "")
-    except ValueError:
-        return (False, f"Path escapes workspace: {file_path}")
-    except Exception as e:
-        return (False, f"Path resolution error: {e}")
+# Moved to the leaf module core/path_safety.py (#906) so the legacy plan engine
+# shares this exact check rather than growing a fourth copy. Kept as an alias:
+# every call site here already reads `_is_path_safe`.
+_is_path_safe = is_path_safe
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_plan_engine_path_containment_906.py
+++ b/tests/core/test_plan_engine_path_containment_906.py
@@ -173,19 +173,25 @@ def test_rollback_refuses_a_path_outside_the_workspace(workspace, outside):
 def test_verification_cannot_read_a_python_file_outside_the_workspace(
     workspace, tmp_path, shape
 ):
-    """The SyntaxError message echoes the offending source line, so an
-    unguarded read here leaks file contents into the step result."""
-    secret = tmp_path / "outside" / "secret.py"
-    secret.parent.mkdir(exist_ok=True)
-    secret.write_text("this is not valid python SECRET-MATERIAL\n")
-    target = str(secret) if shape == "absolute" else f"../outside/{secret.name}"
+    """Unguarded, this branch is an existence-and-syntax oracle for any host .py.
+
+    Asserts on the *containment* error specifically: reporting "Syntax error in
+    ..." would mean the file outside the workspace was opened and parsed, which
+    is the behaviour being removed.
+    """
+    outside_py = tmp_path / "outside" / "secret.py"
+    outside_py.parent.mkdir(exist_ok=True)
+    outside_py.write_text("this is not valid python\n")
+    target = str(outside_py) if shape == "absolute" else f"../outside/{outside_py.name}"
 
     result = _executor(workspace)._execute_verification(
         _step(StepType.VERIFICATION, target)
     )
 
     assert result.status == ExecutionStatus.FAILED
-    assert "SECRET-MATERIAL" not in (result.output or "") + (result.error or "")
+    assert "outside the workspace" in (result.error or ""), (
+        f"parsed a file outside the workspace: {result.error!r}"
+    )
 
 
 def test_verification_existence_probe_is_contained(workspace, outside):

--- a/tests/core/test_plan_engine_path_containment_906.py
+++ b/tests/core/test_plan_engine_path_containment_906.py
@@ -162,3 +162,37 @@ def test_rollback_refuses_a_path_outside_the_workspace(workspace, outside):
 
     assert outside.read_text() == "ORIGINAL"
     assert any("Refused to roll back" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# verification steps read files too (found in review)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", ["absolute", "dotdot"])
+def test_verification_cannot_read_a_python_file_outside_the_workspace(
+    workspace, tmp_path, shape
+):
+    """The SyntaxError message echoes the offending source line, so an
+    unguarded read here leaks file contents into the step result."""
+    secret = tmp_path / "outside" / "secret.py"
+    secret.parent.mkdir(exist_ok=True)
+    secret.write_text("this is not valid python SECRET-MATERIAL\n")
+    target = str(secret) if shape == "absolute" else f"../outside/{secret.name}"
+
+    result = _executor(workspace)._execute_verification(
+        _step(StepType.VERIFICATION, target)
+    )
+
+    assert result.status == ExecutionStatus.FAILED
+    assert "SECRET-MATERIAL" not in (result.output or "") + (result.error or "")
+
+
+def test_verification_existence_probe_is_contained(workspace, outside):
+    """The bare-path branch probes existence; unguarded it is a disclosure oracle."""
+    result = _executor(workspace)._execute_verification(
+        _step(StepType.VERIFICATION, str(outside))
+    )
+
+    assert result.status == ExecutionStatus.FAILED
+    assert "outside the workspace" in (result.error or "")

--- a/tests/core/test_plan_engine_path_containment_906.py
+++ b/tests/core/test_plan_engine_path_containment_906.py
@@ -1,0 +1,136 @@
+"""Plan-engine file operations stay inside the workspace (#906).
+
+``PlanStep.target`` is LLM-generated from task/PRD/imported-issue text — an
+indirect prompt-injection surface. The naive ``self.repo_path / step.target``
+was unsafe twice over: ``pathlib`` lets an *absolute* target replace the base
+entirely, and ``..`` walks out. A poisoned task run with ``--engine plan``
+could therefore write ``~/.ssh/authorized_keys``.
+
+Every test asserts on the **victim file**, not on the returned status, so it
+fails if the operation happens anyway.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.executor import Executor, ExecutionStatus
+from codeframe.core.planner import PlanStep, StepType
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    return ws
+
+
+@pytest.fixture
+def outside(tmp_path):
+    """A file next to — but not inside — the workspace."""
+    victim = tmp_path / "outside" / "authorized_keys"
+    victim.parent.mkdir()
+    victim.write_text("ORIGINAL")
+    return victim
+
+
+def _executor(workspace):
+    return Executor(llm_provider=None, repo_path=workspace)
+
+
+def _step(step_type: StepType, target: str) -> PlanStep:
+    return PlanStep(
+        index=1, type=step_type, description="poisoned step", target=target
+    )
+
+
+def _targets(outside: Path, workspace: Path) -> dict[str, str]:
+    """The two escape shapes, as a planner would emit them."""
+    return {
+        "absolute": str(outside),
+        "dotdot": f"../outside/{outside.name}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", ["absolute", "dotdot"])
+def test_create_cannot_write_outside_the_workspace(workspace, tmp_path, shape):
+    victim = tmp_path / "outside" / "new_file.txt"
+    victim.parent.mkdir()
+    target = str(victim) if shape == "absolute" else f"../outside/{victim.name}"
+
+    result = _executor(workspace)._execute_file_create(
+        _step(StepType.FILE_CREATE, target), context=None
+    )
+
+    assert result.status == ExecutionStatus.FAILED
+    assert not victim.exists(), f"created a file outside the workspace via {shape}"
+
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", ["absolute", "dotdot"])
+def test_edit_cannot_modify_outside_the_workspace(workspace, outside, shape):
+    target = _targets(outside, workspace)[shape]
+
+    result = _executor(workspace)._execute_file_edit(
+        _step(StepType.FILE_EDIT, target), context=None
+    )
+
+    assert result.status == ExecutionStatus.FAILED
+    assert outside.read_text() == "ORIGINAL", f"edited outside the workspace via {shape}"
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", ["absolute", "dotdot"])
+def test_delete_cannot_remove_outside_the_workspace(workspace, outside, shape):
+    target = _targets(outside, workspace)[shape]
+
+    result = _executor(workspace)._execute_file_delete(_step(StepType.FILE_DELETE, target))
+
+    assert result.status == ExecutionStatus.FAILED
+    assert outside.exists(), f"deleted a file outside the workspace via {shape}"
+
+
+# ---------------------------------------------------------------------------
+# The guard must not break the ordinary case
+# ---------------------------------------------------------------------------
+
+
+def test_delete_inside_the_workspace_still_works(workspace):
+    target = workspace / "sub" / "doomed.txt"
+    target.parent.mkdir()
+    target.write_text("bye")
+
+    result = _executor(workspace)._execute_file_delete(
+        _step(StepType.FILE_DELETE, "sub/doomed.txt")
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert not target.exists()
+
+
+def test_symlink_out_of_the_workspace_is_rejected(workspace, outside):
+    """Resolving before the containment check is what catches this."""
+    link = workspace / "escape.txt"
+    link.symlink_to(outside)
+
+    result = _executor(workspace)._execute_file_delete(
+        _step(StepType.FILE_DELETE, "escape.txt")
+    )
+
+    assert result.status == ExecutionStatus.FAILED
+    assert outside.exists()

--- a/tests/core/test_plan_engine_path_containment_906.py
+++ b/tests/core/test_plan_engine_path_containment_906.py
@@ -134,3 +134,31 @@ def test_symlink_out_of_the_workspace_is_rejected(workspace, outside):
 
     assert result.status == ExecutionStatus.FAILED
     assert outside.exists()
+
+
+def test_rollback_refuses_a_path_outside_the_workspace(workspace, outside):
+    """Rollback writes files too, from a recorded path rather than a fresh one.
+
+    The three guarded operations are the only things that record changes, so
+    this cannot be reached today — the check is here because the guarantee
+    would otherwise depend on a caller three methods away.
+    """
+    from datetime import datetime, timezone
+
+    from codeframe.core.executor import FileChange
+
+    executor = _executor(workspace)
+    executor.changes.append(
+        FileChange(
+            path=str(outside),
+            operation="edit",
+            original_content="OVERWRITTEN-BY-ROLLBACK",
+            new_content=None,
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+
+    messages = executor.rollback()
+
+    assert outside.read_text() == "ORIGINAL"
+    assert any("Refused to roll back" in m for m in messages)


### PR DESCRIPTION
Closes #906.

## Problem

`Executor._execute_file_create` / `_edit` / `_delete` each did `self.repo_path / step.target` with no containment check. `step.target` is LLM-generated by the planner from task/PRD/imported-GitHub-issue text — an input this project already treats as an indirect prompt-injection surface.

`pathlib` makes that join dangerous in two distinct ways:

- an **absolute** right-hand side replaces the base entirely — `Path("/repo") / "/home/u/.ssh/authorized_keys"` is `/home/u/.ssh/authorized_keys`
- `..` walks out

So a poisoned task run with `--engine plan` could create, overwrite, or delete any file the operator can write. Writing `~/.ssh/authorized_keys` is code execution. The ReAct engine's equivalent tools already called `_is_path_safe()`.

## Fix

`Executor._resolve_target()` joins and vets in one place; all three operations return a `FAILED` `StepResult` when the target lands outside `repo_path.resolve()`. Both sides are resolved before the check, so a **symlink** pointing out of the workspace is rejected along with `..` and absolute paths.

## On "reuse, don't copy a fourth time"

The acceptance criterion asked for reuse of `_is_path_safe`. Two things stood in the way:

1. It lived in `core/tools.py`, which already imports `is_dangerous_command` from `core/executor.py` — importing back would have been a cycle.
2. It was **already duplicated**: `core/tools.py:51` and `core/agent.py:81` held byte-equivalent implementations. Adding the executor would have made three, and a fourth was exactly what the criterion warned against.

So the check moved to a new leaf module `core/path_safety.py` (stdlib only, same pattern as `core/agent_env.py` from #905), and both existing copies became one-line aliases — call sites still read `_is_path_safe`, so no call-site churn. Net: one implementation, three consumers.

## Also fixed (found in review)

- **Verification steps** had two more unguarded joins of their own — the `.py` syntax-check branch and the bare-path existence probe. Unguarded, an absolute or `../` target makes a verification step an existence-and-syntax oracle for any `.py` on the host.
- **`rollback()`** joins `self.repo_path / change.path` and writes. Safe today only because every recorded path came from a now-guarded operation — an invariant held three methods away. Vetted locally.

## Known limitations

- **`SHELL_COMMAND` steps remain an uncontained write primitive.** `python -c '...write_text("/tmp/x")'` passes `is_dangerous_command()` and runs with the operator's filesystem rights. That is inherent to an engine whose job is running `pytest` / `npm install` / `make`; containing it needs OS-level isolation (worktree/E2B/container), not a path check. Guarding the file steps still removes the *direct* write primitive that required no shell at all.
- **TOCTOU is not closed.** A symlink swapped between the check and the write — exploiting the LLM-generation gap in create/edit — defeats the guard. Every variant requires an attacker already running concurrent code in the workspace, which per the point above already grants unrestricted writes, so this is not an escalation. A re-check immediately before the write would narrow the window without closing it, and would read as a stronger guarantee than it is.

## Tests

`tests/core/test_plan_engine_path_containment_906.py` — 8 tests. Both escape shapes (absolute and `../`) across create, edit, and delete, plus the symlink case and an in-workspace delete proving the guard does not break the ordinary path.

12 tests total with the verification and rollback cases. Every test asserts on the **victim file** rather than the returned status, so it fails if the operation happens anyway; the verification tests assert on the containment error specifically, because reporting `Syntax error in ...` would itself prove the outside file was opened. Mutation-checked: restoring the naive join fails 10 of the 12.
