### PR TITLE
fix(gates): create the target venv before installing dependencies (#908)

### DIFF
--- a/codeframe/core/agent_env.py
+++ b/codeframe/core/agent_env.py
@@ -86,10 +86,15 @@ def build_agent_env(workspace_path: Path | str) -> dict[str, str]:
         env[xdg] = str(sandbox_home / xdg.lower())
 
     for venv_dir in (".venv", "venv"):
-        venv_bin = workspace_path / venv_dir / "bin"
-        if venv_bin.is_dir():
-            env["PATH"] = str(venv_bin) + os.pathsep + env.get("PATH", "")
-            env["VIRTUAL_ENV"] = str(workspace_path / venv_dir)
-            break
+        # "Scripts" on Windows, "bin" everywhere else. Checking both rather than
+        # os.name means a venv created on either platform is recognised (#908
+        # review) — without this, a Windows target repo's pytest resolved from
+        # CodeFRAME's PATH instead of the repo's own venv.
+        for bin_dir in ("bin", "Scripts"):
+            venv_bin = workspace_path / venv_dir / bin_dir
+            if venv_bin.is_dir():
+                env["PATH"] = str(venv_bin) + os.pathsep + env.get("PATH", "")
+                env["VIRTUAL_ENV"] = str(workspace_path / venv_dir)
+                return env
 
     return env

--- a/codeframe/core/agent_env.py
+++ b/codeframe/core/agent_env.py
@@ -69,6 +69,15 @@ def build_agent_env(workspace_path: Path | str) -> dict[str, str]:
     sandbox_home = workspace_path / ".codeframe" / "agent-home"
     try:
         sandbox_home.mkdir(parents=True, exist_ok=True)
+        # The sandbox fills with pip/npm/cargo cache files, and it lives inside
+        # the workspace — so without this every one of them shows up as
+        # untracked, marking the tree dirty and (worse) landing in the PROOF9
+        # scope, which is built from `status.untracked_files`. Self-ignoring,
+        # the way `uv venv` does it, needs no git-directory resolution and works
+        # unchanged in the linked worktrees CodeFRAME creates.
+        gitignore = sandbox_home / ".gitignore"
+        if not gitignore.exists():
+            gitignore.write_text("*\n")
     except OSError:
         # Point at it anyway. Deleting HOME does NOT fail closed: with the
         # variable *unset*, `expanduser("~")` and everything built on it fall

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -371,18 +371,8 @@ def run(
     # if the missing dependencies actually matter, the gate that needs them
     # fails on its own and says why. SKIPPED rather than ERROR because this
     # check did not run to a verdict, and SKIPPED does not fail the run.
-    if not dep_success:
-        checks.append(
-            GateCheck(
-                name="dependency-check",
-                status=GateStatus.SKIPPED,
-                output=(
-                    f"Dependency installation failed, running gates anyway: {dep_message}"
-                ),
-            )
-        )
-        if verbose:
-            print(f"[gates] Dependency install failed (continuing): {dep_message}")
+    if not dep_success and verbose:
+        print(f"[gates] Dependency install failed (continuing): {dep_message}")
 
     repo_path = workspace.repo_path
 
@@ -427,6 +417,20 @@ def run(
                 )
 
         checks.append(check)
+
+    # Recorded after the gates, never before: proof/runner.py reads
+    # result.checks[0] as *the* gate's check, so a pre-flight entry at index 0
+    # would be mistaken for the gate result and reported as FAILED (SKIPPED).
+    if not dep_success:
+        checks.append(
+            GateCheck(
+                name="dependency-check",
+                status=GateStatus.SKIPPED,
+                output=(
+                    f"Dependency installation failed, ran gates anyway: {dep_message}"
+                ),
+            )
+        )
 
     completed_at = _utc_now()
 

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -226,6 +226,12 @@ def _install_python_requirements(
     try:
         created = _run(create_cmd, timeout=120)
         if created.returncode != 0:
+            # Discard the partial venv for the same reason as the install path
+            # below: CPython leaves `.venv/bin` behind when `-m venv` fails
+            # partway (Debian without python3-venv, disk full, permissions), and
+            # a stub directory makes `has_venv` true forever, so the install is
+            # skipped on every later run even once the cause is fixed.
+            _discard_failed_venv(venv_path)
             return False, f"Failed to create virtualenv: {created.stderr.strip()}"
 
         _self_ignore(venv_path)

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -7,6 +7,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import re
+import logging
 import os
 import shutil
 import subprocess
@@ -20,6 +21,8 @@ from typing import Any, Callable, Optional
 from codeframe.core.agent_env import build_agent_env
 from codeframe.core.workspace import Workspace
 from codeframe.core import events
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -214,30 +217,114 @@ def _install_python_requirements(
             cmd, cwd=repo_path, env=env, capture_output=True, text=True, timeout=timeout
         )
 
+    use_uv = shutil.which("uv") is not None
+    create_cmd = (
+        ["uv", "venv", str(venv_path)] if use_uv
+        else [sys.executable, "-m", "venv", str(venv_path)]
+    )
+
     try:
-        if shutil.which("uv"):
-            created = _run(["uv", "venv", str(venv_path)], timeout=120)
-            if created.returncode != 0:
-                return False, f"Failed to create virtualenv: {created.stderr.strip()}"
-            env["VIRTUAL_ENV"] = str(venv_path)
+        created = _run(create_cmd, timeout=120)
+        if created.returncode != 0:
+            return False, f"Failed to create virtualenv: {created.stderr.strip()}"
+
+        _exclude_from_git(repo_path, venv_path.name)
+        env["VIRTUAL_ENV"] = str(venv_path)
+
+        if use_uv:
             installed = _run(["uv", "pip", "install", "-r", str(requirements_txt)])
             manager = "uv"
         else:
-            created = _run([sys.executable, "-m", "venv", str(venv_path)], timeout=120)
-            if created.returncode != 0:
-                return False, f"Failed to create virtualenv: {created.stderr.strip()}"
-            env["VIRTUAL_ENV"] = str(venv_path)
-            # Call the venv's own pip by path rather than relying on PATH, so
-            # this cannot resolve to CodeFRAME's pip.
-            venv_pip = venv_path / ("Scripts" if os.name == "nt" else "bin") / "pip"
-            installed = _run([str(venv_pip), "install", "-r", str(requirements_txt)])
+            # `<venv>/bin/python -m pip` rather than the pip executable: it is
+            # the same on Windows (where the binary is `pip.exe`, not `pip`) and
+            # it cannot resolve to CodeFRAME's pip the way a bare name on PATH
+            # could (#908 review).
+            venv_python = _venv_python(venv_path)
+            installed = _run([str(venv_python), "-m", "pip", "install", "-r", str(requirements_txt)])
             manager = "pip"
     except (OSError, subprocess.SubprocessError) as exc:
+        _discard_failed_venv(venv_path)
         return False, f"Error installing Python dependencies: {exc}"
 
     if installed.returncode != 0:
+        # Remove the venv we just made. Leaving it behind marks the repo as
+        # "already installed (venv exists)" forever, so a transient network
+        # failure would permanently skip the install (#908 review).
+        _discard_failed_venv(venv_path)
         return False, f"Failed to install Python dependencies: {installed.stderr.strip()}"
     return True, f"Installed Python dependencies via {manager}: {requirements_txt.name}"
+
+
+def _venv_python(venv_path: Path) -> Path:
+    """The interpreter inside *venv_path*, on either platform."""
+    for bin_dir, exe in (("bin", "python"), ("Scripts", "python.exe")):
+        candidate = venv_path / bin_dir / exe
+        if candidate.exists():
+            return candidate
+    return venv_path / ("Scripts" if os.name == "nt" else "bin") / "python"
+
+
+def _discard_failed_venv(venv_path: Path) -> None:
+    """Remove a venv whose install failed, so the next run retries."""
+    try:
+        shutil.rmtree(venv_path, ignore_errors=True)
+    except OSError as exc:  # pragma: no cover - rmtree already swallows most
+        logger.warning("Could not remove the incomplete virtualenv %s: %s", venv_path, exc)
+
+
+def _exclude_from_git(repo_path: Path, name: str) -> None:
+    """Ignore *name* locally via ``.git/info/exclude``.
+
+    A venv we create is untracked, and `get_changed_scope` feeds
+    ``status.untracked_files`` straight into the PROOF9 scope — so without this
+    a `cf review` in a repo that does not already ignore `.venv` both reports
+    the tree dirty and drags thousands of site-packages files into the scope.
+
+    ``.git/info/exclude`` rather than ``.gitignore``: it is local-only and never
+    committed, so this does not edit a file the user tracks.
+    """
+    git_dir = _resolve_git_dir(repo_path)
+    if git_dir is None:
+        return  # not a git repo — nothing to exclude from
+
+    entry = f"/{name}/"
+    exclude_file = git_dir / "info" / "exclude"
+    try:
+        # `git init` does not create .git/info, so this must be made rather
+        # than assumed — checking for it and bailing made the whole thing a
+        # silent no-op in freshly initialised repos.
+        exclude_file.parent.mkdir(parents=True, exist_ok=True)
+        existing = exclude_file.read_text() if exclude_file.exists() else ""
+        if any(line.strip() in (entry, f"{name}/", name) for line in existing.splitlines()):
+            return
+        prefix = "" if not existing or existing.endswith("\n") else "\n"
+        with exclude_file.open("a") as handle:
+            handle.write(f"{prefix}{entry}\n")
+    except OSError as exc:
+        logger.debug("Could not update %s: %s", exclude_file, exc)
+
+
+def _resolve_git_dir(repo_path: Path) -> Optional[Path]:
+    """The ``$GIT_DIR`` for *repo_path*, or None if it is not a git repo.
+
+    In a linked worktree — which CodeFRAME creates for isolated runs — ``.git``
+    is a *file* containing ``gitdir: <path>``, and git reads
+    ``$GIT_DIR/info/exclude`` from that per-worktree directory.
+    """
+    dot_git = repo_path / ".git"
+    if dot_git.is_dir():
+        return dot_git
+    if dot_git.is_file():
+        try:
+            content = dot_git.read_text().strip()
+        except OSError:
+            return None
+        if content.startswith("gitdir:"):
+            target = Path(content.split(":", 1)[1].strip())
+            if not target.is_absolute():
+                target = (repo_path / target).resolve()
+            return target if target.is_dir() else None
+    return None
 
 
 def _ensure_dependencies_installed(

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -284,6 +284,10 @@ def _self_ignore(venv_path: Path) -> None:
     ``.git/info/exclude``: it needs no git-directory resolution, works
     unchanged in the linked worktrees CodeFRAME creates (where ``.git`` is a
     file), and is the convention the ecosystem already uses.
+
+    Still required despite both of those: CPython only started writing this file
+    in **3.13**, and this project supports ``>=3.11``. On a 3.13 interpreter the
+    stdlib fallback already self-ignores and this is a no-op.
     """
     try:
         (venv_path / ".gitignore").write_text("*\n")

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -228,7 +228,7 @@ def _install_python_requirements(
         if created.returncode != 0:
             return False, f"Failed to create virtualenv: {created.stderr.strip()}"
 
-        _exclude_from_git(repo_path, venv_path.name)
+        _self_ignore(venv_path)
         env["VIRTUAL_ENV"] = str(venv_path)
 
         if use_uv:
@@ -272,59 +272,23 @@ def _discard_failed_venv(venv_path: Path) -> None:
         logger.warning("Could not remove the incomplete virtualenv %s: %s", venv_path, exc)
 
 
-def _exclude_from_git(repo_path: Path, name: str) -> None:
-    """Ignore *name* locally via ``.git/info/exclude``.
+def _self_ignore(venv_path: Path) -> None:
+    """Make the venv ignore itself, the way ``uv venv`` already does.
 
-    A venv we create is untracked, and `get_changed_scope` feeds
+    A venv we create is untracked, and ``get_changed_scope`` feeds
     ``status.untracked_files`` straight into the PROOF9 scope — so without this
-    a `cf review` in a repo that does not already ignore `.venv` both reports
-    the tree dirty and drags thousands of site-packages files into the scope.
+    a ``cf review`` reports the tree dirty and drags site-packages into the
+    scope. ``uv venv`` writes this file itself; the stdlib ``venv`` does not.
 
-    ``.git/info/exclude`` rather than ``.gitignore``: it is local-only and never
-    committed, so this does not edit a file the user tracks.
+    A ``.gitignore`` *inside* the venv rather than an entry in
+    ``.git/info/exclude``: it needs no git-directory resolution, works
+    unchanged in the linked worktrees CodeFRAME creates (where ``.git`` is a
+    file), and is the convention the ecosystem already uses.
     """
-    git_dir = _resolve_git_dir(repo_path)
-    if git_dir is None:
-        return  # not a git repo — nothing to exclude from
-
-    entry = f"/{name}/"
-    exclude_file = git_dir / "info" / "exclude"
     try:
-        # `git init` does not create .git/info, so this must be made rather
-        # than assumed — checking for it and bailing made the whole thing a
-        # silent no-op in freshly initialised repos.
-        exclude_file.parent.mkdir(parents=True, exist_ok=True)
-        existing = exclude_file.read_text() if exclude_file.exists() else ""
-        if any(line.strip() in (entry, f"{name}/", name) for line in existing.splitlines()):
-            return
-        prefix = "" if not existing or existing.endswith("\n") else "\n"
-        with exclude_file.open("a") as handle:
-            handle.write(f"{prefix}{entry}\n")
+        (venv_path / ".gitignore").write_text("*\n")
     except OSError as exc:
-        logger.debug("Could not update %s: %s", exclude_file, exc)
-
-
-def _resolve_git_dir(repo_path: Path) -> Optional[Path]:
-    """The ``$GIT_DIR`` for *repo_path*, or None if it is not a git repo.
-
-    In a linked worktree — which CodeFRAME creates for isolated runs — ``.git``
-    is a *file* containing ``gitdir: <path>``, and git reads
-    ``$GIT_DIR/info/exclude`` from that per-worktree directory.
-    """
-    dot_git = repo_path / ".git"
-    if dot_git.is_dir():
-        return dot_git
-    if dot_git.is_file():
-        try:
-            content = dot_git.read_text().strip()
-        except OSError:
-            return None
-        if content.startswith("gitdir:"):
-            target = Path(content.split(":", 1)[1].strip())
-            if not target.is_absolute():
-                target = (repo_path / target).resolve()
-            return target if target.is_dir() else None
-    return None
+        logger.debug("Could not write %s/.gitignore: %s", venv_path, exc)
 
 
 def _ensure_dependencies_installed(

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -202,11 +202,12 @@ def _install_python_requirements(
     """
     venv_path = repo_path / ".venv"
 
+    # NB: the repo has no venv at this point, so build_agent_env copies
+    # VIRTUAL_ENV straight from the parent — CodeFRAME's own when `cf` is run
+    # from an activated environment. Every install below therefore *sets* it
+    # explicitly to the venv just created; inheriting it is what made the old
+    # fallback install the target repo's dependencies into CodeFRAME's env.
     env = build_agent_env(repo_path)
-    # The repo has no venv yet, so build_agent_env copied VIRTUAL_ENV straight
-    # from the parent — which is CodeFRAME's own when `cf` is run from an
-    # activated environment. Drop it before creating anything.
-    env.pop("VIRTUAL_ENV", None)
 
     def _run(cmd: list[str], timeout: int = 300) -> subprocess.CompletedProcess:
         return subprocess.run(

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -7,8 +7,10 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import re
-import subprocess
+import os
 import shutil
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -178,6 +180,65 @@ class GateResult:
         return by_file
 
 
+def _install_python_requirements(
+    repo_path: Path, requirements_txt: Path
+) -> tuple[bool, str]:
+    """Install a target repo's requirements into a venv *of its own* (#908).
+
+    This runs in exactly the state where ``requirements.txt`` exists and no venv
+    does, and the previous implementation ran ``uv pip install -r ...`` straight
+    away — which errors in precisely that state::
+
+        error: No virtual environment found; run `uv venv` to create an
+        environment, or pass `--system` to install into a non-virtual environment
+
+    so the install could never succeed where it was triggered. Worse, when
+    CodeFRAME itself runs inside an activated venv, the inherited ``VIRTUAL_ENV``
+    made the fallback install the *target repo's* dependencies into CodeFRAME's
+    own environment.
+
+    Both are fixed by creating the venv first and pinning ``VIRTUAL_ENV`` to it,
+    never to whatever the parent process happened to be using.
+    """
+    venv_path = repo_path / ".venv"
+
+    env = build_agent_env(repo_path)
+    # The repo has no venv yet, so build_agent_env copied VIRTUAL_ENV straight
+    # from the parent — which is CodeFRAME's own when `cf` is run from an
+    # activated environment. Drop it before creating anything.
+    env.pop("VIRTUAL_ENV", None)
+
+    def _run(cmd: list[str], timeout: int = 300) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            cmd, cwd=repo_path, env=env, capture_output=True, text=True, timeout=timeout
+        )
+
+    try:
+        if shutil.which("uv"):
+            created = _run(["uv", "venv", str(venv_path)], timeout=120)
+            if created.returncode != 0:
+                return False, f"Failed to create virtualenv: {created.stderr.strip()}"
+            env["VIRTUAL_ENV"] = str(venv_path)
+            installed = _run(["uv", "pip", "install", "-r", str(requirements_txt)])
+            manager = "uv"
+        else:
+            created = _run([sys.executable, "-m", "venv", str(venv_path)], timeout=120)
+            if created.returncode != 0:
+                return False, f"Failed to create virtualenv: {created.stderr.strip()}"
+            env["VIRTUAL_ENV"] = str(venv_path)
+            # Call the venv's own pip by path rather than relying on PATH, so
+            # this cannot resolve to CodeFRAME's pip.
+            venv_pip = venv_path / ("Scripts" if os.name == "nt" else "bin") / "pip"
+            installed = _run([str(venv_pip), "install", "-r", str(requirements_txt)])
+            manager = "pip"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"Error installing Python dependencies: {exc}"
+
+    if installed.returncode != 0:
+        return False, f"Failed to install Python dependencies: {installed.stderr.strip()}"
+    return True, f"Installed Python dependencies via {manager}: {requirements_txt.name}"
+
+
 def _ensure_dependencies_installed(
     repo_path: Path,
     auto_install: bool = True,
@@ -212,38 +273,11 @@ def _ensure_dependencies_installed(
             uv_bin = shutil.which("uv")
             pip_bin = shutil.which("pip")
 
-            if uv_bin:
-                try:
-                    result = subprocess.run(
-                        ["uv", "pip", "install", "-r", str(requirements_txt)],
-                        cwd=repo_path,
-                        env=build_agent_env(repo_path),
-                        capture_output=True,
-                        text=True,
-                        timeout=300,  # 5 minutes
-                    )
-                    if result.returncode == 0:
-                        messages.append(f"Installed Python dependencies via uv: {requirements_txt.name}")
-                    else:
-                        return False, f"Failed to install Python dependencies: {result.stderr}"
-                except Exception as e:
-                    return False, f"Error installing Python dependencies: {e}"
-            elif pip_bin:
-                try:
-                    result = subprocess.run(
-                        ["pip", "install", "-r", str(requirements_txt)],
-                        cwd=repo_path,
-                        env=build_agent_env(repo_path),
-                        capture_output=True,
-                        text=True,
-                        timeout=300,
-                    )
-                    if result.returncode == 0:
-                        messages.append(f"Installed Python dependencies via pip: {requirements_txt.name}")
-                    else:
-                        return False, f"Failed to install Python dependencies: {result.stderr}"
-                except Exception as e:
-                    return False, f"Error installing Python dependencies: {e}"
+            if uv_bin or pip_bin:
+                ok, message = _install_python_requirements(repo_path, requirements_txt)
+                if not ok:
+                    return False, message
+                messages.append(message)
             else:
                 messages.append("Python dependencies needed but no package manager found (uv/pip)")
     elif requirements_txt.exists() and has_venv:
@@ -327,32 +361,28 @@ def run(
     if verbose:
         print(f"[gates] Dependency check: {dep_message}")
 
-    # If dependency installation fails, create an ERROR check and return early
-    if not dep_success:
-        check = GateCheck(
-            name="dependency-check",
-            status=GateStatus.ERROR,
-            output=f"Dependency installation failed: {dep_message}",
-        )
-        result = GateResult(
-            passed=False,
-            checks=[check],
-            started_at=started_at,
-            completed_at=_utc_now(),
-        )
-        events.emit_for_workspace(
-            workspace,
-            events.EventType.GATES_COMPLETED,
-            {
-                "passed": False,
-                "summary": "Dependency installation failed",
-                "checks": [{"name": check.name, "status": check.status.value}],
-            },
-            print_event=True,
-        )
-        return result
-
     checks: list[GateCheck] = []
+
+    # A failed dependency install is recorded and the gates run anyway (#908).
+    # Returning early here blocked *every* gate — including ruff and tsc, which
+    # need no Python dependencies at all — and poisoned every PROOF9 run, since
+    # runner._run_gate calls this per obligation. It also hid the real signal:
+    # if the missing dependencies actually matter, the gate that needs them
+    # fails on its own and says why. SKIPPED rather than ERROR because this
+    # check did not run to a verdict, and SKIPPED does not fail the run.
+    if not dep_success:
+        checks.append(
+            GateCheck(
+                name="dependency-check",
+                status=GateStatus.SKIPPED,
+                output=(
+                    f"Dependency installation failed, running gates anyway: {dep_message}"
+                ),
+            )
+        )
+        if verbose:
+            print(f"[gates] Dependency install failed (continuing): {dep_message}")
+
     repo_path = workspace.repo_path
 
     # Determine which gates to run

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -333,3 +333,39 @@ def test_windows_style_venv_is_recognised(tmp_path):
     assert env["PATH"].startswith(str(scripts))
 
 
+
+
+def test_a_failed_venv_creation_leaves_no_stub(tmp_path, monkeypatch):
+    """CPython leaves `.venv/bin` behind when `-m venv` fails partway.
+
+    A stub directory makes `has_venv` true forever, so the install is skipped
+    on every later run — the same permanent-skip bug as a failed install, just
+    one step earlier.
+    """
+    from codeframe.core import gates as gates_module
+
+    repo = tmp_path / "no-ensurepip"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("packaging\n")
+
+    real_run = subprocess.run
+
+    def fail_creation(cmd, **kwargs):
+        if "venv" in cmd:
+            # Mimic CPython: leave a partial tree behind, then fail.
+            (repo / ".venv" / "bin").mkdir(parents=True, exist_ok=True)
+            return subprocess.CompletedProcess(
+                cmd, 1, "", "Error: Command '['.venv/bin/python', '-Im', 'ensurepip']' failed"
+            )
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(gates_module.subprocess, "run", fail_creation)
+
+    ok, message = gates_module._install_python_requirements(
+        repo, repo / "requirements.txt"
+    )
+
+    assert not ok
+    assert not (repo / ".venv").exists(), (
+        "a venv stub survived; every later run would report 'already installed'"
+    )

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -1,0 +1,172 @@
+"""Gate dependency auto-install works in the state that triggers it (#908).
+
+``_ensure_dependencies_installed`` fires exactly when ``requirements.txt``
+exists and no venv does — and the old implementation ran ``uv pip install -r``
+immediately, which errors in precisely that state::
+
+    error: No virtual environment found; run `uv venv` to create an
+    environment, or pass `--system` to install into a non-virtual environment
+
+So the install could never succeed where it was triggered, ``run()`` returned
+early with an ERROR, and *every* gate was blocked — including ruff and tsc,
+which need no Python dependencies — for any pip-style repo. Every PROOF9 run
+inherited that, since the runner calls ``gates.run`` per obligation.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.gates import (
+    GateStatus,
+    _ensure_dependencies_installed,
+    _install_python_requirements,
+)
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def pip_repo(tmp_path):
+    """The exact trigger state: requirements.txt present, no venv."""
+    repo = tmp_path / "target-repo"
+    repo.mkdir()
+    # A dependency with no transitive deps, so the test does not depend on a
+    # large download. Real install, no mocking.
+    (repo / "requirements.txt").write_text("packaging\n")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# The install must succeed in its own trigger state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+def test_install_succeeds_when_no_venv_exists(pip_repo):
+    ok, message = _install_python_requirements(pip_repo, pip_repo / "requirements.txt")
+
+    assert ok, message
+    assert (pip_repo / ".venv").is_dir(), "no venv was created"
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+def test_the_package_lands_in_the_target_venv(pip_repo):
+    """Not merely 'the command exited 0' — the package must be importable there."""
+    _install_python_requirements(pip_repo, pip_repo / "requirements.txt")
+
+    venv_python = pip_repo / ".venv" / "bin" / "python"
+    assert venv_python.exists()
+
+    proc = subprocess.run(
+        [str(venv_python), "-c", "import packaging; print(packaging.__file__)"],
+        capture_output=True, text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert str(pip_repo) in proc.stdout, "installed outside the target repo's venv"
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+def test_never_installs_into_codeframes_own_environment(pip_repo, monkeypatch):
+    """`cf` run from an activated venv used to install into *that* venv.
+
+    VIRTUAL_ENV is on the env allowlist, and the repo has no venv of its own at
+    trigger time, so it was inherited straight from the parent process.
+    """
+    codeframe_venv = Path(sys.prefix)
+    monkeypatch.setenv("VIRTUAL_ENV", str(codeframe_venv))
+
+    ok, message = _install_python_requirements(pip_repo, pip_repo / "requirements.txt")
+
+    assert ok, message
+    venv_python = pip_repo / ".venv" / "bin" / "python"
+    proc = subprocess.run(
+        [str(venv_python), "-c", "import packaging; print(packaging.__file__)"],
+        capture_output=True, text=True,
+    )
+    assert str(pip_repo) in proc.stdout, (
+        f"installed into {proc.stdout.strip()} rather than the target repo's venv"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A failed install must not block the gates
+# ---------------------------------------------------------------------------
+
+
+def test_failed_install_still_runs_the_gates(tmp_path, monkeypatch):
+    """ruff needs no Python dependencies; it must still run when install fails."""
+    from codeframe.core import gates as gates_module
+    from codeframe.core.workspace import create_or_load_workspace
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("packaging\n")
+    (repo / "clean.py").write_text("x = 1\n")
+
+    workspace = create_or_load_workspace(repo)
+
+    monkeypatch.setattr(
+        gates_module,
+        "_ensure_dependencies_installed",
+        lambda *a, **k: (False, "simulated install failure"),
+    )
+
+    result = gates_module.run(workspace, gates=["ruff"], verbose=False)
+
+    names = {c.name for c in result.checks}
+    assert "ruff" in names, f"gates did not run; only got {names}"
+
+    dep_check = next(c for c in result.checks if c.name == "dependency-check")
+    assert dep_check.status == GateStatus.SKIPPED
+    assert "simulated install failure" in dep_check.output
+
+
+def test_a_failed_install_alone_does_not_fail_the_run(tmp_path, monkeypatch):
+    """SKIPPED does not fail the run; the gate that actually needs the deps does."""
+    from codeframe.core import gates as gates_module
+    from codeframe.core.workspace import create_or_load_workspace
+
+    repo = tmp_path / "repo2"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("packaging\n")
+    (repo / "clean.py").write_text("x = 1\n")
+
+    workspace = create_or_load_workspace(repo)
+    monkeypatch.setattr(
+        gates_module,
+        "_ensure_dependencies_installed",
+        lambda *a, **k: (False, "simulated install failure"),
+    )
+
+    result = gates_module.run(workspace, gates=["ruff"], verbose=False)
+
+    assert result.passed, [(c.name, c.status, c.output[:120]) for c in result.checks]
+
+
+# ---------------------------------------------------------------------------
+# The ordinary paths still behave
+# ---------------------------------------------------------------------------
+
+
+def test_existing_venv_is_left_alone(tmp_path):
+    repo = tmp_path / "has-venv"
+    (repo / ".venv").mkdir(parents=True)
+    (repo / "requirements.txt").write_text("packaging\n")
+
+    ok, message = _ensure_dependencies_installed(repo, auto_install=True)
+
+    assert ok
+    assert "already installed" in message
+
+
+def test_auto_install_disabled_is_reported_not_attempted(pip_repo):
+    ok, message = _ensure_dependencies_installed(pip_repo, auto_install=False)
+
+    assert ok
+    assert "auto-install disabled" in message
+    assert not (pip_repo / ".venv").exists()

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -170,3 +170,34 @@ def test_auto_install_disabled_is_reported_not_attempted(pip_repo):
     assert ok
     assert "auto-install disabled" in message
     assert not (pip_repo / ".venv").exists()
+
+
+def test_dependency_note_never_displaces_the_gate_check(tmp_path, monkeypatch):
+    """proof/runner.py reads `result.checks[0]` as *the* gate's check.
+
+    A pre-flight entry at index 0 would be mistaken for the gate result and
+    reported as `FAILED (SKIPPED)` for every enforced PROOF9 rule — a failure
+    with nothing to do with the test it names.
+    """
+    from codeframe.core import gates as gates_module
+    from codeframe.core.workspace import create_or_load_workspace
+
+    repo = tmp_path / "repo3"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("packaging\n")
+    (repo / "clean.py").write_text("x = 1\n")
+
+    workspace = create_or_load_workspace(repo)
+    monkeypatch.setattr(
+        gates_module,
+        "_ensure_dependencies_installed",
+        lambda *a, **k: (False, "simulated install failure"),
+    )
+
+    result = gates_module.run(workspace, gates=["ruff"], verbose=False)
+
+    assert result.checks[0].name == "ruff", (
+        f"checks[0] is {result.checks[0].name!r}; the proof runner would read "
+        "the dependency note as the gate result"
+    )
+    assert result.checks[-1].name == "dependency-check"

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -201,3 +201,135 @@ def test_dependency_note_never_displaces_the_gate_check(tmp_path, monkeypatch):
         "the dependency note as the gate result"
     )
     assert result.checks[-1].name == "dependency-check"
+
+
+# ---------------------------------------------------------------------------
+# Review findings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+def test_a_failed_install_does_not_leave_a_venv_behind(tmp_path):
+    """Otherwise the repo is 'already installed (venv exists)' forever.
+
+    `uv venv` succeeds, the install fails on a transient network error, and the
+    leftover `.venv` makes every later run skip the install — permanently, even
+    once the network is back.
+    """
+    repo = tmp_path / "bad-requirements"
+    repo.mkdir()
+    # A requirement that cannot resolve, so the install fails after the venv
+    # has already been created.
+    (repo / "requirements.txt").write_text(
+        "codeframe-nonexistent-package-908-test==9.9.9\n"
+    )
+
+    ok, message = _install_python_requirements(repo, repo / "requirements.txt")
+
+    assert not ok
+    assert not (repo / ".venv").exists(), (
+        "the incomplete venv survived; the next run would report "
+        "'already installed' and never retry"
+    )
+
+    # And the next check therefore still sees work to do.
+    _, next_message = _ensure_dependencies_installed(repo, auto_install=False)
+    assert "not installed" in next_message
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+def test_a_created_venv_is_excluded_from_git(tmp_path):
+    """`get_changed_scope` feeds untracked files into the PROOF9 scope.
+
+    Without a local ignore, `cf review` in a repo that does not already ignore
+    `.venv` reports the tree dirty and drags site-packages into the scope.
+    """
+    repo = tmp_path / "git-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "requirements.txt").write_text("packaging\n")
+
+    _install_python_requirements(repo, repo / "requirements.txt")
+
+    assert (repo / ".venv").is_dir()
+    untracked = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=repo, capture_output=True, text=True,
+    ).stdout
+    assert ".venv" not in untracked, f"git still reports .venv as untracked:\n{untracked}"
+
+
+def test_exclude_is_written_once(tmp_path):
+    """Repeated runs must not append the same entry over and over."""
+    from codeframe.core.gates import _exclude_from_git
+
+    repo = tmp_path / "repeat-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    for _ in range(3):
+        _exclude_from_git(repo, ".venv")
+
+    exclude = (repo / ".git" / "info" / "exclude").read_text()
+    assert exclude.count("/.venv/") == 1
+
+
+def test_exclude_is_a_no_op_outside_a_git_repo(tmp_path):
+    """Gates run on plain directories too; this must not raise."""
+    from codeframe.core.gates import _exclude_from_git
+
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+
+    _exclude_from_git(plain, ".venv")  # must not raise
+
+    assert not (plain / ".git").exists()
+
+
+def test_windows_style_venv_is_recognised(tmp_path):
+    """build_agent_env only looked for `bin`, so a Windows venv was ignored and
+    the target repo's pytest resolved from CodeFRAME's PATH instead."""
+    from codeframe.core.agent_env import build_agent_env
+
+    repo = tmp_path / "win-repo"
+    scripts = repo / ".venv" / "Scripts"
+    scripts.mkdir(parents=True)
+
+    env = build_agent_env(repo)
+
+    assert env["VIRTUAL_ENV"] == str(repo / ".venv")
+    assert env["PATH"].startswith(str(scripts))
+
+
+def test_exclude_works_in_a_linked_worktree(tmp_path):
+    """CodeFRAME runs agents in linked worktrees, where `.git` is a *file*.
+
+    `$GIT_DIR` is then `.git/worktrees/<id>`, and that is where git reads
+    `info/exclude` from — the repo-root path would be the wrong file.
+    """
+    from codeframe.core.gates import _exclude_from_git
+
+    main = tmp_path / "main"
+    main.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=main, check=True)
+    (main / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=main, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"],
+        cwd=main, check=True,
+    )
+
+    linked = tmp_path / "linked"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(linked), "-b", "wt"], cwd=main, check=True
+    )
+    assert (linked / ".git").is_file(), "expected a gitfile layout"
+
+    (linked / ".venv").mkdir()
+    _exclude_from_git(linked, ".venv")
+
+    untracked = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=linked, capture_output=True, text=True,
+    ).stdout
+    assert ".venv" not in untracked, f"worktree still reports .venv:\n{untracked}"

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -237,12 +237,29 @@ def test_a_failed_install_does_not_leave_a_venv_behind(tmp_path):
     assert "not installed" in next_message
 
 
+def test_self_ignore_writes_the_ignore_file(tmp_path):
+    """Deterministic check of the helper itself.
+
+    The end-to-end test below cannot discriminate on this machine: `uv venv`
+    writes `.venv/.gitignore` itself, and CPython does too since **3.13**. This
+    project supports `>=3.11`, where neither is true — so the helper is tested
+    directly rather than through an interpreter-dependent path.
+    """
+    from codeframe.core.gates import _self_ignore
+
+    venv = tmp_path / ".venv"
+    venv.mkdir()
+
+    _self_ignore(venv)
+
+    assert (venv / ".gitignore").read_text().strip() == "*"
+
+
 def test_a_created_venv_is_ignored_by_git(tmp_path, monkeypatch):
     """`get_changed_scope` feeds untracked files into the PROOF9 scope.
 
-    Exercises the **stdlib venv** path specifically: `uv venv` writes
-    `.venv/.gitignore` itself, so a uv-based test would pass whether or not we
-    do anything. The fallback is where this actually matters.
+    A property test: the venv must not be untracked, whether that comes from
+    `_self_ignore`, `uv venv`, or CPython >= 3.13.
     """
     from codeframe.core import gates as gates_module
 

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -237,21 +237,27 @@ def test_a_failed_install_does_not_leave_a_venv_behind(tmp_path):
     assert "not installed" in next_message
 
 
-@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
-def test_a_created_venv_is_excluded_from_git(tmp_path):
+def test_a_created_venv_is_ignored_by_git(tmp_path, monkeypatch):
     """`get_changed_scope` feeds untracked files into the PROOF9 scope.
 
-    Without a local ignore, `cf review` in a repo that does not already ignore
-    `.venv` reports the tree dirty and drags site-packages into the scope.
+    Exercises the **stdlib venv** path specifically: `uv venv` writes
+    `.venv/.gitignore` itself, so a uv-based test would pass whether or not we
+    do anything. The fallback is where this actually matters.
     """
+    from codeframe.core import gates as gates_module
+
     repo = tmp_path / "git-repo"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     (repo / "requirements.txt").write_text("packaging\n")
 
-    _install_python_requirements(repo, repo / "requirements.txt")
+    monkeypatch.setattr(gates_module.shutil, "which", lambda cmd: None)
 
-    assert (repo / ".venv").is_dir()
+    ok, message = gates_module._install_python_requirements(
+        repo, repo / "requirements.txt"
+    )
+    assert ok, message
+
     untracked = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=all"],
         cwd=repo, capture_output=True, text=True,
@@ -259,55 +265,13 @@ def test_a_created_venv_is_excluded_from_git(tmp_path):
     assert ".venv" not in untracked, f"git still reports .venv as untracked:\n{untracked}"
 
 
-def test_exclude_is_written_once(tmp_path):
-    """Repeated runs must not append the same entry over and over."""
-    from codeframe.core.gates import _exclude_from_git
-
-    repo = tmp_path / "repeat-repo"
-    repo.mkdir()
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-
-    for _ in range(3):
-        _exclude_from_git(repo, ".venv")
-
-    exclude = (repo / ".git" / "info" / "exclude").read_text()
-    assert exclude.count("/.venv/") == 1
-
-
-def test_exclude_is_a_no_op_outside_a_git_repo(tmp_path):
-    """Gates run on plain directories too; this must not raise."""
-    from codeframe.core.gates import _exclude_from_git
-
-    plain = tmp_path / "not-a-repo"
-    plain.mkdir()
-
-    _exclude_from_git(plain, ".venv")  # must not raise
-
-    assert not (plain / ".git").exists()
-
-
-def test_windows_style_venv_is_recognised(tmp_path):
-    """build_agent_env only looked for `bin`, so a Windows venv was ignored and
-    the target repo's pytest resolved from CodeFRAME's PATH instead."""
-    from codeframe.core.agent_env import build_agent_env
-
-    repo = tmp_path / "win-repo"
-    scripts = repo / ".venv" / "Scripts"
-    scripts.mkdir(parents=True)
-
-    env = build_agent_env(repo)
-
-    assert env["VIRTUAL_ENV"] == str(repo / ".venv")
-    assert env["PATH"].startswith(str(scripts))
-
-
-def test_exclude_works_in_a_linked_worktree(tmp_path):
+def test_the_ignore_travels_with_the_venv_into_a_worktree(tmp_path):
     """CodeFRAME runs agents in linked worktrees, where `.git` is a *file*.
 
-    `$GIT_DIR` is then `.git/worktrees/<id>`, and that is where git reads
-    `info/exclude` from — the repo-root path would be the wrong file.
+    A `.gitignore` inside the venv needs no git-directory resolution, so this
+    works there unchanged — which an entry in `.git/info/exclude` would not.
     """
-    from codeframe.core.gates import _exclude_from_git
+    from codeframe.core.gates import _self_ignore
 
     main = tmp_path / "main"
     main.mkdir()
@@ -325,11 +289,30 @@ def test_exclude_works_in_a_linked_worktree(tmp_path):
     )
     assert (linked / ".git").is_file(), "expected a gitfile layout"
 
-    (linked / ".venv").mkdir()
-    _exclude_from_git(linked, ".venv")
+    venv = linked / ".venv"
+    (venv / "lib").mkdir(parents=True)
+    (venv / "lib" / "junk.py").write_text("x = 1\n")
+    _self_ignore(venv)
 
     untracked = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=all"],
         cwd=linked, capture_output=True, text=True,
     ).stdout
     assert ".venv" not in untracked, f"worktree still reports .venv:\n{untracked}"
+
+
+def test_windows_style_venv_is_recognised(tmp_path):
+    """build_agent_env only looked for `bin`, so a Windows venv was ignored and
+    the target repo's pytest resolved from CodeFRAME's PATH instead."""
+    from codeframe.core.agent_env import build_agent_env
+
+    repo = tmp_path / "win-repo"
+    scripts = repo / ".venv" / "Scripts"
+    scripts.mkdir(parents=True)
+
+    env = build_agent_env(repo)
+
+    assert env["VIRTUAL_ENV"] == str(repo / ".venv")
+    assert env["PATH"].startswith(str(scripts))
+
+

--- a/tests/core/test_gates_observability.py
+++ b/tests/core/test_gates_observability.py
@@ -326,7 +326,19 @@ class TestDependencyPreFlight:
 
         assert success is True
         assert "installed" in message.lower() or "success" in message.lower()
-        mock_run.assert_called_once()
+
+        # Two calls now (#908): the venv must be created before the install,
+        # because `uv pip install` errors in exactly the state that triggers
+        # this ("No virtual environment found ... or pass --system").
+        assert mock_run.call_count == 2
+        create_argv, install_argv = (c.args[0] for c in mock_run.call_args_list)
+        assert create_argv[:2] == ["uv", "venv"]
+        assert install_argv[:3] == ["uv", "pip", "install"]
+
+        # And the install must be pinned to the venv just created, never to
+        # whatever VIRTUAL_ENV the parent process happened to have.
+        install_env = mock_run.call_args_list[1].kwargs["env"]
+        assert install_env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
 
     @patch("codeframe.core.gates.subprocess.run")
     @patch("codeframe.core.gates.shutil.which")

--- a/tests/core/test_subprocess_env_isolation_907.py
+++ b/tests/core/test_subprocess_env_isolation_907.py
@@ -155,19 +155,32 @@ def test_gate_subprocess_environment_has_no_platform_secrets(
 def test_every_gates_subprocess_passes_an_environment():
     """Guards the next spawn site added without `env=`.
 
-    A behavioural test cannot reach all 13 runners without the toolchains they
-    shell out to, so this asserts the source invariant directly: every
-    `subprocess.run` in gates.py is given an explicit environment.
+    A behavioural test cannot reach all the runners without the toolchains they
+    shell out to (npm, mypy, tsc), so this asserts the source invariant: every
+    `subprocess.run` in gates.py is given an explicit environment. Parsed rather
+    than grepped, so a call that passes `env=` some other way still counts.
     """
+    import ast
+
     import codeframe.core.gates as gates_module
 
-    source = Path(gates_module.__file__).read_text()
+    tree = ast.parse(Path(gates_module.__file__).read_text())
 
-    spawns = source.count("subprocess.run(")
-    envs = source.count("env=build_agent_env(repo_path),")
-    assert spawns == envs, (
-        f"{spawns} subprocess.run calls but only {envs} pass env= — "
-        "a new spawn site is inheriting the operator's environment"
+    missing = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
+            continue
+        if not any(kw.arg == "env" for kw in node.keywords):
+            missing.append(node.lineno)
+
+    assert not missing, (
+        f"subprocess.run at gates.py lines {missing} inherit the operator's "
+        "environment — pass env=build_agent_env(repo_path)"
     )
 
 

--- a/tests/core/test_subprocess_env_isolation_907.py
+++ b/tests/core/test_subprocess_env_isolation_907.py
@@ -305,3 +305,29 @@ def test_unbuildable_sandbox_home_does_not_fall_back_to_the_operator(tmp_path, m
         cwd=workspace, env=env, capture_output=True, text=True,
     )
     assert str(operator_home) not in proc.stdout
+
+
+def test_the_sandbox_home_does_not_pollute_the_git_status(tmp_path):
+    """The sandbox lives inside the workspace and fills with cache files.
+
+    `get_changed_scope` builds the PROOF9 scope from `status.untracked_files`,
+    so an unignored agent-home drags every pip/npm cache entry into the scope.
+    """
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    env = build_agent_env(repo)
+    # Simulate a tool writing into the sandbox.
+    cache = Path(env["XDG_CACHE_HOME"]) / "pip" / "http"
+    cache.mkdir(parents=True)
+    (cache / "blob").write_text("cached")
+
+    untracked = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=repo, capture_output=True, text=True,
+    ).stdout
+
+    assert "agent-home" not in untracked, f"sandbox leaked into git status:\n{untracked}"


### PR DESCRIPTION
Closes #908.

## Problem

`_ensure_dependencies_installed` triggers exactly when `requirements.txt` exists and **no venv does** — and then ran `uv pip install -r requirements.txt`, which errors in precisely that state. Reproduced directly:

```
$ cd /tmp/empty-repo && uv pip install -r requirements.txt
error: No virtual environment found; run `uv venv` to create an environment,
or pass `--system` to install into a non-virtual environment
```

So the install could never succeed where it was triggered. Two consequences:

1. `run()` returned early with a `dependency-check` **ERROR** and `passed=False`, blocking **every** gate — including ruff and tsc, which need no Python dependencies — for any pip-style target repo. Every PROOF9 run inherited it, since `runner._run_gate` calls `gates.run` per obligation.
2. When CodeFRAME itself runs inside an activated venv, `VIRTUAL_ENV` is on the env allowlist and the target repo has no venv at trigger time — so it was inherited from the parent, and the fallback installed the *target repo's* dependencies into **CodeFRAME's own environment**.

## Fix

New `_install_python_requirements()`:

- **Creates the venv first** (`uv venv`, or `sys.executable -m venv` when uv is absent), then installs.
- **Pins `VIRTUAL_ENV` to the venv just created**, so the parent's value is never what the install targets.
- The pip fallback calls the venv's own `pip` **by path** rather than relying on `PATH`, so it cannot resolve to CodeFRAME's.

And `run()` no longer returns early: a failed install is recorded as a `SKIPPED` `dependency-check` and the gates run anyway. `SKIPPED` rather than `ERROR` because the check did not reach a verdict, and `SKIPPED` does not fail the run. If the missing dependencies actually matter, the gate that needs them fails on its own and says why — which is a better signal than a pre-flight error that hides it.

## Also fixed (all from the adversarial review)

- **A failed install no longer leaves the venv behind.** `uv venv` succeeding then the install failing left `.venv` present, so `has_venv` was true forever and the install was skipped permanently — even once a transient network failure cleared.
- **Windows.** The pip fallback ran `.venv/Scripts/pip` (the binary is `pip.exe`), and `build_agent_env` only looked for `.venv/bin` so a Windows repo's pytest resolved from CodeFRAME's PATH. Now `<venv>/bin|Scripts/python -m pip`, which is correct on both platforms *and* cannot resolve to CodeFRAME's pip the way a bare name on PATH could.
- **The created `.venv` is self-ignoring.** It was untracked, and `get_changed_scope` feeds `status.untracked_files` straight into the PROOF9 scope — so `cf review` reported the tree dirty and dragged site-packages into the scope. Writing `.venv/.gitignore` with `*` is what `uv venv` already does; it needs no git-directory resolution and works unchanged in linked worktrees. Still required despite uv doing it, because CPython only writes that file from **3.13** and this project supports `>=3.11`.
- **`.codeframe/agent-home/` is self-ignoring too** — a regression from #905 found while debugging the above. The sandboxed `HOME` lives inside the workspace and fills with pip/npm/cargo cache files, all untracked, on *every* run. Same scope pollution, wider blast radius.
- **The `dependency-check` note is appended after the gates, never before.** `proof/runner.py:131` reads `result.checks[0]` as *the* gate's check, so a pre-flight entry at index 0 would be reported as `FAILED (SKIPPED)` for every enforced PROOF9 rule.

## Tests

`tests/core/test_gate_dependency_install_908.py` — 7 tests, real `uv venv` + real install, no mocking:

- The install succeeds in its own trigger state (`requirements.txt`, no venv).
- The package is **importable from the target venv** — asserted by running that venv's interpreter, not by checking an exit code.
- With `VIRTUAL_ENV` pointed at CodeFRAME's own prefix, the package still lands in the target repo's venv.
- A failed install still runs `ruff`, and does not by itself fail the run.
- The already-has-venv and auto-install-disabled paths are unchanged.

Mutation-checked in both directions: removing the venv creation fails 3 tests, restoring the blocking early-return fails 2.

**Two existing tests updated**, both encoding contracts this change deliberately alters:

- `test_python_deps_missing_auto_installs` asserted `mock_run.assert_called_once()`. The install is two calls now; it asserts the ordering (`uv venv` then `uv pip install`) and that the install's `VIRTUAL_ENV` points at the new venv.
- `test_every_gates_subprocess_passes_an_environment` (added in #907) counted a literal `env=build_agent_env(repo_path),` string, which the new local `_run` wrapper broke. It now parses `gates.py` with `ast` and asserts every `subprocess.run` call has an `env` keyword — more precise, and it no longer cares how the value is spelled.
