### PR TITLE
fix(proof): a SKIPPED gate is unverifiable, not proof (#909)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -687,6 +687,12 @@ def review(
             if check.output and (check.status == GateStatus.FAILED or verbose):
                 console.print(f"    [dim]{check.output}[/dim]")
 
+        # Diagnostics that are not gate verdicts (#909) — e.g. a failed
+        # dependency install. Always shown: the gates may all have passed, and
+        # the operator still needs to know the environment was incomplete.
+        for note in result.notes:
+            console.print(f"  [yellow]note:[/yellow] {note}")
+
         # Summary
         console.print()
         if result.passed:

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -515,6 +515,10 @@ def run(
             "passed": passed,
             "summary": result.summary,
             "checks": [{"name": c.name, "status": c.status.value} for c in checks],
+            # Diagnostics that are not gate verdicts (#909). Carried alongside
+            # the checks so an event consumer still sees, e.g., that the
+            # dependency install failed even when every gate passed.
+            "notes": notes,
         },
         print_event=True,
     )

--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -120,13 +120,18 @@ class GateResult:
 
     Attributes:
         passed: Whether all gates passed
-        checks: List of individual gate checks
+        checks: List of individual gate checks — real gates only
+        notes: Diagnostics that are not gate verdicts (e.g. a failed dependency
+            install). Deliberately not ``checks``: a SKIPPED entry there means
+            "a gate did not run", which PROOF9 reads as unverifiable evidence
+            (#909), and a diagnostic must not carry that meaning.
         started_at: When gates started
         completed_at: When gates completed
     """
 
     passed: bool
     checks: list[GateCheck] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
 
@@ -479,19 +484,13 @@ def run(
 
         checks.append(check)
 
-    # Recorded after the gates, never before: proof/runner.py reads
-    # result.checks[0] as *the* gate's check, so a pre-flight entry at index 0
-    # would be mistaken for the gate result and reported as FAILED (SKIPPED).
+    notes: list[str] = []
     if not dep_success:
-        checks.append(
-            GateCheck(
-                name="dependency-check",
-                status=GateStatus.SKIPPED,
-                output=(
-                    f"Dependency installation failed, ran gates anyway: {dep_message}"
-                ),
-            )
-        )
+        # A note, not a check: `checks` carries gate verdicts, and a SKIPPED
+        # verdict now means "this gate could not be verified" (#909). A failed
+        # dependency install is a diagnostic — if it actually matters, the gate
+        # that needed those dependencies fails on its own and says why.
+        notes.append(f"Dependency installation failed, ran gates anyway: {dep_message}")
 
     completed_at = _utc_now()
 
@@ -503,6 +502,7 @@ def run(
     result = GateResult(
         passed=passed,
         checks=checks,
+        notes=notes,
         started_at=started_at,
         completed_at=completed_at,
     )

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -120,6 +120,7 @@ def _run_gate(
 
         lines: list[str] = []
         all_passed = True
+        unverifiable = False
 
         for rule in enforced:
             result = core_gates.run(
@@ -157,13 +158,46 @@ def _run_gate(
             lines.extend(
                 f"{check.name}: {check.status.value}" for check in result.checks
             )
-            all_passed = all_passed and result.passed
+            lines.extend(result.notes)
+
+            # A SKIPPED gate is not proof (#909). `result.passed` counts SKIPPED
+            # as passing — reasonable for "did anything break?", fatal for
+            # evidence: on a machine without ruff the SEC gate reported PASSED,
+            # attach_evidence recorded satisfied=True, the requirement flipped to
+            # SATISFIED, and the #731 merge gate unblocked on evidence that was
+            # never produced. The scoped path above already refuses this; the
+            # whole-suite path used to contradict it.
+            failed = [
+                c for c in result.checks
+                if c.status in (core_gates.GateStatus.FAILED, core_gates.GateStatus.ERROR)
+            ]
+            skipped = [
+                c for c in result.checks if c.status == core_gates.GateStatus.SKIPPED
+            ]
+            if failed:
+                all_passed = False
+            elif skipped:
+                # Only when nothing failed: a real failure is the stronger
+                # signal and must not be softened into "could not verify".
+                unverifiable = True
+                lines.append(
+                    "UNVERIFIABLE — "
+                    + ", ".join(f"{c.name} did not run ({c.output.strip()[:80]})" for c in skipped)
+                )
+            if not result.checks:
+                unverifiable = True
+                lines.append(f"UNVERIFIABLE — {core_gate_name} produced no checks")
 
         for rule in rules:
             if not rule.must_pass:
                 lines.append(f"{rule.test_id}: informational (must_pass=False, not enforced)")
 
-        outcome = GateOutcome.PASSED if all_passed else GateOutcome.FAILED
+        if not all_passed:
+            outcome = GateOutcome.FAILED
+        elif unverifiable:
+            outcome = GateOutcome.UNVERIFIABLE
+        else:
+            outcome = GateOutcome.PASSED
         return outcome, "\n".join(lines)
     except Exception as exc:
         logger.warning("Gate %s failed to run: %s", gate.value, exc)

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -167,26 +167,21 @@ def _run_gate(
             # SATISFIED, and the #731 merge gate unblocked on evidence that was
             # never produced. The scoped path above already refuses this; the
             # whole-suite path used to contradict it.
-            failed = [
-                c for c in result.checks
-                if c.status in (core_gates.GateStatus.FAILED, core_gates.GateStatus.ERROR)
-            ]
+            all_passed = all_passed and result.passed
+
             skipped = [
                 c for c in result.checks if c.status == core_gates.GateStatus.SKIPPED
             ]
-            if failed:
-                all_passed = False
-            elif skipped:
-                # Only when nothing failed: a real failure is the stronger
-                # signal and must not be softened into "could not verify".
+            # Only downgrade a *pass*: a real failure is the stronger signal and
+            # must never be softened into "could not verify". `result.passed` is
+            # true when every check is PASSED or SKIPPED, so this is exactly the
+            # case where the skips are what produced the pass.
+            if result.passed and skipped:
                 unverifiable = True
                 lines.append(
                     "UNVERIFIABLE — "
                     + ", ".join(f"{c.name} did not run ({c.output.strip()[:80]})" for c in skipped)
                 )
-            if not result.checks:
-                unverifiable = True
-                lines.append(f"UNVERIFIABLE — {core_gate_name} produced no checks")
 
         for rule in rules:
             if not rule.must_pass:

--- a/codeframe/ui/routers/gates_v2.py
+++ b/codeframe/ui/routers/gates_v2.py
@@ -47,6 +47,10 @@ class GateResultResponse(BaseModel):
 
     passed: bool
     checks: list[GateCheckResponse]
+    notes: list[str] = Field(
+        default_factory=list,
+        description="Diagnostics that are not gate verdicts (e.g. a failed dependency install)",
+    )
     summary: str
     started_at: Optional[str]
     completed_at: Optional[str]
@@ -80,6 +84,7 @@ def _result_to_response(result: GateResult) -> GateResultResponse:
     return GateResultResponse(
         passed=result.passed,
         checks=[_check_to_response(c) for c in result.checks],
+        notes=list(result.notes),
         summary=result.summary,
         started_at=result.started_at.isoformat() if result.started_at else None,
         completed_at=result.completed_at.isoformat() if result.completed_at else None,

--- a/tests/core/test_gate_dependency_install_908.py
+++ b/tests/core/test_gate_dependency_install_908.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import pytest
 
 from codeframe.core.gates import (
-    GateStatus,
     _ensure_dependencies_installed,
     _install_python_requirements,
 )
@@ -121,9 +120,9 @@ def test_failed_install_still_runs_the_gates(tmp_path, monkeypatch):
     names = {c.name for c in result.checks}
     assert "ruff" in names, f"gates did not run; only got {names}"
 
-    dep_check = next(c for c in result.checks if c.name == "dependency-check")
-    assert dep_check.status == GateStatus.SKIPPED
-    assert "simulated install failure" in dep_check.output
+    # The note lives in `notes`, not `checks` (#909): a SKIPPED *check* means
+    # "this gate could not be verified", which a dependency diagnostic is not.
+    assert any("simulated install failure" in n for n in result.notes)
 
 
 def test_a_failed_install_alone_does_not_fail_the_run(tmp_path, monkeypatch):
@@ -173,11 +172,11 @@ def test_auto_install_disabled_is_reported_not_attempted(pip_repo):
 
 
 def test_dependency_note_never_displaces_the_gate_check(tmp_path, monkeypatch):
-    """proof/runner.py reads `result.checks[0]` as *the* gate's check.
+    """`checks` carries gate verdicts only.
 
-    A pre-flight entry at index 0 would be mistaken for the gate result and
-    reported as `FAILED (SKIPPED)` for every enforced PROOF9 rule — a failure
-    with nothing to do with the test it names.
+    proof/runner.py reads `result.checks[0]` as *the* gate's check and treats a
+    SKIPPED check as unverifiable evidence (#909), so a pre-flight diagnostic
+    in that list would be reported as a failure of the test it names.
     """
     from codeframe.core import gates as gates_module
     from codeframe.core.workspace import create_or_load_workspace
@@ -196,11 +195,11 @@ def test_dependency_note_never_displaces_the_gate_check(tmp_path, monkeypatch):
 
     result = gates_module.run(workspace, gates=["ruff"], verbose=False)
 
-    assert result.checks[0].name == "ruff", (
-        f"checks[0] is {result.checks[0].name!r}; the proof runner would read "
-        "the dependency note as the gate result"
+    assert [c.name for c in result.checks] == ["ruff"], (
+        f"checks contains {[c.name for c in result.checks]}; the proof runner "
+        "would read a diagnostic as a gate verdict"
     )
-    assert result.checks[-1].name == "dependency-check"
+    assert result.notes, "the diagnostic must still surface somewhere"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_skipped_gate_evidence_909.py
+++ b/tests/core/test_skipped_gate_evidence_909.py
@@ -194,3 +194,74 @@ def test_the_dependency_note_is_not_a_check(tmp_path, monkeypatch):
 
     assert [c.name for c in result.checks] == ["ruff"]
     assert any("simulated install failure" in n for n in result.notes)
+
+
+# ---------------------------------------------------------------------------
+# The note must reach every surface, not just the proof runner
+# ---------------------------------------------------------------------------
+
+
+def _result_with_note() -> core_gates.GateResult:
+    return core_gates.GateResult(
+        passed=True,
+        checks=[core_gates.GateCheck(name="ruff", status=core_gates.GateStatus.PASSED)],
+        notes=["Dependency installation failed, ran gates anyway: boom"],
+    )
+
+
+def test_the_note_reaches_the_gates_completed_event(tmp_path, monkeypatch):
+    """Otherwise an event consumer sees 'All gates passed' and nothing else."""
+    from codeframe.core import events, gates as gates_module
+
+    repo = tmp_path / "evt-repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("packaging\n")
+    (repo / "clean.py").write_text("x = 1\n")
+    ws = create_or_load_workspace(repo)
+
+    monkeypatch.setattr(
+        gates_module,
+        "_ensure_dependencies_installed",
+        lambda *a, **k: (False, "simulated install failure"),
+    )
+
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        events,
+        "emit_for_workspace",
+        lambda ws_, type_, payload, **kw: captured.append(payload),
+    )
+
+    gates_module.run(ws, gates=["ruff"], verbose=False)
+
+    assert captured, "no event emitted"
+    assert any(
+        "simulated install failure" in n for n in captured[-1].get("notes", [])
+    ), f"event payload dropped the diagnostic: {captured[-1]}"
+
+
+def test_the_note_reaches_the_v2_api_response():
+    """The API response schema carried only `checks`."""
+    from codeframe.ui.routers.gates_v2 import _result_to_response
+
+    response = _result_to_response(_result_with_note())
+
+    assert any("Dependency installation failed" in n for n in response.notes)
+
+
+def test_the_note_reaches_the_cli(tmp_path, monkeypatch):
+    """`cf review` printed only checks, so the diagnostic was invisible."""
+    from typer.testing import CliRunner
+
+    from codeframe.cli import app as cli_app
+
+    repo = tmp_path / "cli-repo"
+    repo.mkdir()
+    create_or_load_workspace(repo)
+
+    # `review` imports gates inside the function, so patch the source module.
+    monkeypatch.setattr(core_gates, "run", lambda *a, **k: _result_with_note())
+
+    result = CliRunner().invoke(cli_app.app, ["review", "--workspace", str(repo)])
+
+    assert "Dependency installation failed" in result.output, result.output

--- a/tests/core/test_skipped_gate_evidence_909.py
+++ b/tests/core/test_skipped_gate_evidence_909.py
@@ -11,7 +11,6 @@ The scoped-rule path in ``_run_gate`` already refused to treat SKIPPED as proof.
 The whole-suite path in the same function contradicted it.
 """
 
-from pathlib import Path
 
 import pytest
 
@@ -94,17 +93,6 @@ def test_a_failure_outranks_a_skip(workspace, monkeypatch):
     outcome, _ = _run_gate(workspace, Gate.SEC, [])
 
     assert outcome == GateOutcome.FAILED
-
-
-def test_no_checks_at_all_is_unverifiable(workspace, monkeypatch):
-    """An empty result proves nothing either."""
-    monkeypatch.setattr(
-        core_gates, "run", lambda *a, **k: core_gates.GateResult(passed=True, checks=[])
-    )
-
-    outcome, detail = _run_gate(workspace, Gate.SEC, [])
-
-    assert outcome == GateOutcome.UNVERIFIABLE, detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_skipped_gate_evidence_909.py
+++ b/tests/core/test_skipped_gate_evidence_909.py
@@ -1,0 +1,208 @@
+"""A SKIPPED gate is not proof (#909).
+
+``gates.run()`` computes ``passed = all(status in (PASSED, SKIPPED))``, which is
+right for "did anything break?" and fatal for evidence. The ruff and pytest
+runners return SKIPPED when the binary is absent, so on a machine without ruff
+the SEC gate reported PASSED, ``attach_evidence`` recorded ``satisfied=True``,
+the requirement flipped to SATISFIED, and the #731 PROOF9 merge gate unblocked
+on evidence that was never produced.
+
+The scoped-rule path in ``_run_gate`` already refused to treat SKIPPED as proof.
+The whole-suite path in the same function contradicted it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from codeframe.core import gates as core_gates
+from codeframe.core.proof.models import Gate, GateOutcome
+from codeframe.core.proof.runner import _run_gate
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "clean.py").write_text("x = 1\n")
+    return create_or_load_workspace(repo)
+
+
+def _skipped_result(name: str) -> core_gates.GateResult:
+    """What a runner returns when its binary is absent."""
+    return core_gates.GateResult(
+        passed=True,  # the bug: SKIPPED counts as passing here
+        checks=[
+            core_gates.GateCheck(
+                name=name,
+                status=core_gates.GateStatus.SKIPPED,
+                output=f"{name} not found",
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# The gate outcome
+# ---------------------------------------------------------------------------
+
+
+def test_a_skipped_gate_is_unverifiable_not_passed(workspace, monkeypatch):
+    """The exact reported scenario: ruff absent, SEC gate asked for evidence."""
+    monkeypatch.setattr(core_gates, "run", lambda *a, **k: _skipped_result("ruff"))
+
+    outcome, detail = _run_gate(workspace, Gate.SEC, [])
+
+    assert outcome == GateOutcome.UNVERIFIABLE, detail
+    assert "UNVERIFIABLE" in detail
+    assert "ruff" in detail
+
+
+def test_a_passing_gate_is_still_passed(workspace, monkeypatch):
+    """The fix must not make everything unverifiable."""
+    monkeypatch.setattr(
+        core_gates,
+        "run",
+        lambda *a, **k: core_gates.GateResult(
+            passed=True,
+            checks=[core_gates.GateCheck(name="ruff", status=core_gates.GateStatus.PASSED)],
+        ),
+    )
+
+    outcome, _ = _run_gate(workspace, Gate.SEC, [])
+
+    assert outcome == GateOutcome.PASSED
+
+
+def test_a_failure_outranks_a_skip(workspace, monkeypatch):
+    """A real failure must not be softened into 'could not verify'."""
+    monkeypatch.setattr(
+        core_gates,
+        "run",
+        lambda *a, **k: core_gates.GateResult(
+            passed=False,
+            checks=[
+                core_gates.GateCheck(name="ruff", status=core_gates.GateStatus.FAILED),
+                core_gates.GateCheck(name="mypy", status=core_gates.GateStatus.SKIPPED),
+            ],
+        ),
+    )
+
+    outcome, _ = _run_gate(workspace, Gate.SEC, [])
+
+    assert outcome == GateOutcome.FAILED
+
+
+def test_no_checks_at_all_is_unverifiable(workspace, monkeypatch):
+    """An empty result proves nothing either."""
+    monkeypatch.setattr(
+        core_gates, "run", lambda *a, **k: core_gates.GateResult(passed=True, checks=[])
+    )
+
+    outcome, detail = _run_gate(workspace, Gate.SEC, [])
+
+    assert outcome == GateOutcome.UNVERIFIABLE, detail
+
+
+# ---------------------------------------------------------------------------
+# The consequence: no satisfied evidence, requirement stays open
+# ---------------------------------------------------------------------------
+
+
+def test_a_skipped_gate_leaves_the_requirement_open(workspace, monkeypatch):
+    """End to end — the property the #731 merge gate depends on."""
+    from codeframe.core.proof import ledger
+    from codeframe.core.proof.models import (
+        Obligation,
+        ReqStatus,
+        Requirement,
+        RequirementScope,
+        Severity,
+        Source,
+    )
+    from codeframe.core.proof.runner import run_proof
+
+    ledger.init_proof_tables(workspace)
+    ledger.save_requirement(
+        workspace,
+        Requirement(
+            id="REQ-909",
+            title="a requirement whose only gate cannot run",
+            description="",
+            severity=Severity.HIGH,
+            source=Source.QA,
+            scope=RequirementScope(),
+            obligations=[Obligation(gate=Gate.SEC)],
+            evidence_rules=[],
+            status=ReqStatus.OPEN,
+        ),
+    )
+
+    monkeypatch.setattr(core_gates, "run", lambda *a, **k: _skipped_result("ruff"))
+
+    run_proof(workspace)
+
+    stored = ledger.get_requirement(workspace, "REQ-909")
+    assert stored.status == ReqStatus.OPEN, (
+        f"requirement flipped to {stored.status} on evidence never produced"
+    )
+
+    evidence = ledger.list_evidence(workspace, "REQ-909")
+    assert evidence, "no evidence recorded at all; the test proves nothing"
+    assert not any(e.satisfied for e in evidence), (
+        "a SKIPPED gate recorded satisfied=True evidence"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The #908 dependency note must not be mistaken for a skipped gate
+# ---------------------------------------------------------------------------
+
+
+def test_a_dependency_note_does_not_make_a_passing_gate_unverifiable(
+    workspace, monkeypatch
+):
+    """#908 records a failed dependency install; that is a diagnostic.
+
+    It travels in `notes`, not `checks`, precisely so it cannot be read as
+    "a gate did not run" — the gate here genuinely passed.
+    """
+    monkeypatch.setattr(
+        core_gates,
+        "run",
+        lambda *a, **k: core_gates.GateResult(
+            passed=True,
+            checks=[core_gates.GateCheck(name="ruff", status=core_gates.GateStatus.PASSED)],
+            notes=["Dependency installation failed, ran gates anyway: boom"],
+        ),
+    )
+
+    outcome, detail = _run_gate(workspace, Gate.SEC, [])
+
+    assert outcome == GateOutcome.PASSED
+    assert "Dependency installation failed" in detail, "the note should still surface"
+
+
+def test_the_dependency_note_is_not_a_check(tmp_path, monkeypatch):
+    """Guards the split at the producing end."""
+    from codeframe.core import gates as gates_module
+
+    repo = tmp_path / "dep-repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("packaging\n")
+    (repo / "clean.py").write_text("x = 1\n")
+    ws = create_or_load_workspace(repo)
+
+    monkeypatch.setattr(
+        gates_module,
+        "_ensure_dependencies_installed",
+        lambda *a, **k: (False, "simulated install failure"),
+    )
+
+    result = gates_module.run(ws, gates=["ruff"], verbose=False)
+
+    assert [c.name for c in result.checks] == ["ruff"]
+    assert any("simulated install failure" in n for n in result.notes)

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -262,6 +262,8 @@ export interface GateCheck {
 export interface GateResult {
   passed: boolean;
   checks: GateCheck[];
+  /** Diagnostics that are not gate verdicts (e.g. a failed dependency install). */
+  notes?: string[];
   summary: string;
   started_at: string | null;
   completed_at: string | null;


### PR DESCRIPTION
Closes #909.

## Problem

`gates.run()` computes `passed = all(status in (PASSED, SKIPPED))`. That is right for "did anything break?" and fatal for "is this proven?" — and the ruff and pytest runners return **SKIPPED when the binary is absent**.

So on a machine without ruff:

```
SEC gate → ruff SKIPPED → result.passed=True → GateOutcome.PASSED
        → attach_evidence(satisfied=True) → requirement flips to SATISFIED
        → the #731 PROOF9 merge gate unblocks
```

on evidence that was never produced.

The contradiction lived inside a single function: `_run_gate`'s scoped-rule path already refused to treat SKIPPED as proof, with a comment saying exactly that. The whole-suite path five lines below did `all_passed = all_passed and result.passed`.

## Fix

The change is **additive** — the existing `all_passed and result.passed` line stays, and a pass is *downgraded* to UNVERIFIABLE when skips are what produced it:

```python
all_passed = all_passed and result.passed
skipped = [c for c in result.checks if c.status == SKIPPED]
if result.passed and skipped:
    unverifiable = True
```

`result.passed` is true exactly when every check is PASSED or SKIPPED, so `result.passed and skipped` isolates the bug case. The shape matters: it can only move PASSED → UNVERIFIABLE, never turn a failure into anything else. My first attempt replaced the `result.passed` combination with my own check-inspection and silently lost the failure path — caught by an existing test.

No new machinery was needed downstream: `attach_evidence` already sets `satisfied=(outcome == PASSED)`, so UNVERIFIABLE records `satisfied=False` and the requirement stays OPEN; `run_proof` already excludes unverifiable gates from the pass tally, so a gate that could not run neither proves nor disproves.

## `GateResult.notes` — required for the above to be correct

#908 (merged) recorded a failed dependency install as a `SKIPPED` check named `dependency-check`. Under this change that would make **every** gate unverifiable whenever an install failed — reintroducing the poisoning #908 set out to remove.

A SKIPPED *check* now means "this gate could not be verified". A failed dependency install is not that: it is a diagnostic, and if the missing dependencies actually matter the gate that needs them fails on its own. So `GateResult` gains a `notes: list[str]` field, `checks` carries gate verdicts only, and the note still surfaces in the gate detail. This also retires the `result.checks[0]` positional fragility that #908 had to work around.

## Tests

`tests/core/test_skipped_gate_evidence_909.py` — 6 tests:

- The reported scenario: ruff absent → UNVERIFIABLE, not PASSED.
- A passing gate is still PASSED (the fix must not make everything unverifiable).
- **A failure outranks a skip** — `ruff FAILED` + `mypy SKIPPED` → FAILED, never softened.
- End to end: a requirement whose only gate cannot run stays **OPEN**, with no `satisfied=True` evidence. Asserts evidence *was* recorded first, so "no satisfied evidence" cannot pass vacuously.
- The #908 dependency note does not make a passing gate unverifiable, and still appears in the detail.
- At the producing end, the note lands in `notes` and never in `checks`.

Mutation-checked: restoring `all_passed and result.passed` alone fails 2.

**Two #908 tests updated** — they asserted the dependency diagnostic lived in `checks`, which this PR deliberately changes.

## Consequence worth stating

A repo missing a gate's binary can no longer satisfy that obligation — which is the point, but it means the requirement stays OPEN and the #731 merge gate blocks.

This is not a new *kind* of behaviour: only 3 of the 9 gates have automated runners (`UNIT`/`CONTRACT` → pytest, `SEC` → ruff), and the other six already return UNVERIFIABLE with "no automated runner". Requirements carrying those gates have always been in this position. The escapes are unchanged — `cf proof waive`, or the documented `--override --reason` on the merge gate, which writes an audit record.

The alternative — keep reporting PASSED so merges flow — is the bug.

## One thing I removed

I first added `if not result.checks: unverifiable = True` on the reasoning that "no checks proves nothing". Reading `gates.run()` showed every named gate appends exactly one check unconditionally — including the unknown-gate branch — and `_run_gate` always passes exactly one name, so an empty list is unreachable. The clause only succeeded in reinterpreting two existing tests' lightweight fakes as failures. Dropped, along with the test I had written for it.
