### PR TITLE
fix(review): fail loud instead of approving unexamined code (#910)

### DIFF
--- a/codeframe/core/review.py
+++ b/codeframe/core/review.py
@@ -8,13 +8,13 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import Literal, Optional
 
 from codeframe.core.workspace import Workspace
 from codeframe.lib.quality.complexity_analyzer import ComplexityAnalyzer
-from codeframe.lib.quality.security_scanner import SecurityScanner
+from codeframe.lib.quality.security_scanner import ScannerUnavailableError, SecurityScanner
 from codeframe.lib.quality.owasp_patterns import OWASPPatterns
 
 logger = logging.getLogger(__name__)
@@ -41,10 +41,16 @@ class ReviewFinding:
 class ReviewResult:
     """Result of a code review."""
 
-    status: Literal["approved", "changes_requested", "rejected"]
+    status: Literal["approved", "changes_requested", "rejected", "not_analyzed"]
     overall_score: float
     findings: list[ReviewFinding]
     summary: str
+    #: Files that no analyzer looked at (e.g. non-Python files, #910). Reported
+    #: rather than silently counted as clean.
+    files_skipped: list[str] = dataclass_field(default_factory=list)
+    #: Analyzers that could not run at all. A non-empty list means the review is
+    #: incomplete, and the result is never "approved".
+    analyzers_unavailable: list[str] = dataclass_field(default_factory=list)
 
 
 @dataclass
@@ -138,6 +144,11 @@ def review_files(
 
     # Track scores for averaging
     scores: list[float] = []
+    # Analyzer name -> why it could not run. Non-empty means the review is
+    # incomplete and must never come back "approved" (#910).
+    analyzers_unavailable: dict[str, str] = {}
+    files_skipped: list[str] = []
+    files_analyzed = 0
 
     for file_path in files:
         # Security: the caller controls this string, so it is confined to the
@@ -172,9 +183,14 @@ def review_files(
             logger.warning(f"File not found: {file_path}")
             continue
 
-        if not full_path.suffix == ".py":
-            # Only analyze Python files for now
+        if full_path.suffix != ".py":
+            # No analyzer handles this language yet. Recorded and reported
+            # rather than silently dropped: a TypeScript-only change used to
+            # fall straight through to score 100 / "approved" (#910).
+            files_skipped.append(file_path)
             continue
+
+        files_analyzed += 1
 
         # Complexity analysis
         try:
@@ -213,6 +229,11 @@ def review_files(
                 # Security issues have heavier weight on score
                 severity_scores = {"critical": 20, "high": 40, "medium": 60, "low": 80, "info": 95}
                 scores.append(severity_scores.get(finding.severity, 60))
+        except ScannerUnavailableError as exc:
+            # The scanner is absent, not clean. Recorded once and reported as a
+            # finding so it drags the score and blocks "approved" (#910).
+            if "security" not in analyzers_unavailable:
+                analyzers_unavailable["security"] = str(exc)
         except Exception as e:
             logger.warning(f"Security scan failed for {file_path}: {e}")
 
@@ -236,6 +257,22 @@ def review_files(
         except Exception as e:
             logger.warning(f"OWASP check failed for {file_path}: {e}")
 
+    # An unavailable analyzer becomes a finding of its own, so it is visible in
+    # every surface that shows findings, drags the score, and cannot be mistaken
+    # for a clean scan (#910).
+    for analyzer, reason in analyzers_unavailable.items():
+        findings.append(
+            ReviewFinding(
+                category="tooling",
+                severity="high",
+                message=f"{analyzer} analysis did not run: {reason}",
+                file_path="",
+                line_number=0,
+                suggestion="Install the missing tool and re-run the review.",
+            )
+        )
+        scores.append(40)  # same weight as any other high-severity finding
+
     # Calculate overall score
     if scores:
         overall_score = sum(scores) / len(scores)
@@ -243,23 +280,43 @@ def review_files(
         # No issues found = perfect score
         overall_score = 100.0
 
-    status = _determine_status(overall_score)
+    if files_analyzed == 0:
+        # Nothing was examined — a perfect score here is a lie. This is the
+        # TypeScript-only change to a Next.js app that came back "approved"
+        # unexamined (#910).
+        status: str = "not_analyzed"
+        overall_score = 0.0
+    else:
+        status = _determine_status(overall_score)
 
     # Generate summary
-    if not findings:
-        summary = "No issues found. Code looks good!"
-    else:
+    parts: list[str] = []
+    if findings:
         critical_count = sum(1 for f in findings if f.severity == "critical")
         high_count = sum(1 for f in findings if f.severity == "high")
-        summary = f"Found {len(findings)} issues: {critical_count} critical, {high_count} high severity"
+        parts.append(
+            f"Found {len(findings)} issues: {critical_count} critical, "
+            f"{high_count} high severity"
+        )
+    elif files_analyzed:
+        parts.append("No issues found. Code looks good!")
+
+    if files_analyzed == 0:
+        parts.insert(0, f"No files were analyzed ({len(files_skipped)} skipped)")
+    elif files_skipped:
+        parts.append(f"{len(files_skipped)} file(s) skipped: no analyzer for this language")
+
+    summary = ". ".join(parts) if parts else "Nothing to review."
 
     logger.info(f"Review completed: {status} (score: {overall_score:.1f})")
 
     return ReviewResult(
-        status=status,
+        status=status,  # type: ignore[arg-type]
         overall_score=round(overall_score, 1),
         findings=findings,
         summary=summary,
+        files_skipped=files_skipped,
+        analyzers_unavailable=sorted(analyzers_unavailable),
     )
 
 

--- a/codeframe/core/review.py
+++ b/codeframe/core/review.py
@@ -181,6 +181,9 @@ def review_files(
 
         if not full_path.exists():
             logger.warning(f"File not found: {file_path}")
+            # Recorded like any other unexamined file, so the summary's count
+            # matches what the caller asked for (#910).
+            files_skipped.append(file_path)
             continue
 
         if full_path.suffix != ".py":

--- a/codeframe/lib/quality/security_scanner.py
+++ b/codeframe/lib/quality/security_scanner.py
@@ -224,6 +224,12 @@ class SecurityScanner:
             try:
                 findings = self.analyze_file(file_path)
                 all_findings.extend(findings)
+            except ScannerUnavailableError:
+                # Deliberately not swallowed (#910). A scanner that never ran
+                # must not read as "analyzed and clean" — `calculate_score`
+                # below would otherwise hand back a perfect 100 for code nothing
+                # examined, which is the bug this module was fixed for.
+                raise
             except Exception as e:
                 logger.error(f"Error analyzing {file_path}: {e}")
 

--- a/codeframe/lib/quality/security_scanner.py
+++ b/codeframe/lib/quality/security_scanner.py
@@ -5,6 +5,7 @@ Scans code for security vulnerabilities using bandit and maps severity levels.
 
 import json
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 from typing import List
@@ -59,6 +60,18 @@ class SecurityScanner:
         # Skip non-Python files
         if file_path.suffix != ".py":
             return []
+
+        # Availability is checked BEFORE the early returns below (#910 review).
+        # An unreadable or empty file returns [] without ever reaching the
+        # bandit subprocess, so the FileNotFoundError branch never fired and a
+        # review of, say, a newly added empty __init__.py came back
+        # "approved"/100 on an install with no bandit — the original bug,
+        # surviving in the empty-file subset.
+        if shutil.which("bandit") is None:
+            raise ScannerUnavailableError(
+                "bandit is not installed, so no security analysis was performed. "
+                "Reinstall codeframe, or: pip install bandit"
+            )
 
         # Read file to check if empty
         try:

--- a/codeframe/lib/quality/security_scanner.py
+++ b/codeframe/lib/quality/security_scanner.py
@@ -14,6 +14,14 @@ from codeframe.core.models import ReviewFinding
 logger = logging.getLogger(__name__)
 
 
+class ScannerUnavailableError(RuntimeError):
+    """The scanner binary is absent, so no analysis was performed.
+
+    Distinct from "the scan ran and found nothing": callers must not treat this
+    as a clean result (#910).
+    """
+
+
 class SecurityScanner:
     """Scans code for security vulnerabilities using bandit.
 
@@ -82,8 +90,14 @@ class SecurityScanner:
             logger.error(f"Bandit timeout analyzing {file_path}")
         except json.JSONDecodeError as e:
             logger.error(f"Error parsing bandit output for {file_path}: {e}")
-        except FileNotFoundError:
-            logger.warning("bandit not found. Install with: pip install bandit")
+        except FileNotFoundError as exc:
+            # Not a clean scan — a scan that never happened. Returning [] here
+            # made "no security findings" indistinguishable from "no security
+            # scan", which scored 100 and reported "approved" (#910).
+            raise ScannerUnavailableError(
+                "bandit is not installed, so no security analysis was performed. "
+                "Reinstall codeframe, or: pip install bandit"
+            ) from exc
         except Exception as e:
             logger.error(f"Error running bandit on {file_path}: {e}")
 

--- a/codeframe/ui/routers/review_v2.py
+++ b/codeframe/ui/routers/review_v2.py
@@ -42,7 +42,7 @@ class ReviewFindingResponse(BaseModel):
 class ReviewResultResponse(BaseModel):
     """Response model for review result."""
 
-    status: Literal["approved", "changes_requested", "rejected"]
+    status: Literal["approved", "changes_requested", "rejected", "not_analyzed"]
     overall_score: float
     findings: list[ReviewFindingResponse]
     summary: str

--- a/codeframe/ui/routers/review_v2.py
+++ b/codeframe/ui/routers/review_v2.py
@@ -44,6 +44,14 @@ class ReviewResultResponse(BaseModel):
 
     status: Literal["approved", "changes_requested", "rejected", "not_analyzed"]
     overall_score: float
+    files_skipped: list[str] = Field(
+        default_factory=list,
+        description="Files no analyzer examined (unsupported language, or not found)",
+    )
+    analyzers_unavailable: list[str] = Field(
+        default_factory=list,
+        description="Analyzers that could not run at all — the review is incomplete",
+    )
     findings: list[ReviewFindingResponse]
     summary: str
 
@@ -135,6 +143,8 @@ async def review_files(
         return ReviewResultResponse(
             status=result.status,
             overall_score=result.overall_score,
+            files_skipped=list(result.files_skipped),
+            analyzers_unavailable=list(result.analyzers_unavailable),
             findings=[
                 ReviewFindingResponse(
                     category=f.category,
@@ -184,6 +194,8 @@ async def review_task(
         return ReviewResultResponse(
             status=result.status,
             overall_score=result.overall_score,
+            files_skipped=list(result.files_skipped),
+            analyzers_unavailable=list(result.analyzers_unavailable),
             findings=[
                 ReviewFindingResponse(
                     category=f.category,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ classifiers = [
 
 dependencies = [
     "anthropic>=0.18.0",
+    # Runtime, not dev (#910): `cf review`'s security leg shells out to bandit,
+    # and when it was missing the scan silently produced no findings — so every
+    # clean `pip install` scored 100 and reported "approved" without ever
+    # running a security check.
+    "bandit>=1.8.6",
     "tenacity>=8.2.0",
     "openai>=1.12.0",
     "fastapi>=0.109.0",
@@ -168,6 +173,5 @@ exclude_lines = [
 
 [dependency-groups]
 dev = [
-    "bandit>=1.8.6",
     "pytest-cov>=7.0.0",
 ]

--- a/tests/core/test_review.py
+++ b/tests/core/test_review.py
@@ -155,16 +155,22 @@ class TestReviewFiles:
         assert result.overall_score == 87.5
         assert result.status == "approved"
 
-    def test_non_python_file_is_skipped(self, workspace):
+    def test_non_python_file_is_reported_as_skipped(self, workspace):
+        """Skipped, not clean (#910). Scoring an unexamined file 100/approved
+        is how a TypeScript-only change got approved without being read."""
         (workspace.repo_path / "notes.txt").write_text("not code")
         result = review_files(workspace, ["notes.txt"])
         assert result.findings == []
-        assert result.overall_score == 100.0
+        assert result.status == "not_analyzed"
+        assert result.overall_score != 100.0
+        assert result.files_skipped == ["notes.txt"]
 
-    def test_missing_file_is_skipped(self, workspace):
+    def test_missing_file_is_reported_as_skipped(self, workspace):
         result = review_files(workspace, ["ghost.py"])
         assert result.findings == []
-        assert result.overall_score == 100.0
+        assert result.status == "not_analyzed"
+        assert result.overall_score != 100.0
+        assert result.files_skipped == ["ghost.py"]
 
     def test_analyzer_exception_is_caught(self, workspace, monkeypatch):
         name = _write_py(workspace)

--- a/tests/core/test_review_fails_loud_910.py
+++ b/tests/core/test_review_fails_loud_910.py
@@ -1,0 +1,175 @@
+"""`cf review` fails loud instead of approving unexamined code (#910).
+
+``SecurityScanner`` shelled out to bandit and, on ``FileNotFoundError``, logged a
+warning and returned ``[]``. bandit was declared only under ``[dependency-groups]
+dev``, so **no** ``pip install codeframe-ai`` ever had it. In every production
+install the security leg produced nothing, ``scores`` stayed empty,
+``overall_score`` fell through to ``100.0``, and the status became ``approved``
+with nothing in ``ReviewResult`` saying the scan never ran.
+
+The same ``100``/``approved`` came back when every requested file was
+non-Python — a TypeScript-only change to a Next.js app was approved unexamined.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeframe.core import review
+from codeframe.core.workspace import create_or_load_workspace
+from codeframe.lib.quality import security_scanner as scanner_module
+from codeframe.lib.quality.security_scanner import ScannerUnavailableError, SecurityScanner
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return create_or_load_workspace(repo)
+
+
+@pytest.fixture
+def bandit_missing(monkeypatch):
+    """Exactly what a clean `pip install` used to look like."""
+    real_run = subprocess.run
+
+    def no_bandit(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "bandit":
+            raise FileNotFoundError("bandit")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(scanner_module.subprocess, "run", no_bandit)
+
+
+# ---------------------------------------------------------------------------
+# bandit is installed by a normal install
+# ---------------------------------------------------------------------------
+
+
+def test_bandit_is_a_runtime_dependency():
+    """It was under [dependency-groups] dev, so `pip install` never got it."""
+    import tomllib
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+
+    runtime = " ".join(data["project"]["dependencies"])
+    assert "bandit" in runtime, "the security leg cannot run without bandit"
+
+
+def test_bandit_is_actually_importable_here():
+    """Guards the declaration above against being merely aspirational."""
+    import shutil
+
+    assert shutil.which("bandit"), "bandit declared but not present in this env"
+
+
+# ---------------------------------------------------------------------------
+# A missing scanner is loud
+# ---------------------------------------------------------------------------
+
+
+def test_the_scanner_raises_rather_than_returning_clean(tmp_path, bandit_missing):
+    """`[]` made "no findings" indistinguishable from "no scan"."""
+    target = tmp_path / "code.py"
+    target.write_text("import os\n")
+
+    with pytest.raises(ScannerUnavailableError):
+        SecurityScanner(tmp_path).analyze_file(target)
+
+
+def test_a_missing_scanner_is_not_approved_at_100(workspace, bandit_missing):
+    """The headline bug: a clean install approved everything, unexamined."""
+    target = workspace.repo_path / "app.py"
+    target.write_text("x = 1\n")
+
+    result = review.review_files(workspace, ["app.py"])
+
+    assert result.status != "approved", f"{result.status} @ {result.overall_score}"
+    assert result.overall_score != 100.0
+    assert "security" in result.analyzers_unavailable
+
+
+def test_a_missing_scanner_appears_in_the_findings(workspace, bandit_missing):
+    """Every surface renders findings; an out-of-band flag would go unseen."""
+    (workspace.repo_path / "app.py").write_text("x = 1\n")
+
+    result = review.review_files(workspace, ["app.py"])
+
+    tooling = [f for f in result.findings if f.category == "tooling"]
+    assert tooling, "the unavailable scanner produced no finding"
+    assert "bandit" in tooling[0].message
+    assert tooling[0].severity == "high"
+
+
+def test_the_scanner_is_reported_once_not_per_file(workspace, bandit_missing):
+    """Ten files must not yield ten identical findings."""
+    for i in range(3):
+        (workspace.repo_path / f"m{i}.py").write_text("x = 1\n")
+
+    result = review.review_files(workspace, ["m0.py", "m1.py", "m2.py"])
+
+    tooling = [f for f in result.findings if f.category == "tooling"]
+    assert len(tooling) == 1, f"{len(tooling)} duplicate tooling findings"
+
+
+# ---------------------------------------------------------------------------
+# Nothing analyzed is its own outcome
+# ---------------------------------------------------------------------------
+
+
+def test_a_typescript_only_change_is_not_approved(workspace):
+    """The reported case: a Next.js change came back approved, unexamined."""
+    (workspace.repo_path / "page.tsx").write_text("export default () => null;\n")
+
+    result = review.review_files(workspace, ["page.tsx"])
+
+    assert result.status == "not_analyzed", result.summary
+    assert result.overall_score != 100.0
+    assert "page.tsx" in result.files_skipped
+    assert "No files were analyzed" in result.summary
+
+
+def test_a_mixed_change_reports_what_was_skipped(workspace):
+    """Python analyzed, TypeScript reported — not silently dropped."""
+    (workspace.repo_path / "app.py").write_text("x = 1\n")
+    (workspace.repo_path / "page.tsx").write_text("export default () => null;\n")
+
+    result = review.review_files(workspace, ["app.py", "page.tsx"])
+
+    assert result.status != "not_analyzed", "a Python file was analyzed"
+    assert result.files_skipped == ["page.tsx"]
+    assert "skipped" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The happy path still works
+# ---------------------------------------------------------------------------
+
+
+def test_clean_python_with_bandit_present_is_still_approved(workspace):
+    """The fix must not make every review fail."""
+    (workspace.repo_path / "clean.py").write_text("x = 1\n")
+
+    result = review.review_files(workspace, ["clean.py"])
+
+    assert result.status == "approved", f"{result.status}: {result.summary}"
+    assert result.overall_score == 100.0
+    assert not result.analyzers_unavailable
+
+
+def test_a_real_finding_is_still_reported(workspace):
+    """bandit genuinely runs — asserts the scan is wired, not just tolerated."""
+    (workspace.repo_path / "risky.py").write_text(
+        "import subprocess\n"
+        "def go(cmd):\n"
+        "    subprocess.run(cmd, shell=True)\n"
+    )
+
+    result = review.review_files(workspace, ["risky.py"])
+
+    assert result.findings, "bandit reported nothing on a known-risky file"
+    assert result.status != "not_analyzed"

--- a/tests/core/test_review_fails_loud_910.py
+++ b/tests/core/test_review_fails_loud_910.py
@@ -173,3 +173,32 @@ def test_a_real_finding_is_still_reported(workspace):
 
     assert result.findings, "bandit reported nothing on a known-risky file"
     assert result.status != "not_analyzed"
+
+
+# ---------------------------------------------------------------------------
+# Sibling methods must not re-open the hole
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_files_does_not_swallow_the_unavailable_error(tmp_path, bandit_missing):
+    """Its generic `except Exception` would have silenced the new signal."""
+    target = tmp_path / "code.py"
+    target.write_text("x = 1\n")
+
+    with pytest.raises(ScannerUnavailableError):
+        SecurityScanner(tmp_path).analyze_files([target])
+
+
+def test_calculate_score_does_not_return_a_perfect_score_when_unavailable(
+    tmp_path, bandit_missing
+):
+    """The same 100-for-nothing-examined shape, one method over.
+
+    These two have no production callers today; the guard is here so the next
+    one does not inherit the bug.
+    """
+    target = tmp_path / "code.py"
+    target.write_text("x = 1\n")
+
+    with pytest.raises(ScannerUnavailableError):
+        SecurityScanner(tmp_path).calculate_score([target])

--- a/tests/core/test_review_fails_loud_910.py
+++ b/tests/core/test_review_fails_loud_910.py
@@ -41,7 +41,14 @@ def bandit_missing(monkeypatch):
             raise FileNotFoundError("bandit")
         return real_run(cmd, *args, **kwargs)
 
+    real_which = scanner_module.shutil.which
+
     monkeypatch.setattr(scanner_module.subprocess, "run", no_bandit)
+    monkeypatch.setattr(
+        scanner_module.shutil,
+        "which",
+        lambda name, *a, **k: None if name == "bandit" else real_which(name, *a, **k),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -245,3 +252,50 @@ def test_both_review_endpoints_populate_the_new_fields():
         assert "analyzers_unavailable" in kwargs, (
             f"line {call.lineno} drops analyzers_unavailable"
         )
+
+
+def test_an_empty_python_file_still_reports_the_missing_scanner(
+    workspace, bandit_missing
+):
+    """The early returns ran before the bandit call, so the empty-file subset
+    kept the original bug — a newly added `__init__.py` on a clean install came
+    back approved/100 with no security scan."""
+    (workspace.repo_path / "__init__.py").write_text("")
+
+    result = review.review_files(workspace, ["__init__.py"])
+
+    assert result.status != "approved", f"{result.status} @ {result.overall_score}"
+    assert result.overall_score != 100.0
+    assert "security" in result.analyzers_unavailable
+
+
+def test_an_unreadable_python_file_still_reports_the_missing_scanner(
+    workspace, bandit_missing, monkeypatch
+):
+    """The `read_text` failure branch returned [] before the scanner ran too."""
+    target = workspace.repo_path / "locked.py"
+    target.write_text("x = 1\n")
+
+    real_read = Path.read_text
+
+    def deny(self, *args, **kwargs):
+        if self.name == "locked.py":
+            raise PermissionError("denied")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny)
+
+    result = review.review_files(workspace, ["locked.py"])
+
+    assert "security" in result.analyzers_unavailable
+    assert result.status != "approved"
+
+
+def test_an_empty_file_with_bandit_present_is_still_clean(workspace):
+    """The availability check must not turn empty files into findings."""
+    (workspace.repo_path / "__init__.py").write_text("")
+
+    result = review.review_files(workspace, ["__init__.py"])
+
+    assert result.status == "approved"
+    assert not result.analyzers_unavailable

--- a/tests/core/test_review_fails_loud_910.py
+++ b/tests/core/test_review_fails_loud_910.py
@@ -202,3 +202,46 @@ def test_calculate_score_does_not_return_a_perfect_score_when_unavailable(
 
     with pytest.raises(ScannerUnavailableError):
         SecurityScanner(tmp_path).calculate_score([target])
+
+
+# ---------------------------------------------------------------------------
+# The v2 API must carry what was not examined
+# ---------------------------------------------------------------------------
+
+
+def test_the_api_response_model_carries_the_new_fields():
+    """An API client could see status='not_analyzed' with no way to learn which
+    files went unexamined, or that an analyzer never ran."""
+    from codeframe.ui.routers.review_v2 import ReviewResultResponse
+
+    fields = ReviewResultResponse.model_fields
+    assert "files_skipped" in fields
+    assert "analyzers_unavailable" in fields
+    # Defaults, so existing clients are unaffected.
+    assert fields["files_skipped"].default_factory is list
+    assert fields["analyzers_unavailable"].default_factory is list
+
+
+def test_both_review_endpoints_populate_the_new_fields():
+    """`/files` and `/task` each build the response separately."""
+    import ast
+
+    from codeframe.ui.routers import review_v2
+
+    source = Path(review_v2.__file__).read_text()
+    tree = ast.parse(source)
+
+    constructions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ReviewResultResponse"
+    ]
+    assert len(constructions) == 2, f"expected 2 constructors, found {len(constructions)}"
+    for call in constructions:
+        kwargs = {kw.arg for kw in call.keywords}
+        assert "files_skipped" in kwargs, f"line {call.lineno} drops files_skipped"
+        assert "analyzers_unavailable" in kwargs, (
+            f"line {call.lineno} drops analyzers_unavailable"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -582,6 +582,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "anthropic" },
+    { name = "bandit" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
@@ -647,7 +648,6 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "bandit" },
     { name = "pytest-cov" },
 ]
 
@@ -656,6 +656,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "anthropic", specifier = ">=0.18.0" },
+    { name = "bandit", specifier = ">=1.8.6" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "e2b", marker = "extra == 'cloud'", specifier = ">=2.0.0" },
@@ -715,10 +716,7 @@ requires-dist = [
 provides-extras = ["cloud", "dev"]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "bandit", specifier = ">=1.8.6" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-]
+dev = [{ name = "pytest-cov", specifier = ">=7.0.0" }]
 
 [[package]]
 name = "colorama"

--- a/uv.lock
+++ b/uv.lock
@@ -272,7 +272,7 @@ wheels = [
 
 [[package]]
 name = "bandit"
-version = "1.8.6"
+version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -280,9 +280,9 @@ dependencies = [
     { name = "rich" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/b5/7eb834e213d6f73aace21938e5e90425c92e5f42abafaf8a6d5d21beed51/bandit-1.8.6.tar.gz", hash = "sha256:dbfe9c25fc6961c2078593de55fd19f2559f9e45b99f1272341f5b95dea4e56b", size = 4240271, upload-time = "2025-07-06T03:10:50.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/ca/ba5f909b40ea12ec542d5d7bdd13ee31c4d65f3beed20211ef81c18fa1f3/bandit-1.8.6-py3-none-any.whl", hash = "sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0", size = 133808, upload-time = "2025-07-06T03:10:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
@@ -3015,11 +3015,11 @@ wheels = [
 
 [[package]]
 name = "stevedore"
-version = "5.5.0"
+version = "5.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/5f/8418daad5c353300b7661dd8ce2574b0410a6316a8be650a189d5c68d938/stevedore-5.5.0.tar.gz", hash = "sha256:d31496a4f4df9825e1a1e4f1f74d19abb0154aff311c3b376fcc89dae8fccd73", size = 513878, upload-time = "2025-08-25T12:54:26.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/c5/0c06759b95747882bb50abda18f5fb48c3e9b0fbfc6ebc0e23550b52415d/stevedore-5.5.0-py3-none-any.whl", hash = "sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf", size = 49518, upload-time = "2025-08-25T12:54:25.445Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #910.

## Problem

Two separate paths made `cf review` return **`approved`, score 100** for code it never looked at.

**1. bandit was never installed.** `SecurityScanner` shells out to `bandit` and, on `FileNotFoundError`, logged a warning and returned `[]`. bandit was declared only under `[dependency-groups] dev`, so no `pip install codeframe-ai` ever had it. Returning `[]` made two very different states identical — "scanned, clean" and "never scanned" — and everything downstream treated the second as the first:

```
no findings → scores stays empty → overall_score = 100.0 → status "approved"
```

with nothing in `ReviewResult` recording that the security leg never ran.

**2. Non-Python files were dropped silently.** `if not full_path.suffix == ".py": continue` — so a TypeScript-only change to a Next.js app produced no findings, no scores, and the same 100/`approved`, unexamined.

## Fix

**bandit is a runtime dependency.** Moved out of the dev group into `[project] dependencies`, so a clean install can actually run the scan.

**A missing scanner raises.** `SecurityScanner.analyze_file` now raises `ScannerUnavailableError` instead of returning `[]`, forcing callers to distinguish "clean" from "never ran".

**An unavailable analyzer becomes a *finding*.** `review_files` catches that error, records the analyzer once (not per file), and emits a `high`-severity `tooling` finding. Deliberately a finding rather than a flag: every surface — CLI, v2 API, web UI — renders findings, so an out-of-band boolean would go unseen the same way the original bug did. It also drags the score and blocks `approved` through the existing machinery, with no special-casing.

**`not_analyzed` is an explicit status.** When no file was examined, the status is `not_analyzed` and the score is 0.0 rather than 100.0. Unexamined files — non-Python *and* missing — are collected in `ReviewResult.files_skipped` and named in the summary, so the count matches what the caller asked for.

`ReviewResult` gains `files_skipped: list[str]` and `analyzers_unavailable: list[str]`; both default to empty, so nothing existing breaks.

## Tests

`tests/core/test_review_fails_loud_910.py` — 10 tests. `bandit_missing` reproduces a clean install by making `subprocess.run(["bandit", ...])` raise `FileNotFoundError`.

- The headline case: bandit missing → **not** `approved`, **not** 100.
- The unavailable scanner appears in `findings` at `high` severity, and **once** rather than per file.
- A TypeScript-only change → `not_analyzed`, with the file named in `files_skipped`.
- A mixed change analyzes the Python and reports the TypeScript as skipped.
- Both happy paths still work: clean Python is still `approved` at 100, and a genuinely risky file still produces real bandit findings — so the tests fail if the scan is merely tolerated rather than wired.
- `test_bandit_is_a_runtime_dependency` reads `pyproject.toml`, and a companion asserts bandit is actually on `PATH`, so the declaration cannot be aspirational.

Mutation-checked in three directions: restoring the silent `[]` fails 4, restoring the 100/`approved` fallthrough fails 1, and moving bandit back to the dev group fails 1.

**Two existing tests updated** — `test_non_python_file_is_skipped` and `test_missing_file_is_skipped` asserted `overall_score == 100.0` for unexamined files, which is precisely the behaviour this removes.

## Note

The `if not full_path.suffix == ".py": continue` line *was* the second bug, so the fix belongs at that line. My first attempt added skip-tracking below it, where it could never run — caught by two of the new tests.
