### PR TITLE
fix(deploy): unblock the Deploy workflow (known-hosts, Tailscale routing, pm2 env)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,9 @@ jobs:
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           if [ -z "${SSH_KNOWN_HOSTS}" ]; then
-            echo "❌ SSH_KNOWN_HOSTS secret is not set — see this step's comment to populate it."
+            echo "❌ SSH_KNOWN_HOSTS secret is not set — the deploy cannot verify the server host key."
+            echo "   Populate it from a trusted machine (verify the fingerprint out-of-band first):"
+            echo "     ssh-keyscan -H <host> | gh secret set SSH_KNOWN_HOSTS --env <staging|production>"
             exit 1
           fi
           mkdir -p ~/.ssh
@@ -338,7 +340,9 @@ jobs:
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           if [ -z "${SSH_KNOWN_HOSTS}" ]; then
-            echo "❌ SSH_KNOWN_HOSTS secret is not set — see this step's comment to populate it."
+            echo "❌ SSH_KNOWN_HOSTS secret is not set — the deploy cannot verify the server host key."
+            echo "   Populate it from a trusted machine (verify the fingerprint out-of-band first):"
+            echo "     ssh-keyscan -H <host> | gh secret set SSH_KNOWN_HOSTS --env <staging|production>"
             exit 1
           fi
           mkdir -p ~/.ssh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,17 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
+      # The VPS firewalls port 22 off the public internet; the runner reaches it
+      # over Tailscale instead. HOST must be the box's tailnet MagicDNS name (or
+      # 100.x address), and SSH_KNOWN_HOSTS must be labelled with that same HOST.
+      # Box side: join the tailnet and `ufw allow in on tailscale0 to any port 22`.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Add server to known hosts
         # Pinned host key (no live ssh-keyscan TOFU). Populate the
         # SSH_KNOWN_HOSTS secret from a trusted session with:
@@ -331,6 +342,17 @@ jobs:
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      # The VPS firewalls port 22 off the public internet; the runner reaches it
+      # over Tailscale instead. HOST must be the box's tailnet MagicDNS name (or
+      # 100.x address), and SSH_KNOWN_HOSTS must be labelled with that same HOST.
+      # Box side: join the tailnet and `ufw allow in on tailscale0 to any port 22`.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Add server to known hosts
         # Pinned host key (no live ssh-keyscan TOFU). Populate the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,20 +256,15 @@ jobs:
             echo "Debug: BACKEND_NAME='\${BACKEND_NAME}'"
             echo "Debug: FRONTEND_NAME='\${FRONTEND_NAME}'"
 
-            # Function to check if a PM2 process is online
-            is_process_online() {
-              pm2 describe "\$1" 2>/dev/null | grep -q "online"
-            }
-
-            # Restart both frontend and backend via config file
-            if is_process_online "\${BACKEND_NAME}" && is_process_online "\${FRONTEND_NAME}"; then
-              echo "♻️  Restarting PM2 services..."
-              pm2 restart "\${BACKEND_NAME}" --update-env
-              pm2 restart "\${FRONTEND_NAME}" --update-env
-            else
-              echo "🚀 Starting PM2 services from config..."
-              pm2 start ecosystem.staging.config.js
-            fi
+            # Cold-start from the ecosystem file so its dotenv.config() re-reads
+            # .env.staging on every deploy. A plain `pm2 restart <name> --update-env`
+            # refreshes env from the deploy shell (which never sources .env.staging),
+            # so newly-added vars like WORKSPACE_ROOT (#896) never reach the process
+            # and the backend crash-loops. Delete by name (NOT `pm2 delete all`,
+            # which would kill unrelated apps on this shared box), then start fresh.
+            echo "🔁 (Re)starting PM2 services from config..."
+            pm2 delete "\${BACKEND_NAME}" "\${FRONTEND_NAME}" 2>/dev/null || true
+            pm2 start ecosystem.staging.config.js --update-env
 
             pm2 save
             echo "✅ PM2 services updated"
@@ -633,28 +628,13 @@ jobs:
             BACKEND_NAME="${BACKEND_NAME_PROD}"
             FRONTEND_NAME="${FRONTEND_NAME_PROD}"
 
-            # Function to check if a PM2 process is online
-            is_process_online() {
-              pm2 describe "\$1" 2>/dev/null | grep -q "online"
-            }
-
-            # Handle backend process
-            if is_process_online "\${BACKEND_NAME}"; then
-              echo "♻️  Restarting \${BACKEND_NAME}..."
-              pm2 restart "\${BACKEND_NAME}"
-            else
-              echo "🚀 Starting \${BACKEND_NAME}..."
-              pm2 start ecosystem.production.config.js --only "\${BACKEND_NAME}"
-            fi
-
-            # Handle frontend process
-            if is_process_online "\${FRONTEND_NAME}"; then
-              echo "♻️  Restarting \${FRONTEND_NAME}..."
-              pm2 restart "\${FRONTEND_NAME}"
-            else
-              echo "🚀 Starting \${FRONTEND_NAME}..."
-              pm2 start ecosystem.production.config.js --only "\${FRONTEND_NAME}"
-            fi
+            # Cold-start from the ecosystem file so its dotenv.config() re-reads
+            # .env.production on every deploy — see the staging job for why a plain
+            # `pm2 restart <name>` silently drops newly-added .env vars (#896).
+            # Delete by name (NOT `pm2 delete all`) to spare unrelated apps.
+            echo "🔁 (Re)starting PM2 services from config..."
+            pm2 delete "\${BACKEND_NAME}" "\${FRONTEND_NAME}" 2>/dev/null || true
+            pm2 start ecosystem.production.config.js --update-env
 
             pm2 save
             echo "✅ PM2 services updated"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -122,3 +122,39 @@ For an IP-only or internal host, use the IP as the site address and add
 `Caddyfile.example`. Browsers reject the local CA
 (`NET::ERR_CERT_AUTHORITY_INVALID`) until its root cert is trusted on the client
 (`caddy trust`) or the warning is accepted — this is expected, not a broken deploy.
+
+## CI deploy over Tailscale
+
+The `Deploy` workflow SSHes into the box, but port 22 is firewalled off the
+public internet. The runner reaches the box over a Tailscale tailnet instead, so
+`sshd` never needs a public inbound rule. One-time setup:
+
+**On the box**
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up                       # authenticate; note the assigned 100.x IP / MagicDNS name
+sudo ufw allow in on tailscale0 to any port 22   # let tailnet peers reach sshd
+# keep the public :22 rule scoped to your admin IP (or drop it entirely)
+```
+
+**On the tailnet (admin console → Access Controls)** — allow the CI tag to reach
+the box on 22, e.g.:
+```jsonc
+{ "action": "accept", "src": ["tag:ci"], "dst": ["tag:staging:22"] }
+```
+
+**GitHub secrets** — create a Tailscale OAuth client (scopes: `auth_keys`, tag
+`tag:ci`) and set:
+- `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET` — the OAuth client (repo-level is fine)
+- `HOST` (per environment) — repoint to the box's **tailnet** MagicDNS name or
+  `100.x` address. `HOST` is only ever an SSH target; the public app URL lives in
+  `API_URL`/`WS_URL` and is unaffected.
+- `SSH_KNOWN_HOSTS` (per environment) — same host key as before, but the label
+  must match the new tailnet `HOST`:
+  ```bash
+  # on the box, HOST = the tailnet name/IP you set above
+  HOST=<tailnet-name-or-100.x>
+  for f in /etc/ssh/ssh_host_ed25519_key.pub /etc/ssh/ssh_host_rsa_key.pub; do
+    awk -v h="$HOST" '{print h, $1, $2}' "$f"
+  done   # → paste into: gh secret set SSH_KNOWN_HOSTS --env staging
+  ```


### PR DESCRIPTION
## Why

The **Deploy** workflow had failed on every push to `main` for ~5 days (since 2026-07-24). Investigating turned up **one headline break hiding four more** — each only became visible once the layer above it was cleared. This PR fixes the repo/infra regressions; the account-side pieces (secrets, Tailscale config, box firewall) were done out-of-band during the investigation.

Verified green end-to-end via `workflow_dispatch` on this branch (run passed through **Deploy to Staging → Verify deployment**; backend now `online`, 0 restarts, `/health` returns `healthy`).

## The failure chain

| # | Failure | Root cause | Fix |
|---|---|---|---|
| 1 | `Add server to known hosts` exits 1 | #890 (2026-07-24) required a pinned `SSH_KNOWN_HOSTS` secret that was never populated | Secret set out-of-band; **this PR** makes the guard's error actionable |
| 2 | SSH **times out** | Box firewalls public port 22 against GitHub runner ranges | **This PR:** route CI over Tailscale (connect step in both jobs) |
| 3 | `tailscale up` **403** | OAuth client lacked `auth_keys` write + `tag:ci` | Fixed in Tailscale admin (out-of-band) |
| 4 | SSH **"connection closed"** | Tailscale SSH intercepted :22 with no matching SSH ACL | `tailscale set --ssh=false` on the box (out-of-band) |
| 5 | Health check fails, backend **crash-loops** | #896 fail-closed on `WORKSPACE_ROOT`; the deploy's `pm2 restart <name> --update-env` refreshes env from the deploy shell, which never sources `.env.staging`, so vars *added* to the env file never propagate | **This PR:** cold-start pm2 from the ecosystem file so its `dotenv.config()` re-reads `.env` every deploy |

## What's in this PR (code only)

- **`fix(ci)`** — `SSH_KNOWN_HOSTS` guard now prints the exact `ssh-keyscan … | gh secret set …` command instead of pointing at a comment (both jobs).
- **`ci(deploy)`** — `Connect to Tailscale` step (SHA-pinned `v3.3.0`) in the staging and production jobs, so the runner reaches the box over the tailnet with public :22 closed. Requires `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` secrets and `HOST`/`SSH_KNOWN_HOSTS` pointed at the tailnet — documented in `deploy/README.md`.
- **`fix(deploy)`** — replace `pm2 restart <name> --update-env` with delete-by-name + `pm2 start <ecosystem> --update-env` in both jobs, so newly-added `.env` vars always reach the process. Deletes by name (not `pm2 delete all`) to leave unrelated apps on the shared VPS untouched.
- **`docs`** — `deploy/README.md` "CI deploy over Tailscale" runbook.

## Out-of-band changes already applied (not in this diff)

- Secrets: `SSH_KNOWN_HOSTS` + `HOST` (staging env) → tailnet; `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` (repo).
- Box: joined tailnet, tagged `tag:staging-server`, `tailscale set --ssh=false`.
- Tailnet: OAuth client scoped `auth_keys`+`tag:ci`; ACL grant `tag:ci → tag:staging-server`.

## Follow-ups (not blockers)

- Public :22 on the box is still open — can be locked down now that CI uses the tailnet.
- **Production** deploy got the same fixes but is **unverified** (release-triggered; no prod tailnet secrets set yet).
- `scripts/deploy-staging.sh` uses `pm2 delete all`, which kills unrelated apps on the shared box — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
