### PR TITLE
fix(engines): drop the non-existent `run` subcommand from the kilocode invocation (#1012)

### DIFF
--- a/codeframe/core/adapters/kilocode.py
+++ b/codeframe/core/adapters/kilocode.py
@@ -17,9 +17,16 @@ _KILO_TIMEOUT_EXIT_CODE = 124
 class KilocodeAdapter(SubprocessAdapter):
     """Adapter that delegates code execution to Kilocode CLI.
 
-    Invokes ``kilo run <prompt> --auto --workspace <path>`` for headless
-    non-interactive execution.  The prompt is passed as a positional argument
-    (not via stdin), matching Kilocode's CLI interface.
+    Invokes ``kilo <prompt> --auto --workspace <path>`` for headless
+    non-interactive execution.  The prompt is the CLI's leading positional
+    (not stdin, and **not** behind a subcommand).
+
+    There is no ``run`` subcommand: verified against kilocode 0.22.0, whose
+    usage is ``kilocode [options] [command] [prompt]`` with commands
+    ``auth``/``config``/``debug``/``models`` only. The adapter used to prepend
+    ``run``, which was then swallowed as the prompt — ``--auto`` never took
+    effect, the interactive TUI opened, and the delegated run hung until the
+    timeout having written nothing (#1012).
 
     Note on prompt length: the prompt is passed as a single positional argument.
     Linux supports up to ~2 MB per argument, but macOS caps individual arguments
@@ -45,7 +52,16 @@ class KilocodeAdapter(SubprocessAdapter):
         *,
         timeout_s: int | None = None,
     ) -> None:
-        super().__init__(binary=self._resolve_binary(), timeout_s=timeout_s)
+        super().__init__(
+            binary=self._resolve_binary(),
+            timeout_s=timeout_s,
+            # A coding agent that exits 0 having written nothing is a false
+            # completion: gates then run on an unchanged tree and the task can
+            # be marked DONE with no code. The TUI path this adapter used to
+            # take did exactly that. Same guard as claude-code (#739/#819) and
+            # opencode (#913).
+            require_file_changes=True,
+        )
 
     @property
     def name(self) -> str:  # noqa: D102
@@ -83,7 +99,6 @@ class KilocodeAdapter(SubprocessAdapter):
         """
         cmd = [
             self._binary_path,
-            "run",
             prompt,
             "--auto",
             "--workspace",

--- a/tests/core/adapters/test_kilocode.py
+++ b/tests/core/adapters/test_kilocode.py
@@ -19,8 +19,17 @@ class TestKilocodeAdapter:
 
     @pytest.fixture(autouse=True)
     def _no_git(self):
-        """Prevent _detect_modified_files from calling real git."""
-        with patch.object(KilocodeAdapter, "_detect_modified_files", return_value=[]):
+        """Prevent _detect_modified_files from calling real git.
+
+        Returns a modified file, i.e. a run that actually did work. With
+        ``require_file_changes=True`` (#1012) an empty list means "wrote
+        nothing", which is now a *failure* — so an empty default would make
+        every test here exercise the false-completion guard rather than the
+        behaviour it names. The no-work case has its own test below.
+        """
+        with patch.object(
+            KilocodeAdapter, "_detect_modified_files", return_value=["main.py"]
+        ), patch.object(KilocodeAdapter, "_git_head", return_value="abc123"):
             yield
 
     def test_name(self) -> None:
@@ -43,11 +52,32 @@ class TestKilocodeAdapter:
             adapter = KilocodeAdapter()
         cmd = adapter.build_command("do the thing", Path("/tmp/repo"))
         assert cmd[0] == "/usr/bin/kilo"
-        assert cmd[1] == "run"
         assert "do the thing" in cmd
         assert "--auto" in cmd
         assert "--workspace" in cmd
         assert "/tmp/repo" in cmd
+
+    def test_the_prompt_is_the_first_positional_not_a_run_subcommand(self) -> None:
+        """`kilo` has no `run` command — the prompt is a bare positional.
+
+        Verified against kilocode 0.22.0: `Usage: kilocode [options] [command]
+        [prompt]`, commands are auth/config/debug/models only. With a bogus
+        `run` in front, `run` is consumed as the prompt, `--auto` never takes
+        effect, and the CLI opens the TUI and hangs until the timeout (#1012).
+        """
+        with patch(_WHICH, return_value="/usr/bin/kilo"):
+            adapter = KilocodeAdapter()
+        cmd = adapter.build_command("do the thing", Path("/tmp/repo"))
+
+        assert "run" not in cmd, "`kilo run` opens the TUI and does no work"
+        assert cmd[1] == "do the thing", "the prompt must be the first positional"
+
+    def test_a_zero_work_run_is_not_reported_completed(self) -> None:
+        """The TUI path exits 0 having written nothing — that must not read as success."""
+        with patch(_WHICH, return_value="/usr/bin/kilo"):
+            adapter = KilocodeAdapter()
+
+        assert adapter._require_file_changes is True
 
     def test_prompt_is_not_sent_via_stdin(self) -> None:
         with patch(_WHICH, return_value="/usr/bin/kilo"):

--- a/tests/core/adapters/test_kilocode_smoke_1012.py
+++ b/tests/core/adapters/test_kilocode_smoke_1012.py
@@ -1,0 +1,163 @@
+"""Binary-gated smoke test: the Kilocode adapter against the real CLI (#1012).
+
+The adapter shipped invoking ``kilo run <prompt> …``. **There is no ``run``
+subcommand.** Verified against kilocode 0.22.0: usage is
+``kilocode [options] [command] [prompt]`` and the only commands are ``auth``,
+``config``, ``debug`` and ``models``. So ``run`` was consumed as the prompt,
+``--auto`` never took effect, and the CLI opened its interactive TUI and hung
+until the adapter's timeout — writing nothing, while unit tests built entirely
+from mocks asserted the adapter agreed with itself.
+
+That is the gap this file closes. Every assertion runs the adapter's own
+``build_command`` output against the installed binary, so a future change to the
+invocation that mocked tests would happily accept is caught here instead.
+
+Skipped when ``kilo`` is not installed, so CI without the binary stays green —
+but it is **launch-gating**, not deferred: kilocode is a shipped engine.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.adapters.kilocode import KilocodeAdapter
+
+pytestmark = [
+    pytest.mark.v2,
+    pytest.mark.skipif(
+        shutil.which(KilocodeAdapter._resolve_binary()) is None,
+        reason="kilo CLI not installed",
+    ),
+]
+
+#: Long enough for a real model round-trip, short enough to fail a hang loudly.
+_TIMEOUT_S = 240
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+    # Without a commit HEAD is unborn, `_git_head` returns None, and
+    # `require_file_changes` reads the workspace as "not a git repo" and never
+    # fires — which would silently neuter the writes-nothing assertion.
+    subprocess.run(
+        ["git", "-c", "user.email=test@example.com", "-c", "user.name=test",
+         "commit", "-q", "--allow-empty", "-m", "baseline"],
+        cwd=workspace,
+        check=True,
+    )
+    return workspace
+
+
+def test_there_is_no_run_subcommand() -> None:
+    """The assumption that produced the bug, checked against the binary's own help.
+
+    Asserted on the CLI rather than on our code, so it fails if kilocode ever
+    adds a `run` command and the adapter should be revisited.
+    """
+    proc = subprocess.run(
+        [KilocodeAdapter._resolve_binary(), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    help_text = proc.stdout + proc.stderr
+
+    assert "Commands:" in help_text, "kilo --help no longer lists its commands"
+    commands_block = help_text.split("Commands:", 1)[1]
+    listed = [
+        line.strip().split()[0]
+        for line in commands_block.splitlines()
+        if line.strip() and not line.startswith(" " * 20)
+    ]
+    assert "run" not in listed, (
+        f"kilo now has a `run` command ({listed}); revisit the adapter's invocation"
+    )
+
+
+def test_the_adapter_does_not_prepend_a_subcommand() -> None:
+    """The adapter's own command must put the prompt first, ahead of any flag."""
+    adapter = KilocodeAdapter()
+    cmd = adapter.build_command("say hello", Path("/tmp/repo"))
+
+    assert cmd[1] == "say hello", f"prompt is not the leading positional: {cmd[:3]}"
+
+
+def test_the_old_invocation_hangs_and_writes_nothing(repo: Path) -> None:
+    """Pins the bug, so nobody restores `run` believing it worked.
+
+    The old command opens the TUI: it never reaches a terminal state on its own,
+    so it is killed by the timeout and leaves the workspace untouched.
+    """
+    binary = KilocodeAdapter._resolve_binary()
+    try:
+        subprocess.run(
+            [binary, "run", "Create a file old.txt containing exactly: old",
+             "--auto", "--workspace", str(repo)],
+            capture_output=True,
+            text=True,
+            # The TUI opens immediately and never exits; a short window is
+            # enough to prove it, and keeps this pin cheap.
+            timeout=20,
+        )
+    except subprocess.TimeoutExpired:
+        pass  # the expected outcome — the TUI never exits
+
+    assert not (repo / "old.txt").exists(), (
+        "the old invocation wrote a file; the premise of #1012 no longer holds"
+    )
+
+
+def test_the_adapter_command_actually_writes_a_file(repo: Path) -> None:
+    """Runs exactly what the adapter builds, and asserts on the file produced.
+
+    Not "exit 0" — the TUI path could exit 0 having done nothing, which is the
+    whole false-completion class here.
+    """
+    adapter = KilocodeAdapter(timeout_s=_TIMEOUT_S)
+    result = adapter.run(
+        "task-smoke",
+        "Create a file smoke.txt containing exactly the word ACKNOWLEDGED. "
+        "Do not create or modify any other file.",
+        repo,
+    )
+    if (result.error or "").startswith(("Kilocode execution timed out", "Process timed out")):
+        pytest.skip("kilo did not complete in time")
+
+    written = repo / "smoke.txt"
+    assert written.exists(), (
+        f"the adapter's own command wrote no file — status={result.status!r} "
+        f"error={result.error!r}"
+    )
+    assert result.status == "completed"
+    assert "smoke.txt" in result.modified_files
+
+
+def test_a_run_that_writes_nothing_is_not_reported_completed(repo: Path) -> None:
+    """End to end through `adapter.run`, with a prompt that asks for no changes."""
+    adapter = KilocodeAdapter(timeout_s=_TIMEOUT_S)
+    result = adapter.run(
+        "task-smoke",
+        "Reply with the single word ACKNOWLEDGED. Do not create, edit or "
+        "delete any files.",
+        repo,
+    )
+    if (result.error or "").startswith(("Kilocode execution timed out", "Process timed out")):
+        pytest.skip("kilo did not complete in time")
+
+    changed = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip()
+    if changed:
+        pytest.skip(f"the model wrote files anyway: {changed!r}")
+
+    assert result.status != "completed", (
+        f"a run that wrote nothing was reported {result.status!r} — gates would "
+        f"then pass on an unchanged tree"
+    )

--- a/tests/core/adapters/test_kilocode_smoke_1012.py
+++ b/tests/core/adapters/test_kilocode_smoke_1012.py
@@ -18,6 +18,7 @@ but it is **launch-gating**, not deferred: kilocode is a shipped engine.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -28,6 +29,14 @@ from codeframe.core.adapters.kilocode import KilocodeAdapter
 
 pytestmark = [
     pytest.mark.v2,
+    # Opt-in, not merely binary-gated. These drive real kilocode sessions —
+    # real credentials, real model calls, real money, 20-240s each — so a plain
+    # `uv run pytest` must not start doing that just because the CLI happens to
+    # be installed on the machine.
+    pytest.mark.skipif(
+        os.environ.get("CODEFRAME_ENGINE_SMOKE") != "1",
+        reason="engine smoke tier is opt-in: set CODEFRAME_ENGINE_SMOKE=1",
+    ),
     pytest.mark.skipif(
         shutil.which(KilocodeAdapter._resolve_binary()) is None,
         reason="kilo CLI not installed",

--- a/tests/core/adapters/test_opencode_smoke_913.py
+++ b/tests/core/adapters/test_opencode_smoke_913.py
@@ -17,6 +17,7 @@ shipped multi-model options.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -27,6 +28,14 @@ from codeframe.core.adapters.opencode import OpenCodeAdapter
 
 pytestmark = [
     pytest.mark.v2,
+    # Opt-in, not merely binary-gated. These drive real opencode sessions —
+    # real credentials, real model calls, real money — so a plain
+    # `uv run pytest` must not start doing that just because the CLI happens to
+    # be installed on the machine. (#1012 review)
+    pytest.mark.skipif(
+        os.environ.get("CODEFRAME_ENGINE_SMOKE") != "1",
+        reason="engine smoke tier is opt-in: set CODEFRAME_ENGINE_SMOKE=1",
+    ),
     pytest.mark.skipif(
         shutil.which("opencode") is None, reason="opencode CLI not installed"
     ),


### PR DESCRIPTION
Closes #1012.

## Problem

`KilocodeAdapter.build_command` built `kilo run <prompt> --auto --workspace <path>`. **There is no `run` subcommand.** Verified against kilocode 0.22.0: usage is `kilocode [options] [command] [prompt]` and the only commands are `auth`, `config`, `debug`, `models` — the prompt is a bare positional.

So `run` was swallowed as the prompt, the real prompt became a stray argument, `--auto` never took effect, and the CLI **opened its interactive TUI and hung** until the adapter's timeout, writing nothing. `--engine kilocode` could not do any work at all.

This is the third shipped engine with an invented invocation, after #913 (opencode's non-existent `--non-interactive`) and #914 (codex's invented app-server protocol). Found while building the binary-gated tier for #915 — which is exactly what that tier is for.

## Evidence — reproduced live, both directions

Broken (exactly what the adapter built):

```
$ kilo run "Create a file kilo_probe.txt containing exactly: works" --auto --workspace $D
exit=124                 # killed at the timeout
$ ls $D                  # nothing written
out.log                  # contains the Kilo Code TUI banner
```

Working (identical, minus the bogus subcommand):

```
$ kilo "Create a file kilo_probe.txt containing exactly: works" --auto --workspace $D
exit=0
$ ls $D
kilo_probe.txt           # "✓ Task Completed / Created kilo_probe.txt with the content 'works'"
```

`--workspace` *is* honoured, so unlike #1007 there is no cwd problem here — only the invented subcommand.

## Changes

**The invocation** — `run` removed; the prompt is the leading positional.

**`require_file_changes=True`** — the TUI path could exit 0 having written nothing, and gates would then run on an unchanged tree with the task markable DONE. Same guard claude-code got in #739/#819 and opencode in #913. `KilocodeAdapter` was the last shipped coding-agent adapter without it.

**The unit test was pinning the bug.** It asserted `cmd[1] == "run"` — i.e. that the adapter agrees with itself. It now asserts the prompt is the leading positional and that `run` is absent, so restoring the bug fails the suite.

**A binary-gated smoke tier** (`test_kilocode_smoke_1012.py`) runs the adapter's own `build_command` output against the installed `kilo`:

- `kilo --help` lists no `run` command — asserted against the CLI's own help, so it fails if kilocode ever adds one and the adapter needs revisiting
- the old invocation hangs and writes nothing (pins the bug, so nobody restores it believing it worked)
- the adapter's command **writes a real file** — not "exit 0", which the TUI path could also produce
- a run that writes nothing is not reported `completed`

## Demo — real binary

```
tests/core/adapters/test_kilocode_smoke_1012.py .....            [100%]
5 passed in 53.95s

  17.2s  test_the_adapter_command_actually_writes_a_file          -> smoke.txt written
   9.8s  test_a_run_that_writes_nothing_is_not_reported_completed -> guard fired
  20.0s  test_the_old_invocation_hangs_and_writes_nothing         -> timeout, no file
```

The file on disk is the outcome evidence: the adapter drove real kilocode to completion and the delegated agent wrote real code.

## Review

`codex review --base main` (cross-family, pre-PR) raised one **[P2]**: gating the smoke tests on `shutil.which` alone meant a plain `uv run pytest` on any machine with the CLI installed would start making real model calls — real credentials, real money, network-dependent flakiness.

Confirmed and fixed in 2d8937f: both smoke files now also require `CODEFRAME_ENGINE_SMOKE=1`. I applied it to the pre-existing opencode smoke file too, since it had the same defect. Verified both directions:

```
default:                     202 passed,  9 skipped in  2.3s   (was 53s of real model calls)
CODEFRAME_ENGINE_SMOKE=1:      5 passed             in 54.0s   (real kilo, real files)
```

## Tests

`tests/core/adapters/` — 202 passed, 9 skipped (default); +5 real-binary tests under the opt-in flag. `ruff check` clean.

## Known limitations

- The workflow that sets `CODEFRAME_ENGINE_SMOKE=1` on a schedule with the binaries installed is **#915 (P0.21)**, which this unblocks — its AC1 requires driving a task to a terminal state per engine, which kilocode could not do before this.
- The prompt is still a single positional argument, so kilocode inherits the argv size ceiling that #913 addressed for opencode (macOS caps at 256 KB; Linux at 128 KB per argument). The existing docstring notes it. kilocode has no documented stdin path to fall back to, so unlike opencode there is no fix available here — flagging rather than silently leaving it undocumented.
