### PR TITLE
fix(prd): resolve the provider in get_active_session instead of forcing Anthropic (#917)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1507,7 +1507,9 @@ def prd_generate(
                     session.start_discovery()
             except NoApiKeyError as e:
                 console.print(f"[red]Error:[/red] {e}")
-                console.print("\n[dim]Set ANTHROPIC_API_KEY environment variable to use AI discovery.[/dim]")
+                # The NoApiKeyError text already names the resolved provider's
+                # key; a hardcoded ANTHROPIC_API_KEY hint contradicts it (#917).
+                console.print("\n[dim]Set the API key named above to use AI discovery.[/dim]")
                 raise typer.Exit(1)
 
         console.print("\n[bold]Starting AI-driven PRD discovery...[/bold]")

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -836,7 +836,7 @@ def get_active_session(workspace: Workspace) -> Optional[PrdDiscoverySession]:
         PrdDiscoverySession if found, None if no active session exists
 
     Raises:
-        NoApiKeyError: If session exists but ANTHROPIC_API_KEY is not set
+        NoApiKeyError: If a session exists but the resolved provider's API key is unset
     """
     _ensure_discovery_schema(workspace)
 
@@ -858,20 +858,15 @@ def get_active_session(workspace: Workspace) -> Optional[PrdDiscoverySession]:
     if not row:
         return None
 
-    # Need API key to load session
-    api_key = os.getenv("ANTHROPIC_API_KEY")
-    if not api_key:
-        logger.warning(
-            "Cannot load discovery session %s: ANTHROPIC_API_KEY environment "
-            "variable is not set. Set the API key to resume this session.",
-            row[0],
-        )
-        raise NoApiKeyError(
-            "ANTHROPIC_API_KEY is required to load discovery session. "
-            "Set the environment variable to resume."
-        )
-
-    session = PrdDiscoverySession(workspace, api_key=api_key)
+    # Construct with no api_key so __post_init__ runs the resolution chain
+    # (CODEFRAME_LLM_PROVIDER -> .codeframe/config.yaml -> anthropic, #861).
+    # Reading ANTHROPIC_API_KEY here and passing it explicitly took the legacy
+    # branch and forced the Anthropic path, so a workspace configured for
+    # openai/ollama could start discovery but never resume it — and when an
+    # Anthropic key merely happened to be present, resuming silently switched
+    # provider mid-session. NoApiKeyError from __post_init__ already names the
+    # resolved provider's key. (#917)
+    session = PrdDiscoverySession(workspace)
     session.load_session(row[0])
     return session
 
@@ -1056,14 +1051,16 @@ def get_discovery_status(
     else:
         try:
             session = get_active_session(workspace)
-        except NoApiKeyError:
-            # Session exists but can't load without API key
+        except NoApiKeyError as e:
+            # Session exists but can't load without an API key. Surface the
+            # resolved provider's key from the exception rather than naming
+            # ANTHROPIC_API_KEY unconditionally (#917).
             return {
                 "state": "unknown",
                 "session_id": None,
                 "progress": {},
                 "current_question": None,
-                "error": "ANTHROPIC_API_KEY required to load session",
+                "error": str(e),
             }
 
     if session is None:

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -156,7 +156,9 @@ async def start_discovery(
     except NoApiKeyError as e:
         raise HTTPException(
             status_code=500,
-            detail=f"ANTHROPIC_API_KEY not configured: {e}",
+            # `e` already names the *resolved* provider's key (#917) — do not
+            # prepend ANTHROPIC_API_KEY, which misdirects an openai/ollama user.
+            detail=f"LLM API key not configured: {e}",
         )
     except Exception as e:
         logger.error(f"Failed to start discovery: {e}", exc_info=True)

--- a/tests/core/test_prd_discovery_provider_917.py
+++ b/tests/core/test_prd_discovery_provider_917.py
@@ -1,0 +1,174 @@
+"""`get_active_session` must resolve the provider, not force Anthropic (#917).
+
+`PrdDiscoverySession.__post_init__` was generalized in #861 to resolve through
+`CODEFRAME_LLM_PROVIDER` -> `.codeframe/config.yaml` -> anthropic. But
+`get_active_session` still read `ANTHROPIC_API_KEY` itself and passed it
+explicitly, which takes the legacy branch and forces the Anthropic path.
+
+The user-visible effect: a workspace configured for openai/ollama — a documented,
+supported configuration — could *start* discovery but never *resume* it. `cf prd
+generate` exited with "Set ANTHROPIC_API_KEY", and `POST /api/v2/discovery/start`
+returned 500. Worse, if an Anthropic key happened to be present, resuming
+silently switched provider mid-session.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    """A workspace with one in-progress discovery session on disk."""
+    from codeframe.core.prd_discovery import _ensure_discovery_schema
+
+    ws = MagicMock()
+    ws.id = "ws-917"
+    ws.repo_path = tmp_path
+    db = tmp_path / "codeframe.db"
+    ws.db_path = db
+
+    _ensure_discovery_schema(ws)
+
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        INSERT INTO discovery_sessions
+            (id, workspace_id, state, qa_history, current_question, coverage,
+             created_at, updated_at)
+        VALUES (?, ?, 'discovering', '[]', 'What are you building?', '{}',
+                datetime('now'), datetime('now'))
+        """,
+        ("sess-917", ws.id),
+    )
+    conn.commit()
+    conn.close()
+    return ws
+
+
+def _clear_keys(monkeypatch) -> None:
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "CODEFRAME_LLM_PROVIDER"):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestGetActiveSessionResolvesProvider:
+    def test_resumes_with_openai_and_no_anthropic_key(self, workspace, monkeypatch) -> None:
+        """The headline case: an OpenAI-configured workspace can resume (AC2)."""
+        from codeframe.core import prd_discovery
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+
+        session = prd_discovery.get_active_session(workspace)
+
+        assert session is not None, "an OpenAI workspace could not resume its session"
+        assert session.session_id == "sess-917"
+
+    def test_does_not_force_the_anthropic_provider(self, workspace, monkeypatch) -> None:
+        """Resolution must run, rather than an explicit key short-circuiting it."""
+        from codeframe.core import prd_discovery
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+
+        session = prd_discovery.get_active_session(workspace)
+
+        assert session is not None
+        assert session.api_key is None, (
+            "an explicit api_key takes __post_init__'s legacy branch and forces "
+            "AnthropicProvider regardless of the configured provider"
+        )
+        assert "anthropic" not in type(session._llm_provider).__name__.lower()
+
+    def test_an_anthropic_key_present_does_not_hijack_an_openai_session(
+        self, workspace, monkeypatch
+    ) -> None:
+        """The silent-provider-switch case.
+
+        Previously the mere presence of ANTHROPIC_API_KEY was enough to resume a
+        session on Anthropic even when the workspace was configured otherwise.
+        """
+        from codeframe.core import prd_discovery
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-should-be-ignored")
+
+        session = prd_discovery.get_active_session(workspace)
+
+        assert session is not None
+        assert "anthropic" not in type(session._llm_provider).__name__.lower()
+
+    def test_a_local_provider_needs_no_key_at_all(self, workspace, monkeypatch) -> None:
+        """Ollama has no required key — resuming must not demand one."""
+        from codeframe.core import prd_discovery
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "ollama")
+
+        session = prd_discovery.get_active_session(workspace)
+        assert session is not None
+
+    def test_the_error_names_the_resolved_providers_key(self, workspace, monkeypatch) -> None:
+        """AC3: not 'Set ANTHROPIC_API_KEY' when the provider is OpenAI."""
+        from codeframe.core import prd_discovery
+        from codeframe.core.prd_discovery import NoApiKeyError
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+
+        with pytest.raises(NoApiKeyError) as excinfo:
+            prd_discovery.get_active_session(workspace)
+
+        message = str(excinfo.value)
+        assert "OPENAI_API_KEY" in message
+        assert "ANTHROPIC_API_KEY" not in message
+
+    def test_anthropic_still_works_as_the_default(self, workspace, monkeypatch) -> None:
+        """The default path must be untouched."""
+        from codeframe.core import prd_discovery
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        session = prd_discovery.get_active_session(workspace)
+        assert session is not None
+        assert "anthropic" in type(session._llm_provider).__name__.lower()
+
+    def test_no_active_session_returns_none(self, tmp_path, monkeypatch) -> None:
+        """An empty workspace must not raise about keys before finding nothing."""
+        from codeframe.core import prd_discovery
+        from codeframe.core.prd_discovery import _ensure_discovery_schema
+
+        _clear_keys(monkeypatch)
+        ws = MagicMock()
+        ws.id = "ws-empty"
+        ws.repo_path = tmp_path
+        ws.db_path = tmp_path / "codeframe.db"
+        _ensure_discovery_schema(ws)
+
+        assert prd_discovery.get_active_session(ws) is None
+
+
+class TestApiRoutePath:
+    def test_discovery_start_resumes_under_openai(self, workspace, monkeypatch) -> None:
+        """The route delegates to get_active_session, so it inherits the fix (AC2)."""
+        from codeframe.core import prd_discovery
+
+        _clear_keys(monkeypatch)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+
+        with patch.object(prd_discovery, "logger"):
+            session = prd_discovery.get_active_session(workspace)
+
+        assert session is not None and session.session_id == "sess-917"


### PR DESCRIPTION
Closes #917.

## Problem

`PrdDiscoverySession.__post_init__` was generalized in #861 to resolve the provider through `CODEFRAME_LLM_PROVIDER` → `.codeframe/config.yaml` → anthropic. But `get_active_session` still read `ANTHROPIC_API_KEY` itself and passed it explicitly — and an explicit `api_key` takes `__post_init__`'s legacy branch, pinning the session to `AnthropicProvider`.

So a workspace configured for openai/ollama — a documented, supported configuration — could **start** discovery but never **resume** it:

- `cf prd generate` exited with "Set ANTHROPIC_API_KEY"
- `POST /api/v2/discovery/start` returned 500

And when an Anthropic key merely *happened* to be present, resuming **silently switched provider mid-session**. That is arguably the worse of the two, because it looks like it worked.

## Fix

Construct with no `api_key` and let the resolution chain run. That is the whole change; `__post_init__` already does the right thing and already raises a `NoApiKeyError` naming the *resolved* provider's key.

Three user-facing strings still hardcoded `ANTHROPIC_API_KEY` and would have contradicted that exception, sending an OpenAI user to the wrong variable. They now defer to the resolved message:

| site | was |
|---|---|
| `discovery_v2.py:159` — the 500 detail | `f"ANTHROPIC_API_KEY not configured: {e}"` |
| `cli/app.py:1510` — the hint under the error | `"Set ANTHROPIC_API_KEY environment variable…"` |
| `prd_discovery.py:1061` — `get_discovery_status`'s error field | `"ANTHROPIC_API_KEY required to load session"` |

## Demo — real session on disk, every provider path

Run with `env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u CODEFRAME_LLM_PROVIDER` so nothing leaks in from the environment:

```
OpenAI configured, NO Anthropic key (the reported failure)
  resumed  : sess-demo      provider : OpenAIProvider      api_key : None

Ollama (local, needs no key at all)
  resumed  : sess-demo      provider : OpenAIProvider      api_key : None

OpenAI configured but an Anthropic key is also present
  resumed  : sess-demo      provider : OpenAIProvider      api_key : None      <- no silent switch

Default (anthropic) still works
  resumed  : sess-demo      provider : AnthropicProvider   api_key : None

OpenAI configured, key missing
  NoApiKeyError: OPENAI_API_KEY is required for AI-driven discovery
                 (resolved provider: openai). ...
```

## Acceptance criteria

| AC | Evidence |
|----|----------|
| `get_active_session` constructs with no `api_key` and lets `__post_init__` resolve | one-line change; `test_does_not_force_the_anthropic_provider` asserts `session.api_key is None` *and* a non-Anthropic provider |
| with `CODEFRAME_LLM_PROVIDER=openai` and no `ANTHROPIC_API_KEY`, an in-progress session resumes via CLI and `POST /api/v2/discovery/start` | demo row 1; `test_resumes_with_openai_and_no_anthropic_key` + `TestApiRoutePath` (the route delegates to `get_active_session`, so it inherits the fix) |
| error strings name the resolved provider's key | demo row 5; `test_the_error_names_the_resolved_providers_key` asserts `OPENAI_API_KEY` present **and** `ANTHROPIC_API_KEY` absent; the three hardcoded strings above now defer to the exception |

## Tests

8 new tests in `tests/core/test_prd_discovery_provider_917.py`, including the silent-provider-switch case the issue describes but does not list as an AC. `tests/core/test_prd_discovery.py` (15) and `tests/ui/test_blocking_handler_offload_902.py` still pass — 28 total. `ruff check` clean.

Review: `codex review --base main` (cross-family, pre-PR) — no findings.

## Known limitations

- `start_discovery_session` and the other module-level convenience functions still accept an explicit `api_key` and keep the legacy Anthropic contract when one is passed. That is the documented behaviour of `__post_init__`'s first branch and is out of scope here; this PR only stops `get_active_session` from *manufacturing* such a key.
- The provider is resolved at resume time, so a session started under one provider and resumed after the config changed will use the new one. That is the intended behaviour of the resolution chain, but it is worth naming: session state carries no provider stamp.
