### PR TITLE
fix(chat): make the streaming tool loop provider-neutral (#918)

### DIFF
--- a/codeframe/core/adapters/streaming_chat.py
+++ b/codeframe/core/adapters/streaming_chat.py
@@ -137,6 +137,55 @@ _TOOLS_FOR_API: list[dict] = [
 
 
 # ---------------------------------------------------------------------------
+# Tool-loop continuation
+# ---------------------------------------------------------------------------
+
+
+def build_tool_continuation(
+    *,
+    assistant_text: str,
+    tool_calls: list[dict],
+    tool_results: list[dict],
+) -> list[dict]:
+    """Build the two messages that re-enter the stream after running tools.
+
+    Uses the **internal neutral keys** (``tool_calls`` / ``tool_results``), which
+    every provider already translates: ``AnthropicProvider._convert_messages``
+    turns them into ``tool_use`` / ``tool_result`` blocks, and
+    ``OpenAIProvider._convert_messages`` into ``tool_calls`` /  ``role="tool"``
+    messages.
+
+    This adapter previously emitted Anthropic block form directly. OpenAI's
+    converter only special-cases the neutral keys, so those blocks hit its
+    passthrough branch and raw Anthropic content was POSTed to Chat Completions —
+    a 400 for every openai/ollama/vllm session the moment a tool was called
+    (#918). Emitting neutral keys in this one place fixes every provider at once,
+    rather than adding a second translation layer to each.
+
+    Args:
+        assistant_text: Any prose the model streamed before calling tools.
+        tool_calls: ``{"id", "name", "input"}`` per call, in call order.
+        tool_results: ``{"tool_call_id", "content"}`` per result.
+
+    Returns:
+        ``[assistant_turn, tool_result_turn]``, in that order — Anthropic rejects
+        a tool_result that is not immediately preceded by the assistant message
+        carrying the matching tool_use.
+    """
+    return [
+        {
+            "role": "assistant",
+            "content": assistant_text,
+            "tool_calls": [
+                {"id": tc["id"], "name": tc["name"], "input": tc.get("input") or {}}
+                for tc in tool_calls
+            ],
+        },
+        {"role": "user", "content": "", "tool_results": tool_results},
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
 
@@ -487,34 +536,14 @@ class StreamingChatAdapter:
                 )
 
                 tool_result_blocks.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": tc["id"],
-                        "content": result_text,
-                    }
+                    {"tool_call_id": tc["id"], "content": result_text}
                 )
 
-            # Replay the assistant turn (text + tool_use blocks) followed by the
-            # tool results. The Anthropic API rejects (400) a tool_result user
-            # message that isn't immediately preceded by the assistant message
-            # carrying the matching tool_use blocks.
-            assistant_content: list[dict] = []
-            if assistant_text:
-                assistant_content.append({"type": "text", "text": assistant_text})
-            for tc in pending_tool_calls:
-                assistant_content.append(
-                    {
-                        "type": "tool_use",
-                        "id": tc["id"],
-                        "name": tc["name"],
-                        "input": tc.get("input") or {},
-                    }
-                )
-
-            current_messages = current_messages + [
-                {"role": "assistant", "content": assistant_content},
-                {"role": "user", "content": tool_result_blocks},
-            ]
+            current_messages = current_messages + build_tool_continuation(
+                assistant_text=assistant_text,
+                tool_calls=pending_tool_calls,
+                tool_results=tool_result_blocks,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/adapters/test_streaming_chat_tool_loop_918.py
+++ b/tests/core/adapters/test_streaming_chat_tool_loop_918.py
@@ -1,0 +1,170 @@
+"""The streaming tool loop must be provider-neutral (#918).
+
+`StreamingChatAdapter` is documented provider-agnostic and always offers tools,
+but after executing them it re-entered the stream with **Anthropic-format**
+`tool_use` / `tool_result` blocks. `OpenAIProvider._convert_messages` only
+special-cases the internal neutral keys (`tool_calls` / `tool_results`), so those
+blocks fell through to the passthrough branch and raw Anthropic content was
+POSTed to Chat Completions — a 400 for every interactive session on
+openai/ollama/vllm as soon as the model called a tool.
+
+Both providers already translate the neutral keys, so the fix belongs in the one
+place that emits them rather than as a second translation layer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+def _continuation_messages() -> list[dict]:
+    """The two messages the tool loop appends after executing a tool call.
+
+    Built by driving the adapter's own continuation builder so this test tracks
+    the production shape rather than a copy of it.
+    """
+    from codeframe.core.adapters.streaming_chat import build_tool_continuation
+
+    return build_tool_continuation(
+        assistant_text="Let me check that file.",
+        tool_calls=[{"id": "call_1", "name": "read_file", "input": {"path": "a.py"}}],
+        tool_results=[{"tool_call_id": "call_1", "content": "print('hi')"}],
+    )
+
+
+class TestNeutralContinuationShape:
+    def test_the_assistant_turn_uses_the_neutral_tool_calls_key(self) -> None:
+        assistant, _ = _continuation_messages()
+
+        assert assistant["role"] == "assistant"
+        assert assistant["tool_calls"] == [
+            {"id": "call_1", "name": "read_file", "input": {"path": "a.py"}}
+        ]
+        # Not Anthropic blocks — those are what OpenAI's passthrough branch
+        # forwarded verbatim and the API rejected.
+        assert not isinstance(assistant["content"], list)
+
+    def test_the_tool_result_turn_uses_the_neutral_tool_results_key(self) -> None:
+        _, results = _continuation_messages()
+
+        assert results["tool_results"] == [
+            {"tool_call_id": "call_1", "content": "print('hi')"}
+        ]
+        assert not isinstance(results["content"], list)
+
+
+class TestOpenAIPath:
+    """AC1/AC2 — one tool round-trip through the OpenAI conversion."""
+
+    def _converted(self) -> list[dict]:
+        from codeframe.adapters.llm.openai import OpenAIProvider
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)  # no client/network needed
+        messages = [{"role": "user", "content": "read a.py"}] + _continuation_messages()
+        return provider._convert_messages(messages)
+
+    def test_the_assistant_turn_becomes_openai_tool_calls(self) -> None:
+        converted = self._converted()
+
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        assert "tool_calls" in assistant, (
+            "assistant turn did not convert — raw Anthropic blocks would be POSTed"
+        )
+        call = assistant["tool_calls"][0]
+        assert call["type"] == "function"
+        assert call["id"] == "call_1"
+        assert call["function"]["name"] == "read_file"
+        # OpenAI wants a JSON *string* for arguments, not a dict.
+        assert json.loads(call["function"]["arguments"]) == {"path": "a.py"}
+
+    def test_the_tool_result_becomes_a_role_tool_message(self) -> None:
+        converted = self._converted()
+
+        tool_msgs = [m for m in converted if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "call_1"
+        assert tool_msgs[0]["content"] == "print('hi')"
+
+    def test_no_anthropic_block_survives_into_the_payload(self) -> None:
+        """The actual 400 cause: Anthropic block dicts reaching Chat Completions."""
+        payload = json.dumps(self._converted())
+
+        for leaked in ("tool_use", "tool_result", "tool_use_id"):
+            assert leaked not in payload, f"{leaked!r} leaked into the OpenAI payload"
+
+
+class TestAnthropicPathUnchanged:
+    """The neutral keys must round-trip on Anthropic too — no regression."""
+
+    def _converted(self) -> list[dict]:
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider.__new__(AnthropicProvider)
+        messages = [{"role": "user", "content": "read a.py"}] + _continuation_messages()
+        return provider._convert_messages(messages)
+
+    def test_the_assistant_turn_becomes_a_tool_use_block(self) -> None:
+        converted = self._converted()
+
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        blocks = assistant["content"]
+        assert {"type": "text", "text": "Let me check that file."} in blocks
+        assert {
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "read_file",
+            "input": {"path": "a.py"},
+        } in blocks
+
+    def test_the_tool_result_becomes_a_tool_result_block(self) -> None:
+        converted = self._converted()
+
+        # Anthropic rejects a tool_result that is not immediately preceded by the
+        # assistant message carrying the matching tool_use.
+        assert converted[-2]["role"] == "assistant"
+        assert converted[-1]["role"] == "user"
+        block = converted[-1]["content"][0]
+        assert block["type"] == "tool_result"
+        assert block["tool_use_id"] == "call_1"
+        assert block["content"] == "print('hi')"
+
+
+class TestMultipleToolCalls:
+    def test_every_call_and_result_is_paired(self) -> None:
+        from codeframe.adapters.llm.openai import OpenAIProvider
+        from codeframe.core.adapters.streaming_chat import build_tool_continuation
+
+        messages = build_tool_continuation(
+            assistant_text="",
+            tool_calls=[
+                {"id": "c1", "name": "read_file", "input": {"path": "a.py"}},
+                {"id": "c2", "name": "list_files", "input": {}},
+            ],
+            tool_results=[
+                {"tool_call_id": "c1", "content": "a"},
+                {"tool_call_id": "c2", "content": "b"},
+            ],
+        )
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        converted = provider._convert_messages(messages)
+
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        assert [c["id"] for c in assistant["tool_calls"]] == ["c1", "c2"]
+        assert [m["tool_call_id"] for m in converted if m["role"] == "tool"] == ["c1", "c2"]
+
+    def test_an_empty_assistant_text_still_produces_a_valid_turn(self) -> None:
+        """A model that calls a tool with no prose must not emit a null content."""
+        from codeframe.core.adapters.streaming_chat import build_tool_continuation
+
+        assistant, _ = build_tool_continuation(
+            assistant_text="",
+            tool_calls=[{"id": "c1", "name": "t", "input": {}}],
+            tool_results=[{"tool_call_id": "c1", "content": "r"}],
+        )
+        assert assistant["content"] == ""
+        assert assistant["tool_calls"]

--- a/tests/core/test_streaming_chat.py
+++ b/tests/core/test_streaming_chat.py
@@ -364,6 +364,11 @@ class TestToolCallEvents:
 
         Asserts on the message list actually sent to the provider (via
         MockProvider.calls) rather than only the emitted events.
+
+        Since #918 the adapter emits the *provider-neutral* tool_calls /
+        tool_results keys and each provider translates them, so the pairing is
+        asserted both at the adapter boundary and after Anthropic conversion —
+        the layer the 400 actually came from.
         """
         tool_id = "tool_abc"
         tool_input = {"path": "README.md"}
@@ -398,24 +403,34 @@ class TestToolCallEvents:
         assert len(provider.calls) == 2
         second_turn = provider.calls[1]["messages"]
 
-        # Find the assistant tool_use message and the following tool_result message
+        # Adapter boundary: neutral keys, assistant turn immediately before the
+        # tool_results turn.
         assistant_idx = next(
             i for i, m in enumerate(second_turn)
+            if m["role"] == "assistant" and m.get("tool_calls")
+        )
+        call = second_turn[assistant_idx]["tool_calls"][0]
+        assert call == {"id": tool_id, "name": "read_file", "input": tool_input}
+        results_msg = second_turn[assistant_idx + 1]
+        assert results_msg["role"] == "user"
+        assert results_msg["tool_results"][0]["tool_call_id"] == tool_id
+
+        # Anthropic wire shape after conversion — the original 400 condition.
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+        converted = AnthropicProvider.__new__(AnthropicProvider)._convert_messages(
+            second_turn
+        )
+        wire_idx = next(
+            i for i, m in enumerate(converted)
             if m["role"] == "assistant"
             and isinstance(m["content"], list)
             and any(b.get("type") == "tool_use" for b in m["content"])
         )
-        blocks = second_turn[assistant_idx]["content"]
         # Any preceding text block must come before the tool_use block
-        types = [b["type"] for b in blocks]
-        assert types == ["text", "tool_use"]
-        tool_use_block = next(b for b in blocks if b["type"] == "tool_use")
-        assert tool_use_block["id"] == tool_id
-        assert tool_use_block["name"] == "read_file"
-        assert tool_use_block["input"] == tool_input
-
+        assert [b["type"] for b in converted[wire_idx]["content"]] == ["text", "tool_use"]
         # The very next message pairs the matching tool_result
-        result_msg = second_turn[assistant_idx + 1]
+        result_msg = converted[wire_idx + 1]
         assert result_msg["role"] == "user"
         result_block = next(
             b for b in result_msg["content"] if b["type"] == "tool_result"
@@ -450,9 +465,16 @@ class TestToolCallEvents:
             mock_tool.return_value = "contents"
             _ = [e async for e in adapter.send_message("read main", [])]
 
+        from codeframe.adapters.llm.anthropic import AnthropicProvider
+
         second_turn = provider.calls[1]["messages"]
+        assert next(m for m in second_turn if m.get("tool_calls"))["content"] == ""
+
+        converted = AnthropicProvider.__new__(AnthropicProvider)._convert_messages(
+            second_turn
+        )
         assistant_msg = next(
-            m for m in second_turn
+            m for m in converted
             if m["role"] == "assistant" and isinstance(m["content"], list)
             and any(b.get("type") == "tool_use" for b in m["content"])
         )


### PR DESCRIPTION
Closes #918.

## Problem

`StreamingChatAdapter` is documented provider-agnostic and always offers tools — but after executing them it re-entered the stream with **Anthropic-format** `tool_use` / `tool_result` blocks.

`OpenAIProvider._convert_messages` only special-cases the internal neutral keys (`tool_calls` / `tool_results`), so those blocks fell through to its passthrough branch and raw Anthropic content was POSTed to Chat Completions. Every interactive session on openai/ollama/vllm 400s the moment the model calls a tool — a first-session failure for every non-Anthropic user.

## Fix

**Both providers already translate the neutral keys** — `anthropic.py:371/397` turns them into `tool_use`/`tool_result` blocks, `openai.py:400/409` into `tool_calls` / `role="tool"` messages. So the fix belongs in the one place that *emits* them, not as a second translation layer bolted onto each provider.

Extracted `build_tool_continuation()`, which also makes the shape testable directly rather than only reachable through a live stream.

## Demo — reproduced over real HTTP

A local server speaking the Chat Completions shape, rejecting what the real API rejects:

```
BEFORE (Anthropic blocks)
  FAILED: Error code: 400 - {'error': {'message': "Anthropic block 'tool_use' in an
          'assistant' message — Chat Completions has no such content type",
          'type': 'invalid_request_error'}}

AFTER  (neutral keys)
  HTTP 200 — tool round-trip completed
  assistant reply : The file prints hi.
  roles on wire   : ['user', 'assistant', 'tool']
  role=tool msg   : {"role": "tool", "tool_call_id": "call_1", "content": "print('hi')"}
  tool_calls      : [{"id": "call_1", "type": "function",
                      "function": {"name": "read_file", "arguments": "{\"path\": \"a.py\"}"}}]
```

That is the exact failure the issue describes, reproduced and then fixed — not a mock asserting our own shape back at us.

## Acceptance criteria

| AC | Evidence |
|----|----------|
| continuation uses the internal neutral keys; a test drives one tool round-trip through the OpenAI path and asserts OpenAI-shaped `tool_calls` / `role=tool` | `TestOpenAIPath` — asserts `type: "function"`, the `id`, and that `arguments` is a JSON **string**, plus `role=tool` carrying `tool_call_id` |
| an interactive session against an OpenAI-compatible provider completes a tool call without a 400 | the HTTP demo above; `test_no_anthropic_block_survives_into_the_payload` asserts no `tool_use`/`tool_result`/`tool_use_id` string survives into the serialized payload |

## Tests

9 new in `tests/core/adapters/test_streaming_chat_tool_loop_918.py`, covering both providers, multi-call pairing, and the empty-assistant-text case (a model calling a tool with no prose must not emit a null content).

`TestAnthropicPathUnchanged` pins the ordering constraint that made the original block form necessary: Anthropic rejects a `tool_result` not immediately preceded by the assistant message carrying the matching `tool_use`. Switching to neutral keys preserves that, because Anthropic's converter re-emits the blocks in order.

`tests/core/adapters/` + `tests/adapters/` + `tests/api/test_session_chat_ws.py` — 386 passed. `ruff check` clean. `codex review --base main`: no findings.

## Known limitations

- The demo server validates the *shape* Chat Completions requires, not a live OpenAI account. That is deliberate — it makes the regression reproducible in CI-adjacent conditions without credentials — but it means "no 400 from the real API" is verified against a faithful stand-in rather than the vendor.
- `is_error` on tool results is carried by the Anthropic converter (`tr.get("is_error", False)`) but has no OpenAI equivalent, so a failed tool result reaches OpenAI as ordinary `role=tool` content. Pre-existing and unchanged here; worth knowing when reading failure traces on non-Anthropic providers.
