### PR TITLE
fix(adapters): stop delegated agents inheriting the operator's env and HOME (#996)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,30 @@ CODEFRAME_ENABLE_TEST_ENDPOINTS=1     # Registers the integration-test-only
                                       # production — leave unset except in CI /
                                       # WebSocket integration test runs.
 
+# Delegated-agent HOME sandbox (#996) — default ON (sandboxed)
+CODEFRAME_AGENT_INHERIT_HOME=1        # Run delegated coding CLIs (claude-code,
+                                      # codex, opencode, kilocode) with the
+                                      # operator's REAL $HOME instead of a
+                                      # per-adapter one. Off by default: those
+                                      # subprocesses used to inherit the whole
+                                      # environment and the real HOME, which
+                                      # resolves ~/.codeframe/credentials,
+                                      # ~/.ssh and ~/.config/gh/hosts.yml — on a
+                                      # test machine, 69 env vars (5 of them API
+                                      # keys) down to 12 (0 keys) once fixed.
+                                      # Each adapter now declares the credentials
+                                      # it needs (`credential_env_vars`) and its
+                                      # own login dir (`home_passthrough`, e.g.
+                                      # ~/.claude, ~/.codex), which is symlinked
+                                      # into ~/.codeframe/agent-homes/<adapter>
+                                      # so `claude`/`codex` stay logged in. Set
+                                      # this only if a CLI keeps state somewhere
+                                      # CodeFrame does not forward. It does NOT
+                                      # reopen the env allowlist — separate knob.
+                                      # Like build_agent_env, not containment: an
+                                      # absolute path still reaches whatever the
+                                      # operator can read.
+
 # LLM Provider selection (multi-provider support)
 # Priority: CLI flag > env var > .codeframe/config.yaml > default (anthropic)
 CODEFRAME_LLM_PROVIDER=anthropic      # Provider: anthropic (default), openai, ollama, vllm, compatible

--- a/codeframe/core/adapters/claude_code.py
+++ b/codeframe/core/adapters/claude_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import sys
 from pathlib import Path
@@ -56,6 +57,47 @@ def _guard_settings() -> str:
             }
         }
     )
+
+
+#: Every variable `claude` reads to decide *who it talks to and as whom*, per
+#: code.claude.com/docs/en/bedrock-vertex-proxies + /settings. Enumerated rather
+#: than prefix-matched: `ANTHROPIC_*` would be a wildcard over a namespace we do
+#: not own, and `AWS_*` would hand over the operator's whole AWS identity.
+_CLAUDE_AUTH_VARS: tuple[str, ...] = (
+    # Anthropic API / LLM gateway
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    # Amazon Bedrock
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_AWS_BASE_URL",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "AWS_PROFILE",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    # Google Cloud Agent Platform (Vertex)
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLOUD_ML_REGION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    # Microsoft Foundry
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    # Model pinning — recommended for every cloud-provider deployment
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
 
 
 class ClaudeCodeAdapter(SubprocessAdapter):
@@ -120,6 +162,38 @@ class ClaudeCodeAdapter(SubprocessAdapter):
     @property
     def name(self) -> str:  # noqa: D102
         return "claude-code"
+
+    @classmethod
+    def requirements(cls) -> dict[str, str]:
+        """Environment variables ``cf engines check`` reports on."""
+        return {"ANTHROPIC_API_KEY": "Anthropic API key (unless logged in via `claude`)"}
+
+    @classmethod
+    def credential_env_vars(cls) -> tuple[str, ...]:
+        """Claude Code's own auth, whichever backend it is pointed at (#996).
+
+        Not just ``ANTHROPIC_API_KEY``: Bedrock, Vertex and Foundry are all
+        configured purely through environment variables, so an allowlist that
+        stopped at the API key would silently break every operator running
+        `claude` against a cloud provider — a working setup outside CodeFrame
+        that stopped working inside it. No OpenAI/AWS-unrelated key is forwarded.
+        """
+        return _CLAUDE_AUTH_VARS
+
+    @classmethod
+    def home_passthrough(cls) -> tuple[str, ...]:
+        """`claude` keeps its login here; a bare sandbox home logs it out (#996).
+
+        Cloud credential directories are linked **only** when the operator has
+        actually selected that backend — an ordinary API-key or subscription run
+        has no business reaching ``~/.aws``.
+        """
+        entries = [".claude", ".claude.json"]
+        if os.environ.get("CLAUDE_CODE_USE_BEDROCK"):
+            entries.append(".aws")
+        if os.environ.get("CLAUDE_CODE_USE_VERTEX"):
+            entries.append(".config/gcloud")
+        return tuple(entries)
 
     def build_command(self, prompt: str, workspace_path: Path) -> list[str]:
         """Build claude CLI command.

--- a/codeframe/core/adapters/claude_code.py
+++ b/codeframe/core/adapters/claude_code.py
@@ -59,45 +59,64 @@ def _guard_settings() -> str:
     )
 
 
-#: Every variable `claude` reads to decide *who it talks to and as whom*, per
+#: What `claude` reads to decide who it talks to and as whom, per
 #: code.claude.com/docs/en/bedrock-vertex-proxies + /settings. Enumerated rather
-#: than prefix-matched: `ANTHROPIC_*` would be a wildcard over a namespace we do
-#: not own, and `AWS_*` would hand over the operator's whole AWS identity.
-_CLAUDE_AUTH_VARS: tuple[str, ...] = (
-    # Anthropic API / LLM gateway
+#: than prefix-matched: `ANTHROPIC_*` is a namespace we do not own, and `AWS_*`
+#: would hand over the operator's whole AWS identity.
+#:
+#: Always forwarded — Anthropic API / LLM gateway, plus the model pins, none of
+#: which are another service's credential.
+_ANTHROPIC_VARS: tuple[str, ...] = (
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_BASE_URL",
     "ANTHROPIC_MODEL",
-    # Amazon Bedrock
-    "CLAUDE_CODE_USE_BEDROCK",
-    "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
-    "ANTHROPIC_BEDROCK_BASE_URL",
-    "ANTHROPIC_AWS_BASE_URL",
-    "AWS_REGION",
-    "AWS_DEFAULT_REGION",
-    "AWS_PROFILE",
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_SESSION_TOKEN",
-    # Google Cloud Agent Platform (Vertex)
-    "CLAUDE_CODE_USE_VERTEX",
-    "CLAUDE_CODE_SKIP_VERTEX_AUTH",
-    "ANTHROPIC_VERTEX_BASE_URL",
-    "ANTHROPIC_VERTEX_PROJECT_ID",
-    "CLOUD_ML_REGION",
-    "GOOGLE_APPLICATION_CREDENTIALS",
-    # Microsoft Foundry
-    "CLAUDE_CODE_USE_FOUNDRY",
-    "ANTHROPIC_FOUNDRY_RESOURCE",
-    "ANTHROPIC_FOUNDRY_API_KEY",
-    "ANTHROPIC_FOUNDRY_BASE_URL",
-    # Model pinning — recommended for every cloud-provider deployment
     "ANTHROPIC_DEFAULT_FABLE_MODEL",
     "ANTHROPIC_DEFAULT_OPUS_MODEL",
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
 )
+
+#: Forwarded only when the operator has selected that backend, keyed by its
+#: selector variable. Exported AWS keys are near-universal on a developer
+#: machine — anyone with the AWS CLI installed — and belong to a service
+#: `claude` has nothing to do with unless Bedrock is actually in use. Handing
+#: them over on every run would be the same leak this module exists to close,
+#: just through a narrower hole. (#996 review)
+_CLOUD_BACKEND_VARS: dict[str, tuple[str, ...]] = {
+    "CLAUDE_CODE_USE_BEDROCK": (
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_AWS_BASE_URL",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_PROFILE",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+    ),
+    "CLAUDE_CODE_USE_VERTEX": (
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "CLOUD_ML_REGION",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ),
+    "CLAUDE_CODE_USE_FOUNDRY": (
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_FOUNDRY_API_KEY",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+    ),
+}
+
+#: The credential *directory* each backend needs, same gating.
+_CLOUD_BACKEND_HOMES: dict[str, str] = {
+    "CLAUDE_CODE_USE_BEDROCK": ".aws",
+    "CLAUDE_CODE_USE_VERTEX": ".config/gcloud",
+}
 
 
 class ClaudeCodeAdapter(SubprocessAdapter):
@@ -176,24 +195,31 @@ class ClaudeCodeAdapter(SubprocessAdapter):
         configured purely through environment variables, so an allowlist that
         stopped at the API key would silently break every operator running
         `claude` against a cloud provider — a working setup outside CodeFrame
-        that stopped working inside it. No OpenAI/AWS-unrelated key is forwarded.
+        that stopped working inside it.
+
+        A backend's credentials ride on its selector, so an ordinary API-key run
+        never sees the operator's AWS or GCP identity.
         """
-        return _CLAUDE_AUTH_VARS
+        return _ANTHROPIC_VARS + tuple(
+            var
+            for selector, group in _CLOUD_BACKEND_VARS.items()
+            if os.environ.get(selector)
+            for var in group
+        )
 
     @classmethod
     def home_passthrough(cls) -> tuple[str, ...]:
         """`claude` keeps its login here; a bare sandbox home logs it out (#996).
 
-        Cloud credential directories are linked **only** when the operator has
-        actually selected that backend — an ordinary API-key or subscription run
-        has no business reaching ``~/.aws``.
+        Cloud credential directories are linked on the same selector as their
+        variables above — an ordinary API-key or subscription run has no business
+        reaching ``~/.aws``.
         """
-        entries = [".claude", ".claude.json"]
-        if os.environ.get("CLAUDE_CODE_USE_BEDROCK"):
-            entries.append(".aws")
-        if os.environ.get("CLAUDE_CODE_USE_VERTEX"):
-            entries.append(".config/gcloud")
-        return tuple(entries)
+        return (".claude", ".claude.json") + tuple(
+            entry
+            for selector, entry in _CLOUD_BACKEND_HOMES.items()
+            if os.environ.get(selector)
+        )
 
     def build_command(self, prompt: str, workspace_path: Path) -> list[str]:
         """Build claude CLI command.

--- a/codeframe/core/adapters/codex.py
+++ b/codeframe/core/adapters/codex.py
@@ -39,6 +39,7 @@ from codeframe.core.adapters.agent_adapter import (
     AgentResult,
 )
 from codeframe.core.adapters.git_utils import detect_modified_files
+from codeframe.core.agent_env import build_delegated_agent_env
 from codeframe.core.dangerous_commands import is_dangerous_command
 
 logger = logging.getLogger(__name__)
@@ -150,6 +151,16 @@ class CodexAdapter:
         """Return required environment variables for ``cf engines check``."""
         return {"OPENAI_API_KEY": "OpenAI API key"}
 
+    @classmethod
+    def credential_env_vars(cls) -> tuple[str, ...]:
+        """Plus the gateway override — an operator proxying OpenAI still needs it."""
+        return ("OPENAI_API_KEY", "OPENAI_BASE_URL")
+
+    @classmethod
+    def home_passthrough(cls) -> tuple[str, ...]:
+        """``codex login`` writes here; without it the sandbox home logs it out."""
+        return (".codex",)
+
     # ------------------------------------------------------------------
     # AgentAdapter.run
     # ------------------------------------------------------------------
@@ -173,6 +184,14 @@ class CodexAdapter:
                 stderr=subprocess.PIPE,
                 cwd=str(workspace_path),
                 text=True,
+                # Codex spawns its own process rather than going through
+                # SubprocessAdapter.run, so it needs the #996 env explicitly.
+                env=build_delegated_agent_env(
+                    workspace_path,
+                    adapter_name=self.name,
+                    credential_vars=self.credential_env_vars(),
+                    home_passthrough=self.home_passthrough(),
+                ),
             )
         except FileNotFoundError:
             return AgentResult(

--- a/codeframe/core/adapters/kilocode.py
+++ b/codeframe/core/adapters/kilocode.py
@@ -80,6 +80,11 @@ class KilocodeAdapter(SubprocessAdapter):
         }
 
     @classmethod
+    def home_passthrough(cls) -> tuple[str, ...]:
+        """`kilo` keeps its login here; a bare sandbox home logs it out (#996)."""
+        return (".kilocode",)
+
+    @classmethod
     def check_ready(cls) -> dict[str, bool]:
         """Check if the kilo binary is available on PATH."""
         return {"kilo_binary": shutil.which(cls._resolve_binary()) is not None}

--- a/codeframe/core/adapters/opencode.py
+++ b/codeframe/core/adapters/opencode.py
@@ -127,6 +127,24 @@ class OpenCodeAdapter(SubprocessAdapter):
     def name(self) -> str:  # noqa: D102
         return "opencode"
 
+    @classmethod
+    def requirements(cls) -> dict[str, str]:
+        """Environment variables ``cf engines check`` reports on."""
+        return {
+            "ANTHROPIC_API_KEY": "Anthropic API key (or `opencode auth login`)",
+            "OPENAI_API_KEY": "OpenAI API key (or `opencode auth login`)",
+        }
+
+    @classmethod
+    def credential_env_vars(cls) -> tuple[str, ...]:
+        """opencode is genuinely multi-provider, so both keys are in scope (#996)."""
+        return ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL")
+
+    @classmethod
+    def home_passthrough(cls) -> tuple[str, ...]:
+        """`opencode auth login` writes to both — config and stored credentials."""
+        return (".config/opencode", ".local/share/opencode")
+
     @staticmethod
     def _prompt_exceeds_argv(prompt: str) -> bool:
         """True when the prompt is too large to survive as a single argv entry."""

--- a/codeframe/core/adapters/subprocess_adapter.py
+++ b/codeframe/core/adapters/subprocess_adapter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import subprocess
 import threading
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Callable
 
 from codeframe.core.adapters.agent_adapter import AgentEvent, AgentResult
+from codeframe.core.agent_env import build_delegated_agent_env
 from codeframe.core.adapters.git_utils import detect_modified_files
 from codeframe.core.blocker_detection import classify_error_for_blocker
 
@@ -95,17 +95,44 @@ class SubprocessAdapter:
         return prompt
 
     def get_env(self, workspace_path: Path) -> dict[str, str] | None:
-        """Extra environment variables to layer over the inherited environment.
+        """Extra environment variables to layer over the sanitized base.
 
         Override to point a CLI at a config the adapter controls — e.g. opencode's
-        ``OPENCODE_CONFIG`` permission deny-list (#916). None means "inherit
-        unchanged".
+        ``OPENCODE_CONFIG`` permission deny-list (#916). None means "no extras".
 
-        Note this *adds to* the operator's environment rather than replacing it;
-        confining what a delegated agent inherits is #996's subject, not this
-        hook's.
+        Since #996 the base is ``build_delegated_agent_env`` — a deny-by-default
+        allowlist — rather than the operator's whole environment. To let a
+        variable *through* from the operator's shell, declare it in
+        ``credential_env_vars``; this hook is for values the adapter itself
+        computes.
         """
         return None
+
+    @classmethod
+    def credential_env_vars(cls) -> tuple[str, ...]:
+        """Operator environment variables to forward to the CLI (#996).
+
+        Everything else is dropped, so a key exported into the operator's shell
+        later is excluded by construction. Defaults to whatever the adapter
+        already declares as required — override to add optional ones (gateway
+        base URLs, alternate auth tokens).
+        """
+        return tuple(cls.requirements())
+
+    @classmethod
+    def home_passthrough(cls) -> tuple[str, ...]:
+        """Paths under the operator's real home to link into the sandbox home.
+
+        These CLIs keep their own login in ``~/.claude``, ``~/.codex`` etc., so a
+        HOME sandbox without this logs them out. Paths are relative to the real
+        home; missing ones are skipped.
+        """
+        return ()
+
+    @classmethod
+    def requirements(cls) -> dict[str, str]:
+        """Environment variables ``cf engines check`` reports on."""
+        return {}
 
     def run(
         self,
@@ -127,8 +154,15 @@ class SubprocessAdapter:
         stdout_lines: list[str] = []
         stderr_chunks: list[str] = []
 
-        extra_env = self.get_env(workspace_path)
-        child_env = {**os.environ, **extra_env} if extra_env else None
+        # Deny-by-default rather than the operator's whole environment, and a
+        # per-adapter HOME rather than the one holding the credential store (#996).
+        child_env = build_delegated_agent_env(
+            workspace_path,
+            adapter_name=self.name,
+            credential_vars=self.credential_env_vars(),
+            home_passthrough=self.home_passthrough(),
+        )
+        child_env.update(self.get_env(workspace_path) or {})
 
         try:
             process = subprocess.Popen(

--- a/codeframe/core/agent_env.py
+++ b/codeframe/core/agent_env.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import shutil
+from collections.abc import Iterable
 from pathlib import Path
 
 #: The agent's shell inherits a *deny-by-default* environment. Without this it
@@ -49,6 +52,17 @@ SAFE_ENV_VARS = frozenset({
 #: These default to ``$HOME/...`` when unset, so pinning ``HOME`` alone would
 #: still let an XDG path resolve back to the operator's real home.
 _XDG_VARS = ("XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME")
+
+#: Opt out of the delegated-agent ``HOME`` sandbox (#996). For an operator whose
+#: delegated CLI keeps state somewhere this module does not know to forward, and
+#: who accepts that the agent can then read ``~/.codeframe``, ``~/.ssh``, ``~/.aws``.
+#: Deliberately does *not* reopen the environment allowlist — two separate knobs.
+INHERIT_HOME_ENV = "CODEFRAME_AGENT_INHERIT_HOME"
+
+#: Where each delegated CLI gets its own home. Machine-wide rather than
+#: per-workspace: a per-workspace home would force a fresh CLI login in every
+#: repository, which is the failure the passthrough below exists to avoid.
+_AGENT_HOMES = "agent-homes"
 
 logger = logging.getLogger(__name__)
 
@@ -107,3 +121,147 @@ def build_agent_env(workspace_path: Path | str) -> dict[str, str]:
                 return env
 
     return env
+
+
+def build_delegated_agent_env(
+    workspace_path: Path | str,
+    *,
+    adapter_name: str,
+    credential_vars: Iterable[str] = (),
+    home_passthrough: Iterable[str] = (),
+) -> dict[str, str]:
+    """The environment for a delegated coding CLI (claude, codex, opencode) — #996.
+
+    ``build_agent_env`` above is not usable as-is here: it forwards *no*
+    credentials, and these CLIs cannot do anything without their provider key.
+    So this keeps its deny-by-default allowlist and adds back exactly what the
+    chosen adapter declares — an OpenAI key never reaches Claude Code, and a
+    key exported into the operator's shell tomorrow is excluded by construction
+    rather than by remembering to blocklist it.
+
+    ``HOME`` moves to ``~/.codeframe/agent-homes/<adapter>``, so the delegated
+    agent no longer resolves ``~/.codeframe/credentials``, ``~/.ssh`` or
+    ``~/.aws`` — while ``home_passthrough`` symlinks that CLI's *own* config
+    directory back in, because a naive sandbox simply logs it out and breaks the
+    engine for every subscription-auth operator.
+
+    Same caveat as ``build_agent_env``: this is not containment. The child still
+    runs as the operator, so an absolute path reaches whatever the operator can
+    read. It closes the paths a prompt-injected agent actually takes.
+
+    Args:
+        workspace_path: The workspace the agent runs in (for the PATH/venv work
+            ``build_agent_env`` does).
+        adapter_name: Names the per-adapter home, so two CLIs do not fight over
+            one config directory.
+        credential_vars: Environment variables to forward from the operator's
+            environment. Anything not listed is dropped.
+        home_passthrough: Paths relative to the operator's real home to symlink
+            into the sandbox home (e.g. ``.claude``, ``.config/opencode``).
+            Missing entries are skipped.
+    """
+    env = build_agent_env(workspace_path)
+    real_home = Path(os.path.expanduser("~"))
+
+    for var in credential_vars:
+        if var in os.environ:
+            env[var] = os.environ[var]
+
+    if _inherit_home():
+        logger.warning(
+            "%s is set: the delegated agent runs with the operator's real HOME "
+            "and can read ~/.codeframe, ~/.ssh and ~/.aws.", INHERIT_HOME_ENV
+        )
+        for var in ("HOME", *_XDG_VARS):
+            if var in os.environ:
+                env[var] = os.environ[var]
+            else:
+                # Unset rather than left pointing at the built-in sandbox — the
+                # opt-out means "behave as the operator's shell does".
+                env.pop(var, None)
+        return env
+
+    agent_home = real_home / ".codeframe" / _AGENT_HOMES / _home_slug(adapter_name)
+    try:
+        agent_home.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Point at it anyway — see build_agent_env: an *unset* HOME falls back to
+        # getpwuid() and silently regains the operator's real home.
+        logger.warning(
+            "Could not create the delegated agent home %s; the CLI will run with "
+            "a non-existent HOME rather than the operator's.", agent_home
+        )
+    else:
+        _link_home_passthrough(real_home, agent_home, home_passthrough)
+
+    env["HOME"] = str(agent_home)
+    # The conventional layout, not build_agent_env's flat one: a CLI that reads
+    # $XDG_CONFIG_HOME/opencode and one that reads ~/.config/opencode must land
+    # on the same directory, or the passthrough symlink below is never consulted.
+    env["XDG_CONFIG_HOME"] = str(agent_home / ".config")
+    env["XDG_DATA_HOME"] = str(agent_home / ".local" / "share")
+    env["XDG_CACHE_HOME"] = str(agent_home / ".cache")
+    return env
+
+
+def _home_slug(adapter_name: str) -> str:
+    """One path segment, whatever the adapter calls itself.
+
+    ``adapter_name`` reaches this as ``SubprocessAdapter.name``, which the base
+    class derives from the binary — so an absolute path would otherwise land
+    ``Path / "/usr/bin/claude"`` straight back at the filesystem root, and a
+    ``..`` would climb out of ``~/.codeframe``.
+    """
+    slug = re.sub(r"[^A-Za-z0-9._-]", "-", adapter_name).strip(".-")
+    return slug or "agent"
+
+
+def _inherit_home() -> bool:
+    return os.getenv(INHERIT_HOME_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _link_home_passthrough(
+    real_home: Path, agent_home: Path, entries: Iterable[str]
+) -> None:
+    """Link the delegated CLI's own config back into its sandbox home.
+
+    Only the named entries — linking ``~/.claude`` must not drag ``~/.codeframe``
+    or ``~/.ssh`` along with it. The agent can write *through* a link into that
+    CLI's own config, which it could already do today; the point is that
+    everything else in the operator's home stops being reachable via ``~``.
+    """
+    for entry in entries:
+        source = real_home / entry
+        if not source.exists():
+            continue  # operator has never run this CLI
+        target = agent_home / entry
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                if target.readlink() == source:
+                    continue
+                target.unlink()
+            elif target.exists():
+                # A config dir the CLI made for itself on a run that happened
+                # *before* the operator logged in. Leaving it in place would keep
+                # the delegated agent logged out forever even after they do log
+                # in — the real home is the authority once it exists. Moved
+                # aside rather than deleted: it may hold a login made from
+                # inside the sandbox.
+                stale = target.with_name(target.name + ".superseded")
+                if stale.is_symlink() or not stale.is_dir():
+                    stale.unlink(missing_ok=True)
+                elif stale.is_dir():
+                    shutil.rmtree(stale)
+                target.rename(stale)
+            target.symlink_to(source, target_is_directory=source.is_dir())
+        except OSError as e:
+            # Batch execution runs several workers against the *same* adapter
+            # home, so two of them can reach symlink_to() together and one loses
+            # with FileExistsError. The loser's work is already done.
+            if target.is_symlink() and target.readlink() == source:
+                continue
+            logger.warning(
+                "Could not link %s into the delegated agent home: %s. That CLI "
+                "may need to be re-authenticated.", entry, e
+            )

--- a/codeframe/core/agent_env.py
+++ b/codeframe/core/agent_env.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import shutil
+import threading
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -236,32 +237,41 @@ def _link_home_passthrough(
             continue  # operator has never run this CLI
         target = agent_home / entry
         try:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            if target.is_symlink():
-                if target.readlink() == source:
-                    continue
-                target.unlink()
-            elif target.exists():
-                # A config dir the CLI made for itself on a run that happened
-                # *before* the operator logged in. Leaving it in place would keep
-                # the delegated agent logged out forever even after they do log
-                # in — the real home is the authority once it exists. Moved
-                # aside rather than deleted: it may hold a login made from
-                # inside the sandbox.
-                stale = target.with_name(target.name + ".superseded")
-                if stale.is_symlink() or not stale.is_dir():
-                    stale.unlink(missing_ok=True)
-                elif stale.is_dir():
-                    shutil.rmtree(stale)
-                target.rename(stale)
-            target.symlink_to(source, target_is_directory=source.is_dir())
-        except OSError as e:
-            # Batch execution runs several workers against the *same* adapter
-            # home, so two of them can reach symlink_to() together and one loses
-            # with FileExistsError. The loser's work is already done.
             if target.is_symlink() and target.readlink() == source:
-                continue
+                continue  # already linked
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists() and not target.is_symlink():
+                _move_stale_config_aside(target)
+
+            # Build the link under a private name and rename it into place.
+            # `cf work batch run --strategy parallel` points several workers at
+            # this one home, so check-then-symlink races against itself:
+            # os.replace is atomic and has no such window, and two workers
+            # racing simply both land on the same source.
+            staging = target.with_name(
+                f".{target.name}.codeframe-{os.getpid()}-{threading.get_ident()}"
+            )
+            staging.unlink(missing_ok=True)
+            staging.symlink_to(source, target_is_directory=source.is_dir())
+            os.replace(staging, target)
+        except OSError as e:
             logger.warning(
                 "Could not link %s into the delegated agent home: %s. That CLI "
                 "may need to be re-authenticated.", entry, e
             )
+
+
+def _move_stale_config_aside(target: Path) -> None:
+    """Retire a config dir the CLI made for itself before the operator logged in.
+
+    Leaving it would keep the delegated agent logged out forever even after they
+    do log in — the real home is the authority once it exists. Moved rather than
+    deleted: it may hold a login made from inside the sandbox.
+    """
+    stale = target.with_name(target.name + ".superseded")
+    if stale.is_symlink() or not stale.is_dir():
+        stale.unlink(missing_ok=True)
+    else:
+        shutil.rmtree(stale)
+    target.rename(stale)

--- a/codeframe/core/agent_env.py
+++ b/codeframe/core/agent_env.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-import shutil
 import threading
 from collections.abc import Iterable
 from pathlib import Path
@@ -268,10 +267,18 @@ def _move_stale_config_aside(target: Path) -> None:
     Leaving it would keep the delegated agent logged out forever even after they
     do log in — the real home is the authority once it exists. Moved rather than
     deleted: it may hold a login made from inside the sandbox.
+
+    The backup name is unique per worker. `cf work batch run --strategy parallel`
+    shares one adapter home, so two workers can retire the same directory
+    together; with a fixed ``.superseded`` name the loser would clear the
+    winner's just-moved backup — destroying the very login this preserves.
+    Uniquely named, the loser's rename simply raises FileNotFoundError (the
+    caller's OSError handler swallows it) and the winner's link still lands.
+
+    Retirement happens once per entry — afterwards the target is a symlink and
+    never reaches this branch again — so the unique names do not accumulate.
     """
-    stale = target.with_name(target.name + ".superseded")
-    if stale.is_symlink() or not stale.is_dir():
-        stale.unlink(missing_ok=True)
-    else:
-        shutil.rmtree(stale)
+    stale = target.with_name(
+        f"{target.name}.superseded-{os.getpid()}-{threading.get_ident()}"
+    )
     target.rename(stale)

--- a/tests/core/adapters/test_delegated_agent_env_996.py
+++ b/tests/core/adapters/test_delegated_agent_env_996.py
@@ -415,39 +415,75 @@ def test_each_delegated_adapter_declares_what_it_needs(
 
 
 @pytest.mark.parametrize(
-    "var",
+    "selector,needed",
     [
-        "CLAUDE_CODE_USE_BEDROCK",
-        "AWS_PROFILE",
-        "AWS_SESSION_TOKEN",
-        "CLAUDE_CODE_USE_VERTEX",
-        "ANTHROPIC_VERTEX_PROJECT_ID",
-        "CLOUD_ML_REGION",
-        "GOOGLE_APPLICATION_CREDENTIALS",
-        "CLAUDE_CODE_USE_FOUNDRY",
-        "ANTHROPIC_FOUNDRY_API_KEY",
+        ("CLAUDE_CODE_USE_BEDROCK", ["AWS_PROFILE", "AWS_SESSION_TOKEN", "AWS_REGION"]),
+        (
+            "CLAUDE_CODE_USE_VERTEX",
+            ["ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION",
+             "GOOGLE_APPLICATION_CREDENTIALS"],
+        ),
+        ("CLAUDE_CODE_USE_FOUNDRY", ["ANTHROPIC_FOUNDRY_API_KEY",
+                                     "ANTHROPIC_FOUNDRY_RESOURCE"]),
     ],
 )
-def test_claude_code_cloud_backends_keep_working(var):
+def test_claude_code_cloud_backends_keep_working(selector, needed, monkeypatch):
     """Review finding: Bedrock/Vertex/Foundry are configured *purely* through the
     environment, so an allowlist stopping at ANTHROPIC_API_KEY breaks a setup
     that works fine outside CodeFrame."""
     from codeframe.core.adapters.claude_code import ClaudeCodeAdapter
 
-    assert var in ClaudeCodeAdapter.credential_env_vars()
+    monkeypatch.setenv(selector, "1")
+    forwarded = ClaudeCodeAdapter.credential_env_vars()
+
+    assert selector in forwarded
+    for var in needed:
+        assert var in forwarded
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "ANTHROPIC_FOUNDRY_API_KEY",
+    ],
+)
+def test_cloud_secrets_are_withheld_unless_that_backend_is_selected(
+    env_dumper, operator_home, workspace, monkeypatch, secret
+):
+    """Review finding (bot, [major]): exported AWS keys are near-universal on a
+    developer machine and belong to a service `claude` has nothing to do with
+    unless Bedrock is in use. Asserted on what actually reaches the child, not
+    just on the declared tuple."""
+    from codeframe.core.adapters.claude_code import ClaudeCodeAdapter
+
+    for selector in ("CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX",
+                     "CLAUDE_CODE_USE_FOUNDRY"):
+        monkeypatch.delenv(selector, raising=False)
+    monkeypatch.setenv(secret, "cloud-SHOULD-NOT-LEAK")
+
+    adapter = _make_adapter(env_dumper)
+    adapter.credential_env_vars = ClaudeCodeAdapter.credential_env_vars
+
+    assert "SHOULD-NOT-LEAK" not in _run(adapter, workspace)
 
 
 def test_aws_credentials_are_only_exposed_when_bedrock_is_selected(
     operator_home, monkeypatch
 ):
-    """Forwarding the vars is required; handing every run ~/.aws is not."""
+    """Both halves move together: the directory *and* the variables."""
     from codeframe.core.adapters.claude_code import ClaudeCodeAdapter
 
     monkeypatch.delenv("CLAUDE_CODE_USE_BEDROCK", raising=False)
     assert ".aws" not in ClaudeCodeAdapter.home_passthrough()
+    assert "AWS_ACCESS_KEY_ID" not in ClaudeCodeAdapter.credential_env_vars()
 
     monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
     assert ".aws" in ClaudeCodeAdapter.home_passthrough()
+    assert "AWS_ACCESS_KEY_ID" in ClaudeCodeAdapter.credential_env_vars()
 
 
 def test_the_defaults_are_deny_by_default():

--- a/tests/core/adapters/test_delegated_agent_env_996.py
+++ b/tests/core/adapters/test_delegated_agent_env_996.py
@@ -237,7 +237,45 @@ def test_a_config_dir_the_cli_made_first_is_superseded_by_a_later_login(
     assert linked.is_symlink()
     assert (linked / "session.json").read_text() == "LOGIN-TOKEN"
     # Moved aside, not destroyed — it may hold a login made inside the sandbox.
-    assert (sandbox / ".claude.superseded" / "settings.json").exists()
+    backups = list(sandbox.glob(".claude.superseded-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "settings.json").exists()
+
+
+def test_concurrent_retirement_does_not_destroy_a_sandbox_login(
+    operator_home, workspace
+):
+    """Review finding (bot, [minor]): the retirement step was check-then-rmtree.
+
+    Two workers both pass the "target is a real dir" check; the first renames it
+    to a fixed `.superseded`, the second then rmtree's that backup — deleting a
+    login made from inside the sandbox, exactly what the move exists to keep.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from codeframe.core.agent_env import build_delegated_agent_env
+
+    kwargs = dict(adapter_name="claude-code", home_passthrough=(".claude",))
+
+    login = operator_home / ".claude"
+    stashed = login.rename(operator_home / ".claude-not-yet")
+    sandbox = Path(build_delegated_agent_env(workspace, **kwargs)["HOME"])
+    (sandbox / ".claude").mkdir(parents=True, exist_ok=True)
+    (sandbox / ".claude" / "sandbox-login.json").write_text("MADE-IN-SANDBOX")
+    stashed.rename(login)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        [f.result() for f in [
+            pool.submit(build_delegated_agent_env, workspace, **kwargs)
+            for _ in range(8)
+        ]]
+
+    assert (sandbox / ".claude").is_symlink()
+    preserved = [
+        p for p in sandbox.glob(".claude.superseded-*")
+        if (p / "sandbox-login.json").exists()
+    ]
+    assert preserved, "the sandbox-side login was destroyed by a racing worker"
 
 
 def test_concurrent_workers_do_not_fight_over_the_link(operator_home, workspace):

--- a/tests/core/adapters/test_delegated_agent_env_996.py
+++ b/tests/core/adapters/test_delegated_agent_env_996.py
@@ -1,0 +1,473 @@
+"""Delegated adapters must not inherit the operator's environment or HOME (#996).
+
+`SubprocessAdapter.run` and `CodexAdapter.run` called `Popen` with no ``env=``,
+so a delegated CLI received every exported secret in the operator's shell *and*
+the real ``HOME`` — which resolves ``~/.codeframe/credentials``, ``~/.ssh``,
+``~/.aws``. #905 closed this for the built-in engines only; those CLIs need
+provider credentials to work at all, so it was left open here.
+
+The tests run a **real subprocess** that dumps its own environment, in the style
+of ``test_untrusted_repo_execution_905.py``. Asserting against a mocked ``Popen``
+would only prove the adapter agrees with itself — the exact failure mode that let
+three non-functional engines ship green (#913/#914/#1012).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def env_dumper(tmp_path: Path) -> Path:
+    """An executable that reports its environment, HOME, and what HOME reaches."""
+    script = tmp_path / "bin" / "dump-env"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text(
+        "#!/bin/sh\n"
+        'echo "HOME=$HOME"\n'
+        "env\n"
+        'echo "PASSTHROUGH=$(cat "$HOME/.claude/session.json" 2>/dev/null)"\n'
+        'echo "CREDENTIALS=$(cat "$HOME/.codeframe/credentials.enc" 2>/dev/null)"\n'
+    )
+    script.chmod(0o755)
+    return script
+
+
+@pytest.fixture
+def operator_home(tmp_path: Path, monkeypatch) -> Path:
+    """A stand-in operator HOME holding both a secret and a CLI login."""
+    home = tmp_path / "operator"
+    (home / ".codeframe").mkdir(parents=True)
+    (home / ".codeframe" / "credentials.enc").write_text("SECRET-MATERIAL")
+    (home / ".claude").mkdir()
+    (home / ".claude" / "session.json").write_text("LOGIN-TOKEN")
+    (home / ".ssh").mkdir()
+    (home / ".ssh" / "id_ed25519").write_text("PRIVATE-KEY")
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws
+
+
+def _run(adapter, workspace: Path) -> str:
+    result = adapter.run("task-996", "prompt", workspace)
+    return result.output or ""
+
+
+def _make_adapter(env_dumper: Path, **kwargs):
+    from codeframe.core.adapters.subprocess_adapter import SubprocessAdapter
+
+    return SubprocessAdapter(binary=str(env_dumper), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. Secrets the adapter did not ask for
+# ---------------------------------------------------------------------------
+
+
+def test_an_unrelated_secret_does_not_reach_the_child(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    """The headline exposure: keys for services the engine has nothing to do with."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-SHOULD-NOT-LEAK")
+    monkeypatch.setenv("E2B_API_KEY", "e2b-SHOULD-NOT-LEAK")
+
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    assert "SHOULD-NOT-LEAK" not in output
+
+
+def test_a_secret_exported_later_is_excluded_by_construction(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    """Deny-by-default: a brand-new variable name nobody blocklisted stays out."""
+    monkeypatch.setenv("SOME_FUTURE_PROVIDER_TOKEN", "future-SHOULD-NOT-LEAK")
+
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    assert "SHOULD-NOT-LEAK" not in output
+
+
+def test_the_declared_credential_does_reach_the_child(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    """A credential-free environment would simply break the CLI, so forward the
+    one it declares."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-NEEDED")
+
+    adapter = _make_adapter(env_dumper)
+    adapter.credential_env_vars = (lambda: ("ANTHROPIC_API_KEY",))
+
+    assert "sk-ant-NEEDED" in _run(adapter, workspace)
+
+
+def test_an_undeclared_provider_key_is_withheld(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    """Forwarding is per-adapter: Claude Code has no business with the OpenAI key."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-NEEDED")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-SHOULD-NOT-LEAK")
+
+    adapter = _make_adapter(env_dumper)
+    adapter.credential_env_vars = (lambda: ("ANTHROPIC_API_KEY",))
+
+    output = _run(adapter, workspace)
+    assert "sk-ant-NEEDED" in output
+    assert "SHOULD-NOT-LEAK" not in output
+
+
+# ---------------------------------------------------------------------------
+# 2. HOME no longer points at the credential store
+# ---------------------------------------------------------------------------
+
+
+def test_home_is_not_the_operator_home(env_dumper, operator_home, workspace):
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    home_line = next(li for li in output.splitlines() if li.startswith("HOME="))
+    assert home_line != f"HOME={operator_home}"
+
+
+def test_the_credential_store_is_not_reachable_through_home(
+    env_dumper, operator_home, workspace
+):
+    """`cat ~/.codeframe/credentials.enc` is the path a prompt-injected agent takes."""
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    assert "SECRET-MATERIAL" not in output
+
+
+def test_xdg_paths_do_not_escape_back_to_the_operator_home(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    """XDG_* default to $HOME/..., so pinning HOME alone would leave the door open."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(operator_home / ".config"))
+
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    xdg_lines = [li for li in output.splitlines() if li.startswith("XDG_")]
+    assert xdg_lines, "XDG_* must be set, not merely unset — unset re-resolves to ~"
+
+    agent_homes = str(operator_home / ".codeframe" / "agent-homes")
+    for line in xdg_lines:
+        value = line.split("=", 1)[1]
+        # Under the agent's own home, not the operator's ~/.config (gh/hosts.yml
+        # and friends, which the credential-store pattern does not cover).
+        assert value.startswith(agent_homes), line
+
+
+# ---------------------------------------------------------------------------
+# 3. The CLI's own login still works (the issue's stated design question)
+# ---------------------------------------------------------------------------
+
+
+def test_the_declared_login_directory_is_still_reachable(
+    env_dumper, operator_home, workspace
+):
+    """A naive HOME sandbox logs these CLIs out — which would break the primary
+    engine for every subscription-auth operator."""
+    adapter = _make_adapter(env_dumper)
+    adapter.home_passthrough = (lambda: (".claude",))
+
+    assert "PASSTHROUGH=LOGIN-TOKEN" in _run(adapter, workspace)
+
+
+def test_passthrough_does_not_re_expose_the_rest_of_the_home(
+    env_dumper, operator_home, workspace
+):
+    """Linking ~/.claude must not drag ~/.codeframe or ~/.ssh along with it."""
+    adapter = _make_adapter(env_dumper)
+    adapter.home_passthrough = (lambda: (".claude",))
+
+    output = _run(adapter, workspace)
+    assert "LOGIN-TOKEN" in output
+    assert "SECRET-MATERIAL" not in output
+    assert "PRIVATE-KEY" not in output
+
+
+def test_a_missing_passthrough_entry_is_not_an_error(
+    env_dumper, operator_home, workspace
+):
+    """An operator who has never run the CLI has no config dir yet."""
+    adapter = _make_adapter(env_dumper)
+    adapter.home_passthrough = (lambda: (".nonexistent-cli",))
+
+    assert _run(adapter, workspace)  # ran at all
+
+
+def test_a_config_dir_the_cli_made_first_is_superseded_by_a_later_login(
+    operator_home, workspace
+):
+    """Review finding: the agent stayed logged out *forever*.
+
+    Run once before the operator has ever logged in and the CLI creates its own
+    empty config dir in the sandbox home. Without this, that real directory then
+    blocks the symlink on every later run, so logging in normally never reaches
+    the delegated agent.
+    """
+    from codeframe.core.agent_env import build_delegated_agent_env
+
+    login = operator_home / ".claude"
+    stashed = login.rename(operator_home / ".claude-not-yet")
+
+    env = build_delegated_agent_env(
+        workspace, adapter_name="claude-code", home_passthrough=(".claude",)
+    )
+    sandbox = Path(env["HOME"])
+    (sandbox / ".claude").mkdir(parents=True, exist_ok=True)
+    (sandbox / ".claude" / "settings.json").write_text("{}")
+
+    stashed.rename(login)  # operator runs `claude` and logs in
+
+    build_delegated_agent_env(
+        workspace, adapter_name="claude-code", home_passthrough=(".claude",)
+    )
+
+    linked = sandbox / ".claude"
+    assert linked.is_symlink()
+    assert (linked / "session.json").read_text() == "LOGIN-TOKEN"
+    # Moved aside, not destroyed — it may hold a login made inside the sandbox.
+    assert (sandbox / ".claude.superseded" / "settings.json").exists()
+
+
+def test_concurrent_workers_do_not_fight_over_the_link(operator_home, workspace):
+    """`cf work batch run --strategy parallel` runs several workers against the
+    *same* adapter home, so two can reach symlink_to() together."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from codeframe.core.agent_env import build_delegated_agent_env
+
+    def build():
+        return build_delegated_agent_env(
+            workspace, adapter_name="claude-code", home_passthrough=(".claude",)
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        envs = [f.result() for f in [pool.submit(build) for _ in range(8)]]
+
+    for env in envs:
+        linked = Path(env["HOME"]) / ".claude"
+        assert linked.is_symlink()
+        assert (linked / "session.json").read_text() == "LOGIN-TOKEN"
+
+
+def test_the_agent_home_is_machine_wide_not_per_workspace(
+    env_dumper, operator_home, tmp_path
+):
+    """A per-workspace home would force a fresh CLI login in every repo."""
+    ws_a, ws_b = tmp_path / "a", tmp_path / "b"
+    ws_a.mkdir()
+    ws_b.mkdir()
+    adapter = _make_adapter(env_dumper)
+
+    def home_of(ws):
+        out = _run(adapter, ws)
+        return next(li for li in out.splitlines() if li.startswith("HOME="))
+
+    assert home_of(ws_a) == home_of(ws_b)
+
+
+@pytest.mark.parametrize(
+    "adapter_name", ["/usr/bin/claude", "../../escape", "..", "/", ""]
+)
+def test_the_adapter_name_cannot_escape_the_agent_home_root(
+    operator_home, workspace, adapter_name
+):
+    """``name`` defaults to the *binary*, which the base class resolves to an
+    absolute path — ``Path / "/usr/bin/claude"`` would land at the filesystem
+    root, and ``..`` would climb out of ~/.codeframe."""
+    from codeframe.core.agent_env import build_delegated_agent_env
+
+    env = build_delegated_agent_env(workspace, adapter_name=adapter_name)
+
+    root = operator_home / ".codeframe" / "agent-homes"
+    home = Path(env["HOME"])
+    assert home.parent == root, f"{home} escaped {root}"
+
+
+def test_each_adapter_gets_its_own_home(operator_home, workspace, tmp_path):
+    """Two CLIs must not fight over one config dir."""
+    from codeframe.core.agent_env import build_delegated_agent_env
+
+    a = build_delegated_agent_env(workspace, adapter_name="claude-code")
+    b = build_delegated_agent_env(workspace, adapter_name="codex")
+
+    assert a["HOME"] != b["HOME"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Escape hatch + existing behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_inherit_home_opt_out_restores_the_operator_home(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    monkeypatch.setenv("CODEFRAME_AGENT_INHERIT_HOME", "1")
+
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    assert f"HOME={operator_home}" in output
+
+
+def test_the_opt_out_does_not_re_open_the_environment(
+    env_dumper, operator_home, workspace, monkeypatch
+):
+    """HOME and the env allowlist are independent knobs — opting out of the HOME
+    sandbox must not hand back every exported secret."""
+    monkeypatch.setenv("CODEFRAME_AGENT_INHERIT_HOME", "1")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-SHOULD-NOT-LEAK")
+
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    assert "SHOULD-NOT-LEAK" not in output
+
+
+def test_get_env_extras_still_layer_on(env_dumper, operator_home, workspace):
+    """opencode's OPENCODE_CONFIG deny-list (#916) rides on this hook."""
+    adapter = _make_adapter(env_dumper)
+    adapter.get_env = lambda workspace_path: {"OPENCODE_CONFIG": "/tmp/deny.json"}
+
+    assert "OPENCODE_CONFIG=/tmp/deny.json" in _run(adapter, workspace)
+
+
+def test_path_and_locale_survive(env_dumper, operator_home, workspace):
+    """A sanitized environment that drops PATH would break every CLI outright."""
+    output = _run(_make_adapter(env_dumper), workspace)
+
+    assert "PATH=" in output
+
+
+# ---------------------------------------------------------------------------
+# 5. Codex takes the same path (its own Popen, not the base class's)
+# ---------------------------------------------------------------------------
+
+
+def test_codex_declares_its_credentials_and_login_dir():
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    assert "OPENAI_API_KEY" in CodexAdapter.credential_env_vars()
+    assert ".codex" in CodexAdapter.home_passthrough()
+
+
+def test_codex_spawns_with_a_sanitized_env(monkeypatch, operator_home, workspace):
+    """codex.py has its own Popen; the fix must reach it too."""
+    from codeframe.core.adapters import codex as codex_mod
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-SHOULD-NOT-LEAK")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-NEEDED")
+
+    captured: dict = {}
+
+    class _Boom(OSError):
+        pass
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        raise _Boom("stop here — only the env matters")
+
+    monkeypatch.setattr(codex_mod.subprocess, "Popen", fake_popen)
+
+    adapter = codex_mod.CodexAdapter.__new__(codex_mod.CodexAdapter)
+    adapter._binary_path = "/usr/bin/true"
+    adapter._binary = "codex"
+    adapter._next_id = 0
+    adapter.run("t", "p", workspace)
+
+    env = captured.get("env")
+    assert env is not None, "codex still inherits the operator's environment"
+    assert "TAVILY_API_KEY" not in env
+    assert env.get("OPENAI_API_KEY") == "sk-openai-NEEDED"
+    assert env.get("HOME") != str(operator_home)
+
+
+# ---------------------------------------------------------------------------
+# 6. Per-adapter declarations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module,cls_name,credential,login_dir",
+    [
+        ("claude_code", "ClaudeCodeAdapter", "ANTHROPIC_API_KEY", ".claude"),
+        ("opencode", "OpenCodeAdapter", "ANTHROPIC_API_KEY", ".config/opencode"),
+    ],
+)
+def test_each_delegated_adapter_declares_what_it_needs(
+    module, cls_name, credential, login_dir
+):
+    import importlib
+
+    cls = getattr(importlib.import_module(f"codeframe.core.adapters.{module}"), cls_name)
+
+    assert credential in cls.credential_env_vars()
+    assert login_dir in cls.home_passthrough()
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "CLAUDE_CODE_USE_BEDROCK",
+        "AWS_PROFILE",
+        "AWS_SESSION_TOKEN",
+        "CLAUDE_CODE_USE_VERTEX",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "CLOUD_ML_REGION",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "ANTHROPIC_FOUNDRY_API_KEY",
+    ],
+)
+def test_claude_code_cloud_backends_keep_working(var):
+    """Review finding: Bedrock/Vertex/Foundry are configured *purely* through the
+    environment, so an allowlist stopping at ANTHROPIC_API_KEY breaks a setup
+    that works fine outside CodeFrame."""
+    from codeframe.core.adapters.claude_code import ClaudeCodeAdapter
+
+    assert var in ClaudeCodeAdapter.credential_env_vars()
+
+
+def test_aws_credentials_are_only_exposed_when_bedrock_is_selected(
+    operator_home, monkeypatch
+):
+    """Forwarding the vars is required; handing every run ~/.aws is not."""
+    from codeframe.core.adapters.claude_code import ClaudeCodeAdapter
+
+    monkeypatch.delenv("CLAUDE_CODE_USE_BEDROCK", raising=False)
+    assert ".aws" not in ClaudeCodeAdapter.home_passthrough()
+
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    assert ".aws" in ClaudeCodeAdapter.home_passthrough()
+
+
+def test_the_defaults_are_deny_by_default():
+    """A future adapter that declares nothing forwards nothing."""
+    from codeframe.core.adapters.subprocess_adapter import SubprocessAdapter
+
+    class _New(SubprocessAdapter):
+        @classmethod
+        def requirements(cls) -> dict[str, str]:
+            return {}
+
+    assert _New.credential_env_vars() == ()
+    assert _New.home_passthrough() == ()
+
+
+def test_os_environ_is_not_mutated(env_dumper, operator_home, workspace, monkeypatch):
+    """Building the child env must not disturb the operator's own process."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-still-mine")
+    before = dict(os.environ)
+
+    _run(_make_adapter(env_dumper), workspace)
+
+    assert dict(os.environ) == before


### PR DESCRIPTION
Closes #996.

## The exposure, measured

`SubprocessAdapter.run` and `CodexAdapter.run` called `Popen` with no `env=`. Same probe run before and after, on a real dev machine:

| | before | after |
|---|---|---|
| environment variables | **69** | 12 |
| matching `KEY\|TOKEN\|SECRET\|PASSWORD=` | **5** | 0 |
| `ls ~/.codeframe/` | `credentials.json`, `logs`, … | *(empty)* |
| files in `~/.ssh` | **30** | 0 |
| `~/.config/gh/hosts.yml` | **YES** | no |

The five keys were `E2B`, `GEMINI`, `TAVILY`, `MORPH`, `TWENTYFIRST` — none of which any coding engine has any use for.

## Why #905 left it open

#905 sandboxed the *built-in* engines via `build_agent_env()`. The delegated CLIs are a different problem: they legitimately need provider credentials, and a naive `HOME` sandbox logs them out. That was the issue's stated design question.

`build_delegated_agent_env()` answers it:

1. Start from #905's deny-by-default allowlist — a key exported tomorrow is excluded by construction, not by remembering to blocklist it.
2. Add back only what the adapter declares (`credential_env_vars()`). Claude Code never sees an OpenAI key.
3. `HOME` → `~/.codeframe/agent-homes/<adapter>`. Machine-wide, not per-workspace, so a login survives across repos.
4. Symlink that CLI's own config dir (`home_passthrough()`) back in, so `claude` and `codex` stay logged in.
5. `CODEFRAME_AGENT_INHERIT_HOME=1` opts out of the HOME sandbox **only** — it does not reopen the environment allowlist.

## Verified with real binaries

Adapter tests in this repo have historically mocked `Popen` and asserted the adapter agreed with itself, which is how three non-functional engines shipped green (#913/#914/#1012). These tests run real subprocesses, in the style of `test_untrusted_repo_execution_905.py`.

```
=== real `claude --print` under the sandbox home ===
exit: 0
stdout: SANDBOX-OK

=== codex app-server handshake under the sandbox home ===
{"id":1,"result":{...,"codexHome":"/home/…/.codeframe/agent-homes/codex/.codex",…}}
```

Both CLIs still authenticate. This machine uses subscription login (no `ANTHROPIC_API_KEY` exported at all), which is exactly the case a naive sandbox would have broken.

## Four defects found while building it

Each has a regression test; the two review findings were reproduced before being fixed.

**Path escape (found by the tests).** `adapter_name` arrives as `SubprocessAdapter.name`, which the base class derives from the *binary* — so `Path / "/usr/bin/claude"` landed at the filesystem root, and `..` would climb out of `~/.codeframe`. Now slugged, with a parametrized test over `/usr/bin/claude`, `../../escape`, `..`, `/`, `""`.

**Cloud backends would have broken** *(codex review [P2])*. Bedrock, Vertex **and Foundry** are configured purely through environment variables, so stopping at `ANTHROPIC_API_KEY` would break a `claude` setup that works fine outside CodeFrame. Enumerated from code.claude.com (27 vars) rather than prefix-matched — `ANTHROPIC_*` is a namespace we do not own and `AWS_*` would hand over the operator's whole AWS identity. `~/.aws` and `~/.config/gcloud` are linked only when the operator has actually selected that backend.

**Permanent logout** *(codex review [P2])*. A CLI that runs before the operator has ever logged in creates its own config dir in the sandbox home; the original code left it, which blocked the symlink forever. Reproduced:

```
run 1: sandbox .claude is a real dir: True
run 2: is symlink: False
run 2: agent sees the login: False
```

Now moved aside to `<name>.superseded` — never deleted, since it may hold a login made from inside the sandbox.

**Parallel-worker race.** `cf work batch run --strategy parallel` runs several workers against the same adapter home, so two can reach `symlink_to()` together and one loses with `FileExistsError`. The loser's work is already done, so it no longer warns.

## Scope

Not containment, and not claimed to be — the child still runs as the operator, so an absolute path reaches whatever the operator can read. Only OS-level isolation (worktree/E2B/container) contains a hostile command. This closes the paths a prompt-injected agent actually takes. Same explicit non-goal as #905.

## Testing

- `tests/core/adapters/test_delegated_agent_env_996.py` — 39 tests
- Full CI gate: **4816 passed, 0 failed**; `ruff` clean
- `codex review --base main` — both findings above addressed
