### PR TITLE
fix(tasks): give resume the worker it never had (#1005)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2694,9 +2694,26 @@ def work_resume(
 
             mode = " [dim](dry run)[/dim]" if dry_run else ""
             console.print(f"\n[bold]Executing agent...{mode}[/bold]")
-            state = runtime.execute_agent(
-                workspace, run, dry_run=dry_run, verbose=verbose, engine=engine
-            )
+            try:
+                state = runtime.execute_agent(
+                    workspace, run, dry_run=dry_run, verbose=verbose, engine=engine
+                )
+            except Exception as exc:
+                # resume_run already flipped the run to RUNNING. A misconfig
+                # (missing ANTHROPIC_API_KEY, unknown provider) raises *before*
+                # execute_agent's own try, so without this the run stays RUNNING
+                # with no worker and `work start` refuses the task — the very
+                # wedge this command is being fixed for. Mirrors the web
+                # worker's #722 recovery.
+                try:
+                    runtime.fail_run(workspace, run.id, reason=str(exc))
+                except Exception:
+                    # Only reachable when the run is already terminal (a
+                    # double-fail), which needs no recovery. Swallowed so it
+                    # cannot mask the real error printed below.
+                    pass
+                console.print(f"[red]Error:[/red] {exc}")
+                raise typer.Exit(1)
 
             if state.status == AgentStatus.COMPLETED:
                 console.print("[bold green]Task completed successfully![/bold green]")

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2634,6 +2634,14 @@ def work_start(
 @work_app.command("resume")
 def work_resume(
     task_id: str = typer.Argument(..., help="Task ID to resume (can be partial)"),
+    execute: bool = typer.Option(
+        True,
+        "--execute/--no-execute",
+        help="Run the agent on the resumed run (default: yes)",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without making changes"),
+    verbose: bool = typer.Option(False, "--verbose", help="Show detailed progress"),
+    engine: str = typer.Option("react", "--engine", help="Execution engine: react or plan"),
     workspace_path: Optional[Path] = typer.Option(
         None,
         "--workspace",
@@ -2642,6 +2650,10 @@ def work_resume(
     ),
 ) -> None:
     """Resume work on a blocked task.
+
+    Unlike ``work start``, execution is **on by default**: resuming flips the run
+    to RUNNING, and without a worker the task holds an active run that
+    ``work start`` then refuses to restart — with no way out (#1005).
 
     Example:
         codeframe work resume abc123
@@ -2676,6 +2688,30 @@ def work_resume(
         console.print(f"  Task: {task.title}")
         console.print(f"  Run ID: [dim]{run.id}[/dim]")
         console.print("  Status: [yellow]RUNNING[/yellow]")
+
+        if execute:
+            from codeframe.core.agent import AgentStatus
+
+            mode = " [dim](dry run)[/dim]" if dry_run else ""
+            console.print(f"\n[bold]Executing agent...{mode}[/bold]")
+            state = runtime.execute_agent(
+                workspace, run, dry_run=dry_run, verbose=verbose, engine=engine
+            )
+
+            if state.status == AgentStatus.COMPLETED:
+                console.print("[bold green]Task completed successfully![/bold green]")
+            elif state.status == AgentStatus.BLOCKED:
+                console.print("[yellow]Task blocked - human input needed[/yellow]")
+                if state.blocker:
+                    console.print(f"  Question: {state.blocker.question}")
+                console.print("  Use 'codeframe blocker list' to see blockers")
+            elif state.status == AgentStatus.FAILED:
+                console.print("[red]Task execution failed[/red]")
+        else:
+            console.print(
+                "\n[yellow]Not executed.[/yellow] The run is RUNNING with no worker; "
+                "re-run with --execute to continue it."
+            )
 
     except FileNotFoundError:
         console.print(f"[red]Error:[/red] No workspace found at {path}")

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -769,6 +769,66 @@ async def start_execution(
         )
 
 
+def _spawn_agent_worker(
+    workspace: Workspace,
+    run: Any,
+    task_id: str,
+    *,
+    dry_run: bool = False,
+    verbose: bool = False,
+    engine: str = "react",
+) -> None:
+    """Run the agent for ``run`` on a background thread.
+
+    Shared by ``start`` and ``resume``. It lives in one place because they drifted:
+    resume flipped the run to RUNNING and returned without ever spawning a worker,
+    so the task held an *active* run that nothing executed — and `start_task_run`
+    then refused to start it again, wedging the task until someone edited the
+    database (#1005).
+    """
+    from codeframe.core.models import ErrorEvent
+    from codeframe.ui.routers.streaming_v2 import get_event_publisher
+
+    publisher = get_event_publisher()
+
+    def _run_agent() -> None:
+        try:
+            runtime.execute_agent(
+                workspace,
+                run,
+                dry_run=dry_run,
+                verbose=verbose,
+                event_publisher=publisher,
+                engine=engine,
+            )
+        except Exception as exc:
+            logger.error(f"Background agent failed for task {task_id}: {exc}", exc_info=True)
+            # Reset the run so the task doesn't stay IN_PROGRESS forever
+            # (#722). execute_agent handles errors raised inside its own
+            # try, but common misconfig (missing ANTHROPIC_API_KEY /
+            # unknown provider) raises up front, before that try — this
+            # is the only place that can fail the run. Guarded so an
+            # already-FAILED run (double-fail) can't break the handler.
+            try:
+                runtime.fail_run(workspace, run.id, reason=str(exc))
+            except Exception:
+                logger.debug(
+                    "fail_run skipped for task %s (run not active)",
+                    task_id, exc_info=True,
+                )
+            publisher.publish_sync(
+                task_id,
+                ErrorEvent(
+                    task_id=task_id,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                ),
+            )
+            publisher.complete_task_sync(task_id)
+
+    threading.Thread(target=_run_agent, daemon=True).start()
+
+
 @router.post("/{task_id}/start")
 @rate_limit_ai()
 async def start_single_task(
@@ -815,48 +875,9 @@ async def start_single_task(
         }
 
         if execute:
-            from codeframe.ui.routers.streaming_v2 import get_event_publisher
-            from codeframe.core.models import ErrorEvent
-
-            publisher = get_event_publisher()
-
-            def _run_agent():
-                try:
-                    runtime.execute_agent(
-                        workspace,
-                        run,
-                        dry_run=dry_run,
-                        verbose=verbose,
-                        event_publisher=publisher,
-                        engine=engine,
-                    )
-                except Exception as exc:
-                    logger.error(f"Background agent failed for task {task_id}: {exc}", exc_info=True)
-                    # Reset the run so the task doesn't stay IN_PROGRESS forever
-                    # (#722). execute_agent handles errors raised inside its own
-                    # try, but common misconfig (missing ANTHROPIC_API_KEY /
-                    # unknown provider) raises up front, before that try — this
-                    # is the only place that can fail the run. Guarded so an
-                    # already-FAILED run (double-fail) can't break the handler.
-                    try:
-                        runtime.fail_run(workspace, run.id, reason=str(exc))
-                    except Exception:
-                        logger.debug(
-                            "fail_run skipped for task %s (run not active)",
-                            task_id, exc_info=True,
-                        )
-                    publisher.publish_sync(
-                        task_id,
-                        ErrorEvent(
-                            task_id=task_id,
-                            error=str(exc),
-                            error_type=type(exc).__name__,
-                        ),
-                    )
-                    publisher.complete_task_sync(task_id)
-
-            thread = threading.Thread(target=_run_agent, daemon=True)
-            thread.start()
+            _spawn_agent_worker(
+                workspace, run, task_id, dry_run=dry_run, verbose=verbose, engine=engine
+            )
 
             result["status"] = "executing"
             result["message"] = f"Execution started in background for task {task_id[:8]}. Connect to GET /{task_id}/stream for events."
@@ -934,14 +955,25 @@ async def stop_task(
 async def resume_task(
     request: Request,
     task_id: str,
+    execute: bool = Query(True, description="Run the agent on the resumed run"),
+    dry_run: bool = Query(False, description="Preview changes without making them"),
+    verbose: bool = Query(False, description="Show detailed progress output"),
+    engine: Literal["plan", "react"] = Query("react", description="Execution engine: 'react' (default, ReAct loop) or 'plan' (legacy step-based)"),
     workspace: Workspace = Depends(get_v2_workspace),
 ) -> dict[str, Any]:
     """Resume a blocked task.
 
     This is the v2 equivalent of `cf work resume <task-id>`.
 
+    ``execute`` defaults to **True**, unlike ``start``: the web UI posts here
+    with no query params, and a resumed run nobody executes leaves the task
+    holding an active run that ``start`` then refuses to restart (#1005).
+
     Args:
         task_id: Task to resume
+        execute: Whether to run the agent (default True)
+        dry_run: Preview mode (no actual changes)
+        verbose: Show detailed output
         workspace: v2 Workspace
 
     Returns:
@@ -954,12 +986,21 @@ async def resume_task(
     """
     try:
         run = runtime.resume_run(workspace, task_id)
+
+        message = f"Resumed run {run.id[:8]} for task {task_id[:8]}."
+        if execute:
+            _spawn_agent_worker(
+                workspace, run, task_id, dry_run=dry_run, verbose=verbose, engine=engine
+            )
+            message += f" Connect to GET /{task_id}/stream for events."
+
         return {
             "success": True,
             "run_id": run.id,
             "task_id": task_id,
             "status": run.status.value,
-            "message": f"Resumed run {run.id[:8]} for task {task_id[:8]}.",
+            "executing": execute,
+            "message": message,
         }
     except ValueError as e:
         error_msg = str(e)

--- a/tests/ui/test_resume_starts_worker_1005.py
+++ b/tests/ui/test_resume_starts_worker_1005.py
@@ -23,6 +23,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from codeframe.core import blockers, runtime, tasks
+from codeframe.core.runtime import RunStatus
 from codeframe.core.state_machine import TaskStatus
 
 pytestmark = pytest.mark.v2
@@ -210,3 +211,73 @@ def test_cli_resume_no_execute_opts_out(blocked, recorder, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert calls == []
+
+
+def test_cli_resume_does_not_wedge_when_the_agent_raises(blocked, monkeypatch):
+    """Review finding (bot, [major]): the CLI path re-introduced the very wedge
+    this change fixes.
+
+    `resume_run` has already flipped the run to RUNNING and the task to
+    IN_PROGRESS. `execute_agent` then raises up front for a missing key — before
+    its own try — and the CLI's outer `except ValueError` printed and exited
+    without failing the run. `work start` then rejects the task on "already has
+    an active run", with `work stop` the only way out.
+
+    The web worker recovers from exactly this via fail_run (#722); the CLI had
+    no equivalent, and the recorder in the tests above returns a fake state
+    rather than raising, so nothing covered it.
+    """
+    from typer.testing import CliRunner
+
+    _, ws, task_id, run_id = blocked
+
+    def _boom(*a, **k):
+        raise ValueError("ANTHROPIC_API_KEY is not set")
+
+    monkeypatch.setattr(runtime, "execute_agent", _boom)
+
+    from codeframe.cli.app import app
+    from codeframe.core import workspace as ws_module
+
+    monkeypatch.setattr(ws_module, "get_workspace", lambda p: ws)
+
+    result = CliRunner().invoke(app, ["work", "resume", task_id[:8]])
+
+    assert result.exit_code == 1
+    assert runtime.get_run(ws, run_id).status != RunStatus.RUNNING, (
+        "run left RUNNING with no worker — the task is wedged"
+    )
+    assert tasks.get(ws, task_id).status == TaskStatus.FAILED
+
+
+def test_cli_resume_reports_the_real_error_when_recovery_also_fails(
+    blocked, monkeypatch
+):
+    """The nested except must not itself raise.
+
+    It caught a NameError in review: `logger` is not defined in cli/app.py, so
+    the recovery handler would have masked the actual failure with its own.
+    """
+    from typer.testing import CliRunner
+
+    _, ws, task_id, run_id = blocked
+
+    def _boom(*a, **k):
+        raise ValueError("ANTHROPIC_API_KEY is not set")
+
+    monkeypatch.setattr(runtime, "execute_agent", _boom)
+    monkeypatch.setattr(
+        runtime, "fail_run", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope"))
+    )
+
+    from codeframe.cli.app import app
+    from codeframe.core import workspace as ws_module
+
+    monkeypatch.setattr(ws_module, "get_workspace", lambda p: ws)
+
+    result = CliRunner().invoke(app, ["work", "resume", task_id[:8]])
+
+    assert result.exit_code == 1
+    assert "ANTHROPIC_API_KEY is not set" in result.output, (
+        f"the real error was masked: {result.output!r}"
+    )

--- a/tests/ui/test_resume_starts_worker_1005.py
+++ b/tests/ui/test_resume_starts_worker_1005.py
@@ -1,0 +1,212 @@
+"""Resuming a blocked task must actually run it (#1005 / P0.26).
+
+``POST /tasks/{id}/resume`` called ``runtime.resume_run()`` and returned. That
+flips the run to RUNNING and the task to IN_PROGRESS — and nothing executes it.
+``start`` spawns a background thread for exactly this; resume had no equivalent.
+
+The task is then *wedged*: it holds an active run, so ``start_task_run`` rejects
+any attempt to start it again, and there is no other way to drive it. Every
+BLOCKED task resumed from the web UI hits this.
+
+Asserted on outcome — did a worker actually run the resumed run — not on the
+endpoint returning 200, which it always did.
+"""
+
+import shutil
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core import blockers, runtime, tasks
+from codeframe.core.state_machine import TaskStatus
+
+pytestmark = pytest.mark.v2
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.05):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+@pytest.fixture
+def blocked(monkeypatch):
+    """A workspace whose one task holds a BLOCKED run, ready to resume."""
+    from codeframe.core.workspace import create_or_load_workspace
+
+    tmp = Path(tempfile.mkdtemp())
+    ws_dir = tmp / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    ws = create_or_load_workspace(ws_dir)
+    task = tasks.create(ws, title="t", description="d", status=TaskStatus.READY)
+
+    run = runtime.start_task_run(ws, task.id)
+    blocker = blockers.create(ws, task_id=task.id, question="why?")
+    runtime.block_run(ws, run.id, blocker.id)
+
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import tasks_v2
+
+    app = FastAPI()
+    app.include_router(tasks_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: ws
+    yield TestClient(app), ws, task.id, run.id
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """Record every execute_agent call and let the test wait for one."""
+    calls: list[dict] = []
+    seen = threading.Event()
+
+    def _record(workspace, run, **kwargs):
+        calls.append({"run": run, "kwargs": kwargs})
+        seen.set()
+
+        class _State:
+            status = None
+
+        return _State()
+
+    monkeypatch.setattr(runtime, "execute_agent", _record)
+    return calls, seen
+
+
+# ---------------------------------------------------------------------------
+# The bug
+# ---------------------------------------------------------------------------
+
+
+def test_resume_actually_runs_the_agent(blocked, recorder):
+    client, ws, task_id, run_id = blocked
+    calls, seen = recorder
+
+    r = client.post(f"/api/v2/tasks/{task_id}/resume")
+    assert r.status_code == 200
+
+    assert seen.wait(5.0), (
+        "resume returned 200 but no worker ever ran — the task now holds an "
+        "active run that nothing is executing"
+    )
+    assert len(calls) == 1
+
+
+def test_the_worker_gets_the_resumed_run(blocked, recorder):
+    """Not a fresh run — the one resume_run returned, or the blocked run leaks."""
+    client, ws, task_id, run_id = blocked
+    calls, seen = recorder
+
+    client.post(f"/api/v2/tasks/{task_id}/resume")
+    assert seen.wait(5.0)
+
+    assert calls[0]["run"].id == run_id
+
+
+def test_resume_does_not_wedge_the_task(blocked, monkeypatch):
+    """The user-visible symptom: after resume, nothing can drive the task.
+
+    With no worker the run stays RUNNING forever, so `start` 400s on
+    "already has an active run" and there is no way out but editing the DB.
+    """
+    client, ws, task_id, run_id = blocked
+
+    def _boom(*a, **k):
+        raise ValueError("ANTHROPIC_API_KEY is not set")
+
+    monkeypatch.setattr(runtime, "execute_agent", _boom)
+
+    client.post(f"/api/v2/tasks/{task_id}/resume")
+
+    # A worker that fails up front must fail the run (#722), leaving the task
+    # retryable rather than permanently RUNNING.
+    assert _wait_until(lambda: tasks.get(ws, task_id).status == TaskStatus.FAILED), (
+        f"task stayed {tasks.get(ws, task_id).status} — wedged with an active run"
+    )
+    assert client.post(f"/api/v2/tasks/{task_id}/start").status_code == 200
+
+
+def test_execute_false_keeps_the_flip_only_behaviour(blocked, recorder):
+    """The old behaviour stays reachable for a caller that wants it."""
+    client, ws, task_id, run_id = blocked
+    calls, seen = recorder
+
+    r = client.post(f"/api/v2/tasks/{task_id}/resume", params={"execute": "false"})
+
+    assert r.status_code == 200
+    assert not seen.wait(0.5)
+    assert calls == []
+
+
+def test_the_default_executes_because_the_web_ui_sends_no_params(blocked, recorder):
+    """`tasksApi.resumeExecution` posts with no query params (api.ts), so any
+    other default leaves the bug in place for the only real caller."""
+    client, ws, task_id, run_id = blocked
+    calls, seen = recorder
+
+    client.post(f"/api/v2/tasks/{task_id}/resume")
+
+    assert seen.wait(5.0)
+
+
+def test_start_still_works_through_the_shared_helper(monkeypatch, blocked, recorder):
+    """start and resume now share one worker body — start must not regress."""
+    client, ws, task_id, run_id = blocked
+    calls, seen = recorder
+
+    # Clear the blocked run so start is allowed — the purpose-built helper.
+    runtime.reset_blocked_run(ws, task_id)
+
+    r = client.post(f"/api/v2/tasks/{task_id}/start", params={"execute": "true"})
+
+    assert r.status_code == 200
+    assert seen.wait(5.0)
+
+
+# ---------------------------------------------------------------------------
+# The CLI has the same gap, and no escape hatch at all
+# ---------------------------------------------------------------------------
+
+
+def test_cli_resume_executes(blocked, recorder, monkeypatch):
+    """`cf work resume` flipped state and returned too — and unlike the web UI
+    there was no follow-up command, since `start` rejects the active run."""
+    from typer.testing import CliRunner
+
+    _, ws, task_id, _ = blocked
+    calls, seen = recorder
+
+    from codeframe.cli.app import app
+    from codeframe.core import workspace as ws_module
+
+    monkeypatch.setattr(ws_module, "get_workspace", lambda p: ws)
+
+    result = CliRunner().invoke(app, ["work", "resume", task_id[:8]])
+
+    assert result.exit_code == 0, result.output
+    assert calls, "cf work resume did not execute the resumed run"
+
+
+def test_cli_resume_no_execute_opts_out(blocked, recorder, monkeypatch):
+    from typer.testing import CliRunner
+
+    _, ws, task_id, _ = blocked
+    calls, seen = recorder
+
+    from codeframe.cli.app import app
+    from codeframe.core import workspace as ws_module
+
+    monkeypatch.setattr(ws_module, "get_workspace", lambda p: ws)
+
+    result = CliRunner().invoke(app, ["work", "resume", task_id[:8], "--no-execute"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == []


### PR DESCRIPTION
Closes #1005.

## The bug

`POST /tasks/{id}/resume` called `runtime.resume_run()` and returned. That flips the run to RUNNING and the task to IN_PROGRESS — and nothing executes it. `start` spawns a background thread for exactly this; resume never had an equivalent.

The task is then **wedged**: it holds an *active* run, so `start_task_run()` rejects any attempt to start it again, and nothing is driving the run it does have. The only way out was editing the database.

Every BLOCKED task resumed from the web UI hits this — stall blockers, agent-escalated blockers, and (as of #911) cost-cap blockers, which give users a routine reason to block and resume.

## The CLI was worse

`cf work resume` had the same gap **and no escape at all**. It never executed, and afterwards `cf work start` rejects the active run — so no command existed that would drive the task.

## Fix

The two endpoints drifted, so the thread body is now one helper, `_spawn_agent_worker`, called by both. Resume inherits the #722 `fail_run`/`ErrorEvent` recovery for free — a resumed run whose agent fails up front (missing API key, unknown provider) now resets to FAILED instead of stranding.

`resume`'s `execute` defaults to **True**, unlike `start`'s `False`. `web-ui/src/lib/api.ts:437` posts here with no query params, so any other default would leave the bug in place for the only real caller — and a resumed run that deliberately does no work has no use case. `execute=false` keeps the old flip-only behaviour for anyone who wants it.

`cf work resume` now runs the agent in the foreground by default, matching `cf work start --execute`, with `--no-execute` to opt out (and a message pointing at `--execute` when you do).

Core is untouched: `runtime.resume_run` stays headless and does not learn about threads or event publishers.

## Testing

Asserted on **outcome** — did a worker actually run the resumed run — not on the endpoint returning 200, which it always did.

- `test_resume_actually_runs_the_agent` — a worker runs at all
- `test_the_worker_gets_the_resumed_run` — the same run resume returned, not a fresh one
- `test_resume_does_not_wedge_the_task` — the user-visible symptom: after a failing resume the task is retryable and `start` works again
- `test_execute_false_keeps_the_flip_only_behaviour`
- `test_the_default_executes_because_the_web_ui_sends_no_params`
- `test_start_still_works_through_the_shared_helper` — this one **passes on `main`**, so it pins that extracting the helper does not regress start
- CLI: executes by default, `--no-execute` opts out

`tests/ui/` + `tests/cli/`: **1168 passed**, `ruff` clean.
