### PR TITLE
fix(cli): exit non-zero when a resumed task does not complete (#1005 follow-up)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2724,6 +2724,14 @@ def work_resume(
                 console.print("  Use 'codeframe blocker list' to see blockers")
             elif state.status == AgentStatus.FAILED:
                 console.print("[red]Task execution failed[/red]")
+
+            # Same rule as `work start`: anything short of COMPLETED exits 1, so
+            # `cf work resume <id> && next_step` cannot proceed on a task that
+            # did not finish. Exiting 0 on FAILED made the shell read a failed
+            # run as success. BLOCKED is included for parity with start — it is
+            # equally "normal" there, and one predictable rule beats two.
+            if state.status in (AgentStatus.BLOCKED, AgentStatus.FAILED):
+                raise typer.Exit(1)
         else:
             console.print(
                 "\n[yellow]Not executed.[/yellow] The run is RUNNING with no worker; "

--- a/tests/ui/test_resume_starts_worker_1005.py
+++ b/tests/ui/test_resume_starts_worker_1005.py
@@ -281,3 +281,44 @@ def test_cli_resume_reports_the_real_error_when_recovery_also_fails(
     assert "ANTHROPIC_API_KEY is not set" in result.output, (
         f"the real error was masked: {result.output!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Exit codes must match `work start` (#1005 follow-up review)
+# ---------------------------------------------------------------------------
+
+
+def _invoke_resume_with_status(ws, task_id, status, monkeypatch):
+    from typer.testing import CliRunner
+
+    from codeframe.core.agent import AgentStatus
+
+    class _State:
+        blocker = None
+
+    _State.status = getattr(AgentStatus, status)
+    monkeypatch.setattr(runtime, "execute_agent", lambda *a, **k: _State())
+
+    from codeframe.cli.app import app
+    from codeframe.core import workspace as ws_module
+
+    monkeypatch.setattr(ws_module, "get_workspace", lambda p: ws)
+    return CliRunner().invoke(app, ["work", "resume", task_id[:8]])
+
+
+@pytest.mark.parametrize("status,expected", [
+    ("COMPLETED", 0),
+    ("FAILED", 1),
+    ("BLOCKED", 1),
+])
+def test_cli_resume_exit_code_matches_work_start(
+    blocked, monkeypatch, status, expected
+):
+    """Review finding: resume exited 0 even on FAILED, so
+    `cf work resume <id> && next_step` proceeded on a failed run. `work start`
+    exits 1 for anything short of COMPLETED (app.py) — resume now does too."""
+    _, ws, task_id, _ = blocked
+
+    result = _invoke_resume_with_status(ws, task_id, status, monkeypatch)
+
+    assert result.exit_code == expected, result.output


### PR DESCRIPTION
Post-merge review finding on #1020.

`cf work resume` printed "Task execution failed" and exited **0**, so `cf work resume <id> && next_step` proceeded as if the run had succeeded. `work start` exits 1 for anything short of COMPLETED (`app.py:2610`), and #1020's body promised parity with it.

Matched to `work start` exactly — BLOCKED and FAILED both exit 1. The reviewer suggested gating on FAILED alone, on the grounds that blocking again is a normal outcome of a resume. That is true, but it is equally true of `work start`, which exits 1 anyway; one predictable rule across both commands beats two that differ by a case.

Parametrized test pins all three outcomes (COMPLETED→0, FAILED→1, BLOCKED→1).

`tests/ui/test_resume_starts_worker_1005.py`: 13 passed, `ruff` clean.