### PR TITLE
fix(opencode): work in the task's workspace, not CodeFrame's own (#1007)

### DIFF
--- a/codeframe/core/adapters/opencode.py
+++ b/codeframe/core/adapters/opencode.py
@@ -160,14 +160,24 @@ class OpenCodeAdapter(SubprocessAdapter):
         from stdin, confirmed by its own ``prompt_submit`` log carrying the piped
         text verbatim.
 
+        ``--dir`` is **required**, not belt-and-braces: opencode resolves its
+        project directory from the *parent* process and ignores the ``cwd=``
+        every other adapter relies on, so without it a delegated task edits
+        whatever directory CodeFrame itself was launched from — under
+        ``codeframe serve``, the server's own checkout (#1007). ``require_file_
+        changes`` does not save us: it inspects the workspace, finds nothing and
+        fails the run, correctly reporting failure while the edits have already
+        landed somewhere else.
+
         Args:
             prompt: The task prompt.
-            workspace_path: Workspace root (cwd is set by the base class).
+            workspace_path: Workspace root. Also passed as ``cwd`` by the base
+                class, which opencode does not honour — hence ``--dir``.
 
         Returns:
             Command list for subprocess.Popen.
         """
-        cmd = [self._binary_path, *self._cli_args]
+        cmd = [self._binary_path, *self._cli_args, "--dir", str(workspace_path)]
         if not self._prompt_exceeds_argv(prompt):
             cmd.append(prompt)
         return cmd

--- a/tests/core/adapters/test_engine_smoke_tier.py
+++ b/tests/core/adapters/test_engine_smoke_tier.py
@@ -97,6 +97,12 @@ class Engine:
     #: point the adapter depends on, asserted against the CLI rather than
     #: against our code, so an upstream rename fails here.
     help_must_contain: tuple[str, ...]
+    #: A subcommand whose own ``--help`` is appended before matching. Modern CLIs
+    #: document their real flags there, not at the top level: ``--dir``, which
+    #: the opencode adapter now depends on (#1007), appears only under
+    #: ``opencode run --help``. Without this the tier would silently under-cover
+    #: exactly the flags most likely to drift.
+    help_subcommand: str | None = None
     #: Set when the adapter is known to target a different CLI version than the
     #: one likely installed. The contract check then xfails instead of blocking
     #: every adapter PR — but it is `strict=False`, so it flips to a pass the
@@ -145,7 +151,10 @@ ENGINES = (
     Engine("codex", lambda: "codex", _codex, ("app-server",)),
     # The headless entry point. #913 shipped `--non-interactive`, which does
     # not exist; its own smoke file pins that specific regression.
-    Engine("opencode", lambda: "opencode", _opencode, ("opencode run",)),
+    Engine(
+        "opencode", lambda: "opencode", _opencode,
+        ("opencode run", "--dir"), help_subcommand="run",
+    ),
     # kilocode 0.22.0 takes a bare positional prompt plus these flags and has no
     # `run` subcommand (#1012). kilocode 7.x reinstated `run` and renamed
     # --workspace to --dir, so the adapter is stale against a current install —
@@ -163,12 +172,17 @@ ENGINES = (
 )
 
 
-def _cli_help(binary: str) -> str:
+def _cli_help(binary: str, subcommand: str | None = None) -> str:
     """Return a CLI's help text. Several of these print help on stderr."""
-    proc = subprocess.run(
-        [binary, "--help"], capture_output=True, text=True, timeout=90
-    )
-    return proc.stdout + proc.stderr
+
+    def _run(args: list[str]) -> str:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=90)
+        return proc.stdout + proc.stderr
+
+    text = _run([binary, "--help"])
+    if subcommand:
+        text += "\n" + _run([binary, subcommand, "--help"])
+    return text
 
 
 def _require_binary(engine: Engine) -> str:
@@ -220,7 +234,7 @@ def test_the_cli_still_documents_the_adapters_entry_point(engine: Engine) -> Non
     rename or removal fails here instead of silently producing no-op runs.
     """
     binary = _require_binary(engine)
-    help_text = _cli_help(binary)
+    help_text = _cli_help(binary, engine.help_subcommand)
 
     missing = [s for s in engine.help_must_contain if s not in help_text]
     if missing and engine.known_drift:

--- a/tests/core/adapters/test_opencode.py
+++ b/tests/core/adapters/test_opencode.py
@@ -48,7 +48,9 @@ class TestOpenCodeAdapter:
             adapter = OpenCodeAdapter()
             cmd = adapter.build_command("prompt", Path("/tmp"))
 
-        assert cmd == ["/usr/bin/opencode", "run", "prompt"]
+        # --dir because opencode resolves its project directory from the parent
+        # process and ignores the subprocess cwd (#1007).
+        assert cmd == ["/usr/bin/opencode", "run", "--dir", "/tmp", "prompt"]
         assert "--non-interactive" not in cmd
 
     def test_the_prompt_is_an_argument_not_stdin(self) -> None:
@@ -74,7 +76,9 @@ class TestOpenCodeAdapter:
             adapter = OpenCodeAdapter()
 
         cmd = adapter.build_command(big, Path("/tmp"))
-        assert cmd == ["/usr/bin/opencode", "run"], "oversized prompt must leave argv"
+        assert cmd == ["/usr/bin/opencode", "run", "--dir", "/tmp"], (
+            "oversized prompt must leave argv — but the workspace must not"
+        )
         assert adapter.get_stdin(big) == big, "…and must still reach opencode"
 
         # The real limit, not just a big number: this is executable as argv.

--- a/tests/core/adapters/test_opencode_dir_1007.py
+++ b/tests/core/adapters/test_opencode_dir_1007.py
@@ -1,0 +1,173 @@
+"""opencode must work in the task's workspace, not CodeFrame's own (#1007 / P0.27).
+
+Every ``SubprocessAdapter`` targets a workspace by passing ``cwd=workspace_path``
+to ``Popen``. **opencode does not honour it** — it resolves its project directory
+from the *parent* process, so a delegated task edits whatever directory CodeFrame
+itself is running from. Under ``codeframe serve`` that is the server's own
+checkout.
+
+``require_file_changes`` does not catch it: the guard inspects the *workspace*,
+finds no changes and fails the run — correctly reporting failure while the edits
+have already landed elsewhere.
+
+The binary-gated test below reads the project directory out of opencode's own
+``session_start`` event, which it emits **before** contacting any model. That
+makes the check independent of opencode's backend availability — the issue's own
+investigation stalled because two ``--dir`` attempts timed out, and a plain run
+timed out right after.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.adapters.opencode import OpenCodeAdapter
+
+pytestmark = pytest.mark.v2
+
+_HAS_OPENCODE = shutil.which("opencode") is not None
+requires_opencode = pytest.mark.skipif(
+    not _HAS_OPENCODE, reason="opencode binary not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# Command construction — runs everywhere
+# ---------------------------------------------------------------------------
+
+
+def test_the_command_names_the_workspace(tmp_path: Path) -> None:
+    adapter = OpenCodeAdapter.__new__(OpenCodeAdapter)
+    adapter._binary_path = "/usr/bin/opencode"
+    adapter._cli_args = ["run"]
+
+    cmd = adapter.build_command("do a thing", tmp_path)
+
+    assert "--dir" in cmd
+    assert cmd[cmd.index("--dir") + 1] == str(tmp_path)
+
+
+def test_dir_precedes_the_positional_message(tmp_path: Path) -> None:
+    """``opencode run [options] [message..]`` — a flag after the positional
+    array is swallowed as part of the message."""
+    adapter = OpenCodeAdapter.__new__(OpenCodeAdapter)
+    adapter._binary_path = "/usr/bin/opencode"
+    adapter._cli_args = ["run"]
+
+    cmd = adapter.build_command("do a thing", tmp_path)
+
+    assert cmd.index("--dir") < cmd.index("do a thing")
+
+
+def test_an_oversized_prompt_still_carries_the_workspace(tmp_path: Path) -> None:
+    """The >128 KiB prompt goes to stdin, but the workspace must not go with it."""
+    adapter = OpenCodeAdapter.__new__(OpenCodeAdapter)
+    adapter._binary_path = "/usr/bin/opencode"
+    adapter._cli_args = ["run"]
+
+    cmd = adapter.build_command("x" * (200 * 1024), tmp_path)
+
+    assert cmd[cmd.index("--dir") + 1] == str(tmp_path)
+    assert len(cmd) == 4  # binary, run, --dir, path — no positional
+
+
+# ---------------------------------------------------------------------------
+# Against the real binary
+# ---------------------------------------------------------------------------
+
+
+def _session_cwd(output: str) -> str | None:
+    """The project directory opencode resolved, from its own session_start.
+
+    The events arrive embedded in OSC-777 terminal notifications, so they are
+    located by prefix and decoded with ``raw_decode`` — a regex cannot bound the
+    object, whose nested braces defeat any non-greedy match.
+    """
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r'\{"v":1,', output):
+        try:
+            event, _ = decoder.raw_decode(output[match.start():])
+        except json.JSONDecodeError:
+            continue
+        if event.get("event") == "session_start":
+            return event.get("cwd")
+    return None
+
+
+@requires_opencode
+def test_opencode_documents_dir(tmp_path: Path) -> None:
+    """Pins the flag against upstream drift — kilocode renamed exactly this one
+    out from under its adapter (#1015)."""
+    proc = subprocess.run(
+        ["opencode", "run", "--help"], capture_output=True, text=True, timeout=120
+    )
+    # opencode writes its help to stderr.
+    assert "--dir" in proc.stdout + proc.stderr
+
+
+@requires_opencode
+def test_the_adapter_resolves_the_workspace_not_the_parent_cwd(tmp_path: Path) -> None:
+    """The discriminating condition: parent cwd is a *different* directory.
+
+    Reads opencode's resolved project dir from session_start, so it does not
+    depend on a model turn completing.
+    """
+    workspace = tmp_path / "workspace"
+    elsewhere = tmp_path / "elsewhere"
+    workspace.mkdir()
+    elsewhere.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+
+    adapter = OpenCodeAdapter.__new__(OpenCodeAdapter)
+    adapter._binary_path = shutil.which("opencode")
+    adapter._cli_args = ["run"]
+    cmd = adapter.build_command("say ok", workspace)
+
+    try:
+        proc = subprocess.run(
+            cmd, cwd=str(elsewhere), capture_output=True, text=True, timeout=180
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("opencode did not respond within 180s")
+
+    resolved = _session_cwd(proc.stdout + proc.stderr)
+    if resolved is None:
+        pytest.skip("opencode emitted no session_start event to inspect")
+
+    assert Path(resolved).resolve() == workspace.resolve(), (
+        f"opencode worked in {resolved}, not the task's workspace {workspace}. "
+        "Without --dir it resolves the project from the parent process, so a "
+        "delegated task edits whatever directory CodeFrame was launched from."
+    )
+
+
+@requires_opencode
+def test_without_dir_it_takes_the_parent_cwd(tmp_path: Path) -> None:
+    """Pins the bug itself, so nobody drops --dir believing cwd= is enough."""
+    workspace = tmp_path / "workspace"
+    elsewhere = tmp_path / "elsewhere"
+    workspace.mkdir()
+    elsewhere.mkdir()
+
+    try:
+        proc = subprocess.run(
+            ["opencode", "run", "say ok"],
+            cwd=str(workspace), capture_output=True, text=True, timeout=180,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("opencode did not respond within 180s")
+
+    resolved = _session_cwd(proc.stdout + proc.stderr)
+    if resolved is None:
+        pytest.skip("opencode emitted no session_start event to inspect")
+
+    # If this ever starts equalling `workspace`, opencode began honouring cwd=
+    # and the --dir workaround can be revisited.
+    if Path(resolved).resolve() == workspace.resolve():
+        pytest.xfail("opencode now honours cwd= — revisit the --dir workaround")

--- a/tests/core/adapters/test_opencode_smoke_913.py
+++ b/tests/core/adapters/test_opencode_smoke_913.py
@@ -100,13 +100,9 @@ def test_the_adapter_command_actually_writes_a_file(repo: Path) -> None:
         pytest.skip(f"opencode did not complete within {_TIMEOUT_S}s")
 
     produced = repo / "smoke.txt"
-    if not produced.exists() and "smoke.txt" in proc.stdout:
-        # opencode reported writing the file but it is not in the workspace —
-        # it resolves its project directory from the *parent* process, ignoring
-        # the subprocess cwd every other adapter relies on. Tracked as
-        # #1007 [P0.27]; distinct from this issue's contract.
-        pytest.xfail("opencode ignored cwd and wrote outside the workspace")
-
+    # The xfail that used to sit here — opencode reporting a write that landed
+    # outside the workspace, because it resolves its project directory from the
+    # parent process — is fixed in #1007: build_command now passes --dir.
     assert produced.exists(), (
         f"the adapter's command wrote nothing.\n"
         f"cmd={cmd}\nstdout={proc.stdout[-2000:]}\nstderr={proc.stderr[-2000:]}"


### PR DESCRIPTION
Closes #1007.

## The bug

Every `SubprocessAdapter` targets a task's workspace with `cwd=workspace_path`. **opencode does not honour it** — it resolves its project directory from the *parent* process, so a delegated task edits whatever directory CodeFRAME is running from. Under `codeframe serve`, that is the server's own checkout.

`require_file_changes` does not save us: the guard inspects the *workspace*, finds no changes and fails the run — correctly reporting failure while the edits have already landed somewhere else.

## Verification

The issue's own investigation stalled here: two `--dir` attempts timed out at 240s and 280s, and a plain `opencode run` timed out right afterwards, so `--dir` could not be confirmed. opencode's backend is still returning `UnknownError` for every turn today.

That turned out not to matter. **opencode emits its resolved project directory in a `session_start` event before contacting any model**, so the check needs no successful turn:

```
BASELINE  cwd=<target>, no --dir   →  "cwd":"/tmp"                    ← the parent shell's dir
WITH      --dir <target>           →  "cwd":"/tmp/oc1007-dir-wogj..." ← the target
```

Both directions are now pinned by binary-gated tests, and both genuinely run here (not skipped):

```
test_the_adapter_resolves_the_workspace_not_the_parent_cwd PASSED
test_without_dir_it_takes_the_parent_cwd                   PASSED
```

The second pins the *bug*, so nobody drops `--dir` believing `cwd=` is enough — and it xfails loudly if opencode ever starts honouring `cwd=`.

## A gap this exposed in #915's contract tier

Adding `--dir` to the tier's expectations for opencode **failed**: `--dir` appears only under `opencode run --help`, and the tier could only read top-level `--help`. So the flags most likely to drift — subcommand flags, which is where modern CLIs put everything — were invisible to the tier that exists to catch exactly that.

`Engine` gains `help_subcommand`, and the opencode entry now pins `--dir`. kilocode 7.x needs the same mechanism (#1015), where `--dir` also lives under `run`.

Had I not checked, this would have broken the required `Engine CLI Contract` check.

## Also

- Removes the `pytest.xfail` in `test_opencode_smoke_913.py` that tracked this issue.
- Updates the two existing `test_opencode.py` tests that assert the exact command list.
- opencode writes `--help` to **stderr**, which the tier's `_cli_help` already handled and my first draft of the new test did not.

## Testing

`tests/core/adapters/`: 298 passed. `ruff` clean. Full gate re-running on the clean branch.
