### PR TITLE
fix(codex): accept `codex login` as authentication (#1010)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2543,8 +2543,10 @@ def work_start(
         if execute:
             from codeframe.core.engine_registry import is_external_engine
             if engine == "codex":
-                from codeframe.cli.validators import require_openai_api_key
-                require_openai_api_key()
+                # Not the OpenAI key check: `codex login` is the common way in
+                # and sets no env var at all (#1010).
+                from codeframe.cli.validators import require_codex_auth
+                require_codex_auth()
             elif engine == "cloud":
                 from codeframe.cli.validators import require_e2b_api_key
                 require_e2b_api_key()
@@ -3997,8 +3999,10 @@ def batch_run(
         # Validate API key before batch execution
         from codeframe.core.engine_registry import is_external_engine
         if engine == "codex":
-            from codeframe.cli.validators import require_openai_api_key
-            require_openai_api_key()
+            # Not the OpenAI key check: `codex login` is the common way in
+            # and sets no env var at all (#1010).
+            from codeframe.cli.validators import require_codex_auth
+            require_codex_auth()
         elif engine == "cloud":
             from codeframe.cli.validators import require_e2b_api_key
             require_e2b_api_key()

--- a/codeframe/cli/validators.py
+++ b/codeframe/cli/validators.py
@@ -122,3 +122,32 @@ def require_e2b_api_key() -> str:
         "Get your key at https://e2b.dev"
     )
     raise typer.Exit(1)
+
+
+def require_codex_auth() -> None:
+    """Ensure the codex CLI can reach a model, by either route (#1010).
+
+    Not ``require_openai_api_key``: ``codex login`` stores ChatGPT-plan
+    credentials in ``auth.json`` and writes ``"OPENAI_API_KEY": null`` in that
+    same file, so gating on the environment variable refused the common case —
+    ``--engine codex`` was unusable for anyone who had simply logged in, even
+    though the adapter and the binary both worked.
+
+    Raises:
+        typer.Exit: If codex is authenticated by neither route.
+    """
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    if CodexAdapter.is_authenticated():
+        return
+
+    load_env_files()
+    if CodexAdapter.is_authenticated():
+        return
+
+    console.print(
+        "[red]Error:[/red] codex is not authenticated. "
+        "Run [bold]codex login[/bold], or set OPENAI_API_KEY in your "
+        "environment or a .env file."
+    )
+    raise typer.Exit(1)

--- a/codeframe/core/adapters/codex.py
+++ b/codeframe/core/adapters/codex.py
@@ -183,7 +183,11 @@ class CodexAdapter:
 
         try:
             auth = json.loads((cls.codex_home() / "auth.json").read_text())
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError, ValueError):
+            # ValueError also covers UnicodeDecodeError from read_text() — a
+            # genuinely corrupt auth.json must read as "not authenticated",
+            # not crash the caller. JSONDecodeError is itself a ValueError, so
+            # this is the whole family. (#1010 review)
             return False
 
         if not isinstance(auth, dict):

--- a/codeframe/core/adapters/codex.py
+++ b/codeframe/core/adapters/codex.py
@@ -22,6 +22,7 @@ their own id — an unanswered one hangs the turn.
 
 from __future__ import annotations
 
+import os
 import json
 import logging
 import queue
@@ -148,8 +149,57 @@ class CodexAdapter:
 
     @classmethod
     def requirements(cls) -> dict[str, str]:
-        """Return required environment variables for ``cf engines check``."""
-        return {"OPENAI_API_KEY": "OpenAI API key"}
+        """No *required* environment variables (#1010).
+
+        ``OPENAI_API_KEY`` used to be listed here, and ``cf engines check`` marks
+        any unsatisfied entry as an unmet requirement and exits 1 — so a codex
+        authenticated by ``codex login`` (which sets no variable at all, and
+        records ``"OPENAI_API_KEY": null`` in its own auth.json) was reported as
+        broken while working perfectly. ``check_ready`` below answers the real
+        question, by either route.
+        """
+        return {}
+
+    @classmethod
+    def codex_home(cls) -> Path:
+        """Where codex keeps its state. ``$CODEX_HOME`` is documented by the CLI."""
+        override = os.environ.get("CODEX_HOME")
+        return Path(override) if override else Path.home() / ".codex"
+
+    @classmethod
+    def is_authenticated(cls) -> bool:
+        """True when codex can actually talk to a model (#1010).
+
+        ``OPENAI_API_KEY`` is *not* the test. ``codex login`` writes ChatGPT-plan
+        credentials to ``auth.json`` and records ``"OPENAI_API_KEY": null`` in
+        the very same file — so gating on the environment variable refuses the
+        common case, where the CLI works perfectly well.
+
+        Presence of the file is not the test either: ``codex logout`` can leave
+        it behind with empty tokens.
+        """
+        if os.environ.get("OPENAI_API_KEY"):
+            return True
+
+        try:
+            auth = json.loads((cls.codex_home() / "auth.json").read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+
+        if not isinstance(auth, dict):
+            return False
+        if auth.get("OPENAI_API_KEY"):
+            return True
+        tokens = auth.get("tokens")
+        return bool(isinstance(tokens, dict) and tokens.get("access_token"))
+
+    @classmethod
+    def check_ready(cls) -> dict[str, bool]:
+        """What ``cf engines check`` reports for codex."""
+        return {
+            "codex_binary": shutil.which("codex") is not None,
+            "authenticated": cls.is_authenticated(),
+        }
 
     @classmethod
     def credential_env_vars(cls) -> tuple[str, ...]:

--- a/tests/core/adapters/test_codex_auth_1010.py
+++ b/tests/core/adapters/test_codex_auth_1010.py
@@ -1,0 +1,218 @@
+"""`--engine codex` must run when the codex CLI is logged in (#1010 / P0.28).
+
+`cf work start --engine codex --execute` and `cf work batch run --engine codex`
+both called `require_openai_api_key()`, which exits when `OPENAI_API_KEY` is
+unset. But codex does not need that variable — `codex login` writes ChatGPT-plan
+credentials to `~/.codex/auth.json`, and the #914 end-to-end demo drove a real
+`codex app-server` to completion with no `OPENAI_API_KEY` at all.
+
+A real logged-in auth.json on this machine, for reference:
+
+    auth_mode      = 'chatgpt'
+    OPENAI_API_KEY = None          # literally null
+    tokens         = {access_token, account_id, id_token, refresh_token}
+
+So the env var is not merely an incomplete proof of auth — the logged-in file
+explicitly records it as absent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def codex_home(tmp_path: Path, monkeypatch) -> Path:
+    home = tmp_path / "codex-home"
+    home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return home
+
+
+def _write_auth(home: Path, payload: dict) -> None:
+    (home / "auth.json").write_text(json.dumps(payload))
+
+
+def _chatgpt_login() -> dict:
+    """The shape `codex login` actually writes for a ChatGPT-plan account."""
+    return {
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": None,
+        "last_refresh": "2026-08-01T00:00:00.000000000Z",
+        "tokens": {
+            "access_token": "at",
+            "account_id": "acct",
+            "id_token": "it",
+            "refresh_token": "rt",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def test_a_chatgpt_login_counts_as_authenticated(codex_home):
+    """The headline case: `codex login`, no OPENAI_API_KEY anywhere."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    _write_auth(codex_home, _chatgpt_login())
+
+    assert CodexAdapter.is_authenticated()
+
+
+def test_the_env_key_still_counts(codex_home, monkeypatch):
+    """codex honours OPENAI_API_KEY too — it stays a valid alternative."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+
+    assert CodexAdapter.is_authenticated()
+
+
+def test_an_api_key_stored_in_auth_json_counts(codex_home):
+    """`codex login --api-key` writes the key into the file instead."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    _write_auth(codex_home, {"auth_mode": "apikey", "OPENAI_API_KEY": "sk-stored"})
+
+    assert CodexAdapter.is_authenticated()
+
+
+def test_neither_is_not_authenticated(codex_home):
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    assert not CodexAdapter.is_authenticated()
+
+
+def test_a_logged_out_auth_json_is_not_authenticated(codex_home):
+    """`codex logout` can leave the file behind with nothing in it — presence
+    alone must not be the test."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    _write_auth(codex_home, {"auth_mode": "chatgpt", "OPENAI_API_KEY": None,
+                             "tokens": {}})
+
+    assert not CodexAdapter.is_authenticated()
+
+
+def test_a_corrupt_auth_json_is_not_authenticated(codex_home):
+    (codex_home / "auth.json").write_text("{not json")
+
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    assert not CodexAdapter.is_authenticated()
+
+
+def test_codex_home_is_honoured(tmp_path, monkeypatch):
+    """codex documents $CODEX_HOME; hard-coding ~/.codex would miss a relocated
+    install."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    elsewhere = tmp_path / "relocated"
+    elsewhere.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    monkeypatch.setenv("CODEX_HOME", str(elsewhere))
+    _write_auth(elsewhere, _chatgpt_login())
+
+    assert CodexAdapter.is_authenticated()
+
+
+def test_check_ready_reports_the_login(codex_home):
+    """AC3: `cf engines check` must not flag a missing key when logged in."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    _write_auth(codex_home, _chatgpt_login())
+
+    assert CodexAdapter.check_ready().get("authenticated") is True
+
+
+def test_check_ready_reports_the_absence(codex_home):
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    assert CodexAdapter.check_ready().get("authenticated") is False
+
+
+# ---------------------------------------------------------------------------
+# The CLI gate — the actual user-visible bug
+# ---------------------------------------------------------------------------
+
+
+def test_the_cli_does_not_refuse_a_logged_in_codex(codex_home, monkeypatch):
+    """AC1: `--engine codex` runs with no OPENAI_API_KEY when codex is logged in."""
+    from codeframe.cli.validators import require_codex_auth
+
+    _write_auth(codex_home, _chatgpt_login())
+
+    require_codex_auth()  # must not raise
+
+
+def test_the_cli_still_fails_fast_when_unauthenticated(codex_home, capsys, monkeypatch):
+    """AC2: and the message names *both* ways to authenticate."""
+    import typer
+
+    import codeframe.cli.validators as validators
+    from codeframe.cli.validators import require_codex_auth
+
+    # The validator falls back to .env files, and this machine (like CI) may
+    # have a real OPENAI_API_KEY in one. Pin the unauthenticated case.
+    monkeypatch.setattr(validators, "load_env_files", lambda: None)
+
+    with pytest.raises(typer.Exit):
+        require_codex_auth()
+
+    message = capsys.readouterr().out
+    assert "codex login" in message
+    assert "OPENAI_API_KEY" in message
+
+
+def test_work_start_uses_the_codex_check_not_the_openai_one(monkeypatch, codex_home):
+    """The gate at the call site is what actually blocked the user."""
+    import codeframe.cli.validators as validators
+
+    _write_auth(codex_home, _chatgpt_login())
+
+    called: list[str] = []
+    monkeypatch.setattr(
+        validators, "require_openai_api_key",
+        lambda: called.append("openai") or "k",
+    )
+
+    from codeframe.cli.app import app  # noqa: F401  (import side effects only)
+
+    validators.require_codex_auth()
+    assert called == [], "the codex path must not go through require_openai_api_key"
+
+
+def test_engines_check_calls_codex_ready_when_logged_in(codex_home):
+    """AC3, at the surface the user actually sees.
+
+    `cf engines check` marks *any* unsatisfied entry as an unmet requirement and
+    exits 1, so listing OPENAI_API_KEY under `requirements()` reported a working
+    logged-in codex as broken.
+    """
+    from codeframe.core.engine_registry import check_requirements
+
+    _write_auth(codex_home, _chatgpt_login())
+
+    reqs = check_requirements("codex")
+
+    assert all(reqs.values()), f"logged-in codex reported not ready: {reqs}"
+    assert reqs["authenticated"] is True
+
+
+def test_engines_check_still_flags_an_unauthenticated_codex(codex_home):
+    from codeframe.core.engine_registry import check_requirements
+
+    reqs = check_requirements("codex")
+
+    assert reqs["authenticated"] is False
+    assert not all(reqs.values())

--- a/tests/core/adapters/test_codex_auth_1010.py
+++ b/tests/core/adapters/test_codex_auth_1010.py
@@ -205,8 +205,13 @@ def test_engines_check_calls_codex_ready_when_logged_in(codex_home):
 
     reqs = check_requirements("codex")
 
-    assert all(reqs.values()), f"logged-in codex reported not ready: {reqs}"
     assert reqs["authenticated"] is True
+    # The specific claim: no *credential* entry is reported unmet. Not
+    # `all(reqs.values())` — codex_binary is legitimately False wherever the CLI
+    # is not installed, which is every CI runner.
+    assert "OPENAI_API_KEY" not in reqs, (
+        f"a logged-in codex is still flagged for a missing key: {reqs}"
+    )
 
 
 def test_engines_check_still_flags_an_unauthenticated_codex(codex_home):
@@ -214,5 +219,5 @@ def test_engines_check_still_flags_an_unauthenticated_codex(codex_home):
 
     reqs = check_requirements("codex")
 
+    # `not all(...)` would pass trivially wherever the binary is absent.
     assert reqs["authenticated"] is False
-    assert not all(reqs.values())

--- a/tests/core/adapters/test_codex_auth_1010.py
+++ b/tests/core/adapters/test_codex_auth_1010.py
@@ -221,3 +221,23 @@ def test_engines_check_still_flags_an_unauthenticated_codex(codex_home):
 
     # `not all(...)` would pass trivially wherever the binary is absent.
     assert reqs["authenticated"] is False
+
+
+def test_a_non_utf8_auth_json_is_not_authenticated(codex_home):
+    """Review finding (bot, [minor]): read_text() raises UnicodeDecodeError — a
+    ValueError, not an OSError — on a corrupt file, which crashed the check
+    instead of failing closed."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    (codex_home / "auth.json").write_bytes(b"\xff\xfe\x00\x00not-utf8")
+
+    assert CodexAdapter.is_authenticated() is False
+
+
+def test_a_directory_where_auth_json_should_be_is_not_authenticated(codex_home):
+    """The OSError half of the same guard."""
+    from codeframe.core.adapters.codex import CodexAdapter
+
+    (codex_home / "auth.json").mkdir()
+
+    assert CodexAdapter.is_authenticated() is False


### PR DESCRIPTION
Closes #1010.

## The bug

`cf work start --engine codex --execute` and `cf work batch run --engine codex` called `require_openai_api_key()`, which exits when `OPENAI_API_KEY` is unset. codex does not need that variable — `codex login` stores ChatGPT-plan credentials in `auth.json`, and #914's end-to-end demo drove a real `codex app-server` to completion with none set.

So the advertised `--engine codex` was unusable for the common case, while the adapter and the binary both worked fine.

## The env var is not just incomplete proof — the file says so

A real logged-in `auth.json` on this machine:

```
auth_mode      = 'chatgpt'
OPENAI_API_KEY = None          # literally null
tokens         = {access_token, account_id, id_token, refresh_token}
```

`codex login` records `OPENAI_API_KEY: null` in the very file that proves you are authenticated.

## Fix

`CodexAdapter.is_authenticated()` accepts either route — the env var, an API key stored in `auth.json` (`codex login --api-key`), or ChatGPT tokens. Presence of the file is *not* enough: `codex logout` can leave it behind with empty tokens. `$CODEX_HOME` is honoured, since the CLI documents it.

`require_codex_auth()` replaces `require_openai_api_key()` at both call sites, and its message names both ways in.

## A second surface, found by running the command

AC3 asks that `cf engines check` report codex ready when logged in. It did not, for a different reason: the command treats **any** unsatisfied entry as an unmet requirement and exits 1, so `requirements()` listing `OPENAI_API_KEY` reported a working logged-in codex as broken.

`requirements()` now returns `{}` and `check_ready()` reports `codex_binary` + `authenticated` — the question actually being asked. (`credential_env_vars()` is overridden explicitly on this adapter, so it is unaffected.)

## Verification against the real logged-in codex

With no `OPENAI_API_KEY` in the environment:

```
codex_home:       /home/frankbria/.codex
is_authenticated: True
check_ready:      {'codex_binary': True, 'authenticated': True}
```

And all three AC4 cases:

```
logged in,  no key  → {'codex_binary': True, 'authenticated': True}
logged out, no key  → {'codex_binary': True, 'authenticated': False}
logged out, w/ key  → {'codex_binary': True, 'authenticated': True}
```

## Testing

`tests/core/adapters/test_codex_auth_1010.py` — 14 tests covering logged-in-no-env-key, env-key-no-login, key-stored-in-auth.json, neither, logged-out-with-empty-tokens, corrupt file, `$CODEX_HOME` relocation, and both `engines check` verdicts. `ruff` clean.

One test pins the unauthenticated case against `load_env_files()`, since this machine (and CI) may carry a real `OPENAI_API_KEY` in a `.env`.

## Note

This composes with #996: `~/.codex` is symlinked into the delegated agent's sandbox home, so the login keeps working for the spawned `codex app-server` too.
