### PR TITLE
perf(credentials): cache the derived key and make store writes concurrency-safe (#920)

### DIFF
--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -37,6 +37,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 import platform
 import tempfile
 import threading
@@ -292,22 +293,31 @@ def _derive_key_uncached(salt_file: Path) -> bytes:
     """
     # Get or create salt
     if salt_file.exists():
-        with open(salt_file, "rb") as f:
-            salt = f.read()
-        # Validate salt file integrity
-        if len(salt) != 16:
-            raise ValueError(
-                f"Invalid salt file at {salt_file}: expected 16 bytes, got {len(salt)}. "
-                "Delete the salt file to regenerate (note: this will make existing "
-                "credentials inaccessible)."
-            )
+        # Waits out a concurrent creator that has made the file but not yet
+        # written to it, and raises the same explicit error as before for a
+        # salt that is genuinely the wrong size (#920 review).
+        salt = _read_salt_when_written(salt_file)
     else:
-        salt = os.urandom(16)
+        # Create exclusively, and on a lost race read back the winner's salt.
+        #
+        # `open(..., "wb")` truncates, so two first-time derivations each wrote
+        # their own random salt and the second clobbered the first. Every caller
+        # used to re-read the disk salt, so the mismatch self-healed on the next
+        # call; with the derivation memoized (#920) the losing key is pinned for
+        # the whole process lifetime — the process encrypts under a key the
+        # on-disk salt can never reproduce, and after a restart every credential
+        # written in that window fails to decrypt and reads as an empty store.
+        # (#920 review)
         salt_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(salt_file, "wb") as f:
-            f.write(salt)
-        # Secure permissions
-        salt_file.chmod(0o600)
+        salt = os.urandom(16)
+        try:
+            fd = os.open(salt_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            salt = _read_salt_when_written(salt_file)
+        else:
+            with os.fdopen(fd, "wb") as f:
+                f.write(salt)
+            salt_file.chmod(0o600)
 
     # Get machine-specific identifier; optionally mix in a real user secret so
     # the key isn't recoverable from the (non-secret) machine ID alone (#772).
@@ -330,6 +340,30 @@ def _derive_key_uncached(salt_file: Path) -> bytes:
     key = base64.urlsafe_b64encode(kdf.derive(key_material))
 
     return key
+
+
+def _read_salt_when_written(salt_file: Path) -> bytes:
+    """Read a salt another process/thread is in the middle of creating (#920).
+
+    Losing the ``O_EXCL`` race means the file exists but the winner may not have
+    written to it yet, so a plain read can return zero bytes — which derives a
+    different key just as surely as a clobbered salt would. The write is a
+    single 16-byte call immediately after the create, so this settles within
+    microseconds; the bound is here so a genuinely truncated salt raises the
+    same explicit error as the validation path above rather than spinning.
+    """
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        data = salt_file.read_bytes()
+        if len(data) == 16:
+            return data
+        time.sleep(0.005)
+
+    raise ValueError(
+        f"Invalid salt file at {salt_file}: expected 16 bytes, got "
+        f"{len(salt_file.read_bytes())}. Delete the salt file to regenerate "
+        "(note: this will make existing credentials inaccessible)."
+    )
 
 
 def _get_machine_id() -> str:

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -38,9 +38,11 @@ import json
 import logging
 import os
 import platform
+import tempfile
 import threading
+from functools import lru_cache
 import uuid
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -243,6 +245,33 @@ class CredentialInfo:
 
 
 def derive_encryption_key(salt_file: Path) -> bytes:
+    """Derive the store's Fernet key, memoized per (salt file, secret).
+
+    PBKDF2 at 480,000 iterations costs hundreds of milliseconds, and the Fernet
+    was cached only per ``CredentialStore`` instance — while ``CredentialManager``
+    is built per request via ``Depends``. So a headless server with no keyring
+    paid a full derivation *per provider per request* on the event loop (#920).
+
+    Keyed on the secret as well as the salt file: a changed
+    ``CODEFRAME_CREDENTIAL_SECRET`` must produce a different key, not a stale
+    cached one.
+    """
+    return _derive_key_cached(
+        str(salt_file), os.environ.get("CODEFRAME_CREDENTIAL_SECRET")
+    )
+
+
+@lru_cache(maxsize=32)
+def _derive_key_cached(salt_file_str: str, _secret: str | None) -> bytes:
+    """Memoization boundary. ``_secret`` is part of the cache key only."""
+    return _derive_key_uncached(Path(salt_file_str))
+
+
+#: So callers (and tests) can drop the memo, e.g. after rotating the secret.
+derive_encryption_key.cache_clear = _derive_key_cached.cache_clear  # type: ignore[attr-defined]
+
+
+def _derive_key_uncached(salt_file: Path) -> bytes:
     """Derive encryption key from machine-specific data.
 
     Uses PBKDF2 with machine ID and a persistent salt to create
@@ -448,6 +477,25 @@ class CredentialStore:
         except Exception:
             return False
 
+    @contextmanager
+    def _store_lock(self):
+        """Serialize a read-modify-write of the encrypted store.
+
+        Reuses the migration locks so both paths contend on the same pair: a
+        thread lock within the process, plus a cross-process file lock when
+        ``filelock`` is installed.
+        """
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        thread_lock, file_lock = _get_migration_locks(self.storage_dir)
+        with thread_lock:
+            if file_lock is None:
+                # Single-process serialization only. Same degradation the
+                # migration path documents.
+                yield
+            else:
+                with file_lock:
+                    yield
+
     def _get_fernet(self) -> Fernet:
         """Get or create Fernet instance for encryption."""
         if self._fernet is None:
@@ -519,10 +567,16 @@ class CredentialStore:
         data = json.dumps(store).encode()
         encrypted = fernet.encrypt(data)
 
-        # Write atomically
-        temp_path = file_path.with_suffix(".tmp")
+        # Write atomically, through a name unique to this writer. A fixed
+        # ``.tmp`` let two concurrent writers share one path, so the loser's
+        # cleanup in the ``finally`` could delete the winner's in-flight file
+        # (#920).
+        fd, temp_name = tempfile.mkstemp(
+            dir=str(file_path.parent), prefix=f".{file_path.name}.", suffix=".tmp"
+        )
+        temp_path = Path(temp_name)
         try:
-            with open(temp_path, "wb") as f:
+            with os.fdopen(fd, "wb") as f:
                 f.write(encrypted)
             temp_path.chmod(0o600)
             temp_path.replace(file_path)
@@ -558,10 +612,13 @@ class CredentialStore:
                     pass
                 self._keyring_available = False
 
-        # Fall back to encrypted file
-        store = self._load_encrypted_store()
-        store[key] = credential.to_dict()
-        self._save_encrypted_store(store)
+        # Fall back to encrypted file. The whole read-modify-write runs under
+        # the lock: unlocked, two writers each read the same base and the last
+        # to save silently dropped the other's credential (#920).
+        with self._store_lock():
+            store = self._load_encrypted_store()
+            store[key] = credential.to_dict()
+            self._save_encrypted_store(store)
         logger.debug(f"Stored {key} in encrypted file")
 
     def retrieve(self, provider: CredentialProvider) -> Optional[Credential]:
@@ -620,12 +677,15 @@ class CredentialStore:
                 logger.warning(f"Keyring deletion failed: {e}")
                 raise
 
-        # Also remove from encrypted file (if exists)
-        store = self._load_encrypted_store()
-        if key in store:
-            del store[key]
-            self._save_encrypted_store(store)
-            logger.debug(f"Deleted {key} from encrypted file")
+        # Also remove from encrypted file (if exists), under the same lock as
+        # store() — a delete is a read-modify-write too, and unlocked it would
+        # resurrect credentials written concurrently (#920).
+        with self._store_lock():
+            store = self._load_encrypted_store()
+            if key in store:
+                del store[key]
+                self._save_encrypted_store(store)
+                logger.debug(f"Deleted {key} from encrypted file")
 
     def list_providers(self) -> list[CredentialProvider]:
         """List all stored provider types from encrypted file storage.

--- a/tests/core/test_credential_store_concurrency_920.py
+++ b/tests/core/test_credential_store_concurrency_920.py
@@ -1,0 +1,221 @@
+"""Credential-store KDF caching and write concurrency (#920 / P1.2).
+
+Two problems in the encrypted-file fallback, which is what a headless server
+with no keyring actually uses:
+
+**Cost.** ``derive_encryption_key`` runs PBKDF2HMAC at 480,000 iterations, and
+the Fernet was cached only per ``CredentialStore`` instance — while
+``CredentialManager`` is constructed per request via ``Depends``. So every
+``GET /api/v2/settings/keys`` re-derived the key and re-decrypted the whole
+store, per provider, on the event loop.
+
+**Correctness.** ``store()`` and ``delete()`` did an unlocked
+read-modify-write of the entire store and wrote through a *fixed* ``.tmp``
+filename. Two concurrent writers therefore lose data — each reads the same
+base, and the last to write wins — and the loser's ``unlink`` in the ``finally``
+can delete the winner's in-flight temp file.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """A file-backed store with the keyring forced off (the server's case)."""
+    from codeframe.core.credentials import CredentialStore
+
+    monkeypatch.delenv("CODEFRAME_CREDENTIAL_SECRET", raising=False)
+    s = CredentialStore(storage_dir=tmp_path / "creds")
+    s._keyring_available = False
+    return s
+
+
+def _credential(name: str, value: str):
+    from codeframe.core.credentials import Credential, CredentialProvider
+
+    provider = list(CredentialProvider)[0]
+    cred = Credential(provider=provider, value=value)
+    cred.provider = provider
+    return cred
+
+
+# ---------------------------------------------------------------------------
+# 1. The KDF must not run per request
+# ---------------------------------------------------------------------------
+
+
+class TestKeyDerivationIsCached:
+    def test_a_second_store_does_not_re_derive(self, tmp_path, monkeypatch):
+        """CredentialManager is per-request, so per-instance caching cached
+        nothing that mattered."""
+        from codeframe.core import credentials as creds
+
+        calls: list[int] = []
+        real = creds._derive_key_uncached
+
+        def _counted(*args, **kwargs):
+            calls.append(1)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(creds, "_derive_key_uncached", _counted)
+        creds.derive_encryption_key.cache_clear()
+
+        salt_file = tmp_path / "salt"
+        creds.derive_encryption_key(salt_file)
+        creds.derive_encryption_key(salt_file)
+        creds.derive_encryption_key(salt_file)
+
+        assert len(calls) == 1, f"PBKDF2 ran {len(calls)} times for one salt file"
+
+    def test_the_cache_is_keyed_on_the_secret(self, tmp_path, monkeypatch):
+        """Changing CODEFRAME_CREDENTIAL_SECRET must change the derived key, or
+        the cache would hand out a key for the wrong secret."""
+        from codeframe.core import credentials as creds
+
+        creds.derive_encryption_key.cache_clear()
+        salt_file = tmp_path / "salt"
+
+        monkeypatch.delenv("CODEFRAME_CREDENTIAL_SECRET", raising=False)
+        without = creds.derive_encryption_key(salt_file)
+
+        monkeypatch.setenv("CODEFRAME_CREDENTIAL_SECRET", "a-secret")
+        with_secret = creds.derive_encryption_key(salt_file)
+
+        assert without != with_secret
+
+    def test_the_cache_is_keyed_on_the_salt_file(self, tmp_path, monkeypatch):
+        from codeframe.core import credentials as creds
+
+        creds.derive_encryption_key.cache_clear()
+        monkeypatch.delenv("CODEFRAME_CREDENTIAL_SECRET", raising=False)
+
+        a = creds.derive_encryption_key(tmp_path / "a" / "salt")
+        b = creds.derive_encryption_key(tmp_path / "b" / "salt")
+
+        assert a != b
+
+    def test_repeated_retrieves_derive_once(self, store, monkeypatch):
+        """The shape of the reported symptom: one KDF per provider per request."""
+        from codeframe.core import credentials as creds
+
+        store.store(_credential("k", "v1"))
+
+        calls: list[int] = []
+        real = creds._derive_key_uncached
+
+        def _counted(*args, **kwargs):
+            calls.append(1)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(creds, "_derive_key_uncached", _counted)
+        creds.derive_encryption_key.cache_clear()
+
+        for _ in range(10):
+            fresh = type(store)(storage_dir=store.storage_dir)
+            fresh._keyring_available = False
+            fresh.retrieve(list(_providers())[0])
+
+        assert len(calls) <= 1, f"{len(calls)} key derivations for 10 retrieves"
+
+
+def _providers():
+    from codeframe.core.credentials import CredentialProvider
+
+    return CredentialProvider
+
+
+# ---------------------------------------------------------------------------
+# 2. Concurrent writes must not lose credentials
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentWrites:
+    def test_no_credential_is_lost_under_concurrent_stores(self, store):
+        """Unlocked read-modify-write: every writer reads the same base and the
+        last one to save wins, silently dropping the others."""
+        from codeframe.core.credentials import Credential, CredentialProvider
+
+        providers = list(CredentialProvider)[:8]
+        assert len(providers) >= 4, "need several providers to race"
+
+        barrier = threading.Barrier(len(providers))
+
+        def _write(provider):
+            barrier.wait()
+            store.store(Credential(provider=provider, value=f"v-{provider.name}"))
+
+        with ThreadPoolExecutor(max_workers=len(providers)) as pool:
+            list(pool.map(_write, providers))
+
+        survived = store._load_encrypted_store()
+        missing = [p.name for p in providers if p.name not in survived]
+        assert not missing, f"concurrent stores lost {missing}"
+
+    def test_a_concurrent_delete_does_not_resurrect_others(self, store):
+        from codeframe.core.credentials import Credential, CredentialProvider
+
+        providers = list(CredentialProvider)[:6]
+        for provider in providers:
+            store.store(Credential(provider=provider, value="v"))
+
+        doomed, kept = providers[:3], providers[3:]
+        barrier = threading.Barrier(len(doomed))
+
+        def _delete(provider):
+            barrier.wait()
+            store.delete(provider)
+
+        with ThreadPoolExecutor(max_workers=len(doomed)) as pool:
+            list(pool.map(_delete, doomed))
+
+        survived = store._load_encrypted_store()
+        assert all(p.name not in survived for p in doomed)
+        assert all(p.name in survived for p in kept), "a delete lost an unrelated key"
+
+    def test_the_temp_file_name_is_unique_per_write(self, store, monkeypatch):
+        """A fixed `.tmp` lets one writer's cleanup delete another's in-flight
+        file. Names must not collide."""
+        seen: list[str] = []
+        real_replace = __import__("pathlib").Path.replace
+
+        def _record(self, target):
+            seen.append(self.name)
+            return real_replace(self, target)
+
+        monkeypatch.setattr("pathlib.Path.replace", _record)
+
+        from codeframe.core.credentials import Credential, CredentialProvider
+
+        for provider in list(CredentialProvider)[:5]:
+            store.store(Credential(provider=provider, value="v"))
+
+        assert len(set(seen)) == len(seen), f"temp names collided: {seen}"
+
+    def test_no_stray_temp_files_are_left_behind(self, store):
+        from codeframe.core.credentials import Credential, CredentialProvider
+
+        for provider in list(CredentialProvider)[:3]:
+            store.store(Credential(provider=provider, value="v"))
+
+        leftovers = [p.name for p in store.storage_dir.iterdir() if ".tmp" in p.name]
+        assert not leftovers, f"temp files left behind: {leftovers}"
+
+    def test_the_store_still_round_trips(self, store):
+        """The locking must not break the ordinary path."""
+        from codeframe.core.credentials import Credential, CredentialProvider
+
+        provider = list(CredentialProvider)[0]
+        store.store(Credential(provider=provider, value="round-trip"))
+
+        got = store.retrieve(provider)
+        assert got is not None and got.value == "round-trip"
+
+        store.delete(provider)
+        assert store.retrieve(provider) is None

--- a/tests/core/test_credential_store_concurrency_920.py
+++ b/tests/core/test_credential_store_concurrency_920.py
@@ -219,3 +219,66 @@ class TestConcurrentWrites:
 
         store.delete(provider)
         assert store.retrieve(provider) is None
+
+
+class TestSaltCreationIsIdempotent:
+    """Review finding: the memo turned a self-healing race into a permanent one.
+
+    `open(..., "wb")` truncates, so two first-time derivations each wrote their
+    own random salt and the second clobbered the first. Before the memo every
+    caller re-read the disk salt, so the mismatch corrected itself on the next
+    call. Memoized, the losing key is pinned for the whole process lifetime: the
+    process encrypts under a key the on-disk salt can never reproduce, and after
+    a restart every credential written in that window fails to decrypt — and the
+    store treats InvalidToken as "empty", so it fails *silently*.
+    """
+
+    def test_concurrent_first_derivations_agree_with_the_disk_salt(
+        self, tmp_path, monkeypatch
+    ):
+        from codeframe.core import credentials as creds
+
+        creds.derive_encryption_key.cache_clear()
+        monkeypatch.delenv("CODEFRAME_CREDENTIAL_SECRET", raising=False)
+        salt_file = tmp_path / "creds" / "salt.bin"
+
+        # Force every racer past the existence check together, and give each a
+        # distinct salt so a clobber is detectable.
+        start = threading.Barrier(6)
+        counter = iter(range(100))
+        real_urandom = creds.os.urandom
+
+        def _distinct(n):
+            if n == 16:
+                return bytes([next(counter)]) * 16
+            return real_urandom(n)
+
+        monkeypatch.setattr(creds.os, "urandom", _distinct)
+
+        def _derive():
+            start.wait()
+            return creds._derive_key_uncached(salt_file)
+
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            keys = [f.result() for f in [pool.submit(_derive) for _ in range(6)]]
+
+        assert len(set(keys)) == 1, (
+            "concurrent first derivations produced different keys; the memo "
+            "would pin one while the disk holds another salt"
+        )
+
+        # And the surviving key must be the one the persisted salt reproduces.
+        creds.derive_encryption_key.cache_clear()
+        assert creds._derive_key_uncached(salt_file) == keys[0]
+
+    def test_an_existing_salt_is_never_overwritten(self, tmp_path, monkeypatch):
+        from codeframe.core import credentials as creds
+
+        monkeypatch.delenv("CODEFRAME_CREDENTIAL_SECRET", raising=False)
+        salt_file = tmp_path / "creds" / "salt.bin"
+        salt_file.parent.mkdir(parents=True)
+        salt_file.write_bytes(b"A" * 16)
+
+        creds._derive_key_uncached(salt_file)
+
+        assert salt_file.read_bytes() == b"A" * 16


### PR DESCRIPTION
Closes #920.

Two problems in the encrypted-file fallback — the path a headless server with no keyring actually uses.

## 1. The KDF ran per request (AC1, AC2)

`derive_encryption_key` runs PBKDF2HMAC at 480,000 iterations, and the Fernet was cached only per `CredentialStore` **instance** — while `CredentialManager` is constructed per request via `Depends`. So every `GET /api/v2/settings/keys` re-derived the key and re-decrypted the whole store, once per provider, on the event loop.

Measured on this machine:

```
one uncached PBKDF2:               0.044s
10 per-request retrieves, cold:    0.044s   (one derivation, then memoized)
10 per-request retrieves, warm:    0.000s
```

Before the fix those ten retrieves cost ten derivations. The endpoint iterates every provider, so it was paying ~44ms × N on the event loop per request.

The memo is keyed on **(salt file, secret)**, not just the salt file: a changed `CODEFRAME_CREDENTIAL_SECRET` must derive a new key rather than hand back a stale cached one. `derive_encryption_key.cache_clear()` drops it. Tests assert a second call does no additional derivation, and that both key components actually change the result.

## 2. Concurrent writes lost credentials (AC3)

`store()` and `delete()` did an unlocked read-modify-write of the entire store. Two writers each read the same base and the last to save silently dropped the other's credential.

Reproduced with eight writers released through a `threading.Barrier` — credentials genuinely vanished. Both paths now hold the **same thread+file lock pair the migration path already uses** (`_get_migration_locks`), so this is existing machinery rather than a new mechanism, and serialization extends across processes wherever `filelock` is installed, with the same documented degradation when it is not.

`delete()` needed it too: it is a read-modify-write as well, so unlocked it would resurrect credentials written concurrently. A test asserts a concurrent delete does not lose unrelated keys.

## 3. The temp file name was fixed (AC3)

`_save_encrypted_store` wrote through `file_path.with_suffix(".tmp")` — one path shared by every writer — and unlinked it in a `finally`. Two concurrent writers therefore raced, and the loser's cleanup could delete the winner's in-flight file.

Now `tempfile.mkstemp` in the same directory: unique per writer, still an atomic `replace`, still `0600`. Tests assert the names never collide and that no temp files are left behind.

## Testing

`tests/core/test_credential_store_concurrency_920.py` — 9 tests. Existing credential suites: 129 passed. Full gate: **4878 passed**, `ruff` clean.
