### PR TITLE
fix(batch): stop reconciliation writing states nothing consumes (#921)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -2104,11 +2104,35 @@ def _execute_parallel(
             config_watcher_p.stop()
 
 
+#: Results the reconciler may have recorded from *outside* the batch. A worker
+#: must not clobber them: when a task is completed manually mid-batch, the
+#: reconciler kills the subprocess and records COMPLETED, and the worker then
+#: sees the non-zero exit and would report FAILED — reverting the user's own
+#: DONE in the batch accounting and counting it as a failure. (#921)
+_TERMINAL_BATCH_RESULTS = frozenset({"COMPLETED"})
+
+
+def _record_task_result(batch: "BatchRun", task_id: str, status: str) -> None:
+    """Record a worker's result unless a terminal one is already recorded.
+
+    Only COMPLETED is protected. A recorded FAILED or BLOCKED is the worker's
+    own earlier verdict and may legitimately be replaced, and RUNNING is a
+    placeholder that must still resolve.
+    """
+    if batch.results.get(task_id) in _TERMINAL_BATCH_RESULTS:
+        logger.info(
+            "Task %s already recorded as %s (completed outside the batch); "
+            "not overwriting with %s",
+            task_id, batch.results[task_id], status,
+        )
+        return
+    batch.results[task_id] = status
+
+
 def _start_reconciliation_thread(
     workspace: Workspace,
     batch: BatchRun,
     interval_seconds: int = 30,
-    github_checker: Optional[Callable] = None,
 ) -> threading.Event:
     """Start a daemon thread that periodically reconciles batch state.
 
@@ -2121,7 +2145,7 @@ def _start_reconciliation_thread(
     from codeframe.core.reconciliation import ReconciliationEngine
 
     stop_event = threading.Event()
-    engine = ReconciliationEngine(workspace, github_checker=github_checker)
+    engine = ReconciliationEngine(workspace)
 
     def _loop() -> None:
         while not stop_event.wait(timeout=interval_seconds):
@@ -2351,10 +2375,10 @@ def _execute_group_parallel(
             exec_ctx.cleanup()
 
         # Record result (thread-safe due to GIL for simple dict operations)
-        batch.results[task_id] = result_status
+        _record_task_result(batch, task_id, result_status)
         _save_batch(workspace, batch)
 
-        return task_id, result_status
+        return task_id, batch.results[task_id]
 
     # Execute tasks in parallel using thread pool
     with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING
 
 from codeframe.core import blockers, tasks
 from codeframe.core.state_machine import TaskStatus
@@ -52,18 +52,10 @@ class ReconciliationEngine:
 
     Args:
         workspace: The workspace to check tasks in.
-        github_checker: Optional callable(task_id, task) -> list[ExternalStateChange]
-            for GitHub issue state sync. If None, GitHub checks are skipped.
     """
 
-    def __init__(
-        self,
-        workspace: Workspace,
-        *,
-        github_checker: Optional[Callable] = None,
-    ) -> None:
+    def __init__(self, workspace: Workspace) -> None:
         self._workspace = workspace
-        self._github_checker = github_checker
 
     def check_task(self, task_id: str) -> list[ExternalStateChange]:
         """Check a single task for external state changes.
@@ -98,13 +90,12 @@ class ReconciliationEngine:
                     details={"blockers_resolved": len(task_blockers)},
                 ))
 
-        # Check GitHub issue state if checker is available
-        if self._github_checker:
-            try:
-                gh_changes = self._github_checker(task_id, task)
-                changes.extend(gh_changes)
-            except Exception as exc:
-                logger.warning("GitHub check failed for task %s: %s", task_id, exc)
+        # An injectable GitHub issue-state check used to hang off this point.
+        # It was passed at neither conductor call site, so it advertised a
+        # capability that did not exist. Removed rather than half-built: a real
+        # check means a network call per task per tick, against a PAT, with its
+        # own rate-limit and caching design — that is a feature with its own
+        # issue, not a parameter. (#921)
 
         return changes
 
@@ -168,9 +159,16 @@ class ReconciliationEngine:
                 elif change.change_type == "blocker_resolved":
                     result.tasks_requeued.append(change.task_id)
 
-                    # Update batch results to signal re-queue
+                    # Clear any recorded outcome instead of writing "READY".
+                    # RunStatus has no such value, and resume_batch's retryable
+                    # set is {FAILED, BLOCKED, RUNNING} — so the marker made the
+                    # task permanently ineligible for `cf work batch resume`
+                    # while RECONCILIATION_TASK_REQUEUED told the user it would
+                    # re-run. With no entry at all, resume's `tid not in
+                    # batch.results` branch picks it up, which is what
+                    # "re-queued" means. (#921)
                     if hasattr(batch, "results"):
-                        batch.results[change.task_id] = "READY"
+                        batch.results.pop(change.task_id, None)
 
                     logger.info(
                         "Task %s blocker resolved — re-queued",

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -13,7 +13,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from codeframe.core import engine_stats, events, tasks
-from codeframe.core.state_machine import TaskStatus
+from codeframe.core.state_machine import TaskStatus, can_transition
 from codeframe.core.workspace import Workspace, get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -429,8 +429,19 @@ def fail_run(workspace: Workspace, run_id: str, reason: str = "") -> Run:
         print_event=True,
     )
 
-    # Update task status to FAILED
-    tasks.update_status(workspace, run.task_id, TaskStatus.FAILED)
+    # Update task status to FAILED — but only when the state machine permits it.
+    # A task completed outside the batch is already DONE, which allows only
+    # {READY, MERGED}; raising here left the run row written and the event
+    # emitted, then threw into the caller. The run really did fail; the task's
+    # terminal state is the user's and is not ours to overturn. (#921)
+    task = tasks.get(workspace, run.task_id)
+    if task and can_transition(task.status, TaskStatus.FAILED):
+        tasks.update_status(workspace, run.task_id, TaskStatus.FAILED)
+    elif task:
+        logger.info(
+            "Run %s failed but task %s is %s; leaving the task status alone",
+            run_id, run.task_id, task.status.value,
+        )
 
     run.status = RunStatus.FAILED
     run.completed_at = datetime.fromisoformat(now)

--- a/tests/core/test_batch_reconciliation_921.py
+++ b/tests/core/test_batch_reconciliation_921.py
@@ -1,0 +1,235 @@
+"""Batch reconciliation writes states nothing consumes (#921 / P1.3).
+
+Three defects, each verified against the code before being fixed:
+
+1. **The requeue marker is dead.** ``apply_changes`` wrote the literal
+   ``"READY"`` into ``batch.results`` for a blocker-resolved task. ``RunStatus``
+   has no such value, and ``resume_batch``'s retryable set is
+   ``{"FAILED", "BLOCKED", "RUNNING"}`` — and the task *is* in ``results``, so
+   the ``tid not in batch.results`` fallback does not save it either. The task
+   is permanently ineligible for ``cf work batch resume`` while
+   ``RECONCILIATION_TASK_REQUEUED`` tells the user it will re-run.
+
+2. **An external completion is overwritten.** The reconciler kills the
+   subprocess and records ``COMPLETED``; the worker then sees the non-zero exit
+   and unconditionally does ``batch.results[task_id] = result_status``. The
+   user's manual DONE is silently reverted and counted as a failure.
+   ``fail_run`` compounds it by transitioning DONE → READY.
+
+3. **``github_checker`` is advertised but unwired.** Neither
+   ``_start_reconciliation_thread`` call site passes it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return create_or_load_workspace(ws_dir)
+
+
+def _batch_with(results: dict, task_ids: list[str]):
+    """A minimal stand-in carrying just what the code under test touches."""
+    class _Batch:
+        pass
+
+    b = _Batch()
+    b.id = "batch-921"
+    b.task_ids = list(task_ids)
+    b.results = dict(results)
+    return b
+
+
+def _change(task_id: str, change_type: str):
+    from codeframe.core.reconciliation import ExternalStateChange
+
+    return ExternalStateChange(
+        task_id=task_id,
+        change_type=change_type,
+        source="test",
+        details={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. batch.results must only hold RunStatus values
+# ---------------------------------------------------------------------------
+
+
+class TestRequeueMarker:
+    def test_no_non_runstatus_value_is_written(self, workspace):
+        """AC1. 'READY' is not a RunStatus — nothing downstream consumes it."""
+        from codeframe.core.reconciliation import (
+            ReconciliationEngine,
+            ReconciliationResult,
+        )
+        from codeframe.core.runtime import RunStatus
+
+        engine = ReconciliationEngine(workspace)
+        batch = _batch_with({"t1": "RUNNING"}, ["t1"])
+        result = ReconciliationResult()
+        result.changes_detected.append(_change("t1", "blocker_resolved"))
+
+        engine.apply_changes(result, batch, active_processes={})
+
+        valid = {s.value for s in RunStatus}
+        for task_id, value in batch.results.items():
+            assert value in valid, f"{task_id} holds {value!r}, not a RunStatus"
+
+    def test_a_requeued_task_is_resume_eligible(self, workspace):
+        """AC2. The user is told it will re-run, so resume must pick it up."""
+        from codeframe.core.reconciliation import (
+            ReconciliationEngine,
+            ReconciliationResult,
+        )
+
+        engine = ReconciliationEngine(workspace)
+        batch = _batch_with({"t1": "RUNNING", "t2": "COMPLETED"}, ["t1", "t2"])
+        result = ReconciliationResult()
+        result.changes_detected.append(_change("t1", "blocker_resolved"))
+
+        engine.apply_changes(result, batch, active_processes={})
+
+        retryable = {"FAILED", "BLOCKED", "RUNNING"}
+        eligible = [
+            tid for tid in batch.task_ids
+            if batch.results.get(tid) in retryable or tid not in batch.results
+        ]
+        assert "t1" in eligible, (
+            "a re-queued task is permanently ineligible for `cf work batch resume`"
+        )
+        assert "t2" not in eligible, "a completed task must stay done"
+
+    def test_the_requeue_is_still_reported(self, workspace):
+        """The fix must not silently drop the signal it was meant to carry."""
+        from codeframe.core.reconciliation import (
+            ReconciliationEngine,
+            ReconciliationResult,
+        )
+
+        engine = ReconciliationEngine(workspace)
+        batch = _batch_with({"t1": "RUNNING"}, ["t1"])
+        result = ReconciliationResult()
+        result.changes_detected.append(_change("t1", "blocker_resolved"))
+
+        engine.apply_changes(result, batch, active_processes={})
+
+        assert "t1" in result.tasks_requeued
+
+
+# ---------------------------------------------------------------------------
+# 2. An external completion must survive the worker
+# ---------------------------------------------------------------------------
+
+
+class TestExternalCompletionSurvives:
+    def test_a_completed_result_is_not_overwritten_by_a_failure(self, workspace):
+        """AC3. The reconciler kills the subprocess, the worker sees the
+        non-zero exit and reports FAILED — the manual DONE must win."""
+        from codeframe.core.conductor import _record_task_result
+
+        batch = _batch_with({"t1": "COMPLETED"}, ["t1"])
+
+        _record_task_result(batch, "t1", "FAILED")
+
+        assert batch.results["t1"] == "COMPLETED", (
+            "the user's manual DONE was reverted and counted as a failure"
+        )
+
+    def test_an_ordinary_result_is_recorded(self, workspace):
+        from codeframe.core.conductor import _record_task_result
+
+        batch = _batch_with({}, ["t1"])
+
+        _record_task_result(batch, "t1", "FAILED")
+
+        assert batch.results["t1"] == "FAILED"
+
+    def test_a_running_placeholder_is_replaced(self, workspace):
+        """Only terminal results are protected — RUNNING must still resolve."""
+        from codeframe.core.conductor import _record_task_result
+
+        batch = _batch_with({"t1": "RUNNING"}, ["t1"])
+
+        _record_task_result(batch, "t1", "COMPLETED")
+
+        assert batch.results["t1"] == "COMPLETED"
+
+    def test_fail_run_does_not_disturb_a_done_task(self, workspace):
+        """Pins the guarantee, which turned out to come from the state machine.
+
+        The issue expected fail_run to revert the manual DONE via a permitted
+        DONE -> READY transition. It does not: fail_run transitions the task to
+        *FAILED*, and DONE only permits {READY, MERGED}, so the state machine
+        refuses it. The damage was entirely in the batch accounting above.
+
+        fail_run should nonetheless not leave that refusal as an escaping
+        exception after it has already written the run row.
+        """
+        from codeframe.core import runtime, tasks
+        from codeframe.core.state_machine import TaskStatus
+
+        task = tasks.create(workspace, title="t", description="d",
+                            status=TaskStatus.READY)
+        run = runtime.start_task_run(workspace, task.id)
+        tasks.update_status(workspace, task.id, TaskStatus.DONE)
+
+        runtime.fail_run(workspace, run.id, reason="subprocess killed")
+
+        assert tasks.get(workspace, task.id).status == TaskStatus.DONE
+        assert runtime.get_run(workspace, run.id).status.value == "FAILED"
+
+    def test_fail_run_still_fails_a_running_task(self, workspace):
+        """The ordinary path must keep working."""
+        from codeframe.core import runtime, tasks
+        from codeframe.core.state_machine import TaskStatus
+
+        task = tasks.create(workspace, title="t", description="d",
+                            status=TaskStatus.READY)
+        run = runtime.start_task_run(workspace, task.id)
+
+        runtime.fail_run(workspace, run.id, reason="boom")
+
+        assert tasks.get(workspace, task.id).status == TaskStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# 3. No advertised-but-unwired parameter
+# ---------------------------------------------------------------------------
+
+
+class TestNoDeadGithubChecker:
+    def test_the_parameter_is_gone(self):
+        """AC4. It was passed at neither call site, so it advertised a
+        capability that did not exist. Removed rather than half-built; a real
+        issue-state check is its own feature, with its own auth and rate limits.
+        """
+        import inspect
+
+        from codeframe.core import conductor
+        from codeframe.core.reconciliation import ReconciliationEngine
+
+        assert "github_checker" not in inspect.signature(
+            ReconciliationEngine.__init__
+        ).parameters
+        assert "github_checker" not in inspect.signature(
+            conductor._start_reconciliation_thread
+        ).parameters
+
+    def test_no_reference_survives(self):
+        """A leftover branch or docstring claim is the same lie."""
+        from pathlib import Path
+
+        for module in ("core/reconciliation.py", "core/conductor.py"):
+            text = Path("codeframe") / module
+            assert "github_checker" not in text.read_text(), (
+                f"{module} still references github_checker"
+            )

--- a/tests/core/test_reconciliation.py
+++ b/tests/core/test_reconciliation.py
@@ -174,31 +174,6 @@ class TestReconciliationEngine:
 
         assert changes == []
 
-    def test_check_task_with_github_checker(self) -> None:
-        from codeframe.core.reconciliation import ExternalStateChange, ReconciliationEngine
-        from codeframe.core.state_machine import TaskStatus
-
-        workspace = MagicMock()
-
-        def github_checker(task_id, task):
-            return [ExternalStateChange(
-                task_id=task_id, change_type="closed",
-                source="github", details={},
-            )]
-
-        engine = ReconciliationEngine(workspace, github_checker=github_checker)
-
-        mock_task = MagicMock()
-        mock_task.status = TaskStatus.IN_PROGRESS
-        mock_task.id = "t1"
-
-        with patch("codeframe.core.reconciliation.tasks.get", return_value=mock_task):
-            changes = engine.check_task("t1")
-
-        assert len(changes) == 1
-        assert changes[0].change_type == "closed"
-        assert changes[0].source == "github"
-
     def test_check_all_active_catches_errors(self) -> None:
         from codeframe.core.reconciliation import ReconciliationEngine
 


### PR DESCRIPTION
Closes #921.

## 1. The requeue marker was dead (AC1, AC2)

`apply_changes` wrote the literal `"READY"` into `batch.results` for a blocker-resolved task. `RunStatus` has no such value, and `resume_batch`'s retryable set is `{"FAILED", "BLOCKED", "RUNNING"}` — and crucially the task **is** in `results`, so the `tid not in batch.results` fallback did not rescue it either.

So a task the user was told had been re-queued (`RECONCILIATION_TASK_REQUEUED`) was permanently ineligible for `cf work batch resume`.

The entry is now **cleared** rather than marked. That is literally what "re-queued" means — no outcome recorded — and it is a state `resume_batch` already understands, so no downstream change was needed.

## 2. An external completion was overwritten (AC3)

The reconciler kills the subprocess and records `COMPLETED`. The worker then saw the non-zero exit and did an unconditional `batch.results[task_id] = result_status` — reverting the user's manual DONE in the batch accounting and counting it as a failure.

Writes now go through `_record_task_result`, which refuses to overwrite a `COMPLETED` recorded from outside the batch. Only `COMPLETED` is protected: a recorded `FAILED`/`BLOCKED` is the worker's own earlier verdict and may legitimately be replaced, and `RUNNING` is a placeholder that must still resolve. All three cases are tested.

## A correction to the issue's premise

The issue expected `fail_run` to revert the manual DONE, parenthesising that "DONE→READY is an allowed transition".

**It does not.** `fail_run` transitions the task to *FAILED*, and `DONE` permits only `{READY, MERGED}`, so the state machine already refused it. Verified directly:

```
before: TaskStatus.DONE
fail_run RAISED: InvalidTransitionError Invalid transition: DONE -> FAILED.
                 Allowed transitions from DONE: READY, MERGED
after : TaskStatus.DONE
run   : RunStatus.FAILED
```

What actually happened was worse-shaped than harmless: `fail_run` wrote the run row and emitted `RUN_FAILED`, **then** raised into the caller — swallowed at `conductor.py:2492` by the #742 handler, which then returned `FAILED` and triggered the overwrite above.

So the user-visible harm the issue describes is real, but it lived entirely in the batch accounting. The task transition in `fail_run` is now conditional on `can_transition`, so a task whose terminal state belongs to the user is left alone without an exception escaping a partially-applied operation.

## 3. `github_checker` is gone (AC4)

`ReconciliationEngine` advertised it and **neither** `_start_reconciliation_thread` call site passed it — it promised a capability that did not exist.

Removed rather than half-built. A real issue-state check means a network call per task per 30s tick, against the single machine-wide PAT, with its own rate-limit and caching design. That is a feature, not a parameter, so it is filed as **#1032** with the constraints spelled out — the capability is documented, not silently dropped.

The test that exercised the parameter goes with it.

## Testing

`tests/core/test_batch_reconciliation_921.py` — 10 tests. Full gate: **4895 passed**, `ruff` clean.
