### PR TITLE
fix(proof): stop scoped runs silently skipping non-file requirements (#922)

### DIFF
--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -199,7 +199,25 @@ def _run_gate(
         return GateOutcome.FAILED, str(exc)
 
 
+def _report_scope_skipped(run_id: str, skipped: list[str]) -> None:
+    """Surface requirements a scoped run did not evaluate (#922).
+
+    Dropping them with a bare ``continue`` is how ``overall_passed=True`` came
+    to coexist with a merge gate that still blocked on the very same
+    requirements — the user had no way to see the two were talking about
+    different sets.
+    """
+    if not skipped:
+        return
+    logger.warning(
+        "Proof run %s: %d requirement(s) not evaluated — out of scope for the "
+        "current changes: %s. Re-run with --full to include them.",
+        run_id, len(skipped), ", ".join(sorted(skipped)),
+    )
+
+
 def run_proof(
+
     workspace: Workspace,
     *,
     full: bool = False,
@@ -266,11 +284,14 @@ def run_proof(
     artifact_dir = workspace.state_dir / "proof_artifacts"
     artifact_dir.mkdir(exist_ok=True)
 
+    scope_skipped: list[str] = []
+
     for req in reqs:
         # Check scope intersection (unless full mode or scope detection failed)
         # None changed_scope means "failed to detect" → run everything (fail closed)
         if not full and changed_scope is not None:
             if not intersects(req.scope, changed_scope):
+                scope_skipped.append(req.id)
                 continue
 
         req_results: list[tuple[Gate, GateOutcome]] = []
@@ -352,5 +373,7 @@ def run_proof(
             duration_ms=duration_ms,
         ),
     )
+
+    _report_scope_skipped(run_id, scope_skipped)
 
     return results

--- a/codeframe/core/proof/scope.py
+++ b/codeframe/core/proof/scope.py
@@ -59,23 +59,55 @@ def get_changed_scope(workspace: Workspace) -> "RequirementScope | None":
 
 
 def intersects(req_scope: RequirementScope, changed_scope: RequirementScope) -> bool:
-    """Check if a requirement scope overlaps with changed scope.
+    """Whether a requirement's scope overlaps the changed scope.
 
-    Returns True if any field has common elements. File matching
-    supports prefix matching (req file "src/auth/" matches changed
-    file "src/auth/login.py").
+    Two rules, in order:
+
+    **Comparable dimensions.** ``routes``, ``apis``, ``components`` and ``tags``
+    match by exact set intersection; ``files`` match by prefix, so a requirement
+    scoped to ``src/auth/`` covers a changed ``src/auth/login.py``. Prefix
+    matching respects path boundaries — ``src/auth`` does not swallow
+    ``src/authentication/x.py``.
+
+    **Nothing comparable → in scope.** ``get_changed_scope`` can only report
+    *files*, but a requirement captured as ``GET /api/tasks`` or ``/login`` has
+    no file dimension at all. Requiring same-field overlap therefore excluded
+    such requirements from every default (scoped) run, permanently: the run
+    reported ``overall_passed=True`` while the merge gate still blocked on them
+    (#922). When no dimension of the requirement can be compared against the
+    changed scope, it is treated as in scope — the same fail-closed convention
+    ``run_proof`` already applies when scope detection fails outright.
     """
-    # Direct set intersection for routes, apis, components, tags
+    compared_any = False
+
     for field_name in ("routes", "apis", "components", "tags"):
         req_items = set(getattr(req_scope, field_name))
         changed_items = set(getattr(changed_scope, field_name))
-        if req_items & changed_items:
-            return True
+        if req_items and changed_items:
+            compared_any = True
+            if req_items & changed_items:
+                return True
 
-    # File matching — exact match only (no directory expansion)
     req_files = set(req_scope.files)
     changed_files = set(changed_scope.files)
-    if req_files & changed_files:
-        return True
+    if req_files and changed_files:
+        compared_any = True
+        if _files_intersect(req_files, changed_files):
+            return True
 
+    # Nothing could be compared — fail closed rather than silently skip.
+    return not compared_any
+
+
+def _files_intersect(req_files: set[str], changed_files: set[str]) -> bool:
+    """Exact or directory-prefix match between two file sets."""
+    for req_file in req_files:
+        prefix = req_file.rstrip("/")
+        for changed_file in changed_files:
+            if changed_file == req_file or changed_file == prefix:
+                return True
+            # Path-boundary aware: "src/auth" covers "src/auth/login.py" but
+            # not "src/authentication/x.py".
+            if changed_file.startswith(prefix + "/"):
+                return True
     return False

--- a/tests/core/test_proof_scope_922.py
+++ b/tests/core/test_proof_scope_922.py
@@ -1,0 +1,171 @@
+"""Scoped proof runs silently skip non-file requirements (#922 / P1.4).
+
+``get_changed_scope`` only ever populates ``files``, while
+``build_scope_from_capture`` routinely classifies capture input into ``routes``
+(``/login``), ``apis`` (``GET /api/x``) and ``tags``. ``intersects`` requires
+same-field overlap, so such a requirement can *never* intersect a changed scope.
+
+Both surfaces run scoped by default — the CLI's ``--full`` defaults False and
+the API's ``full: bool = False`` — so ``run_proof`` walked straight past those
+requirements, reported ``overall_passed=True``, and the merge gate then blocked
+on the very same requirements. A dead end unless the user happened to know about
+``--full``.
+
+The ``intersects`` docstring also advertised prefix matching ("req file
+``src/auth/`` matches changed file ``src/auth/login.py``") that the code did not
+implement — contradicted by its own inline comment two lines below.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+def _scope(**kwargs):
+    from codeframe.core.proof.models import RequirementScope
+
+    return RequirementScope(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. A requirement with no file dimension must not be silently excluded
+# ---------------------------------------------------------------------------
+
+
+class TestNonFileScopesAreNotExcluded:
+    def test_an_api_scoped_requirement_matches_a_file_change(self):
+        """AC1. The headline case: `GET /api/tasks` against a git file list."""
+        from codeframe.core.proof.scope import intersects
+
+        req = _scope(apis=["GET /api/tasks"])
+        changed = _scope(files=["codeframe/ui/routers/tasks_v2.py"])
+
+        assert intersects(req, changed), (
+            "an API-scoped requirement can never match a file-only changed "
+            "scope, so a default scoped run skips it forever"
+        )
+
+    def test_a_route_scoped_requirement_matches(self):
+        from codeframe.core.proof.scope import intersects
+
+        assert intersects(_scope(routes=["/login"]), _scope(files=["a.py"]))
+
+    def test_a_tag_scoped_requirement_matches(self):
+        from codeframe.core.proof.scope import intersects
+
+        assert intersects(_scope(tags=["auth"]), _scope(files=["a.py"]))
+
+    def test_a_file_scoped_requirement_still_discriminates(self):
+        """The point of scoping survives: an unrelated file does not match."""
+        from codeframe.core.proof.scope import intersects
+
+        req = _scope(files=["src/auth/login.py"])
+
+        assert intersects(req, _scope(files=["src/auth/login.py"]))
+        assert not intersects(req, _scope(files=["docs/readme.md"]))
+
+    def test_a_mixed_scope_still_discriminates_on_its_files(self):
+        """A requirement that *does* name files is judged on them."""
+        from codeframe.core.proof.scope import intersects
+
+        req = _scope(files=["src/auth/login.py"], tags=["auth"])
+
+        assert not intersects(req, _scope(files=["docs/readme.md"]))
+
+    def test_an_empty_requirement_scope_matches_everything(self):
+        """Nothing to compare — fail closed, the convention already used when
+        scope detection fails entirely."""
+        from codeframe.core.proof.scope import intersects
+
+        assert intersects(_scope(), _scope(files=["a.py"]))
+
+
+# ---------------------------------------------------------------------------
+# 2. Prefix matching — the docstring's promise
+# ---------------------------------------------------------------------------
+
+
+class TestFilePrefixMatching:
+    def test_a_directory_scope_matches_files_beneath_it(self):
+        """AC3. The docstring promised exactly this example."""
+        from codeframe.core.proof.scope import intersects
+
+        assert intersects(
+            _scope(files=["src/auth/"]), _scope(files=["src/auth/login.py"])
+        )
+
+    def test_a_directory_scope_without_a_trailing_slash_matches(self):
+        from codeframe.core.proof.scope import intersects
+
+        assert intersects(
+            _scope(files=["src/auth"]), _scope(files=["src/auth/login.py"])
+        )
+
+    def test_a_directory_scope_does_not_match_a_sibling_prefix(self):
+        """`src/auth` must not swallow `src/authentication/…`."""
+        from codeframe.core.proof.scope import intersects
+
+        assert not intersects(
+            _scope(files=["src/auth"]), _scope(files=["src/authentication/x.py"])
+        )
+
+    def test_the_docstring_matches_the_implementation(self):
+        """The docstring described prefix matching the code did not do, and its
+        own inline comment said the opposite."""
+        from codeframe.core.proof.scope import intersects
+
+        doc = intersects.__doc__ or ""
+        if "prefix" in doc.lower():
+            assert intersects(
+                _scope(files=["src/auth/"]), _scope(files=["src/auth/login.py"])
+            ), "docstring promises prefix matching that does not work"
+
+
+# ---------------------------------------------------------------------------
+# 3. Skips must be reported, not dropped
+# ---------------------------------------------------------------------------
+
+
+class TestSkipsAreReported:
+    def test_run_proof_reports_what_it_skipped(self, tmp_path, monkeypatch):
+        """AC2. A silent `continue` is how overall_passed=True coexisted with a
+        merge gate that still blocked."""
+        from codeframe.core.proof import runner
+
+        skipped: list[str] = []
+        monkeypatch.setattr(
+            runner, "_report_scope_skipped",
+            lambda run_id, ids: skipped.extend(ids),
+            raising=False,
+        )
+
+        assert hasattr(runner, "_report_scope_skipped"), (
+            "run_proof must have somewhere to report scope-skipped requirements"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. End to end: the exact scenario from the issue
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultScopedRunEndToEnd:
+    def test_an_api_scoped_requirement_is_not_skipped_by_a_default_run(
+        self, tmp_path, monkeypatch
+    ):
+        """AC4. Capture `GET /api/tasks`, run a *default* (scoped) proof run,
+        assert the requirement is considered rather than dropped."""
+        from codeframe.core.proof.scope import build_scope_from_capture, intersects
+
+        captured = build_scope_from_capture("GET /api/tasks")
+        assert captured.apis, "capture should classify this as an api scope"
+        assert not captured.files, "…and give it no file dimension"
+
+        changed = _scope(files=["codeframe/ui/routers/tasks_v2.py"])
+
+        assert intersects(captured, changed), (
+            "the default scoped run drops this requirement, reports "
+            "overall_passed=True, and the merge gate then blocks on it"
+        )


### PR DESCRIPTION
Closes #922.

## The dead end

`get_changed_scope` can only report **files** — it reads git status. But `build_scope_from_capture` classifies most capture input into `routes` (`/login`), `apis` (`GET /api/x`) and `tags`, and `intersects` required *same-field* overlap.

So a requirement captured as `GET /api/tasks` could never intersect a changed scope. Ever.

Both surfaces run scoped by default — the CLI's `--full` defaults False, the API's `full: bool = False` — so `run_proof` walked past those requirements with a bare `continue`, reported `overall_passed=True`, and `cf pr merge`'s PROOF9 gate then blocked on the very same requirements. The user saw a passing proof run and a blocked merge citing requirements the run had never mentioned, with no way out short of knowing about `--full`.

## Fail closed (AC1)

`intersects` now tracks whether *any* dimension was comparable. When none was, the requirement is in scope — the same convention `run_proof` already applies when scope detection fails outright (`None changed_scope` → run everything).

Requirements that **do** name files are still judged on them, so scoping keeps its point. Verified end to end through the real capture parser:

```
'GET /api/tasks'                   -> {'apis':   [...]}  in-scope=True
'/login'                           -> {'routes': [...]}  in-scope=True
'auth'                             -> {'tags':   [...]}  in-scope=True
'docs/readme.md'                   -> {'files':  [...]}  in-scope=False   ← still discriminates
'codeframe/ui/routers/tasks_v2.py' -> {'files':  [...]}  in-scope=True
```

## The docstring described code that did not exist (AC3)

`intersects` advertised prefix matching — *"req file `src/auth/` matches changed file `src/auth/login.py`"* — while its own inline comment two lines below said **"exact match only (no directory expansion)"**.

Implemented rather than deleted: it is the more useful of the two readings and users may well have relied on the documented behaviour. It respects path boundaries, so `src/auth` does not swallow `src/authentication/x.py`. A test per branch, including one that asserts the docstring and the implementation agree.

## Skips are reported (AC2)

A bare `continue` is how `overall_passed=True` came to coexist with a merge gate blocking on the same requirements — nothing told the user the two were talking about different sets. `run_proof` now collects skipped requirement ids and logs them with the count and the `--full` remedy.

## Testing

`tests/core/test_proof_scope_922.py` — 12 tests across all four ACs, including the issue's exact scenario (capture `GET /api/tasks`, default scoped run, assert not skipped).

Existing proof suites: 115 passed. Full gate: **4898 passed**, `ruff` clean.

## Note on blast radius

This makes scoped runs evaluate *more* requirements, not fewer — the safe direction, and what AC1 asked for. A requirement with no file dimension now always runs in scoped mode; that is the intended trade for never silently skipping one.
