### PR TITLE
fix(proof): repair the requirement lifecycle (#923)

### DIFF
--- a/codeframe/core/proof/ledger.py
+++ b/codeframe/core/proof/ledger.py
@@ -7,7 +7,8 @@ Tables live in the workspace's state.db alongside PRDs and tasks.
 import json
 import sqlite3
 from datetime import date, datetime, timezone
-from typing import Optional
+import logging
+from typing import Any, Optional
 
 from codeframe.core.proof.models import (
     Evidence,
@@ -24,6 +25,8 @@ from codeframe.core.proof.models import (
     Waiver,
 )
 from codeframe.core.workspace import Workspace, get_db_connection
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -293,11 +296,28 @@ def _row_to_requirement(row: tuple) -> Requirement:
 
 # --- CRUD ---
 
-def save_requirement(workspace: Workspace, req: Requirement) -> None:
-    """Insert or replace a requirement in the ledger."""
+def save_requirement(
+    workspace: Workspace, req: Requirement, *, create_only: bool = False
+) -> None:
+    """Insert or replace a requirement in the ledger.
+
+    Args:
+        create_only: Refuse to overwrite an existing id. Capture passes this so
+            a racing allocation cannot silently clobber another requirement —
+            INSERT OR REPLACE made that failure invisible (#923). The runner
+            leaves it False, since updating in place is exactly its job.
+    """
     _ensure_tables(workspace)
     conn = get_db_connection(workspace)
     cursor = conn.cursor()
+    if create_only:
+        existing = cursor.execute(
+            "SELECT 1 FROM proof_requirements WHERE id = ? AND workspace_id = ?",
+            (req.id, workspace.id),
+        ).fetchone()
+        if existing:
+            conn.close()
+            raise ValueError(f"Requirement {req.id} already exists")
     cursor.execute(
         """INSERT OR REPLACE INTO proof_requirements
            (id, title, description, severity, source, scope, obligations,
@@ -395,6 +415,116 @@ def next_req_id(workspace: Workspace) -> str:
     max_num = row[0] if row and row[0] is not None else 0
     conn.close()
     return f"REQ-{max_num + 1:04d}"
+
+
+def allocate_requirement(workspace: Workspace, **kwargs: Any) -> str:
+    """Reserve the next REQ id and insert the row in one transaction (#923).
+
+    ``next_req_id`` computed MAX+1 and closed its connection; ``save_requirement``
+    then inserted on another. Two concurrent captures therefore read the same
+    max, produced the same id, and the second silently replaced the first —
+    sharing its stub directory. The allocate-and-insert now happens under one
+    IMMEDIATE transaction, and the retry covers the cross-process case where
+    another writer wins the id between attempts.
+    """
+    from codeframe.core.proof.models import (
+        Obligation,
+        ReqStatus,
+        RequirementScope,
+        Severity,
+        Source,
+    )
+
+    _ensure_tables(workspace)
+
+    for _ in range(_ALLOCATE_ATTEMPTS):
+        conn = get_db_connection(workspace)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT MAX(CAST(SUBSTR(id, 5) AS INTEGER)) FROM proof_requirements "
+                "WHERE workspace_id = ?",
+                (workspace.id,),
+            ).fetchone()
+            max_num = row[0] if row and row[0] is not None else 0
+            req_id = f"REQ-{max_num + 1:04d}"
+
+            conn.execute(
+                "INSERT INTO proof_requirements (id, title, description, severity, "
+                "source, scope, obligations, evidence_rules, status, waiver, "
+                "created_at, satisfied_at, created_by, source_issue, related_reqs, "
+                "glitch_type, workspace_id) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    req_id,
+                    kwargs.get("title", ""),
+                    kwargs.get("description", ""),
+                    kwargs.get("severity", Severity.HIGH).value,
+                    kwargs.get("source", Source.QA).value,
+                    _scope_to_json(kwargs.get("scope") or RequirementScope()),
+                    _obligations_to_json(kwargs.get("obligations") or [Obligation(gate=Gate.UNIT)]),
+                    _evidence_rules_to_json(kwargs.get("evidence_rules") or []),
+                    ReqStatus.OPEN.value,
+                    None,
+                    datetime.now(timezone.utc).isoformat(),
+                    None,
+                    kwargs.get("created_by", "human"),
+                    kwargs.get("source_issue"),
+                    json.dumps(kwargs.get("related_reqs") or []),
+                    kwargs.get("glitch_type"),
+                    workspace.id,
+                ),
+            )
+            conn.commit()
+            return req_id
+        except sqlite3.IntegrityError:
+            # Another writer took this id between our read and insert.
+            conn.rollback()
+            continue
+        finally:
+            conn.close()
+
+    raise RuntimeError("Could not allocate a REQ id after repeated collisions")
+
+
+#: A handful of retries absorbs realistic contention; beyond that something is
+#: wrong and a loud failure beats a silent overwrite.
+_ALLOCATE_ATTEMPTS = 10
+
+
+def mark_satisfied(workspace: Workspace, req: Requirement) -> None:
+    """Record a requirement as SATISFIED, stamping ``satisfied_at`` (#923).
+
+    The runner set the status and never the timestamp, so the ledger column and
+    the API field were permanently null.
+    """
+    from codeframe.core.proof.models import ReqStatus
+
+    req.status = ReqStatus.SATISFIED
+    req.satisfied_at = datetime.now(timezone.utc)
+    save_requirement(workspace, req)
+
+
+def reopen_requirement(workspace: Workspace, req_id: str, *, reason: str = "") -> None:
+    """Return a SATISFIED requirement to OPEN after a regression (#923).
+
+    Without this there was no path back: the runner loaded only OPEN
+    requirements, so once satisfied a requirement could never re-fail, and the
+    #731 merge gate — which inspects only open requirements — blocked nothing.
+
+    A WAIVED requirement is left alone. A waiver is a human decision about an
+    accepted risk, and a gate result must not silently overturn it.
+    """
+    from codeframe.core.proof.models import ReqStatus
+
+    req = get_requirement(workspace, req_id)
+    if req is None or req.status == ReqStatus.WAIVED:
+        return
+
+    req.status = ReqStatus.OPEN
+    req.satisfied_at = None
+    save_requirement(workspace, req)
+    logger.info("REQ %s re-opened: %s", req_id, reason or "regressed")
 
 
 def save_evidence(workspace: Workspace, evidence: Evidence) -> None:

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -199,6 +199,24 @@ def _run_gate(
         return GateOutcome.FAILED, str(exc)
 
 
+def _requirements_for_run(workspace: Workspace, *, full: bool) -> list:
+    """Which requirements a run evaluates (#923).
+
+    A scoped run keeps the cheap behaviour — open requirements only. A ``--full``
+    run also re-verifies SATISFIED ones, because otherwise there was no path
+    back: the runner loaded only OPEN, so once satisfied a requirement could
+    never re-fail on a later regression, and the #731 merge gate — which
+    inspects only *open* requirements — then blocked nothing.
+
+    WAIVED requirements stay out of both. A waiver is an accepted risk recorded
+    by a human, not something a gate result should quietly overturn.
+    """
+    reqs = ledger.list_requirements(workspace, status=ReqStatus.OPEN)
+    if full:
+        reqs = reqs + ledger.list_requirements(workspace, status=ReqStatus.SATISFIED)
+    return reqs
+
+
 def run_proof(
     workspace: Workspace,
     *,
@@ -231,7 +249,7 @@ def run_proof(
         logger.info("Expired %d waivers", len(expired))
 
     # Get all open requirements
-    reqs = ledger.list_requirements(workspace, status=ReqStatus.OPEN)
+    reqs = _requirements_for_run(workspace, full=full)
     if not reqs:
         completed_at = datetime.now(timezone.utc)
         ledger.save_run(
@@ -317,8 +335,19 @@ def run_proof(
             # an unverifiable obligation leaves it OPEN (and waivable).
             all_passed = all(o == GateOutcome.PASSED for _, o in req_results)
             if all_passed and len(req_results) == len(req.obligations):
-                req.status = ReqStatus.SATISFIED
-            ledger.save_requirement(workspace, req)
+                # mark_satisfied stamps satisfied_at, which the ledger column
+                # and the API field never carried before (#923).
+                ledger.mark_satisfied(workspace, req)
+            elif req.status == ReqStatus.SATISFIED:
+                # A previously satisfied requirement that no longer passes is a
+                # regression: return it to OPEN so it re-fails and the merge
+                # gate sees it again (#923).
+                ledger.reopen_requirement(
+                    workspace, req.id,
+                    reason="obligations no longer all pass",
+                )
+            else:
+                ledger.save_requirement(workspace, req)
 
     completed_at = datetime.now(timezone.utc)
     duration_ms = int((completed_at - started_at).total_seconds() * 1000)

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -24,6 +24,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
+from codeframe.core.proof import ledger as proof_ledger
 from codeframe.core.proof.capture import capture_requirement
 from codeframe.core.proof.ledger import (
     get_requirement,
@@ -47,6 +48,7 @@ from codeframe.core.proof.models import (
 from codeframe.core.proof.runner import run_proof
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
+from codeframe.auth.dependencies import require_auth
 from codeframe.ui.dependencies import get_v2_workspace
 from codeframe.ui.response_models import ErrorCodes, api_error
 from codeframe.ui.routers._helpers import atomic_write_json
@@ -81,6 +83,19 @@ def _evict_run_cache() -> None:
 # ============================================================================
 
 
+def _actor(auth: dict) -> str:
+    """The audit identity for an authenticated request (#923).
+
+    Same convention as the merge-override audit in ``pr_v2``: "local-admin"
+    only when auth is explicitly disabled, and an authenticated principal
+    without a user_id stays "unknown" rather than being invented.
+    """
+    return str(
+        auth.get("user_id")
+        or ("local-admin" if auth.get("type") == "disabled" else "unknown")
+    )
+
+
 class CaptureRequirementRequest(BaseModel):
     """Request body for capturing a requirement from a glitch."""
 
@@ -89,7 +104,8 @@ class CaptureRequirementRequest(BaseModel):
     where: str = Field(..., min_length=1, description="Location (file, route, API, tag) where glitch occurred")
     severity: Severity = Field(..., description="Severity: critical, high, medium, low")
     source: Source = Field(..., description="Source: production, qa, dogfooding, monitoring, user_report")
-    created_by: str = Field(default="human", description="Who captured this requirement")
+    # created_by is NOT accepted from the body: it is taken from the
+    # authenticated principal, so the record cannot be forged (#923).
     source_issue: Optional[str] = Field(default=None, description="External issue reference (e.g. GH-123)")
 
 
@@ -99,7 +115,9 @@ class WaiveRequirementRequest(BaseModel):
     reason: str = Field(..., min_length=1, description="Why this requirement is being waived")
     expires: Optional[date] = Field(default=None, description="ISO date when waiver expires (e.g. 2026-06-01)")
     manual_checklist: list[str] = Field(default_factory=list, description="Manual verification steps")
-    approved_by: str = Field(default="", description="Who approved this waiver")
+    # approved_by is NOT accepted from the body. A waiver bypasses the #731
+    # merge gate, so who approved it must be the authenticated principal
+    # rather than whatever the caller typed (#923).
 
 
 class RunProofRequest(BaseModel):
@@ -315,6 +333,7 @@ async def capture_requirement_endpoint(
     request: Request,
     body: CaptureRequirementRequest,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> CaptureRequirementResponse:
     """Capture a requirement from a glitch report.
 
@@ -329,7 +348,7 @@ async def capture_requirement_endpoint(
             where=body.where,
             severity=body.severity,
             source=body.source,
-            created_by=body.created_by,
+            created_by=_actor(auth),
             source_issue=body.source_issue,
         )
         resp = _req_to_response(req)
@@ -492,7 +511,21 @@ async def get_run_status_endpoint(
     the POST returns. Returns 404 if run_id is unknown.
     """
     cached = _run_cache.get((str(workspace.repo_path), run_id))
-    if cached is None:
+    if cached is not None:
+        return RunStatusResponse(
+            run_id=run_id,
+            status="complete",
+            results=cached["results"],
+            passed=cached["passed"],
+            message=cached["message"],
+        )
+
+    # Fall back to the ledger. The cache is in-process and expires after 300s,
+    # so a run that is durably persisted 404'd after expiry or a restart — the
+    # record existed and the API denied it (#923). The per-gate results live
+    # only in the cache, so a ledger hit reports the durable facts.
+    persisted = proof_ledger.get_run(workspace, run_id)
+    if persisted is None:
         raise HTTPException(
             status_code=404,
             detail=api_error(
@@ -501,12 +534,16 @@ async def get_run_status_endpoint(
                 f"No proof run with id {run_id}",
             ),
         )
+
     return RunStatusResponse(
         run_id=run_id,
         status="complete",
-        results=cached["results"],
-        passed=cached["passed"],
-        message=cached["message"],
+        results={},
+        passed=persisted.overall_passed,
+        message=(
+            "Run recovered from the ledger; per-gate results are no longer "
+            "cached. Use GET /proof/runs/{run_id}/evidence for the detail."
+        ),
     )
 
 
@@ -517,6 +554,7 @@ async def waive_requirement_endpoint(
     req_id: str,
     body: WaiveRequirementRequest,
     workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
 ) -> RequirementResponse:
     """Waive a requirement with a reason and optional expiry date."""
     existing = get_requirement(workspace, req_id)
@@ -534,7 +572,7 @@ async def waive_requirement_endpoint(
         reason=body.reason,
         expires=body.expires,
         manual_checklist=body.manual_checklist,
-        approved_by=body.approved_by,
+        approved_by=_actor(auth),
     )
     updated = waive_requirement(workspace, req_id, waiver)
     return _req_to_response(updated)

--- a/tests/core/test_proof_requirement_lifecycle_923.py
+++ b/tests/core/test_proof_requirement_lifecycle_923.py
@@ -1,0 +1,235 @@
+"""PROOF9 requirement lifecycle defects (#923 / P1.5).
+
+Five independent problems, each verified against the code first:
+
+1. **A satisfied requirement is never re-verified.** ``run_proof`` loads only
+   ``ReqStatus.OPEN`` and, on pass, sets ``SATISFIED`` — with no path that ever
+   re-opens it. A later regression never re-fails, and the #731 merge gate
+   (which inspects only *open* requirements) then blocks nothing.
+2. **``satisfied_at`` is never assigned**, so the ledger column and the API
+   field are permanently null.
+3. **REQ ids collide.** ``next_req_id`` computes ``MAX+1`` and closes its
+   connection; ``save_requirement`` then does ``INSERT OR REPLACE`` on a
+   separate one. Two concurrent captures silently overwrite each other.
+4. **Run lookup is cache-only.** ``GET /proof/runs/{run_id}`` reads a 300s
+   in-process cache and 404s for runs that are durably persisted.
+5. **A waiver is unattributable.** ``approved_by`` comes from the request body,
+   so a merge-gate bypass records whatever the caller typed.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return create_or_load_workspace(ws_dir)
+
+
+def _requirement(req_id: str, title: str = "t"):
+    from codeframe.core.proof.models import (
+        Gate,
+        Obligation,
+        ReqStatus,
+        Requirement,
+        RequirementScope,
+        Severity,
+        Source,
+    )
+
+    return Requirement(
+        id=req_id,
+        title=title,
+        description="d",
+        severity=Severity.HIGH,
+        source=Source.QA,
+        scope=RequirementScope(),
+        obligations=[Obligation(gate=Gate.UNIT)],
+        evidence_rules=[],
+        status=ReqStatus.OPEN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. satisfied_at, and re-verification
+# ---------------------------------------------------------------------------
+
+
+class TestSatisfiedLifecycle:
+    def test_satisfied_at_is_recorded(self, workspace):
+        """AC1. The column and the API field were permanently null."""
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.models import ReqStatus
+
+        req = _requirement("REQ-0001")
+        ledger.save_requirement(workspace, req)
+
+        ledger.mark_satisfied(workspace, req)
+
+        stored = ledger.get_requirement(workspace, "REQ-0001")
+        assert stored.status == ReqStatus.SATISFIED
+        assert stored.satisfied_at is not None, "satisfied_at never assigned"
+
+    def test_a_satisfied_requirement_is_loaded_by_a_full_run(self, workspace):
+        """AC2. Loading only OPEN meant a regression could never re-fail."""
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.runner import _requirements_for_run
+
+        satisfied = _requirement("REQ-0001")
+        ledger.save_requirement(workspace, satisfied)
+        ledger.mark_satisfied(workspace, satisfied)
+        ledger.save_requirement(workspace, _requirement("REQ-0002"))
+
+        ids = {r.id for r in _requirements_for_run(workspace, full=True)}
+
+        assert ids == {"REQ-0001", "REQ-0002"}, (
+            "a --full run must re-verify satisfied requirements, or a "
+            "regression never re-fails and the merge gate blocks nothing"
+        )
+
+    def test_a_scoped_run_still_prioritises_open_requirements(self, workspace):
+        """The default run keeps its cheaper behaviour."""
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.runner import _requirements_for_run
+
+        satisfied = _requirement("REQ-0001")
+        ledger.save_requirement(workspace, satisfied)
+        ledger.mark_satisfied(workspace, satisfied)
+        ledger.save_requirement(workspace, _requirement("REQ-0002"))
+
+        ids = {r.id for r in _requirements_for_run(workspace, full=False)}
+
+        assert "REQ-0002" in ids
+
+    def test_a_satisfied_requirement_can_return_to_open(self, workspace):
+        """AC2, the pass → break → re-fail path."""
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.models import ReqStatus
+
+        req = _requirement("REQ-0001")
+        ledger.save_requirement(workspace, req)
+        ledger.mark_satisfied(workspace, req)
+
+        ledger.reopen_requirement(workspace, req.id, reason="gate LINT regressed")
+
+        stored = ledger.get_requirement(workspace, "REQ-0001")
+        assert stored.status == ReqStatus.OPEN
+        assert stored.satisfied_at is None, "a re-opened requirement is not satisfied"
+
+    def test_reopening_a_waived_requirement_is_refused(self, workspace):
+        """A waiver is a human decision; a gate result must not silently undo it."""
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.models import ReqStatus, Waiver
+
+        req = _requirement("REQ-0001")
+        req.status = ReqStatus.WAIVED
+        req.waiver = Waiver(reason="accepted", expires=None,
+                            manual_checklist=[], approved_by="alice")
+        ledger.save_requirement(workspace, req)
+
+        ledger.reopen_requirement(workspace, req.id, reason="regressed")
+
+        assert ledger.get_requirement(workspace, "REQ-0001").status == ReqStatus.WAIVED
+
+
+# ---------------------------------------------------------------------------
+# 3. REQ id allocation
+# ---------------------------------------------------------------------------
+
+
+class TestReqIdAllocation:
+    def test_concurrent_captures_get_distinct_ids(self, workspace):
+        """AC3. MAX+1 outside a transaction plus INSERT OR REPLACE means two
+        captures silently overwrite each other and share a stub directory."""
+        from codeframe.core.proof import ledger
+
+        def _capture(n: int) -> str:
+            req_id = ledger.allocate_requirement(workspace, title=f"t{n}")
+            return req_id
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            ids = list(pool.map(_capture, range(8)))
+
+        assert len(set(ids)) == len(ids), f"colliding REQ ids: {sorted(ids)}"
+
+    def test_save_refuses_to_clobber_an_existing_id(self, workspace):
+        """AC3. INSERT OR REPLACE let a second capture overwrite the first."""
+        from codeframe.core.proof import ledger
+
+        ledger.save_requirement(workspace, _requirement("REQ-0001", title="first"))
+
+        with pytest.raises(ValueError):
+            ledger.save_requirement(
+                workspace, _requirement("REQ-0001", title="second"), create_only=True
+            )
+
+        assert ledger.get_requirement(workspace, "REQ-0001").title == "first"
+
+    def test_an_ordinary_update_still_works(self, workspace):
+        """The runner updates requirements in place on every run."""
+        from codeframe.core.proof import ledger
+
+        req = _requirement("REQ-0001", title="first")
+        ledger.save_requirement(workspace, req)
+
+        req.title = "updated"
+        ledger.save_requirement(workspace, req)
+
+        assert ledger.get_requirement(workspace, "REQ-0001").title == "updated"
+
+
+# ---------------------------------------------------------------------------
+# 4. Durable run lookup
+# ---------------------------------------------------------------------------
+
+
+class TestRunLookupFallsBackToLedger:
+    def test_a_persisted_run_resolves_after_the_cache_expires(self, workspace):
+        """AC4. The endpoint read only a 300s in-process cache, so a durably
+        persisted run 404'd after expiry or a restart."""
+        from datetime import datetime, timezone
+
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.models import ProofRun
+
+        started = datetime.now(timezone.utc)
+        ledger.save_run(
+            workspace,
+            ProofRun(
+                run_id="run-923", workspace_id=workspace.id, started_at=started,
+                completed_at=started, triggered_by="human", overall_passed=True,
+                duration_ms=1,
+            ),
+        )
+
+        assert ledger.get_run(workspace, "run-923") is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. Waiver attribution
+# ---------------------------------------------------------------------------
+
+
+class TestWaiverAttribution:
+    def test_the_request_model_no_longer_carries_approved_by(self):
+        """AC5. Taken from the body, a merge-gate bypass records whatever the
+        caller typed — the one field that must be the authenticated principal."""
+        from codeframe.ui.routers.proof_v2 import WaiveRequirementRequest as WaiveRequest
+
+        assert "approved_by" not in WaiveRequest.model_fields, (
+            "approved_by must come from require_auth, not the request body"
+        )
+
+    def test_the_capture_model_no_longer_carries_created_by(self):
+        from codeframe.ui.routers.proof_v2 import CaptureRequirementRequest as CaptureRequest
+
+        assert "created_by" not in CaptureRequest.model_fields

--- a/tests/ui/test_proof_v2.py
+++ b/tests/ui/test_proof_v2.py
@@ -120,7 +120,12 @@ class TestCaptureRequirement:
             assert (repo / rel).exists()
 
     def test_capture_with_optional_fields(self, test_client):
-        """Optional fields (created_by, source_issue) are accepted."""
+        """source_issue is accepted from the body; created_by is not (#923).
+
+        created_by used to be taken from the request, so a capture record was
+        whatever the caller typed. It now comes from the authenticated
+        principal — "local-admin" here, since the test suite runs auth-off.
+        """
         body = self._valid_body(
             created_by="ci-bot",
             source_issue="GH-123",
@@ -128,7 +133,9 @@ class TestCaptureRequirement:
         response = test_client.post("/api/v2/proof/requirements", json=body)
         assert response.status_code == 201
         data = response.json()
-        assert data["created_by"] == "ci-bot"
+        assert data["created_by"] != "ci-bot", (
+            "created_by must not be forgeable from the request body"
+        )
         assert data["source_issue"] == "GH-123"
 
     def test_capture_status_defaults_to_open(self, test_client):


### PR DESCRIPTION
Closes #923. Five independent problems in the requirement lifecycle.

## 1. A satisfied requirement was never re-verified (AC2)

`run_proof` loaded only `ReqStatus.OPEN` and, on pass, set `SATISFIED` — with **no path that ever re-opened it**. A later regression could never re-fail, and the #731 merge gate, which inspects only *open* requirements, then blocked on nothing.

PROOF9's promise is "Glitch → capture → New REQ → **Enforced forever**". The loop was one-way.

`--full` runs now also load SATISFIED requirements, and a requirement whose obligations stop passing returns to OPEN. Tests cover pass → break → re-fail.

`WAIVED` stays out of both. A waiver is an accepted risk recorded by a human; a gate result must not quietly overturn it.

## 2. `satisfied_at` was never assigned (AC1)

The status was set and the timestamp never was, so the ledger column and the API field were permanently null. `mark_satisfied` stamps it; re-opening clears it.

## 3. REQ ids collided (AC3)

`next_req_id` computed `MAX+1` and closed its connection; `save_requirement` then did `INSERT OR REPLACE` on a *separate* one. Two concurrent captures read the same max, produced the same id, and the second silently replaced the first — sharing its stub directory.

`allocate_requirement` now does allocate-and-insert under one `BEGIN IMMEDIATE`, retrying when another writer takes the id first, and `save_requirement` grows a `create_only` guard that refuses to clobber. Eight concurrent captures now get eight distinct ids; the ordinary in-place update the runner performs on every run still works.

## 4. Run lookup was cache-only (AC4)

`GET /proof/runs/{run_id}` read a 300s in-process cache and 404'd for runs that were **durably persisted** — the record existed and the API denied it, after expiry or any restart.

It now falls back to `ledger.get_run`, reporting the durable facts and pointing at the evidence endpoint for per-gate detail (which lives only in the cache).

## 5. A waiver was unattributable (AC5)

`approved_by` and `created_by` came from the **request body**, so a #731 merge-gate bypass recorded whatever the caller typed — on the one field whose entire purpose is accountability.

Both now derive from `require_auth`'s principal, reusing the convention already established by `pr_v2`'s merge-override audit: `"local-admin"` only when auth is explicitly disabled, `"unknown"` for an authenticated principal without a `user_id`. The fields are removed from the request models entirely, so there is nothing left to forge.

## Testing

`tests/core/test_proof_requirement_lifecycle_923.py` — 11 tests across all five ACs, including 8 concurrent captures and the waived-requirement carve-out.

`test_capture_with_optional_fields` asserted the old forgeable behaviour (`created_by == "ci-bot"` straight from the body); it now asserts the opposite.

Proof suites: 179 passed. Full gate: **4906 passed**, `ruff` clean.

## Note

Branched before #922 merged, so `runner.py` will need a trivial merge with #1034. No logical overlap — that PR touches scope intersection, this one touches which requirements are loaded.
