### PR TITLE
fix(proof): run a real security scanner for the SEC gate (#925)

### DIFF
--- a/codeframe/core/gates.py
+++ b/codeframe/core/gates.py
@@ -447,7 +447,7 @@ def run(
         gates = _detect_available_gates(repo_path)
 
     # Known gate names
-    known_gates = {"pytest", "ruff", "mypy", "npm-test", "npm-lint", "tsc", "python-build", "npm-build"}
+    known_gates = {"pytest", "ruff", "bandit", "mypy", "npm-test", "npm-lint", "tsc", "python-build", "npm-build"}
 
     # Run each gate
     for gate_name in gates:
@@ -455,6 +455,8 @@ def run(
             check = _run_pytest(repo_path, verbose, test_selector=test_selector)
         elif gate_name == "ruff":
             check = _run_ruff(repo_path, verbose)
+        elif gate_name == "bandit":
+            check = _run_bandit(repo_path, verbose)
         elif gate_name == "mypy":
             check = _run_mypy(repo_path, verbose)
         elif gate_name == "npm-test":
@@ -685,6 +687,76 @@ def _run_pytest(
             status=GateStatus.ERROR,
             output=str(e),
         )
+
+
+def _run_bandit(repo_path: Path, verbose: bool = False) -> GateCheck:
+    """Run bandit — the security scanner behind the PROOF9 SEC gate (#925).
+
+    SEC used to map to ``ruff``, so a clean *lint* recorded checksummed
+    "security" evidence in the ledger while the repo's own bandit-based
+    SecurityScanner sat unwired behind /api/v2/review.
+
+    SKIPPED, not PASSED, when bandit is absent. A security gate that cannot run
+    must never report clean — the proof layer turns SKIPPED into UNVERIFIABLE
+    (#909), which is the honest answer.
+    """
+    import time
+
+    start = time.time()
+
+    if not shutil.which("bandit") and not shutil.which("uv"):
+        return GateCheck(
+            name="bandit",
+            status=GateStatus.SKIPPED,
+            output="bandit not found — no security analysis was performed",
+        )
+
+    if shutil.which("bandit"):
+        cmd = ["bandit", "-r", ".", "-q", "-f", "txt"]
+    else:
+        cmd = ["uv", "run", "bandit", "-r", ".", "-q", "-f", "txt"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=repo_path,
+            env=build_agent_env(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except FileNotFoundError:
+        return GateCheck(
+            name="bandit",
+            status=GateStatus.SKIPPED,
+            output="bandit could not be executed — no security analysis was performed",
+        )
+    except subprocess.TimeoutExpired:
+        return GateCheck(
+            name="bandit",
+            status=GateStatus.ERROR,
+            output="bandit timed out after 300s",
+        )
+
+    duration_ms = int((time.time() - start) * 1000)
+    output = result.stdout + ("\n" + result.stderr if result.stderr else "")
+
+    # bandit exits 1 when it reports findings, 0 when clean. Anything else is
+    # the scanner itself failing, which is not evidence of a clean tree.
+    if result.returncode == 0:
+        status = GateStatus.PASSED
+    elif result.returncode == 1:
+        status = GateStatus.FAILED
+    else:
+        status = GateStatus.ERROR
+
+    return GateCheck(
+        name="bandit",
+        status=status,
+        exit_code=result.returncode,
+        output=output if verbose else output[:4000],
+        duration_ms=duration_ms,
+    )
 
 
 def _run_ruff(repo_path: Path, verbose: bool = False) -> GateCheck:

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -70,7 +70,9 @@ def _load_proof_config(workspace: Workspace) -> tuple[Optional[set[Gate]], str]:
 _GATE_TO_CORE: dict[Gate, str] = {
     Gate.UNIT: "pytest",
     Gate.CONTRACT: "pytest",
-    Gate.SEC: "ruff",
+    # bandit, not ruff: a clean *lint* used to record checksummed "security"
+    # evidence in the ledger (#925).
+    Gate.SEC: "bandit",
 }
 
 # Map a gate outcome to the persisted obligation status string.

--- a/tests/core/test_proof_evidence_rules.py
+++ b/tests/core/test_proof_evidence_rules.py
@@ -225,15 +225,21 @@ class TestRunGateEnforcement:
         assert "test_unit_b" in output
 
     @patch("codeframe.core.gates.run")
-    def test_sec_gate_enforces_pytest_rule_alongside_ruff(self, mock_run, workspace):
-        """A SEC requirement is NOT satisfied by a green ruff run alone when
-        its named test_sec_* regression test is missing."""
+    def test_sec_gate_enforces_pytest_rule_alongside_its_scanner(
+        self, mock_run, workspace
+    ):
+        """A SEC requirement is NOT satisfied by a green scanner run alone when
+        its named test_sec_* regression test is missing.
+
+        The scanner is bandit since #925 — SEC used to map to ruff, so a clean
+        *lint* recorded checksummed security evidence.
+        """
         from codeframe.core.proof.runner import _run_gate
 
         def fake_run(ws, gates=None, verbose=False, test_selector=None, **kw):
             if test_selector:  # scoped pytest run for the rule → missing
                 return _gate_result(GateStatus.FAILED, 5, "no tests ran")
-            return _gate_result(GateStatus.PASSED, 0, "ruff clean")
+            return _gate_result(GateStatus.PASSED, 0, "no security findings")
 
         mock_run.side_effect = fake_run
         outcome, output = _run_gate(
@@ -244,7 +250,10 @@ class TestRunGateEnforcement:
         # Both the scoped pytest run and the ruff run happened
         called_gates = [c.kwargs.get("gates") or c.args[1] for c in mock_run.call_args_list]
         assert ["pytest"] in called_gates
-        assert ["ruff"] in called_gates
+        assert ["bandit"] in called_gates
+        assert ["ruff"] not in called_gates, (
+            "the SEC gate must not be verified by a linter"
+        )
 
     def test_unit_stub_name_matches_evidence_rule(self):
         """The generated UNIT stub must define the exact function the

--- a/tests/core/test_proof_sec_gate_925.py
+++ b/tests/core/test_proof_sec_gate_925.py
@@ -1,0 +1,150 @@
+"""The PROOF9 SEC gate ran a linter, not a security scanner (#925 / P1.7).
+
+``_GATE_TO_CORE`` mapped ``Gate.SEC`` to ``"ruff"``. For a SECURITY_ISSUE
+requirement with no pytest-style evidence rules, the SEC obligation's evidence
+artifact was plain ``ruff check .`` output — and a clean lint recorded
+checksummed *security* evidence in the ledger.
+
+Meanwhile the repo's own bandit-based ``SecurityScanner`` and ``OWASPPatterns``
+were reachable only from ``/api/v2/review``: a complete, unwired security path
+sitting next to a headline gate that overstated what it proved.
+
+The scanner already fails closed when bandit is missing (#910), raising
+``ScannerUnavailableError`` rather than reporting a clean scan — so wiring it up
+also satisfies "never PASSED when it cannot run".
+"""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+_HAS_BANDIT = shutil.which("bandit") is not None
+requires_bandit = pytest.mark.skipif(not _HAS_BANDIT, reason="bandit not installed")
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return create_or_load_workspace(ws_dir)
+
+
+def _write_insecure(workspace) -> None:
+    """A file with a finding bandit reliably reports (B605: shell injection)."""
+    (workspace.repo_path / "insecure.py").write_text(
+        textwrap.dedent(
+            """
+            import os
+
+            def run_it(user_input):
+                os.system("echo " + user_input)
+            """
+        ).lstrip()
+    )
+
+
+def _write_clean(workspace) -> None:
+    (workspace.repo_path / "clean.py").write_text("VALUE = 1\n")
+
+
+# ---------------------------------------------------------------------------
+# 1. SEC must not be a linter
+# ---------------------------------------------------------------------------
+
+
+class TestSecGateIsNotRuff:
+    def test_sec_no_longer_maps_to_ruff(self):
+        """AC1. A clean lint recorded checksummed 'security' evidence."""
+        from codeframe.core.proof.models import Gate
+        from codeframe.core.proof.runner import _GATE_TO_CORE
+
+        assert _GATE_TO_CORE.get(Gate.SEC) != "ruff", (
+            "the SEC gate's evidence artifact was `ruff check .` output"
+        )
+
+    def test_sec_maps_to_a_security_scanner(self):
+        from codeframe.core.proof.models import Gate
+        from codeframe.core.proof.runner import _GATE_TO_CORE
+
+        assert _GATE_TO_CORE.get(Gate.SEC) == "bandit"
+
+
+# ---------------------------------------------------------------------------
+# 2. It finds real findings
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityGateRuns:
+    @requires_bandit
+    def test_a_known_finding_fails_the_gate(self, workspace):
+        """AC2. os.system with interpolated input is B605."""
+        from codeframe.core.gates import GateStatus, _run_bandit
+
+        _write_insecure(workspace)
+
+        check = _run_bandit(workspace.repo_path)
+
+        assert check.status == GateStatus.FAILED, (
+            f"bandit finding not reported as a failure: {check.output[:400]}"
+        )
+
+    @requires_bandit
+    def test_a_clean_tree_passes(self, workspace):
+        from codeframe.core.gates import GateStatus, _run_bandit
+
+        _write_clean(workspace)
+
+        assert _run_bandit(workspace.repo_path).status == GateStatus.PASSED
+
+    @requires_bandit
+    def test_the_finding_is_named_in_the_output(self, workspace):
+        """The artifact must say what was found, not just that it failed."""
+        from codeframe.core.gates import _run_bandit
+
+        _write_insecure(workspace)
+
+        output = _run_bandit(workspace.repo_path).output.lower()
+
+        assert "insecure.py" in output
+
+
+# ---------------------------------------------------------------------------
+# 3. Never PASSED when it cannot run
+# ---------------------------------------------------------------------------
+
+
+class TestFailsClosed:
+    def test_a_missing_scanner_is_not_a_pass(self, workspace, monkeypatch):
+        """AC3. The whole point: a gate that cannot run must not report clean."""
+        from codeframe.core import gates as core_gates
+
+        monkeypatch.setattr(core_gates.shutil, "which", lambda name: None)
+        _write_clean(workspace)
+
+        check = core_gates._run_bandit(workspace.repo_path)
+
+        assert check.status != core_gates.GateStatus.PASSED, (
+            "a missing scanner reported a clean security gate"
+        )
+
+    def test_a_missing_scanner_is_unverifiable_at_the_proof_layer(
+        self, workspace, monkeypatch
+    ):
+        """SKIPPED at the gate layer must surface as UNVERIFIABLE, not PASSED —
+        the #909 rule, applied to the gate that most needs it."""
+        from codeframe.core import gates as core_gates
+        from codeframe.core.proof.models import Gate, GateOutcome
+        from codeframe.core.proof.runner import _run_gate
+
+        monkeypatch.setattr(core_gates.shutil, "which", lambda name: None)
+
+        outcome, _ = _run_gate(workspace, Gate.SEC, rules=[])
+
+        assert outcome != GateOutcome.PASSED


### PR DESCRIPTION
Closes #925.

## The SEC gate ran a linter

`_GATE_TO_CORE` mapped `Gate.SEC` to `"ruff"`. For a SECURITY_ISSUE requirement with no pytest-style evidence rules, the SEC obligation's evidence artifact was plain `ruff check .` output — so **a clean lint recorded checksummed "security" evidence in the ledger**.

Meanwhile the repo's own bandit-based `SecurityScanner` and `OWASPPatterns` were reachable only from `/api/v2/review`: a complete, working security path sitting unwired next to the headline gate that overstated what it proved.

## The fix

A `bandit` gate joins the existing pytest/ruff/mypy runners in `core/gates.py`, and `Gate.SEC` points at it.

Verified against a real finding:

```
>> Issue: [B605:start_process_with_a_shell] Starting a process with a shell,
   possible injection detected, security issue.
   Severity: High   Confidence: High
status: FAILED | exit: 1
```

## Exit-code handling (AC3)

- `0` → PASSED (clean)
- `1` → FAILED (findings)
- anything else → **ERROR**, because the scanner itself failing is not evidence of a clean tree
- bandit absent → **SKIPPED**, which the proof layer already turns into UNVERIFIABLE (#909)

So a security gate that cannot run never reports clean. bandit has been a runtime dependency since #910, so this is reliable in a normal install and honest in a broken one.

## Testing

`tests/core/test_proof_sec_gate_925.py` — 7 tests: the mapping, a real bandit finding failing the gate, a clean tree passing, the finding named in the artifact, and both fail-closed paths (gate layer and proof layer).

`test_sec_gate_enforces_pytest_rule_alongside_ruff` asserted SEC invoked ruff; it now asserts bandit **and** that ruff is not invoked for it.

Gates + proof suites: 205 passed. Full gate: **4913 passed**, `ruff` clean.

## Scope note

This wires the SEC gate to the scanner the repo already ships. `OWASPPatterns` remains review-only — folding it in is a larger change about what constitutes a finding, and the AC is satisfied by bandit, which is what `SecurityScanner` itself runs.
