### PR TITLE
fix(pr): resolve the workspace upward in the PROOF9 merge gate (#926)

### DIFF
--- a/codeframe/cli/pr_commands.py
+++ b/codeframe/cli/pr_commands.py
@@ -428,15 +428,23 @@ def _check_merge_gate(
     """
     from codeframe.core.proof import ledger as proof_ledger
     from codeframe.core.proof.models import ReqStatus
-    from codeframe.core.workspace import get_workspace
+    from codeframe.core.workspace import find_workspace_root, get_workspace
 
     reason = (override_reason or "").strip()
     if override and not reason:
         console.print("[red]Error:[/red] --reason is required with --override")
         raise typer.Exit(1)
 
+    # Resolve upward: get_workspace looks only in the exact directory given, so
+    # running this from any subdirectory of a workspace raised FileNotFoundError
+    # and the gate silently did not apply — no warning, no audit record,
+    # indistinguishable from the genuine no-workspace case (#926).
+    root = find_workspace_root(Path.cwd())
+    if root is None:
+        return None
+
     try:
-        workspace = get_workspace(Path.cwd())
+        workspace = get_workspace(root)
     except FileNotFoundError:
         return None
 

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -897,6 +897,35 @@ def create_or_load_workspace(repo_path: Path, tech_stack: Optional[str] = None) 
     )
 
 
+def find_workspace_root(start: Path) -> Optional[Path]:
+    """The nearest enclosing workspace root, or None (#926).
+
+    ``get_workspace`` looks for ``.codeframe/`` in exactly the directory it is
+    given. So ``cf pr merge`` from ``repo/src/`` raised FileNotFoundError, which
+    ``_check_merge_gate`` reads as "no workspace here, nothing to gate" — the
+    #731 PROOF9 merge gate silently did not apply, with no warning and no audit
+    record, from the directory people actually run git commands in.
+
+    Walks up from ``start``, so a nested workspace wins over its parent: the one
+    you are *in* is the one that governs.
+
+    The marker is the state database, not the ``.codeframe/`` directory alone.
+    The machine-wide ``~/.codeframe`` holds the credential store, agent homes
+    and logs — so matching on the directory name would make every path under
+    ``$HOME`` resolve to a "workspace" rooted at the home directory, and
+    ``/tmp/.codeframe`` would do the same for every temp path.
+    """
+    try:
+        current = start.resolve()
+    except OSError:
+        return None
+
+    for candidate in (current, *current.parents):
+        if (candidate / CODEFRAME_DIR / STATE_DB_NAME).is_file():
+            return candidate
+    return None
+
+
 def get_workspace(repo_path: Path) -> Workspace:
     """Load an existing workspace.
 

--- a/tests/cli/test_merge_gate_subdir_926.py
+++ b/tests/cli/test_merge_gate_subdir_926.py
@@ -1,0 +1,156 @@
+"""`cf pr merge` skipped its PROOF9 gate from any subdirectory (#926 / P1.8).
+
+``_check_merge_gate`` calls ``get_workspace(Path.cwd())`` and returns None on
+``FileNotFoundError``. But ``get_workspace`` performs no upward search — it
+looks for ``.codeframe/`` in exactly the directory given.
+
+So running ``cf pr merge 42`` from ``repo/src/`` — which is where most people
+actually are when they run git commands — silently skipped the #731 merge gate.
+No warning, no audit record, indistinguishable from the intended
+"no workspace here, nothing to gate" case. The existing tests only covered
+cwd == repo root and cwd == an empty directory, so the gap sat exactly between
+them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return create_or_load_workspace(repo)
+
+
+# ---------------------------------------------------------------------------
+# 1. Upward resolution
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceRootLookup:
+    def test_finds_the_workspace_from_a_subdirectory(self, workspace):
+        from codeframe.core.workspace import find_workspace_root
+
+        nested = workspace.repo_path / "src" / "deep" / "nested"
+        nested.mkdir(parents=True)
+
+        assert find_workspace_root(nested) == workspace.repo_path
+
+    def test_finds_it_at_the_root_itself(self, workspace):
+        from codeframe.core.workspace import find_workspace_root
+
+        assert find_workspace_root(workspace.repo_path) == workspace.repo_path
+
+    def test_returns_none_outside_any_workspace(self, tmp_path):
+        from codeframe.core.workspace import find_workspace_root
+
+        elsewhere = tmp_path / "not-a-workspace"
+        elsewhere.mkdir()
+
+        assert find_workspace_root(elsewhere) is None
+
+    def test_stops_at_the_nearest_workspace(self, workspace):
+        """A nested workspace wins over its parent — the one you are *in*."""
+        from codeframe.core.workspace import create_or_load_workspace, find_workspace_root
+
+        inner_dir = workspace.repo_path / "packages" / "inner"
+        inner_dir.mkdir(parents=True)
+        inner = create_or_load_workspace(inner_dir)
+
+        assert find_workspace_root(inner_dir / "src") == inner.repo_path
+
+    def test_a_missing_directory_does_not_raise(self, tmp_path):
+        from codeframe.core.workspace import find_workspace_root
+
+        assert find_workspace_root(tmp_path / "does-not-exist") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. The gate itself
+# ---------------------------------------------------------------------------
+
+
+class TestMergeGateFromSubdirectory:
+    def _open_requirement(self, workspace):
+        from codeframe.core.proof import ledger
+        from codeframe.core.proof.models import (
+            Gate,
+            Obligation,
+            ReqStatus,
+            Requirement,
+            RequirementScope,
+            Severity,
+            Source,
+        )
+
+        ledger.save_requirement(
+            workspace,
+            Requirement(
+                id="REQ-0001",
+                title="unfixed glitch",
+                description="d",
+                severity=Severity.HIGH,
+                source=Source.QA,
+                scope=RequirementScope(),
+                obligations=[Obligation(gate=Gate.UNIT)],
+                evidence_rules=[],
+                status=ReqStatus.OPEN,
+            ),
+        )
+
+    def test_the_gate_blocks_from_a_subdirectory(self, workspace, monkeypatch):
+        """AC2. This is the whole bug: the gate silently did not apply."""
+        import typer
+
+        from codeframe.cli.pr_commands import _check_merge_gate
+
+        self._open_requirement(workspace)
+        nested = workspace.repo_path / "src"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+
+        with pytest.raises(typer.Exit):
+            _check_merge_gate(override=False, override_reason=None)
+
+    def test_the_gate_still_blocks_from_the_root(self, workspace, monkeypatch):
+        import typer
+
+        from codeframe.cli.pr_commands import _check_merge_gate
+
+        self._open_requirement(workspace)
+        monkeypatch.chdir(workspace.repo_path)
+
+        with pytest.raises(typer.Exit):
+            _check_merge_gate(override=False, override_reason=None)
+
+    def test_a_workspaceless_directory_still_merges(self, tmp_path, monkeypatch):
+        """AC3. The genuine no-workspace case must stay ungated."""
+        from codeframe.cli.pr_commands import _check_merge_gate
+
+        elsewhere = tmp_path / "plain"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        assert _check_merge_gate(override=False, override_reason=None) is None
+
+    def test_an_override_from_a_subdirectory_is_audited(self, workspace, monkeypatch):
+        """The bypass must record against the workspace it actually found."""
+        from codeframe.cli.pr_commands import _check_merge_gate
+
+        self._open_requirement(workspace)
+        nested = workspace.repo_path / "src"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+
+        result = _check_merge_gate(override=True, override_reason="shipping anyway")
+
+        assert result is not None
+        found_workspace, bypassed = result
+        assert found_workspace.repo_path == workspace.repo_path
+        assert any(r["id"] == "REQ-0001" for r in bypassed)


### PR DESCRIPTION
Closes #926.

## The gate skipped itself from any subdirectory

`_check_merge_gate` calls `get_workspace(Path.cwd())` and returns `None` on `FileNotFoundError`. But `get_workspace` performs **no upward search** — it looks for `.codeframe/` in exactly the directory given.

So `cf pr merge 42` run from `repo/src/` — where people actually are when they run git commands — silently skipped the #731 PROOF9 merge gate. No warning, no audit record, indistinguishable from the intended "no workspace here, nothing to gate" case.

The existing tests covered `cwd == repo root` and `cwd == empty dir`. The gap sat precisely between them.

## The marker is the state database, not the directory name

`find_workspace_root` walks up from the cwd, so a nested workspace wins over its parent — the one you are *in* governs.

The first draft matched on `.codeframe/` being a directory, and the new tests **failed immediately**: `/tmp/.codeframe` exists on this machine, and so does `~/.codeframe` — it holds the credential store, agent homes and logs. Matching the directory name alone would have made **every path under `$HOME`** resolve to a "workspace" rooted at the home directory. That is a worse bug than the one being fixed.

Requiring `.codeframe/state.db` distinguishes a real workspace from the machine-wide state dir. Verified against real paths:

```
root from repo/     : /tmp/gate926/repo
root from src/deep/ : /tmp/gate926/repo
root from /tmp      : None      ← /tmp/.codeframe exists
root from $HOME     : None      ← ~/.codeframe exists (credential store)
```

## Testing

`tests/cli/test_merge_gate_subdir_926.py` — 9 tests:

- resolution from a nested subdirectory, from the root, outside any workspace, with a *nested* workspace preferred over its parent, and for a non-existent directory
- the gate **blocks** from a subdirectory with an open requirement (AC2)
- it still blocks from the root
- a genuinely workspace-less cwd still merges ungated (AC3)
- an override from a subdirectory audits against the workspace it actually found

PR + workspace suites: 803 passed. Full gate: **4927 passed**, `ruff` clean.

## Scope note

`cf status` and the other commands that call `get_workspace(cwd)` share the original limitation. Left alone deliberately: this issue is scoped to the merge gate, which is the one where silence has a security consequence. Widening the resolution everywhere is a behaviour change for every command and belongs in its own issue.
