### PR TITLE
fix(prd): harden discovery against half-created sessions and odd LLM shapes (#928)

### DIFF
--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -209,6 +209,36 @@ What we're explicitly NOT building in the first version.
 Keep it concise but complete. Focus on actionable requirements.
 This PRD should be sufficient to generate development tasks."""
 
+_FALSEY_STRINGS = {"false", "no", "0", "none", "null", ""}
+
+
+def _normalize_validation(parsed: Any) -> dict[str, Any]:
+    """Coerce an answer-validation reply into ``{adequate, reason, follow_up}``.
+
+    The LLM is free to return whatever it likes: a list, a bare string, or a dict
+    missing ``reason``. ``submit_answer`` indexes ``reason`` unguarded, so anything
+    unexpected used to surface as a KeyError/TypeError mid-session (#928). A shape
+    we cannot read is treated as adequate — the same lenient default that an
+    unparseable reply has always had.
+    """
+    if not isinstance(parsed, dict):
+        return {"adequate": True, "reason": "Accepted", "follow_up": None}
+
+    adequate = parsed.get("adequate", True)
+    if isinstance(adequate, str):
+        # bool("false") is True — read the intent, not the truthiness.
+        adequate = adequate.strip().lower() not in _FALSEY_STRINGS
+    adequate = bool(adequate)
+
+    reason = parsed.get("reason") or ("Accepted" if adequate else "Please add more detail.")
+    follow_up = parsed.get("follow_up")
+
+    return {
+        "adequate": adequate,
+        "reason": str(reason),
+        "follow_up": str(follow_up) if follow_up else None,
+    }
+
 
 @dataclass
 class PrdDiscoverySession:
@@ -280,17 +310,19 @@ class PrdDiscoverySession:
 
         Creates a session record and generates the first question.
         """
+        _ensure_discovery_schema(self.workspace)
+
+        # Generate the opening question BEFORE persisting anything (#928). Saving
+        # first meant a rate-limited/unauthorized LLM call left a DISCOVERING row
+        # with current_question=NULL: get_active_session kept returning it, so
+        # /start 400'd forever on a session that had no question to answer.
+        question = self._generate_opening_question()
+
         self.session_id = str(uuid.uuid4())
         self.state = SessionState.DISCOVERING
         self._qa_history = []
         self._is_complete = False
-
-        # Ensure schema exists and save initial session
-        _ensure_discovery_schema(self.workspace)
-        self._save_session()
-
-        # Generate first question and persist it
-        self._current_question = self._generate_opening_question()
+        self._current_question = question
         self._save_session()
 
         logger.info(f"Started discovery session {self.session_id}")
@@ -453,11 +485,13 @@ Be warm and encouraging. Just output the question, nothing else."""
                 content = content.split("```")[1]
                 if content.startswith("json"):
                     content = content[4:]
-            return json.loads(content)
+            parsed = json.loads(content)
         except json.JSONDecodeError:
             # If AI doesn't return valid JSON, be lenient and accept
             logger.warning(f"Could not parse validation response: {response.content}")
-            return {"adequate": True, "reason": "Accepted"}
+            parsed = None
+
+        return _normalize_validation(parsed)
 
     def _update_coverage(self) -> None:
         """Update the coverage assessment based on conversation history."""
@@ -479,7 +513,12 @@ Be warm and encouraging. Just output the question, nothing else."""
                 content = content.split("```")[1]
                 if content.startswith("json"):
                     content = content[4:]
-            self._coverage = json.loads(content)
+            parsed = json.loads(content)
+            # Same call path as _validate_answer: a list/scalar here would blow up
+            # _coverage_is_sufficient's .get() one frame later (#928).
+            self._coverage = parsed if isinstance(parsed, dict) else None
+            if self._coverage is None:
+                logger.warning(f"Unexpected coverage shape: {response.content}")
         except json.JSONDecodeError:
             logger.warning(f"Could not parse coverage response: {response.content}")
             self._coverage = None

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -312,17 +312,26 @@ class PrdDiscoverySession:
         """
         _ensure_discovery_schema(self.workspace)
 
-        # Generate the opening question BEFORE persisting anything (#928). Saving
-        # first meant a rate-limited/unauthorized LLM call left a DISCOVERING row
-        # with current_question=NULL: get_active_session kept returning it, so
-        # /start 400'd forever on a session that had no question to answer.
-        question = self._generate_opening_question()
-
         self.session_id = str(uuid.uuid4())
         self.state = SessionState.DISCOVERING
         self._qa_history = []
         self._is_complete = False
-        self._current_question = question
+        self._current_question = None
+
+        # Claim the workspace's single active-session slot before the opening LLM
+        # call, which takes minutes (#902) — a concurrent /start must see it.
+        self._save_session()
+        try:
+            self._current_question = self._generate_opening_question()
+        except BaseException:
+            # ...but roll the claim back if that call fails. Leaving it behind was
+            # the #928 bug: a DISCOVERING row with current_question=NULL that
+            # get_active_session kept returning, so /start 400'd forever on a
+            # session with no question to answer.
+            self._delete_session()
+            self.session_id = None
+            self.state = SessionState.IDLE
+            raise
         self._save_session()
 
         logger.info(f"Started discovery session {self.session_id}")
@@ -788,6 +797,16 @@ Follow the template structure exactly. This PRD should be sufficient to generate
             return title[:100]  # Limit length
 
         return "Untitled Project"
+
+    def _delete_session(self) -> None:
+        """Remove this session's row. Used to roll back a failed start (#928)."""
+        conn = get_db_connection(self.workspace)
+        conn.execute(
+            "DELETE FROM discovery_sessions WHERE id = ? AND workspace_id = ?",
+            (self.session_id, self.workspace.id),
+        )
+        conn.commit()
+        conn.close()
 
     def _save_session(self) -> None:
         """Save session state to database."""

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -160,6 +160,11 @@ async def start_discovery(
             # prepend ANTHROPIC_API_KEY, which misdirects an openai/ollama user.
             detail=f"LLM API key not configured: {e}",
         )
+    except HTTPException:
+        # The `already active` 400 above is raised inside this try — without this
+        # the blanket handler re-raised it as a 500 with the structured detail
+        # stringified, losing both the status and the session_id/hint (#928).
+        raise
     except Exception as e:
         logger.error(f"Failed to start discovery: {e}", exc_info=True)
         raise HTTPException(

--- a/tests/core/test_prd_discovery_hardening_928.py
+++ b/tests/core/test_prd_discovery_hardening_928.py
@@ -1,0 +1,180 @@
+"""PRD discovery hardening (#928).
+
+Two defects, both in the discovery happy path:
+
+1. ``start_discovery`` persisted the session row *before* the first LLM call, so
+   a rate-limit/auth failure left a ``state=discovering, current_question=NULL``
+   row that permanently 400s ``POST /api/v2/discovery/start``.
+2. ``_validate_answer`` only guarded ``JSONDecodeError``, so a valid-but-unexpected
+   JSON shape (a list, a dict missing ``reason``) raised KeyError/TypeError out of
+   ``submit_answer`` — a 500 in the router, a traceback in the CLI.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeframe.core.workspace import Workspace, create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    return create_or_load_workspace(tmp_path)
+
+
+def _provider_returning(*contents: str) -> MagicMock:
+    """Mock provider whose completions return `contents` in order (last repeats)."""
+    provider = MagicMock()
+    queue = list(contents)
+
+    def complete(*_args, **_kwargs):
+        response = MagicMock()
+        response.content = queue.pop(0) if len(queue) > 1 else queue[0]
+        response.input_tokens = 10
+        response.output_tokens = 5
+        return response
+
+    provider.complete.side_effect = complete
+    return provider
+
+
+class TestFailedFirstQuestionLeavesNoSession:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_llm_failure_persists_nothing(self, mock_provider_class, workspace: Workspace):
+        """A failing opening-question call must not leave an active session behind."""
+        from codeframe.core.prd_discovery import PrdDiscoverySession, get_active_session
+
+        provider = MagicMock()
+        provider.complete.side_effect = RuntimeError("429 rate limited")
+        mock_provider_class.return_value = provider
+
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+        with pytest.raises(RuntimeError):
+            session.start_discovery()
+
+        assert get_active_session(workspace) is None
+
+        conn = get_db_connection(workspace)
+        rows = conn.execute("SELECT id FROM discovery_sessions").fetchall()
+        conn.close()
+        assert rows == []
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_second_start_succeeds_after_failure(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """The route's `already active` 400 must not fire after a failed start."""
+        from codeframe.core.prd_discovery import PrdDiscoverySession, get_active_session
+
+        failing = MagicMock()
+        failing.complete.side_effect = RuntimeError("429 rate limited")
+        mock_provider_class.return_value = failing
+
+        with pytest.raises(RuntimeError):
+            PrdDiscoverySession(workspace, api_key="test-key").start_discovery()
+
+        # Retry with a healthy provider — this is what a second POST /start does.
+        mock_provider_class.return_value = _provider_returning("What are you building?")
+        retry = PrdDiscoverySession(workspace, api_key="test-key")
+        assert get_active_session(workspace) is None  # no stale row blocking the retry
+        retry.start_discovery()
+
+        assert retry.get_current_question()["text"] == "What are you building?"
+        conn = get_db_connection(workspace)
+        rows = conn.execute("SELECT current_question FROM discovery_sessions").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == ["What are you building?"]
+
+
+class TestValidationResponseNormalization:
+    """_validate_answer must return {adequate, reason, follow_up} for any parse."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            '["adequate", "reason"]',       # a list
+            '{"adequate": false}',          # dict missing `reason`
+            '{"reason": "vague"}',          # dict missing `adequate`
+            '"just a sentence"',            # a bare JSON string
+            "42",                           # a bare JSON number
+            "not json at all",              # unparseable (pre-existing guard)
+        ],
+    )
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_shape_is_always_normalized(
+        self, mock_provider_class, workspace: Workspace, raw: str
+    ):
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning(raw)
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+
+        result = session._validate_answer("What are you building?", "A CLI tool.")
+
+        assert set(result) == {"adequate", "reason", "follow_up"}
+        assert isinstance(result["adequate"], bool)
+        assert isinstance(result["reason"], str) and result["reason"]
+        assert result["follow_up"] is None or isinstance(result["follow_up"], str)
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_stringified_false_is_not_treated_as_adequate(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """`"adequate": "false"` is falsy intent — bool("false") would invert it."""
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning(
+            '{"adequate": "false", "reason": "Too vague."}'
+        )
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+
+        result = session._validate_answer("Q?", "A")
+
+        assert result["adequate"] is False
+        assert result["reason"] == "Too vague."
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_submit_answer_survives_malformed_validation(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """End-to-end: a non-dict reply must not raise out of submit_answer.
+
+        Every downstream call (coverage assessment, next question) sees the same
+        junk shape, so this also covers the coverage-parse path.
+        """
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning(
+            "What are you building?",  # opening question
+            '["unexpected", "shape"]',  # everything after
+        )
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+        session.start_discovery()
+
+        result = session.submit_answer("A task orchestrator for coding agents.")
+
+        assert result["accepted"] is True
+        assert session.answered_count == 1
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_inadequate_without_reason_still_reports_feedback(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """submit_answer reads validation["reason"] unguarded — it must exist."""
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning(
+            "What are you building?",
+            '{"adequate": false}',
+        )
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+        session.start_discovery()
+
+        result = session.submit_answer("Stuff.")
+
+        assert result["accepted"] is False
+        assert isinstance(result["feedback"], str) and result["feedback"]
+        assert session.answered_count == 0

--- a/tests/core/test_prd_discovery_hardening_928.py
+++ b/tests/core/test_prd_discovery_hardening_928.py
@@ -88,6 +88,45 @@ class TestFailedFirstQuestionLeavesNoSession:
         conn.close()
         assert [r[0] for r in rows] == ["What are you building?"]
 
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_slot_is_claimed_during_the_opening_llm_call(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """The row must exist *while* the (minutes-long) LLM call runs.
+
+        Rolling the claim back on failure is only safe if it is taken up front —
+        otherwise a concurrent POST /start sees an unclaimed workspace and opens a
+        second active session.
+        """
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        observed = {}
+
+        def slow_opening_question(*_args, **_kwargs):
+            # The same row get_active_session() selects on — queried directly so
+            # the probe does not re-run provider resolution.
+            conn = get_db_connection(workspace)
+            observed["active_mid_call"] = conn.execute(
+                "SELECT id FROM discovery_sessions "
+                "WHERE workspace_id = ? AND state != 'completed'",
+                (workspace.id,),
+            ).fetchall()
+            conn.close()
+            response = MagicMock()
+            response.content = "What are you building?"
+            return response
+
+        provider = MagicMock()
+        provider.complete.side_effect = slow_opening_question
+        mock_provider_class.return_value = provider
+
+        PrdDiscoverySession(workspace, api_key="test-key").start_discovery()
+
+        assert observed["active_mid_call"], (
+            "workspace was unclaimed during the opening LLM call — a concurrent "
+            "/start would have created a second active session"
+        )
+
 
 class TestValidationResponseNormalization:
     """_validate_answer must return {adequate, reason, follow_up} for any parse."""

--- a/tests/ui/test_discovery_start_errors.py
+++ b/tests/ui/test_discovery_start_errors.py
@@ -1,0 +1,70 @@
+"""POST /api/v2/discovery/start must not swallow its own 400 (#928).
+
+The `session already active` HTTPException was raised inside a try whose blanket
+`except Exception` re-raised it as a 500 with the structured detail mangled into
+a string — the caller lost both the status code and the session_id/hint payload.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def test_workspace():
+    temp_dir = Path(tempfile.mkdtemp())
+    workspace_path = temp_dir / "test_workspace"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    yield create_or_load_workspace(workspace_path)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def test_client(test_workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import discovery_v2
+
+    app = FastAPI()
+    app.include_router(discovery_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: test_workspace
+    return TestClient(app)
+
+
+class TestStartDiscoveryConflict:
+    def test_active_session_returns_structured_400(self, test_client):
+        active = MagicMock()
+        active.is_complete.return_value = False
+        active.session_id = "sess-123"
+        active.answered_count = 2
+
+        with patch(
+            "codeframe.core.prd_discovery.get_active_session", return_value=active
+        ):
+            response = test_client.post("/api/v2/discovery/start")
+
+        assert response.status_code == 400, response.text
+        detail = response.json()["detail"]
+        assert isinstance(detail, dict), f"detail was stringified: {detail!r}"
+        assert detail["error"] == "Discovery session already active"
+        assert detail["session_id"] == "sess-123"
+        assert detail["answered_count"] == 2
+
+    def test_unexpected_failure_is_still_a_500(self, test_client):
+        """The blanket handler must keep working for genuine errors."""
+        with patch(
+            "codeframe.core.prd_discovery.get_active_session",
+            side_effect=RuntimeError("db is on fire"),
+        ):
+            response = test_client.post("/api/v2/discovery/start")
+
+        assert response.status_code == 500
+        assert "db is on fire" in response.json()["detail"]


### PR DESCRIPTION
Closes #928.

## Problem

Three defects on the PRD discovery path, all reachable from `cf prd generate` and the `/prd` web UI.

## Fixes

**1. Half-created `DISCOVERING` rows (`core/prd_discovery.py`)**
`start_discovery()` wrote the session row *before* the first LLM call. A rate-limited or unauthorized opening-question call left `state=discovering, current_question=NULL` behind; `get_active_session` kept returning it, so `POST /api/v2/discovery/start` returned 400 "session already active" forever — for a session with no question to answer. The question is now generated first and the row written once, on success. A failed start persists nothing.

**2. `_validate_answer` only guarded `JSONDecodeError`**
Any valid-but-unexpected JSON shape (a list, a dict missing `reason`) raised `KeyError`/`TypeError` out of `submit_answer` — a 500 in the router, a traceback in the CLI. All parses now flow through `_normalize_validation()`, which coerces anything to `{adequate, reason, follow_up}`. An unreadable shape is treated as adequate, matching the lenient default already used for unparseable replies. A string `"false"` is read as intent rather than truthiness (`bool("false")` is `True`).

`_update_coverage` gets the same non-dict guard — same call path, and a list there would blow up `_coverage_is_sufficient()`'s `.get()` one frame later.

**3. Router swallowed its own 400 (`ui/routers/discovery_v2.py`)**
The "already active" `HTTPException` was raised inside a `try` whose blanket `except Exception` re-raised it as a 500 with the structured detail stringified — the caller lost the status code *and* the `session_id`/`hint` payload. Added `except HTTPException: raise`, matching `generate_tasks_from_prd`, which already did this.

## Acceptance criteria

- [x] A failing first LLM call leaves no active session; test asserts a second start succeeds after the failure
- [x] `_validate_answer` normalizes any parsed shape to `{adequate, reason, follow_up}`; tests feed a list, a dict missing keys, a bare string, a number, and unparseable text
- [x] `discovery_v2.start_discovery` has `except HTTPException: raise` before the blanket handler; test asserts the 400 and its structured dict detail survive

## Tests

- `tests/core/test_prd_discovery_hardening_928.py` — 11 tests (RED before, GREEN after)
- `tests/ui/test_discovery_start_errors.py` — 2 tests, including a control asserting genuine errors are still 500s

Verified locally: `tests/core -k "prd or discovery"` (149 passed), `tests/ui -k "prd or discovery"` (39 passed), `tests/cli/test_prd_generate.py` (10 passed), `ruff check` clean.

## Known limitations

- `_normalize_validation` coerces a non-string `reason`/`follow_up` with `str()`, so a nested object would surface as its repr in user-facing feedback. Non-crashing, and no worse than the previous behavior for the shapes that did parse.
- Sessions already stuck in the DB from before this fix are not migrated — a stale `current_question=NULL` row still blocks `/start` until reset via `POST /api/v2/discovery/reset`.
