### PR TITLE
fix(chat,react): replay recent history and revive tier-2 compaction (#929)

### DIFF
--- a/codeframe/core/adapters/streaming_chat.py
+++ b/codeframe/core/adapters/streaming_chat.py
@@ -44,6 +44,10 @@ _MAX_HISTORY_TOKENS = 180_000
 # Maps the persisted (display-oriented) message roles onto the two roles the
 # Anthropic Messages API accepts. Roles absent from this map (e.g. "system",
 # "error") are UI-only and dropped from the replay list. See _load_history.
+# How many of the most recent persisted messages to replay. _truncate_history
+# trims further by token budget; this only bounds the query.
+_MAX_REPLAY_MESSAGES = 100
+
 _REPLAY_ROLE_MAP = {
     "user": "user",
     "assistant": "assistant",
@@ -277,7 +281,10 @@ class StreamingChatAdapter:
             List of ``{"role": "user"|"assistant", "content": str}`` dicts in
             chronological order.
         """
-        rows = self._db_repo.get_messages(self._session_id)
+        # The NEWEST window, not the oldest: get_messages() orders ascending and
+        # defaults to LIMIT 100, so past 100 messages this replayed the opening
+        # of the conversation every turn and never the current one (#929).
+        rows = self._db_repo.get_recent_messages(self._session_id, limit=_MAX_REPLAY_MESSAGES)
         history: list[dict] = []
         for r in rows:
             role = _REPLAY_ROLE_MAP.get(r["role"])

--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -52,6 +52,25 @@ DEFAULT_COMPACTION_THRESHOLD = 0.85
 PRESERVE_RECENT_PAIRS = 5
 DEFAULT_CONTEXT_WINDOW = 200_000  # All Claude 4.x models
 
+
+def _assistant_user_pairs(messages: list[dict], cutoff: int):
+    """Yield the index of each (assistant, user) turn pair below ``cutoff``.
+
+    Position-based, not parity-based: a leading user message (as ``_react_loop``
+    seeds) or any stray system row shifts every later turn by one, and an
+    even/odd assumption then misses every pair (#929).
+    """
+    i = 0
+    while i < cutoff - 1:
+        if (
+            messages[i].get("role") == "assistant"
+            and messages[i + 1].get("role") == "user"
+        ):
+            yield i
+            i += 2
+        else:
+            i += 1
+
 # Reason string emitted when a stall timeout triggers a blocker — used to
 # set the correct BlockerOrigin ("system") vs agent-generated blockers.
 _REASON_STALL_DETECTED = "stall_detected"
@@ -1576,15 +1595,14 @@ class ReactAgent:
         cutoff = len(messages) - preserve_count
         indices_to_remove: set[int] = set()
 
-        # Build a map of file reads and edits in the compactable zone
-        # Process pairs: assistant at even index, user at odd index
-        for i in range(0, cutoff - 1, 2):
+        # Pair (assistant, user) turns wherever they occur in the compactable
+        # zone. This used to walk range(0, cutoff-1, 2) and assume assistants sat
+        # at even indices — but _react_loop seeds a *user* message at index 0, so
+        # in production the role check rejected every pair and tier 2 removed
+        # nothing, dropping every long run straight to lossy tier 3 (#929).
+        for i in _assistant_user_pairs(messages, cutoff):
             assistant = messages[i]
             user = messages[i + 1]
-
-            # Validate expected role pairing before processing
-            if assistant.get("role") != "assistant" or user.get("role") != "user":
-                continue
 
             tool_calls = assistant.get("tool_calls", [])
             if not tool_calls:
@@ -1599,8 +1617,10 @@ class ReactAgent:
                 # Look for a later read of the same file without an edit in between
                 has_edit_between = False
                 has_later_read = False
-                for j in range(i + 2, len(messages) - 1, 2):
+                for j in range(i + 2, len(messages)):
                     later_assistant = messages[j]
+                    if later_assistant.get("role") != "assistant":
+                        continue
                     later_tcs = later_assistant.get("tool_calls", [])
                     if not later_tcs:
                         continue

--- a/codeframe/platform_store/repositories/interactive_sessions.py
+++ b/codeframe/platform_store/repositories/interactive_sessions.py
@@ -152,6 +152,11 @@ class InteractiveSessionRepository(BaseRepository):
     def get_messages(
         self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict]:
+        """Page through a session's messages oldest-first.
+
+        For chat replay use :meth:`get_recent_messages` — this one's ascending
+        order plus a default limit means it returns the *oldest* window (#929).
+        """
         rows = self._fetchall(
             """
             SELECT * FROM session_messages
@@ -161,13 +166,31 @@ class InteractiveSessionRepository(BaseRepository):
             """,
             (session_id, limit, offset),
         )
-        result = []
-        for row in rows:
-            d = self._row_to_dict(row)
-            if d.get("metadata"):
-                try:
-                    d["metadata"] = json.loads(d["metadata"])
-                except (json.JSONDecodeError, TypeError):
-                    d["metadata"] = None
-            result.append(d)
-        return result
+        return [self._message_row_to_dict(row) for row in rows]
+
+    def get_recent_messages(self, session_id: str, limit: int = 100) -> list[dict]:
+        """Return the NEWEST ``limit`` messages, in chronological order.
+
+        Chat replay needs the tail of the conversation, not its head. Selecting
+        with the ascending `get_messages` default fed the model the first 100
+        rows forever once a session passed 100 messages (#929).
+        """
+        rows = self._fetchall(
+            """
+            SELECT * FROM session_messages
+            WHERE session_id = ?
+            ORDER BY created_at DESC, rowid DESC
+            LIMIT ?
+            """,
+            (session_id, limit),
+        )
+        return [self._message_row_to_dict(row) for row in reversed(rows)]
+
+    def _message_row_to_dict(self, row) -> dict:
+        d = self._row_to_dict(row)
+        if d.get("metadata"):
+            try:
+                d["metadata"] = json.loads(d["metadata"])
+            except (json.JSONDecodeError, TypeError):
+                d["metadata"] = None
+        return d

--- a/tests/core/test_react_agent_compaction.py
+++ b/tests/core/test_react_agent_compaction.py
@@ -441,151 +441,15 @@ class TestTier1CompactToolResults:
 # ---------------------------------------------------------------------------
 
 
-class TestTier2RemoveIntermediateSteps:
-    """Tests for _remove_intermediate_steps (Tier 2)."""
-
-    def test_removes_redundant_file_reads(self, workspace, provider):
-        """If same file is read twice, earlier read should be removed."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        messages = []
-        # First read of main.py (old, should be removed)
-        a, u = _make_pair(
-            tool_name="read_file",
-            tool_input={"path": "main.py"},
-            tool_result_content="old contents",
-            tc_id="tc-old-read",
-        )
-        messages.extend([a, u])
-        # Second read of main.py (newer, should be kept)
-        a, u = _make_pair(
-            tool_name="read_file",
-            tool_input={"path": "main.py"},
-            tool_result_content="new contents",
-            tc_id="tc-new-read",
-        )
-        messages.extend([a, u])
-        # Add recent pairs to push old reads outside preserve zone
-        for i in range(PRESERVE_RECENT_PAIRS):
-            a, u = _make_pair(tool_result_content=f"c{i}", tc_id=f"tc{i}")
-            messages.extend([a, u])
-
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        # First read pair should be removed
-        assert saved > 0
-        assert len(result) < len(messages)
-        # The remaining read_file for main.py should have "new contents"
-        remaining_reads = [
-            m for m in result
-            if m.get("tool_results") and any(
-                "new contents" in tr["content"] for tr in m["tool_results"]
-            )
-        ]
-        assert len(remaining_reads) >= 1
-
-    def test_keeps_reads_with_intervening_edit(self, workspace, provider):
-        """If a file was edited between reads, both reads should be kept."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        messages = []
-        # Read main.py
-        a, u = _make_pair(
-            tool_name="read_file",
-            tool_input={"path": "main.py"},
-            tool_result_content="before edit",
-            tc_id="tc-read1",
-        )
-        messages.extend([a, u])
-        # Edit main.py (intervening write)
-        a, u = _make_pair(
-            tool_name="edit_file",
-            tool_input={"path": "main.py", "edits": []},
-            tool_result_content="edit applied",
-            tc_id="tc-edit",
-        )
-        messages.extend([a, u])
-        # Read main.py again
-        a, u = _make_pair(
-            tool_name="read_file",
-            tool_input={"path": "main.py"},
-            tool_result_content="after edit",
-            tc_id="tc-read2",
-        )
-        messages.extend([a, u])
-        for i in range(PRESERVE_RECENT_PAIRS):
-            a, u = _make_pair(tool_result_content=f"c{i}", tc_id=f"tc{i}")
-            messages.extend([a, u])
-
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        # First read should NOT be removed because there was an edit in between
-        assert saved == 0
-
-    def test_removes_passed_test_results(self, workspace, provider):
-        """Test outputs showing 'passed' should be removed when outside preserve zone."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        messages = []
-        # Passed test result
-        a, u = _make_pair(
-            tool_name="run_tests",
-            tool_input={"test_path": "tests/"},
-            tool_result_content="5 passed in 0.3s",
-            tc_id="tc-test",
-        )
-        messages.extend([a, u])
-        for i in range(PRESERVE_RECENT_PAIRS):
-            a, u = _make_pair(tool_result_content=f"c{i}", tc_id=f"tc{i}")
-            messages.extend([a, u])
-
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        assert saved > 0
-        assert len(result) < len(messages)
-
-    def test_preserves_recent_pairs(self, workspace, provider):
-        """Last PRESERVE_RECENT_PAIRS*2 messages should not be removed."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        messages = []
-        for i in range(PRESERVE_RECENT_PAIRS):
-            a, u = _make_pair(
-                tool_name="read_file",
-                tool_input={"path": "same.py"},
-                tool_result_content=f"content_{i}",
-                tc_id=f"tc{i}",
-            )
-            messages.extend([a, u])
-
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        # All within preserve zone — nothing removed
-        assert saved == 0
-        assert len(result) == len(messages)
-
-    def test_keeps_test_results_with_failures(self, workspace, provider):
-        """Test output containing both 'passed' and 'failed' should NOT be removed."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        messages = []
-        # Mixed test result (has failures — should be kept)
-        a, u = _make_pair(
-            tool_name="run_tests",
-            tool_input={"test_path": "tests/"},
-            tool_result_content="5 passed, 3 failed in 2.1s",
-            tc_id="tc-mixed",
-        )
-        messages.extend([a, u])
-        for i in range(PRESERVE_RECENT_PAIRS):
-            a, u = _make_pair(tool_result_content=f"c{i}", tc_id=f"tc{i}")
-            messages.extend([a, u])
-
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        # Should NOT be removed because it contains failure info
-        assert saved == 0
-        assert len(result) == len(messages)
+# Tier-2 tests live in test_react_agent_tier2_shape_929.py.
+#
+# The versions that used to be here built [assistant, user, assistant, ...] —
+# assistants at even indices. _react_loop seeds a *user* message at index 0, so
+# that shape never occurs in production; the tests passed against a branch the
+# real agent could not reach and hid the fact that tier 2 removed nothing (#929).
+# They were replaced (not merely reshaped) with assertions on the loop's actual
+# message shape, which also check *which* messages survive rather than only that
+# the list shrank.
 
 
 # ---------------------------------------------------------------------------
@@ -814,32 +678,10 @@ class TestCompactConversation:
         assert [id(m) for m in messages] == original_ids
 
 
-# ---------------------------------------------------------------------------
-# Tests: Tier 2 role validation
-# ---------------------------------------------------------------------------
-
-
-class TestTier2RoleValidation:
-    """Tests for tier 2 role-checking in message pairing."""
-
-    def test_skips_non_standard_role_pairs(self, workspace, provider):
-        """Tier 2 should skip message pairs that don't follow assistant/user pattern."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        # Create messages with a system message breaking the pair pattern
-        messages = [
-            {"role": "system", "content": "system prompt"},
-            {"role": "user", "content": "hello"},
-        ]
-        # Add enough normal pairs for the preserve zone
-        for i in range(PRESERVE_RECENT_PAIRS + 1):
-            a, u = _make_pair(tool_result_content=f"c{i}", tc_id=f"tc{i}")
-            messages.extend([a, u])
-
-        # Should not crash on non-standard pair
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        assert isinstance(result, list)
+# Tier-2 role validation now lives in test_react_agent_tier2_shape_929.py
+# (test_unrelated_roles_do_not_desync_pairing), which asserts a stray system row
+# does not hide the pairs after it — the version here only asserted the result
+# was still a list, which stayed true while tier 2 silently did nothing (#929).
 
 
 # ---------------------------------------------------------------------------
@@ -994,29 +836,8 @@ class TestTier1TokenSavings:
         assert saved > 0
 
 
-class TestTier2UniqueReads:
-    """Additional Tier 2 tests."""
-
-    def test_keeps_unique_reads(self, workspace, provider):
-        """Reads of different files should all be kept."""
-        from codeframe.core.react_agent import ReactAgent, PRESERVE_RECENT_PAIRS
-
-        agent = ReactAgent(workspace=workspace, llm_provider=provider)
-        messages = []
-        # Each file is read only once
-        for i in range(PRESERVE_RECENT_PAIRS + 2):
-            a, u = _make_pair(
-                tool_name="read_file",
-                tool_input={"path": f"unique_{i}.py"},
-                tool_result_content=f"unique content {i}",
-                tc_id=f"tc{i}",
-            )
-            messages.extend([a, u])
-
-        result, saved = agent._remove_intermediate_steps(list(messages))
-        # No redundant reads — nothing should be removed
-        assert saved == 0
-        assert len(result) == len(messages)
+# test_keeps_unique_reads moved to test_react_agent_tier2_shape_929.py
+# (test_unique_reads_are_all_kept), rebuilt on the _react_loop message shape.
 
 
 class TestCompactionOrchestrationAdvanced:

--- a/tests/core/test_react_agent_tier2_shape_929.py
+++ b/tests/core/test_react_agent_tier2_shape_929.py
@@ -1,0 +1,199 @@
+"""Tier-2 compaction must work on the message list `_react_loop` actually builds (#929).
+
+`_remove_intermediate_steps` walked `range(0, cutoff - 1, 2)` and treated even
+indices as assistant turns. `_react_loop` seeds a **user** message at index 0, so
+in production assistants sit at odd indices, the role check rejected every pair,
+and tier 2 removed nothing — every long run fell straight through to lossy tier 3.
+
+The existing tier-2 tests in `test_react_agent_compaction.py` built
+`[assistant, user, ...]`, which is why the dead branch looked covered. These tests
+build the list the way the loop does.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from codeframe.adapters.llm.mock import MockProvider
+from codeframe.core.workspace import Workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    state_dir = tmp_path / ".codeframe"
+    state_dir.mkdir()
+    return Workspace(
+        id="ws-test",
+        repo_path=tmp_path,
+        state_dir=state_dir,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        tech_stack="Python with uv",
+    )
+
+
+@pytest.fixture
+def agent(workspace):
+    from codeframe.core.react_agent import ReactAgent
+
+    return ReactAgent(workspace=workspace, llm_provider=MockProvider())
+
+
+def _seed() -> list[dict]:
+    """The leading user message `_react_loop` always starts with."""
+    return [{"role": "user", "content": "Implement the task described in the system prompt."}]
+
+
+def _pair(tool_name="read_file", tool_input=None, result="ok", is_error=False, tc_id="tc1"):
+    if tool_input is None:
+        tool_input = {"path": "test.py"}
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": tc_id, "name": tool_name, "input": tool_input}],
+    }
+    user = {
+        "role": "user",
+        "content": "",
+        "tool_results": [
+            {"tool_call_id": tc_id, "content": result, "is_error": is_error}
+        ],
+    }
+    return [assistant, user]
+
+
+def _filler(count: int) -> list[dict]:
+    out: list[dict] = []
+    for i in range(count):
+        out += _pair(tool_input={"path": f"filler_{i}.py"}, result=f"c{i}", tc_id=f"f{i}")
+    return out
+
+
+class TestTier2OnReactLoopShape:
+    def test_redundant_read_is_removed(self, agent):
+        """Two reads of the same file with no edit between → the older pair goes."""
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = (
+            _seed()
+            + _pair(tool_input={"path": "main.py"}, result="old", tc_id="r1")
+            + _pair(tool_input={"path": "main.py"}, result="new", tc_id="r2")
+            + _filler(PRESERVE_RECENT_PAIRS)
+        )
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved > 0, "tier 2 removed nothing on a _react_loop-shaped list"
+        assert len(result) == len(messages) - 2
+        kept = [
+            tr["content"]
+            for m in result
+            for tr in m.get("tool_results", [])
+        ]
+        assert "new" in kept and "old" not in kept
+
+    def test_passed_test_output_is_removed(self, agent):
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = (
+            _seed()
+            + _pair(
+                tool_name="run_tests",
+                tool_input={"test_path": "tests/"},
+                result="5 passed in 0.3s",
+                tc_id="t1",
+            )
+            + _filler(PRESERVE_RECENT_PAIRS)
+        )
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved > 0
+        assert len(result) == len(messages) - 2
+        assert all("passed in 0.3s" not in str(m) for m in result)
+
+    def test_intervening_edit_keeps_both_reads(self, agent):
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = (
+            _seed()
+            + _pair(tool_input={"path": "main.py"}, result="before", tc_id="r1")
+            + _pair(
+                tool_name="edit_file",
+                tool_input={"path": "main.py", "edits": []},
+                result="edited",
+                tc_id="e1",
+            )
+            + _pair(tool_input={"path": "main.py"}, result="after", tc_id="r2")
+            + _filler(PRESERVE_RECENT_PAIRS)
+        )
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved == 0
+        assert len(result) == len(messages)
+
+    def test_failing_test_output_is_kept(self, agent):
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = (
+            _seed()
+            + _pair(
+                tool_name="run_tests",
+                tool_input={"test_path": "tests/"},
+                result="5 passed, 3 failed in 2.1s",
+                tc_id="t1",
+            )
+            + _filler(PRESERVE_RECENT_PAIRS)
+        )
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved == 0
+        assert len(result) == len(messages)
+
+    def test_unique_reads_are_all_kept(self, agent):
+        """Reads of different files are not redundant."""
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = _seed()
+        for i in range(PRESERVE_RECENT_PAIRS + 2):
+            messages += _pair(
+                tool_input={"path": f"unique_{i}.py"}, result=f"u{i}", tc_id=f"u{i}"
+            )
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved == 0
+        assert len(result) == len(messages)
+
+    def test_recent_pairs_are_preserved(self, agent):
+        """A redundant read inside the preserve zone must survive."""
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = _seed()
+        for i in range(PRESERVE_RECENT_PAIRS):
+            messages += _pair(tool_input={"path": "same.py"}, result=f"c{i}", tc_id=f"s{i}")
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved == 0
+        assert len(result) == len(messages)
+
+    def test_unrelated_roles_do_not_desync_pairing(self, agent):
+        """A stray system message must not hide the pairs that follow it."""
+        from codeframe.core.react_agent import PRESERVE_RECENT_PAIRS
+
+        messages = (
+            [{"role": "system", "content": "system prompt"}]
+            + _seed()
+            + _pair(tool_input={"path": "main.py"}, result="old", tc_id="r1")
+            + _pair(tool_input={"path": "main.py"}, result="new", tc_id="r2")
+            + _filler(PRESERVE_RECENT_PAIRS)
+        )
+
+        result, saved = agent._remove_intermediate_steps(list(messages))
+
+        assert saved > 0, "pairing desynced after an odd number of leading messages"
+        assert len(result) == len(messages) - 2

--- a/tests/core/test_streaming_chat.py
+++ b/tests/core/test_streaming_chat.py
@@ -31,6 +31,8 @@ def _make_db_repo(messages: list[dict] | None = None):
     """Create a mock DB repo with pre-loaded messages."""
     repo = MagicMock()
     repo.get_messages.return_value = messages or []
+    # _load_history reads the newest window, not the oldest page (#929).
+    repo.get_recent_messages.return_value = messages or []
     repo.add_message.return_value = {"id": str(uuid.uuid4())}
     return repo
 

--- a/tests/core/test_streaming_chat_history_929.py
+++ b/tests/core/test_streaming_chat_history_929.py
@@ -1,0 +1,107 @@
+"""Chat replay must load the NEWEST messages, not the oldest (#929).
+
+`_load_history` called `get_messages(session_id)` with no limit; the repository
+default is `ORDER BY created_at LIMIT 100`. Past 100 persisted messages every
+turn replayed the *first* 100 — ancient context — and the model never saw the
+conversation the user was actually having.
+"""
+
+import pytest
+
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def repo():
+    db = Database(":memory:")
+    db.initialize()
+    return db.interactive_sessions
+
+
+def _seed(repo, count: int) -> str:
+    session = repo.create(workspace_path="/tmp/ws-history")
+    for i in range(count):
+        repo.add_message(
+            session["id"],
+            role="user" if i % 2 == 0 else "assistant",
+            content=f"msg {i:04d}",
+        )
+    return session["id"]
+
+
+class TestGetRecentMessages:
+    def test_returns_the_newest_window_in_chronological_order(self, repo):
+        session_id = _seed(repo, 150)
+
+        rows = repo.get_recent_messages(session_id, limit=100)
+
+        assert len(rows) == 100
+        assert rows[0]["content"] == "msg 0050"
+        assert rows[-1]["content"] == "msg 0149"
+
+    def test_returns_everything_when_under_the_limit(self, repo):
+        session_id = _seed(repo, 5)
+
+        rows = repo.get_recent_messages(session_id, limit=100)
+
+        assert [r["content"] for r in rows] == [f"msg {i:04d}" for i in range(5)]
+
+    def test_metadata_is_decoded_like_get_messages(self, repo):
+        session = repo.create(workspace_path="/tmp/ws-meta")
+        repo.add_message(
+            session["id"], role="assistant", content="hi", metadata={"model": "m1"}
+        )
+
+        rows = repo.get_recent_messages(session["id"], limit=10)
+
+        assert rows[0]["metadata"] == {"model": "m1"}
+
+    def test_get_messages_still_pages_oldest_first(self, repo):
+        """The REST transcript endpoint pages on ascending order — unchanged."""
+        session_id = _seed(repo, 5)
+
+        page1 = repo.get_messages(session_id, limit=3, offset=0)
+        page2 = repo.get_messages(session_id, limit=3, offset=3)
+
+        assert [r["content"] for r in page1] == ["msg 0000", "msg 0001", "msg 0002"]
+        assert [r["content"] for r in page2] == ["msg 0003", "msg 0004"]
+
+
+class TestLoadHistoryUsesRecentMessages:
+    def test_latest_turn_is_present_past_the_limit(self, repo):
+        """With >100 persisted messages the current turn must survive replay."""
+        from codeframe.core.adapters.streaming_chat import StreamingChatAdapter
+
+        session_id = _seed(repo, 150)
+
+        adapter = StreamingChatAdapter.__new__(StreamingChatAdapter)
+        adapter._session_id = session_id
+        adapter._db_repo = repo
+
+        history = adapter._load_history()
+
+        contents = [m["content"] for m in history]
+        assert "msg 0149" in contents, "replay dropped the most recent message"
+        assert "msg 0000" not in contents, "replay is still anchored to the oldest rows"
+        assert contents == sorted(contents), "history must stay chronological"
+
+    def test_display_only_roles_are_still_dropped(self, repo):
+        """The #765 role collapsing must survive the query change."""
+        from codeframe.core.adapters.streaming_chat import StreamingChatAdapter
+
+        session = repo.create(workspace_path="/tmp/ws-roles")
+        repo.add_message(session["id"], role="user", content="q")
+        repo.add_message(session["id"], role="thinking", content="hmm")
+        repo.add_message(session["id"], role="error", content="boom")
+        repo.add_message(session["id"], role="tool_result", content="out")
+
+        adapter = StreamingChatAdapter.__new__(StreamingChatAdapter)
+        adapter._session_id = session["id"]
+        adapter._db_repo = repo
+
+        history = adapter._load_history()
+
+        assert [m["role"] for m in history] == ["user", "assistant", "user"]
+        assert all(m["content"] != "boom" for m in history)


### PR DESCRIPTION
Closes #929.

## 1. Chat replay loaded the OLDEST 100 messages

`_load_history` called `get_messages(session_id)` with no limit. The repository default is `ORDER BY created_at LIMIT 100` — ascending. Past 100 persisted messages, every turn replayed the *opening* of the conversation and the model never saw what the user was currently talking about.

Added `InteractiveSessionRepository.get_recent_messages()` (`ORDER BY created_at DESC LIMIT ?`, then reversed back to chronological) and pointed `_load_history` at it with an explicit `_MAX_REPLAY_MESSAGES = 100`.

`get_messages` is deliberately **unchanged** — `interactive_sessions_v2.py:277` pages the transcript UI on it with an offset and needs ascending order. A test pins that.

## 2. Tier-2 compaction was a production no-op

`_remove_intermediate_steps` walked `range(0, cutoff - 1, 2)`, treating even indices as assistant turns and odd as user. But `_react_loop` seeds a **user** message at index 0 (`react_agent.py:439`), so in production assistants sit at *odd* indices. The role guard at the top of the loop therefore rejected every pair and `continue`d — tier 2 never removed anything, and every long run fell straight through to lossy tier 3 summarization.

Pairing is now positional (`_assistant_user_pairs`): walk forward, take `(assistant, user)` wherever adjacent, skip one on a mismatch. The inner "was this file read again later" scan had the same even-stride bug and now iterates every following assistant message.

## 3. The tier-2 tests built a shape production never produces

Every test in `TestTier2RemoveIntermediateSteps` (plus `TestTier2RoleValidation` and `TestTier2UniqueReads`) constructed `[assistant, user, assistant, ...]` — assistants at even indices. That is why a dead branch looked fully covered.

Those were **replaced**, not reshaped, by `tests/core/test_react_agent_tier2_shape_929.py`, which builds the list the way `_react_loop` does and asserts *which* messages survive rather than only that the list shrank. Breadcrumb comments were left at both old locations pointing at the new file. Mapping:

| Removed | Replacement |
|---|---|
| `test_removes_redundant_file_reads` | `test_redundant_read_is_removed` (also asserts the *newer* read is what's kept) |
| `test_keeps_reads_with_intervening_edit` | `test_intervening_edit_keeps_both_reads` |
| `test_removes_passed_test_results` | `test_passed_test_output_is_removed` (also asserts the content is gone) |
| `test_preserves_recent_pairs` | `test_recent_pairs_are_preserved` |
| `test_keeps_test_results_with_failures` | `test_failing_test_output_is_kept` |
| `test_keeps_unique_reads` | `test_unique_reads_are_all_kept` |
| `test_skips_non_standard_role_pairs` (asserted only `isinstance(result, list)`) | `test_unrelated_roles_do_not_desync_pairing` (asserts pairs after a stray system row are still found) |

`tests/core/test_streaming_chat.py`'s `_make_db_repo` now stubs `get_recent_messages` — the collaborator changed, no assertion was touched.

## Acceptance criteria

- [x] `_load_history` retrieves the MOST RECENT messages; a test with >100 persisted messages asserts the latest turn is present (and that the oldest is gone)
- [x] Tier-2 compaction removes redundant reads / passed-test transcripts on a message list built the way `_react_loop` builds it (tests seed a leading user message)

## Tests

13 new tests across two files, verified RED before the fix. Local: `tests/core -k "react or streaming or chat or compact"` 304 passed, `tests/ -k session` 89 passed, `tests/unit/test_interactive_sessions_api.py` passed, `ruff check` clean.

Third-party review: `codex review --base main` — no findings.

## Known limitations

- `get_recent_messages` breaks `created_at` ties with `rowid DESC`. Two messages written in the same microsecond order by insertion, which is right, but this relies on the table having a rowid (it does — no `WITHOUT ROWID`).
- Tier 2 still only inspects `tool_calls[0]`, so an assistant turn with several tool calls is judged by its first. Pre-existing; not touched here.
