### PR TITLE
fix(tasks): make status updates atomic and roll back partial PATCH writes (#930)

### DIFF
--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -17,7 +17,11 @@ from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import urlparse
 
-from codeframe.core.state_machine import TaskStatus, validate_transition
+from codeframe.core.state_machine import (
+    InvalidTransitionError,
+    TaskStatus,
+    validate_transition,
+)
 from codeframe.core.workspace import Workspace, get_db_connection
 from codeframe.core.prd import PrdRecord
 
@@ -467,14 +471,30 @@ def update_status(
     conn = get_db_connection(workspace)
     try:
         cursor = conn.cursor()
+        # Compare-and-set on the status we just validated against (#930). Without
+        # `AND status = ?` two writers could each validate against stale state and
+        # both commit — landing a transition the state machine rejects, and firing
+        # the GitHub auto-close twice for one DONE.
         cursor.execute(
             """
             UPDATE tasks
             SET status = ?, updated_at = ?
-            WHERE workspace_id = ? AND id = ?
+            WHERE workspace_id = ? AND id = ? AND status = ?
             """,
-            (new_status.value, now, workspace.id, task_id),
+            (new_status.value, now, workspace.id, task_id, task.status.value),
         )
+        if cursor.rowcount == 0:
+            conn.rollback()
+            observed = cursor.execute(
+                "SELECT status FROM tasks WHERE workspace_id = ? AND id = ?",
+                (workspace.id, task_id),
+            ).fetchone()
+            if observed is None:
+                raise ValueError(f"Task not found: {task_id}")
+            # Someone else moved the row between our read and this write. Surfaced
+            # as InvalidTransitionError so existing handlers (409 in the router)
+            # keep working; `.current` carries the status we actually observed.
+            raise InvalidTransitionError(TaskStatus(observed[0]), new_status)
         conn.commit()
     finally:
         conn.close()

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -278,26 +278,39 @@ def get_task(
     return TaskResponse.from_task(task)
 
 
-def _restore_task(workspace, task_id: str, snapshot, original_auto_close) -> None:
-    """Best-effort revert of the reversible writes a failed PATCH made (#930).
+def _restore_task(
+    workspace,
+    task_id: str,
+    snapshot,
+    restore_fields: bool,
+    restore_auto_close: bool,
+) -> None:
+    """Best-effort revert of the writes THIS failed PATCH actually made (#930).
 
-    Restores from the pre-PATCH snapshot rather than tracking which individual
-    writes landed — rewriting a field to the value it already holds is a no-op
-    beyond ``updated_at``. Never raises: it runs on an error path, and masking
-    the original failure would be worse than an incomplete undo.
+    Only the writes that landed are undone. Restoring unconditionally from the
+    snapshot would let a status-only PATCH that loses the compare-and-set race
+    rewrite title/description/priority it never touched — clobbering the field
+    updates of whichever concurrent request won.
+
+    Never raises: it runs on an error path, and masking the original failure
+    would be worse than an incomplete undo.
     """
-    restores = [
-        lambda: tasks.update(
-            workspace,
-            task_id,
-            title=snapshot.title,
-            description=snapshot.description,
-            priority=snapshot.priority,
-        ),
-    ]
-    if original_auto_close is not None:
+    restores = []
+    if restore_fields:
         restores.append(
-            lambda: tasks.update_auto_close(workspace, task_id, original_auto_close)
+            lambda: tasks.update(
+                workspace,
+                task_id,
+                title=snapshot.title,
+                description=snapshot.description,
+                priority=snapshot.priority,
+            )
+        )
+    if restore_auto_close:
+        restores.append(
+            lambda: tasks.update_auto_close(
+                workspace, task_id, snapshot.auto_close_github_issue
+            )
         )
 
     # Independently, so a restore that fails for the same reason the write did
@@ -384,10 +397,10 @@ def update_task(
         # order matters: everything reversible first, and the ONE irreversible
         # step — the status transition, which dispatches the GitHub issue close —
         # strictly last. A failure before it leaves nothing to undo externally,
-        # and `_snapshot` restores the DB values this request had already written
-        # (#930). Previously the status change committed before the field update,
-        # so a failure there returned 500 with the task already DONE and the issue
-        # possibly closed, and the retry 400'd on DONE -> DONE.
+        # and `_restore_task` reverts the DB values this request had already
+        # written (#930). Previously the status change committed before the field
+        # update, so a failure there returned 500 with the task already DONE and
+        # the issue possibly closed, and the retry 400'd on DONE -> DONE.
         snapshot = current if current is not None else tasks.get(workspace, task_id)
         if snapshot is None:
             raise HTTPException(
@@ -401,7 +414,10 @@ def update_task(
             if body.auto_close_github_issue is not None
             else None
         )
-        wrote_anything = False
+        # Tracked per write, not as one flag: rolling back a field this request
+        # never touched would clobber whatever concurrent request did touch it.
+        wrote_auto_close = False
+        wrote_fields = False
 
         try:
             # The auto-close preference must land before the transition so a
@@ -410,7 +426,7 @@ def update_task(
             # the freshly-saved flag. (#565)
             if body.auto_close_github_issue is not None:
                 tasks.update_auto_close(workspace, task_id, body.auto_close_github_issue)
-                wrote_anything = True
+                wrote_auto_close = True
 
             if any(v is not None for v in (body.title, body.description, body.priority)):
                 tasks.update(
@@ -420,7 +436,7 @@ def update_task(
                     description=body.description,
                     priority=body.priority,
                 )
-                wrote_anything = True
+                wrote_fields = True
 
             # Late opt-in: enabling the flag (false -> true) on a task that is
             # ALREADY DONE — with no status transition in this request — won't
@@ -439,7 +455,9 @@ def update_task(
         except InvalidTransitionError:
             # Pre-validation passed, so the task moved between the check and the
             # apply. Undo this request's writes so it leaves no side effect.
-            _restore_task(workspace, task_id, snapshot, original_auto_close)
+            _restore_task(
+                workspace, task_id, snapshot, wrote_fields, wrote_auto_close
+            )
             raise HTTPException(
                 status_code=409,
                 detail=api_error(
@@ -450,8 +468,9 @@ def update_task(
         except HTTPException:
             raise
         except Exception:
-            if wrote_anything:
-                _restore_task(workspace, task_id, snapshot, original_auto_close)
+            _restore_task(
+                workspace, task_id, snapshot, wrote_fields, wrote_auto_close
+            )
             raise
 
         # Re-read so the response reflects every change above.

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -278,6 +278,41 @@ def get_task(
     return TaskResponse.from_task(task)
 
 
+def _restore_task(workspace, task_id: str, snapshot, original_auto_close) -> None:
+    """Best-effort revert of the reversible writes a failed PATCH made (#930).
+
+    Restores from the pre-PATCH snapshot rather than tracking which individual
+    writes landed — rewriting a field to the value it already holds is a no-op
+    beyond ``updated_at``. Never raises: it runs on an error path, and masking
+    the original failure would be worse than an incomplete undo.
+    """
+    restores = [
+        lambda: tasks.update(
+            workspace,
+            task_id,
+            title=snapshot.title,
+            description=snapshot.description,
+            priority=snapshot.priority,
+        ),
+    ]
+    if original_auto_close is not None:
+        restores.append(
+            lambda: tasks.update_auto_close(workspace, task_id, original_auto_close)
+        )
+
+    # Independently, so a restore that fails for the same reason the write did
+    # (a broken tasks.update, say) does not skip the others.
+    for restore in restores:
+        try:
+            restore()
+        except Exception:  # noqa: BLE001 - see docstring
+            logger.error(
+                "Failed to roll back PATCH for task %s; state may be partial",
+                task_id,
+                exc_info=True,
+            )
+
+
 @router.patch("/{task_id}", response_model=TaskResponse)
 @rate_limit_standard()
 def update_task(
@@ -345,58 +380,82 @@ def update_task(
                     ),
                 )
 
-        # Persist the auto-close preference FIRST so the DONE transition below
-        # sees the value requested in THIS PATCH. That makes a combined request
-        # behave correctly both ways: {status: DONE, opt-in} closes the issue and
-        # {status: DONE, opt-OUT} does not — core reads the freshly-saved flag.
+        # These writes are separate commits across separate core calls, so the
+        # order matters: everything reversible first, and the ONE irreversible
+        # step — the status transition, which dispatches the GitHub issue close —
+        # strictly last. A failure before it leaves nothing to undo externally,
+        # and `_snapshot` restores the DB values this request had already written
+        # (#930). Previously the status change committed before the field update,
+        # so a failure there returned 500 with the task already DONE and the issue
+        # possibly closed, and the retry 400'd on DONE -> DONE.
+        snapshot = current if current is not None else tasks.get(workspace, task_id)
+        if snapshot is None:
+            raise HTTPException(
+                status_code=404,
+                detail=api_error(
+                    "Task not found", ErrorCodes.NOT_FOUND, f"No task with id {task_id}"
+                ),
+            )
         original_auto_close = (
-            current.auto_close_github_issue
-            if (current is not None and body.auto_close_github_issue is not None)
+            snapshot.auto_close_github_issue
+            if body.auto_close_github_issue is not None
             else None
         )
-        if body.auto_close_github_issue is not None:
-            tasks.update_auto_close(
-                workspace, task_id, body.auto_close_github_issue
-            )
+        wrote_anything = False
 
-        # Apply the (pre-validated) status transition. Core closes the linked
-        # issue here when the task is opted in and transitions to DONE.
-        if new_status is not None:
-            try:
-                tasks.update_status(workspace, task_id, new_status)
-            except InvalidTransitionError:
-                # Pre-validation passed, so the task state changed concurrently
-                # between the check and the apply. Roll back the flag we just
-                # persisted so this failed request leaves no side effect.
-                if original_auto_close is not None:
-                    tasks.update_auto_close(workspace, task_id, original_auto_close)
-                raise HTTPException(
-                    status_code=409,
-                    detail=api_error(
-                        "Task state changed concurrently; please retry.",
-                        ErrorCodes.CONFLICT,
-                    ),
+        try:
+            # The auto-close preference must land before the transition so a
+            # combined request behaves correctly both ways: {status: DONE, opt-in}
+            # closes the issue and {status: DONE, opt-OUT} does not — core reads
+            # the freshly-saved flag. (#565)
+            if body.auto_close_github_issue is not None:
+                tasks.update_auto_close(workspace, task_id, body.auto_close_github_issue)
+                wrote_anything = True
+
+            if any(v is not None for v in (body.title, body.description, body.priority)):
+                tasks.update(
+                    workspace,
+                    task_id,
+                    title=body.title,
+                    description=body.description,
+                    priority=body.priority,
                 )
+                wrote_anything = True
 
-        # Late opt-in: enabling the flag (false -> true) on a task that is ALREADY
-        # DONE — with no status transition in this request — won't trigger core's
-        # transition-based close, so fire it explicitly here.
-        if (
-            body.auto_close_github_issue
-            and original_auto_close is False
-            and new_status is None
-        ):
-            tasks.autoclose_if_done(workspace, tasks.get(workspace, task_id))
+            # Late opt-in: enabling the flag (false -> true) on a task that is
+            # ALREADY DONE — with no status transition in this request — won't
+            # trigger core's transition-based close, so fire it explicitly.
+            if (
+                body.auto_close_github_issue
+                and original_auto_close is False
+                and new_status is None
+            ):
+                tasks.autoclose_if_done(workspace, tasks.get(workspace, task_id))
 
-        # Update remaining fields; re-reads current state so the returned task
-        # reflects every change (including the auto-close flag above).
-        task = tasks.update(
-            workspace,
-            task_id,
-            title=body.title,
-            description=body.description,
-            priority=body.priority,
-        )
+            # Last: applies the transition and, on DONE, closes the linked issue.
+            if new_status is not None:
+                tasks.update_status(workspace, task_id, new_status)
+
+        except InvalidTransitionError:
+            # Pre-validation passed, so the task moved between the check and the
+            # apply. Undo this request's writes so it leaves no side effect.
+            _restore_task(workspace, task_id, snapshot, original_auto_close)
+            raise HTTPException(
+                status_code=409,
+                detail=api_error(
+                    "Task state changed concurrently; please retry.",
+                    ErrorCodes.CONFLICT,
+                ),
+            )
+        except HTTPException:
+            raise
+        except Exception:
+            if wrote_anything:
+                _restore_task(workspace, task_id, snapshot, original_auto_close)
+            raise
+
+        # Re-read so the response reflects every change above.
+        task = tasks.get(workspace, task_id)
 
         return TaskResponse.from_task(task)
 

--- a/tests/core/test_tasks_atomic_status_930.py
+++ b/tests/core/test_tasks_atomic_status_930.py
@@ -1,0 +1,106 @@
+"""update_status must be a compare-and-set, not read-then-blind-write (#930).
+
+`update_status` read the task, validated the transition, then UPDATEd on
+`(workspace_id, id)` only — no guard on the status it had just validated against
+and no transaction spanning the read and the write. Two writers could each pass
+validation against stale state and both commit, and two racing DONE transitions
+each fired the GitHub auto-close.
+
+The race is exercised deterministically (a stale read is injected) rather than
+with threads: timing-based concurrency tests in this repo flake under full-suite
+load — see #976 and #1038.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from codeframe.core import tasks
+from codeframe.core.state_machine import InvalidTransitionError
+from codeframe.core.tasks import TaskStatus
+from codeframe.core.workspace import Workspace, create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    return create_or_load_workspace(tmp_path)
+
+
+@pytest.fixture
+def task(workspace: Workspace):
+    return tasks.create(
+        workspace, title="Race me", description="d", status=TaskStatus.READY
+    )
+
+
+def _db_status(workspace: Workspace, task_id: str) -> str:
+    conn = get_db_connection(workspace)
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    conn.close()
+    return row[0]
+
+
+class TestUpdateStatusIsCompareAndSet:
+    def test_stale_writer_loses_and_changes_nothing(self, workspace, task):
+        """The second of two writers that both validated against READY must fail."""
+        stale = tasks.get(workspace, task.id)  # snapshot at READY
+
+        tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)  # writer A wins
+        assert _db_status(workspace, task.id) == TaskStatus.IN_PROGRESS.value
+
+        # Writer B validated against the same stale READY snapshot.
+        with patch.object(tasks, "get", return_value=stale):
+            with pytest.raises(InvalidTransitionError):
+                tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)
+
+        assert _db_status(workspace, task.id) == TaskStatus.IN_PROGRESS.value
+
+    def test_loser_does_not_rewrite_updated_at(self, workspace, task):
+        stale = tasks.get(workspace, task.id)
+        tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)
+        before = tasks.get(workspace, task.id).updated_at
+
+        with patch.object(tasks, "get", return_value=stale):
+            with pytest.raises(InvalidTransitionError):
+                tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)
+
+        assert tasks.get(workspace, task.id).updated_at == before
+
+    def test_normal_transition_still_works(self, workspace, task):
+        tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)
+        result = tasks.update_status(workspace, task.id, TaskStatus.DONE)
+
+        assert result.status == TaskStatus.DONE
+        assert _db_status(workspace, task.id) == TaskStatus.DONE.value
+
+    def test_missing_task_still_raises_value_error(self, workspace):
+        with pytest.raises(ValueError, match="not found"):
+            tasks.update_status(workspace, "no-such-task", TaskStatus.DONE)
+
+
+class TestGithubAutocloseFiresOnce:
+    def test_racing_done_transitions_close_the_issue_once(self, workspace, task):
+        tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)
+        stale = tasks.get(workspace, task.id)  # snapshot at IN_PROGRESS
+
+        with patch.object(tasks, "_dispatch_github_autoclose") as dispatch:
+            tasks.update_status(workspace, task.id, TaskStatus.DONE)  # writer A
+
+            with patch.object(tasks, "get", return_value=stale):
+                with pytest.raises(InvalidTransitionError):
+                    tasks.update_status(workspace, task.id, TaskStatus.DONE)  # writer B
+
+        assert dispatch.call_count == 1, (
+            "the losing DONE transition still fired the GitHub auto-close"
+        )
+
+    def test_autoclose_still_fires_on_a_normal_done(self, workspace, task):
+        tasks.update_status(workspace, task.id, TaskStatus.IN_PROGRESS)
+
+        with patch.object(tasks, "_dispatch_github_autoclose") as dispatch:
+            tasks.update_status(workspace, task.id, TaskStatus.DONE)
+
+        assert dispatch.call_count == 1

--- a/tests/ui/test_tasks_patch_rollback_930.py
+++ b/tests/ui/test_tasks_patch_rollback_930.py
@@ -21,7 +21,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from codeframe.core import tasks
-from codeframe.core.state_machine import TaskStatus
+from codeframe.core.state_machine import InvalidTransitionError, TaskStatus
 from codeframe.core.workspace import create_or_load_workspace
 
 pytestmark = pytest.mark.v2
@@ -110,6 +110,54 @@ class TestPatchLeavesNoPartialState:
         assert after.status == TaskStatus.DONE
         assert after.title == "new title"
         assert after.priority == 9
+
+
+class TestRollbackOnlyUndoesThisRequestsWrites:
+    """The rollback must not clobber a concurrent writer's fields.
+
+    Raised by `codex review` on this PR: a status-only PATCH that loses the new
+    compare-and-set race must not rewrite title/description/priority from its
+    snapshot — it never wrote them, and the request that won may have.
+    """
+
+    def test_status_only_patch_losing_the_race_leaves_fields_alone(
+        self, client_and_task
+    ):
+        """The winner must write AFTER our snapshot, or the test proves nothing."""
+        client, ws, task_id = client_and_task
+
+        def winner_lands_then_we_lose(*_args, **_kwargs):
+            # Runs inside the request, after `current` was snapshotted — exactly
+            # the interleaving the compare-and-set surfaces as a lost update.
+            tasks.update(ws, task_id, title="winner's title", priority=1)
+            raise InvalidTransitionError(TaskStatus.DONE, TaskStatus.DONE)
+
+        with patch.object(tasks, "update_status", side_effect=winner_lands_then_we_lose):
+            response = client.patch(f"/api/v2/tasks/{task_id}", json={"status": "DONE"})
+
+        assert response.status_code == 409, response.text
+        after = tasks.get(ws, task_id)
+        assert after.title == "winner's title", "rollback clobbered a field it never wrote"
+        assert after.priority == 1
+
+    def test_status_only_patch_losing_the_race_leaves_auto_close_alone(
+        self, client_and_task
+    ):
+        """Guard, not a reproduction: the flagged version skipped the auto-close
+        restore for a status-only PATCH anyway (`original_auto_close` was None).
+        This pins the behavior now that the skip is driven by `wrote_auto_close`.
+        """
+        client, ws, task_id = client_and_task
+
+        def winner_lands_then_we_lose(*_args, **_kwargs):
+            tasks.update_auto_close(ws, task_id, True)
+            raise InvalidTransitionError(TaskStatus.DONE, TaskStatus.DONE)
+
+        with patch.object(tasks, "update_status", side_effect=winner_lands_then_we_lose):
+            response = client.patch(f"/api/v2/tasks/{task_id}", json={"status": "DONE"})
+
+        assert response.status_code == 409
+        assert tasks.get(ws, task_id).auto_close_github_issue is True
 
 
 class TestPatchHappyPathUnchanged:

--- a/tests/ui/test_tasks_patch_rollback_930.py
+++ b/tests/ui/test_tasks_patch_rollback_930.py
@@ -1,0 +1,164 @@
+"""PATCH /api/v2/tasks/{id} must not leave partial state on failure (#930).
+
+The handler performed up to four independent commits — auto-close flag, status
+transition (which fires the GitHub issue close), then the title/description/
+priority update. A failure at the final update returned 500 with the status
+change already committed and the issue possibly closed; the retry then 400'd on
+DONE -> DONE.
+
+The writes are now ordered so the irreversible one (the status transition, which
+dispatches the GitHub close) happens last, and any failure restores the
+reversible values captured before the first write.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core import tasks
+from codeframe.core.state_machine import TaskStatus
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def client_and_task():
+    tmp = Path(tempfile.mkdtemp())
+    ws_dir = tmp / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    ws = create_or_load_workspace(ws_dir)
+    task = tasks.create(
+        ws,
+        title="original title",
+        description="original description",
+        status=TaskStatus.IN_PROGRESS,
+        priority=3,
+        github_issue_number=7,
+        external_url="https://github.com/acme/app/issues/7",
+        auto_close_github_issue=False,
+    )
+
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import tasks_v2
+
+    app = FastAPI()
+    app.include_router(tasks_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: ws
+    yield TestClient(app, raise_server_exceptions=False), ws, task.id
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestPatchLeavesNoPartialState:
+    def test_field_update_failure_rolls_back_everything(self, client_and_task):
+        """An injected failure in the field update must revert the whole PATCH."""
+        client, ws, task_id = client_and_task
+
+        with patch.object(tasks, "update", side_effect=RuntimeError("disk full")):
+            response = client.patch(
+                f"/api/v2/tasks/{task_id}",
+                json={
+                    "title": "new title",
+                    "priority": 9,
+                    "status": "DONE",
+                    "auto_close_github_issue": True,
+                },
+            )
+
+        assert response.status_code == 500
+
+        after = tasks.get(ws, task_id)
+        assert after.status == TaskStatus.IN_PROGRESS, "status change survived a failed PATCH"
+        assert after.title == "original title"
+        assert after.priority == 3
+        assert after.auto_close_github_issue is False
+
+    def test_failed_patch_does_not_close_the_github_issue(self, client_and_task):
+        """The irreversible side effect must not fire when the PATCH fails."""
+        client, ws, task_id = client_and_task
+
+        with (
+            patch.object(tasks, "update", side_effect=RuntimeError("disk full")),
+            patch.object(tasks, "_dispatch_github_autoclose") as dispatch,
+        ):
+            client.patch(
+                f"/api/v2/tasks/{task_id}",
+                json={"title": "new title", "status": "DONE",
+                      "auto_close_github_issue": True},
+            )
+
+        dispatch.assert_not_called()
+
+    def test_failed_patch_is_retryable(self, client_and_task):
+        """After the rollback the same PATCH must succeed, not 400 on DONE->DONE."""
+        client, ws, task_id = client_and_task
+        payload = {"title": "new title", "priority": 9, "status": "DONE"}
+
+        with patch.object(tasks, "update", side_effect=RuntimeError("disk full")):
+            assert client.patch(f"/api/v2/tasks/{task_id}", json=payload).status_code == 500
+
+        with patch.object(tasks, "_dispatch_github_autoclose"):
+            retry = client.patch(f"/api/v2/tasks/{task_id}", json=payload)
+
+        assert retry.status_code == 200, retry.text
+        after = tasks.get(ws, task_id)
+        assert after.status == TaskStatus.DONE
+        assert after.title == "new title"
+        assert after.priority == 9
+
+
+class TestPatchHappyPathUnchanged:
+    def test_combined_status_and_fields_apply(self, client_and_task):
+        client, ws, task_id = client_and_task
+
+        with patch.object(tasks, "_dispatch_github_autoclose") as dispatch:
+            response = client.patch(
+                f"/api/v2/tasks/{task_id}",
+                json={
+                    "title": "shipped",
+                    "description": "done and dusted",
+                    "priority": 1,
+                    "status": "DONE",
+                    "auto_close_github_issue": True,
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["title"] == "shipped"
+        assert body["description"] == "done and dusted"
+        assert body["priority"] == 1
+        assert body["status"] == "DONE"
+        assert body["auto_close_github_issue"] is True
+        dispatch.assert_called_once()
+
+        after = tasks.get(ws, task_id)
+        assert after.status == TaskStatus.DONE
+        assert after.title == "shipped"
+
+    def test_opt_out_on_done_does_not_close(self, client_and_task):
+        client, ws, task_id = client_and_task
+
+        with patch.object(tasks, "_close_issue_background") as closer:
+            response = client.patch(
+                f"/api/v2/tasks/{task_id}",
+                json={"status": "DONE", "auto_close_github_issue": False},
+            )
+
+        assert response.status_code == 200, response.text
+        closer.assert_not_called()
+
+    def test_fields_only_patch_does_not_touch_status(self, client_and_task):
+        client, ws, task_id = client_and_task
+
+        response = client.patch(f"/api/v2/tasks/{task_id}", json={"title": "renamed"})
+
+        assert response.status_code == 200, response.text
+        after = tasks.get(ws, task_id)
+        assert after.title == "renamed"
+        assert after.status == TaskStatus.IN_PROGRESS


### PR DESCRIPTION
Closes #930.

## 1. `update_status` was a read-then-blind-write

`core/tasks.py` read the task, validated the transition, then UPDATEd on `(workspace_id, id)` alone — no guard on the status it had just validated against, and no transaction spanning the read and the write. Two writers could each pass validation against stale state and both commit, landing a transition the state machine rejects. Both then reached `_dispatch_github_autoclose`, so one DONE closed the linked issue twice.

Now a compare-and-set:

```sql
UPDATE tasks SET status = ?, updated_at = ?
WHERE workspace_id = ? AND id = ? AND status = ?   -- the status we validated against
```

`rowcount == 0` means the row moved under us: rollback, re-read the status actually in the DB, and raise `InvalidTransitionError` carrying it. The router already maps that to a 409. The loser raises *before* the auto-close dispatch, so the close fires at most once per real transition.

## 2. PATCH could 500 with the status change already committed

The handler made up to four independent commits, with the status transition — the **only irreversible one**, since it closes the GitHub issue — in the middle. A failure in the final field update returned 500 with the task already DONE and the issue possibly closed, and the retry then 400'd on DONE → DONE.

Two changes:
- **Ordering**: every reversible write lands first (auto-close flag → title/description/priority), and the status transition is strictly last. A failure before it has nothing external to undo.
- **Rollback**: `_restore_task` reverts this request's writes from a pre-PATCH snapshot on any failure. Each restore is attempted independently, so one failing — plausibly for the same reason the original write did — does not skip the others.

The response is now re-read at the end rather than taken from `tasks.update`'s return value, since that call no longer runs last.

## Acceptance criteria

- [x] `update_status` uses a conditional UPDATE guarded on the observed status; a concurrency test shows exactly one of two racing transitions wins
- [x] GitHub auto-close fires at most once per DONE transition under that test
- [x] PATCH applies all field updates in one transaction **or rolls the status change back**; test asserts no partial state after an injected failure

## Demo (real threads, real SQLite)

8 threads released simultaneously on a barrier, all attempting IN_PROGRESS → DONE:

| | before (`main`) | after |
|---|---|---|
| winners | **8** | **1** |
| losers (409-mapped) | 0 | 7 |
| GitHub auto-close dispatches | **8** | **1** |

PATCH with an injected failure in the field update:

| | before (`main`) | after |
|---|---|---|
| HTTP | 500 | 500 |
| status after | **DONE** (committed) | IN_PROGRESS (unchanged) |
| auto_close flag after | **True** (committed) | False (unchanged) |
| GitHub issue closed | **yes** | no |
| retry with same payload | **400** (DONE → DONE) | 200 |

## Tests

12 new tests (6 RED before the fix, 6 happy-path controls that passed throughout). Regression sweep: **604 passed** across `tests/core` + `tests/ui` filtered on task/runtime/conductor/batch/status. `ruff check` clean.

## Known limitations

- The compare-and-set makes a *lost* update indistinguishable from a genuinely illegal transition at the type level — both are `InvalidTransitionError`. `.current` carries the observed status so a caller can tell them apart, but no caller retries today, so no separate exception type was introduced.
- `_restore_task` is best-effort and logs (never raises) on failure; masking the original error would be worse than an incomplete undo. A rollback that itself fails leaves a logged partial state.
- The GitHub issue close remains irreversible by nature. This PR makes it the last thing that happens, not something that can be undone.
