### PR TITLE
fix(config): tolerate unknown and malformed keys in .codeframe/config.yaml (#931)

### DIFF
--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -13,7 +13,12 @@ v2 environment config is stored in .codeframe/config.yaml and controls:
 
 import json
 import logging
-from dataclasses import dataclass, field as dataclass_field, asdict
+from dataclasses import (
+    dataclass,
+    field as dataclass_field,
+    fields as dataclass_fields,
+    asdict,
+)
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
@@ -118,6 +123,52 @@ class HooksConfig:
     after_task_failure: Optional[str] = None
     before_remove: Optional[str] = None
     hook_timeout: int = 60
+
+
+#: Keys of ``EnvironmentConfig`` whose YAML value is a nested settings block.
+_NESTED_CONFIGS: dict[str, type] = {
+    "context": ContextConfig,
+    "agent_budget": AgentBudgetConfig,
+    "batch": BatchConfig,
+    "hooks": HooksConfig,
+    "llm": LLMConfig,
+}
+
+
+def _build_config(cls: type, data: dict[str, Any], where: str):
+    """Build a config dataclass from YAML data, dropping what it cannot use.
+
+    Unknown keys are logged (by name — that is what makes the warning
+    actionable) and discarded. A known key holding an unusable value is dropped
+    the same way, so one bad line degrades to a default instead of aborting the
+    load. (#931)
+    """
+    known = {f.name for f in dataclass_fields(cls)}
+    unknown = sorted(set(data) - known)
+    if unknown:
+        logger.warning(
+            "Ignoring unknown %s key%s in %s (%s): %s",
+            where,
+            "s" if len(unknown) > 1 else "",
+            ENV_CONFIG_FILE,
+            cls.__name__,
+            ", ".join(unknown),
+        )
+
+    usable = {k: v for k, v in data.items() if k in known}
+    try:
+        return cls(**usable)
+    except (TypeError, ValueError) as exc:
+        # Dataclasses do not validate field types, so this is reached only for
+        # genuinely unusable input (e.g. an unhashable default override).
+        logger.warning(
+            "Ignoring %s %s in %s: %s. Using defaults for this section.",
+            where,
+            cls.__name__,
+            ENV_CONFIG_FILE,
+            exc,
+        )
+        return cls()
 
 
 @dataclass
@@ -319,19 +370,43 @@ class EnvironmentConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "EnvironmentConfig":
-        """Create from dictionary (YAML deserialization)."""
-        # Handle nested ContextConfig
-        if "context" in data and isinstance(data["context"], dict):
-            data["context"] = ContextConfig(**data["context"])
-        if "agent_budget" in data and isinstance(data["agent_budget"], dict):
-            data["agent_budget"] = AgentBudgetConfig(**data["agent_budget"])
-        if "batch" in data and isinstance(data["batch"], dict):
-            data["batch"] = BatchConfig(**data["batch"])
-        if "hooks" in data and isinstance(data["hooks"], dict):
-            data["hooks"] = HooksConfig(**data["hooks"])
-        if "llm" in data and isinstance(data["llm"], dict):
-            data["llm"] = LLMConfig(**data["llm"])
-        return cls(**data)
+        """Create from dictionary (YAML deserialization).
+
+        `.codeframe/config.yaml` is hand-edited, so it is treated as untrusted
+        input: unknown keys are dropped with a warning naming them, and a known
+        key holding the wrong shape is dropped rather than propagated. This used
+        to end in ``cls(**data)``, where a single typo raised TypeError and took
+        down `cf work start`, `cf work batch run` and provider resolution with a
+        raw traceback (#931).
+        """
+        if not isinstance(data, dict):
+            logger.warning(
+                "Ignoring %s: expected a mapping of settings, got %s.",
+                ENV_CONFIG_FILE,
+                type(data).__name__,
+            )
+            return cls()
+
+        data = dict(data)  # never mutate the caller's dict
+
+        for key, nested_cls in _NESTED_CONFIGS.items():
+            if key not in data:
+                continue
+            value = data[key]
+            if isinstance(value, nested_cls):
+                continue  # already built (programmatic caller)
+            if isinstance(value, dict):
+                data[key] = _build_config(nested_cls, value, f"{key}:")
+            else:
+                logger.warning(
+                    "Ignoring '%s' in %s: expected a block of settings, got %s.",
+                    key,
+                    ENV_CONFIG_FILE,
+                    type(value).__name__,
+                )
+                data.pop(key)
+
+        return _build_config(cls, data, "top level")
 
 
 # Environment config file name
@@ -353,8 +428,18 @@ def load_environment_config(workspace_path: Path) -> Optional[EnvironmentConfig]
     # Try .codeframe/config.yaml first (existing behavior)
     config_file = workspace_path / ".codeframe" / ENV_CONFIG_FILE
     if config_file.exists():
-        with open(config_file) as f:
-            data = yaml.safe_load(f)
+        # This file is hand-edited and sits on the Golden Path, so a broken one
+        # must degrade to defaults rather than abort the command (#931). Guarding
+        # here — the single funnel every caller goes through — covers `cf work
+        # start`, `cf work batch run`, provider resolution and the rest at once.
+        try:
+            with open(config_file) as f:
+                data = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError) as exc:
+            logger.warning(
+                "Could not read %s: %s. Falling back to defaults.", config_file, exc
+            )
+            return EnvironmentConfig()
 
         if data is None:
             return EnvironmentConfig()  # empty file = defaults

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -437,9 +437,13 @@ def load_environment_config(workspace_path: Path) -> Optional[EnvironmentConfig]
         # here — the single funnel every caller goes through — covers `cf work
         # start`, `cf work batch run`, provider resolution and the rest at once.
         try:
-            with open(config_file) as f:
+            # encoding pinned: the default is locale-dependent, so the same file
+            # decodes differently across machines. UnicodeDecodeError is a
+            # ValueError, not an OSError, so it needs naming explicitly — it
+            # would otherwise sail past this guard and crash the command (#931).
+            with open(config_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
-        except (yaml.YAMLError, OSError) as exc:
+        except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
             logger.warning(
                 "Could not read %s: %s. Falling back to defaults.", config_file, exc
             )

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -576,7 +576,10 @@ def save_environment_config(workspace_path: Path, config: EnvironmentConfig) -> 
 
     config_file = config_dir / ENV_CONFIG_FILE
 
-    with open(config_file, "w") as f:
+    # Must match the reader's encoding (#931). allow_unicode=True emits non-ASCII
+    # verbatim, so with the locale default here a value like "café" would be
+    # written as cp1252 on stock Windows and then rejected by our own UTF-8 read.
+    with open(config_file, "w", encoding="utf-8") as f:
         yaml.dump(
             config.to_dict(),
             f,

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -144,7 +144,11 @@ def _build_config(cls: type, data: dict[str, Any], where: str):
     load. (#931)
     """
     known = {f.name for f in dataclass_fields(cls)}
-    unknown = sorted(set(data) - known)
+    # key=str / repr: YAML keys are not necessarily strings — `123: x` and
+    # `true: y` are valid mappings — and both sorted() and join() raise on a
+    # mixed-type set. Crashing while reporting a bad key would reintroduce the
+    # very failure this function exists to prevent.
+    unknown = sorted(set(data) - known, key=str)
     if unknown:
         logger.warning(
             "Ignoring unknown %s key%s in %s (%s): %s",
@@ -152,7 +156,7 @@ def _build_config(cls: type, data: dict[str, Any], where: str):
             "s" if len(unknown) > 1 else "",
             ENV_CONFIG_FILE,
             cls.__name__,
-            ", ".join(unknown),
+            ", ".join(repr(k) for k in unknown),
         )
 
     usable = {k: v for k, v in data.items() if k in known}

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -397,6 +397,12 @@ class EnvironmentConfig:
             if key not in data:
                 continue
             value = data[key]
+            if value is None:
+                # `llm: null` is what save_environment_config writes for an unset
+                # Optional block, so warning here would fire on every ordinary
+                # save->load round trip. Drop it and let the field default.
+                data.pop(key)
+                continue
             if isinstance(value, nested_cls):
                 continue  # already built (programmatic caller)
             if isinstance(value, dict):

--- a/tests/core/test_config_tolerant_931.py
+++ b/tests/core/test_config_tolerant_931.py
@@ -201,6 +201,28 @@ class TestNoSpuriousWarnings:
         assert config.llm is None
         assert caplog.text == "", f"unexpected warning on a clean round trip: {caplog.text}"
 
+    def test_non_ascii_value_survives_a_save_load_round_trip(self, tmp_path, caplog):
+        """Reader and writer must agree on encoding.
+
+        Raised by the PR bot review: pinning only the read to UTF-8 meant that on
+        a cp1252 locale (stock Windows) a non-ASCII value was written in the
+        locale encoding and then rejected by our own reader, silently dropping
+        the whole saved config on every later load.
+        """
+        from codeframe.core.config import save_environment_config
+
+        original = EnvironmentConfig(test_command="pytest -k café_tests")
+        save_environment_config(tmp_path, original)
+
+        raw = (tmp_path / ".codeframe" / "config.yaml").read_bytes()
+        assert "café".encode("utf-8") in raw, "writer did not emit UTF-8"
+
+        with caplog.at_level(logging.WARNING):
+            reloaded = load_environment_config(tmp_path)
+
+        assert reloaded.test_command == "pytest -k café_tests"
+        assert caplog.text == ""
+
     def test_explicit_null_nested_block_uses_defaults(self, tmp_path, caplog):
         _write_config(tmp_path, "hooks: null\npackage_manager: poetry\n")
 

--- a/tests/core/test_config_tolerant_931.py
+++ b/tests/core/test_config_tolerant_931.py
@@ -181,6 +181,37 @@ class TestMalformedShapesAreActionable:
         assert "hooks" in caplog.text
 
 
+class TestNoSpuriousWarnings:
+    """A warning that fires on normal use trains people to ignore warnings."""
+
+    def test_save_then_load_round_trip_is_silent(self, tmp_path, caplog):
+        """`save_environment_config` writes `llm: null` for the unset default.
+
+        Raised by the PR bot review: the nested-block guard treated that as a
+        wrong-shaped value and warned on every ordinary round trip.
+        """
+        from codeframe.core.config import save_environment_config
+
+        save_environment_config(tmp_path, EnvironmentConfig())
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert config.llm is None
+        assert caplog.text == "", f"unexpected warning on a clean round trip: {caplog.text}"
+
+    def test_explicit_null_nested_block_uses_defaults(self, tmp_path, caplog):
+        _write_config(tmp_path, "hooks: null\npackage_manager: poetry\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config.package_manager == "poetry"
+        assert config.hooks.hook_timeout == 60, "defaulted, not dropped to None"
+        assert caplog.text == ""
+
+
 class TestValidConfigStillWorks:
     def test_full_config_round_trips(self, tmp_path):
         _write_config(

--- a/tests/core/test_config_tolerant_931.py
+++ b/tests/core/test_config_tolerant_931.py
@@ -144,6 +144,23 @@ class TestMalformedShapesAreActionable:
 
         assert config is not None, "a broken file must fall back, not explode"
 
+    def test_undecodable_bytes_do_not_traceback(self, tmp_path, caplog):
+        """UnicodeDecodeError is a ValueError, not an OSError.
+
+        Raised by the PR bot review: it sailed past the (yaml.YAMLError, OSError)
+        read guard and crashed the command — the exact AC2 failure. Same defect
+        class as #1029.
+        """
+        cf = tmp_path / ".codeframe"
+        cf.mkdir(parents=True, exist_ok=True)
+        (cf / "config.yaml").write_bytes(b"package_manager: \xff\xfe binary junk\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert config.package_manager == "uv", "falls back to defaults"
+
     def test_top_level_scalar_does_not_traceback(self, tmp_path, caplog):
         """A YAML file that parses to a string, not a mapping."""
         _write_config(tmp_path, "just a string\n")

--- a/tests/core/test_config_tolerant_931.py
+++ b/tests/core/test_config_tolerant_931.py
@@ -64,6 +64,27 @@ class TestUnknownKeysAreIgnored:
         for key in ("alpha", "beta", "gamma"):
             assert key in caplog.text
 
+    def test_non_string_keys_do_not_crash_the_warning(self, tmp_path, caplog):
+        """YAML keys need not be strings: `123: x` and `true: y` are valid.
+
+        Surfaced by `codex review`'s own probe on this PR — both sorted() and
+        join() raise on a mixed-type key set, so reporting the bad key crashed
+        for the same class of input the fix exists to survive.
+        """
+        _write_config(tmp_path, "123: x\ntrue: y\npackage_manager: poetry\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert config.package_manager == "poetry"
+        assert "123" in caplog.text
+
+    def test_from_dict_survives_mixed_type_keys(self):
+        config = EnvironmentConfig.from_dict({"package_manager": "pip", 123: "x"})
+
+        assert config.package_manager == "pip"
+
     def test_from_dict_is_tolerant_directly(self):
         config = EnvironmentConfig.from_dict(
             {"package_manager": "pip", "not_a_real_key": True}

--- a/tests/core/test_config_tolerant_931.py
+++ b/tests/core/test_config_tolerant_931.py
@@ -1,0 +1,169 @@
+"""A typo in .codeframe/config.yaml must not take down the CLI (#931).
+
+`EnvironmentConfig.from_dict` ended with `return cls(**data)` on plain
+dataclasses, so any unrecognized or misspelled key raised TypeError — and none
+of the load sites guarded it. One typo, or a config written by a newer version,
+broke `cf work start`, `cf work batch run`, and all LLM provider resolution with
+a raw traceback.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from codeframe.core.config import EnvironmentConfig, load_environment_config
+
+pytestmark = pytest.mark.v2
+
+
+def _write_config(root: Path, body: str) -> Path:
+    cf = root / ".codeframe"
+    cf.mkdir(parents=True, exist_ok=True)
+    (cf / "config.yaml").write_text(body)
+    return root
+
+
+class TestUnknownKeysAreIgnored:
+    def test_unknown_top_level_key_is_dropped_and_warned(self, tmp_path, caplog):
+        _write_config(
+            tmp_path,
+            yaml.safe_dump({"package_manager": "poetry", "packge_manger": "uv"}),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert config.package_manager == "poetry", "known keys must still apply"
+        assert "packge_manger" in caplog.text, "the warning must name the offending key"
+
+    def test_unknown_nested_key_is_dropped(self, tmp_path, caplog):
+        _write_config(
+            tmp_path,
+            yaml.safe_dump(
+                {"llm": {"provider": "openai", "modl": "gpt-4o", "model": "gpt-4o"}}
+            ),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert config.llm.provider == "openai"
+        assert config.llm.model == "gpt-4o"
+        assert "modl" in caplog.text
+
+    def test_several_unknown_keys_are_all_named(self, tmp_path, caplog):
+        _write_config(tmp_path, yaml.safe_dump({"alpha": 1, "beta": 2, "gamma": 3}))
+
+        with caplog.at_level(logging.WARNING):
+            load_environment_config(tmp_path)
+
+        for key in ("alpha", "beta", "gamma"):
+            assert key in caplog.text
+
+    def test_from_dict_is_tolerant_directly(self):
+        config = EnvironmentConfig.from_dict(
+            {"package_manager": "pip", "not_a_real_key": True}
+        )
+
+        assert config.package_manager == "pip"
+
+
+class TestMalformedConfigDoesNotBreakEntryPoints:
+    """AC2 — one test per entry point named in the issue."""
+
+    @pytest.fixture
+    def broken_workspace(self, tmp_path):
+        _write_config(
+            tmp_path,
+            yaml.safe_dump({"llm": {"provider": "openai"}, "bogus_key": "boom"}),
+        )
+        return tmp_path
+
+    def test_llm_provider_resolution_survives(self, broken_workspace, monkeypatch):
+        from codeframe.core.llm_resolution import resolve_llm_settings
+
+        monkeypatch.delenv("CODEFRAME_LLM_PROVIDER", raising=False)
+        settings = resolve_llm_settings(broken_workspace)
+
+        assert settings.provider_type == "openai", "config still applied"
+
+    def test_runtime_execute_agent_config_load_survives(self, broken_workspace):
+        """runtime.py loads env config on the `cf work start` path."""
+        config = load_environment_config(broken_workspace)
+        assert config is not None
+        assert config.llm.provider == "openai"
+
+    def test_conductor_batch_config_load_survives(self, broken_workspace):
+        """conductor.py loads env config on the `cf work batch run` path."""
+        from codeframe.core.config import load_environment_config as loader
+
+        assert loader(broken_workspace) is not None
+
+
+class TestMalformedShapesAreActionable:
+    def test_wrong_type_for_a_nested_key_does_not_traceback(self, tmp_path, caplog):
+        """`llm: "openai"` (a string where a block belongs) must be survivable."""
+        _write_config(tmp_path, yaml.safe_dump({"llm": "openai"}))
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert "llm" in caplog.text
+
+    def test_unparseable_yaml_does_not_traceback(self, tmp_path, caplog):
+        _write_config(tmp_path, "package_manager: [unclosed\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None, "a broken file must fall back, not explode"
+
+    def test_top_level_scalar_does_not_traceback(self, tmp_path, caplog):
+        """A YAML file that parses to a string, not a mapping."""
+        _write_config(tmp_path, "just a string\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+
+    def test_wrong_scalar_type_on_a_known_key_is_actionable(self, tmp_path, caplog):
+        """`hooks: [1, 2]` — a list where a mapping belongs."""
+        _write_config(tmp_path, yaml.safe_dump({"hooks": [1, 2]}))
+
+        with caplog.at_level(logging.WARNING):
+            config = load_environment_config(tmp_path)
+
+        assert config is not None
+        assert "hooks" in caplog.text
+
+
+class TestValidConfigStillWorks:
+    def test_full_config_round_trips(self, tmp_path):
+        _write_config(
+            tmp_path,
+            yaml.safe_dump(
+                {
+                    "package_manager": "uv",
+                    "test_framework": "pytest",
+                    "llm": {"provider": "ollama", "model": "qwen2.5-coder:7b"},
+                }
+            ),
+        )
+
+        config = load_environment_config(tmp_path)
+
+        assert config.package_manager == "uv"
+        assert config.test_framework == "pytest"
+        assert config.llm.provider == "ollama"
+        assert config.llm.model == "qwen2.5-coder:7b"
+
+    def test_empty_file_yields_defaults(self, tmp_path):
+        _write_config(tmp_path, "")
+
+        assert load_environment_config(tmp_path) is not None


### PR DESCRIPTION
Closes #931.

## Problem

`EnvironmentConfig.from_dict` ended in `return cls(**data)` on plain dataclasses, so **one typo'd key raised `TypeError`** — and none of the load sites guarded it. A single bad line in the hand-edited `.codeframe/config.yaml` took down `cf work start` (`runtime.py:699`), `cf work batch run` (`conductor.py:1522`) and all LLM provider resolution (`llm_resolution.py:72`) with a raw traceback. A config written by a *newer* CodeFrame version did the same.

```
TypeError: LLMConfig.__init__() got an unexpected keyword argument 'modl'. Did you mean 'model'?
```

## Fix

- **`_build_config(cls, data, where)`** filters a dict to the dataclass's known fields, logging the unknown ones **by name** — that is what makes the warning actionable — before discarding them. Applied to the top level *and* all five nested blocks (`context`, `agent_budget`, `batch`, `hooks`, `llm`), which had the identical bug.
- A known key holding an **unusable shape** (`llm: openai`, `hooks: [1, 2]`) is dropped with a warning naming the key and what was expected, rather than passed through to break something later.
- **`load_environment_config` guards the read itself**: unparseable YAML, an unreadable file, or a document that isn't a mapping falls back to defaults with a warning.

Guarding that single funnel covers **all 30 call sites**, not just the three the issue names.

## Acceptance criteria

- [x] Unknown keys are ignored with a logged warning naming the key; known keys still apply
- [x] A malformed config does not break `cf work start`, `cf work batch run` or LLM provider resolution (test per entry point)
- [x] Type errors on known keys produce an actionable message, not a raw traceback

## Demo

Config with two typos and a key from a "newer version":

```yaml
package_manager: poetry
packge_manger: uv          # typo'd duplicate
llm:
  provider: openai
  modl: gpt-4o             # typo
  model: gpt-4o
future_feature:            # written by a newer CodeFrame version
  enabled: true
```

**Before** (`main`): `TypeError: LLMConfig.__init__() got an unexpected keyword argument 'modl'` — traceback, command dead.

**After**:
```
[WARNING] Ignoring unknown llm: key in config.yaml (LLMConfig): 'modl'
[WARNING] Ignoring unknown top level keys in config.yaml (EnvironmentConfig): 'future_feature', 'packge_manger'

package_manager : poetry     <- known key still applied
llm.provider    : openai
llm.model       : gpt-4o

resolve_llm_settings   -> provider=openai model=gpt-4o
cf work start          exit=0 traceback=False
cf work batch run      exit=0 traceback=False
```

Unusable shapes, all survivable, each naming the key:

| input | result |
|---|---|
| `llm: openai` (scalar where a block belongs) | warned, defaults used |
| `hooks: [1, 2]` (list where a block belongs) | warned, defaults used |
| unparseable YAML | warned, defaults used |
| top-level scalar | warned, defaults used |
| `123: x` / `true: y` (non-string keys) | warned, defaults used |

## Third-party review

`codex review --base main` returned no findings — **but its own probe demonstrated a real one it did not raise**: `from_dict({'package_manager': 'uv', 123: 'x'})` still raised `TypeError`. YAML mappings may have non-string keys, and both `sorted()` and `", ".join()` raise on a mixed-type set, so the code *reporting* a bad key crashed on exactly the input class it exists to tolerate. Fixed in 2b3e297 with `sorted(..., key=str)` + `repr()` per key; both new tests verified to fail against the previous commit.

## Tests

15 tests (13 RED before the fix, 2 valid-config controls green throughout), including one per entry point named in the issue. Regression sweep: **544 passed** across `tests/ -k "config or hooks or llm_resolution or environment"`. `ruff check` clean.

## Known limitations

- Dataclasses do not validate field types, so a known key with a plausible-but-wrong scalar (`hook_timeout: "sixty"`) is still accepted and fails later at use. Catching that needs per-field type coercion, which is beyond this issue's scope.
- `EnvironmentConfig.validate()` already exists for value-level checks but is not invoked by the loader; this PR does not change that.
