### PR TITLE
fix(costs): price the shipped defaults, record unpriced as unknown (#932)

### DIFF
--- a/codeframe/core/adapters/builtin.py
+++ b/codeframe/core/adapters/builtin.py
@@ -10,7 +10,11 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional
 
-from codeframe.core.adapters.agent_adapter import AgentEvent, AgentResult
+from codeframe.core.adapters.agent_adapter import (
+    AdapterTokenUsage,
+    AgentEvent,
+    AgentResult,
+)
 
 if TYPE_CHECKING:
     from codeframe.adapters.llm.base import LLMProvider
@@ -22,6 +26,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _MAX_STALL_RETRIES = 1
+
+
+def _adapter_token_usage(agent: object) -> Optional[AdapterTokenUsage]:
+    """Build AdapterTokenUsage from a builtin agent's accumulated records.
+
+    Returns None when the agent recorded nothing — an absent figure is honest,
+    a zero one claims the run was free. Never raises: token reporting must not
+    be able to fail a run that already succeeded.
+    """
+    if agent is None:
+        return None
+    try:
+        totals = agent.get_total_tokens()  # type: ignore[attr-defined]
+        if not totals or not (totals.get("input_tokens") or totals.get("output_tokens")):
+            return None
+        records = agent.get_token_usage()  # type: ignore[attr-defined]
+        models = {r.get("model") for r in records if r.get("model")}
+        return AdapterTokenUsage(
+            input_tokens=totals.get("input_tokens", 0),
+            output_tokens=totals.get("output_tokens", 0),
+            # Only name a model when the run used exactly one; a mixed run has
+            # no single answer and guessing would mis-price it downstream.
+            model=next(iter(models)) if len(models) == 1 else None,
+            cost_usd=totals.get("estimated_cost_usd"),
+        )
+    except Exception:  # noqa: BLE001 - see docstring
+        logger.warning("Could not read token usage from agent", exc_info=True)
+        return None
 
 
 class BuiltinReactAdapter:
@@ -107,7 +139,7 @@ class BuiltinReactAdapter:
             try:
                 agent = _build_agent()
                 status = agent.run(task_id)
-                return self._map_status(status)
+                return self._map_status(status, agent)
             except StallDetectedError as exc:
                 logger.warning(
                     "Stall detected (attempt %d): %s",
@@ -124,8 +156,14 @@ class BuiltinReactAdapter:
         return AgentResult(status="failed", error="Unexpected: stall retry loop exhausted")
 
     @staticmethod
-    def _map_status(status: object) -> AgentResult:
-        """Map AgentStatus enum to AgentResult."""
+    def _map_status(status: object, agent: object = None) -> AgentResult:
+        """Map AgentStatus enum to AgentResult, carrying the agent's token usage.
+
+        The builtin engines are the *default*, and this used to drop the token
+        counts on the floor — so engine stats and the Costs page reported 0 for
+        every ordinary run while the delegated adapters reported real figures
+        (#932). ReactAgent already accumulates the numbers.
+        """
         from codeframe.core.agent import AgentStatus
 
         status_map = {
@@ -137,6 +175,7 @@ class BuiltinReactAdapter:
         return AgentResult(
             status=result_status,
             output=f"ReactAgent finished with status: {status.value}",  # type: ignore[union-attr]
+            token_usage=_adapter_token_usage(agent),
         )
 
 

--- a/codeframe/core/models.py
+++ b/codeframe/core/models.py
@@ -688,7 +688,10 @@ class TokenUsage(BaseModel):
     model_name: str = Field(..., description="e.g., claude-sonnet-4-5")
     input_tokens: int = Field(..., ge=0)
     output_tokens: int = Field(..., ge=0)
-    estimated_cost_usd: float = Field(..., ge=0.0)
+    # None = the model has no pricing, so spend is UNKNOWN for this call. Kept
+    # distinct from 0.0 (a priced-at-free call) so unpriced usage is excluded
+    # from cost sums instead of counted as free (#932).
+    estimated_cost_usd: Optional[float] = Field(None, ge=0.0)
     actual_cost_usd: Optional[float] = Field(None, ge=0.0)
     call_type: CallType = CallType.OTHER
     session_id: Optional[str] = Field(None, description="SDK session ID for conversation tracking")

--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -1121,12 +1121,13 @@ class ReactAgent:
         # — tokens recorded but $0 spent — because MODEL_PRICING was missing the
         # shipped default (claude-haiku-4-5), so a membership test false-fired on
         # a legitimately-priced run. calculate_cost now returns None for unpriced
-        # models, so the question has a real answer. The outcome heuristic is
-        # kept as a second condition: it also catches a run whose prior recorded
-        # cost is unexpectedly zero.
-        if self._has_unpriced_records() or (
-            spent == 0.0 and self._tokens_recorded() > 0
-        ):
+        # models, so the question has a real answer.
+        #
+        # The outcome heuristic is NOT kept as a fallback: a deployment can price
+        # a local model at 0/0 via CODEFRAME_MODEL_PRICING, which is a real $0 —
+        # "spent nothing" would then read as "cannot measure" and abort a run
+        # that is correctly measured as free.
+        if self._has_unpriced_records():
             return (
                 f"A cost cap of ${cap:.2f} is configured, but spend cannot be "
                 f"measured for {', '.join(sorted(self._models_used())) or 'this model'} "

--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -377,14 +377,39 @@ class ReactAgent:
 
             total = 0.0
             for record in self._token_records:
-                total += MetricsTracker.calculate_cost(
+                cost = MetricsTracker.calculate_cost(
                     record["model"],
                     record["input_tokens"],
                     record["output_tokens"],
                 )
+                # None = unpriced; skip it rather than adding 0.0. Callers that
+                # care whether anything was unpriced ask _has_unpriced_records().
+                if cost is not None:
+                    total += cost
             return round(total, 6)
         except Exception:
             return 0.0
+
+    def _has_unpriced_records(self) -> bool:
+        """True when any recorded call used a model with no pricing.
+
+        Asked directly now that ``calculate_cost`` returns None for unpriced
+        models. The cost cap used to infer this from the *outcome* ($0 spent
+        despite tokens recorded) because the pricing table was missing the
+        shipped default and a membership test false-fired on it (#932).
+        """
+        try:
+            from codeframe.lib.metrics_tracker import MetricsTracker
+
+            return any(
+                MetricsTracker.calculate_cost(
+                    r["model"], r["input_tokens"], r["output_tokens"]
+                )
+                is None
+                for r in self._token_records
+            )
+        except Exception:
+            return False
 
     def _persist_token_usage(self, task_id: str) -> None:
         """Persist accumulated token records to the workspace database.
@@ -1086,23 +1111,22 @@ class ReactAgent:
         if cap is None:
             return None
 
-        # A cap we cannot measure is not a cap. MetricsTracker.calculate_cost
-        # returns $0.00 for models it has no pricing for, so with e.g.
-        # --llm-provider openai the guard below would see $0.00 forever and
-        # never fire — the same silently-inert control this issue is about, one
-        # layer down. Refuse before spending rather than pretend (#911 review).
+        # A cap we cannot measure is not a cap: an unpriced model would keep the
+        # running total at $0.00 forever and the guard would never fire — the
+        # same silently-inert control #911 was about, one layer down. Refuse
+        # before spending rather than pretend.
         spent = self._prior_task_cost_usd + self._estimate_total_cost()
 
-        # A cap we cannot measure is not a cap. `calculate_cost` returns $0.00
-        # for models it has no pricing for, so the check below would see $0.00
-        # forever and never fire — the same silently-inert control this issue is
-        # about, one layer down.
-        #
-        # Detected by *outcome* (tokens recorded but zero cost) rather than by
-        # MODEL_PRICING membership: the table holds three keys, so a membership
-        # test false-fires on ordinary Anthropic models like the default
-        # claude-haiku-4-5 and blocks a legitimately-priced run (#911 review).
-        if spent == 0.0 and self._tokens_recorded() > 0:
+        # Asked directly (#932). This used to infer "unpriced" from the outcome
+        # — tokens recorded but $0 spent — because MODEL_PRICING was missing the
+        # shipped default (claude-haiku-4-5), so a membership test false-fired on
+        # a legitimately-priced run. calculate_cost now returns None for unpriced
+        # models, so the question has a real answer. The outcome heuristic is
+        # kept as a second condition: it also catches a run whose prior recorded
+        # cost is unexpectedly zero.
+        if self._has_unpriced_records() or (
+            spent == 0.0 and self._tokens_recorded() > 0
+        ):
             return (
                 f"A cost cap of ${cap:.2f} is configured, but spend cannot be "
                 f"measured for {', '.join(sorted(self._models_used())) or 'this model'} "

--- a/codeframe/lib/metrics_tracker.py
+++ b/codeframe/lib/metrics_tracker.py
@@ -48,13 +48,63 @@ from codeframe.platform_store.database import Database
 
 logger = logging.getLogger(__name__)
 
-# Model pricing as of 2025-11 (per million tokens)
-# Source: Anthropic pricing page
+# Model pricing (per million tokens).
+#
+# Every model named by a DEFAULT_*_MODEL constant in adapters/llm/base.py MUST
+# have an entry here — a missing default silently prices the whole shipped path
+# at $0 (#932), which is what happened to claude-haiku-4-5.
+# tests/core/test_cost_accounting_932.py enforces that.
+#
+# This table is a convenience, not the source of truth: rates change and new
+# models ship between releases, so CODEFRAME_MODEL_PRICING overrides it without
+# needing a new version.
 MODEL_PRICING = {
+    # Anthropic
     "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
     "claude-opus-4": {"input": 15.00, "output": 75.00},
+    "claude-opus-4-5": {"input": 5.00, "output": 25.00},
     "claude-haiku-4": {"input": 0.80, "output": 4.00},
+    "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
+    # OpenAI (advertised as a supported provider)
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
 }
+
+#: JSON object merged over MODEL_PRICING, e.g.
+#: CODEFRAME_MODEL_PRICING='{"qwen2.5-coder:7b": {"input": 0, "output": 0}}'
+#: Local models are legitimately free — an explicit 0 records $0.00 as a fact,
+#: which is different from having no pricing at all.
+MODEL_PRICING_ENV_VAR = "CODEFRAME_MODEL_PRICING"
+
+
+def _pricing_table() -> Dict[str, Dict[str, float]]:
+    """MODEL_PRICING with any CODEFRAME_MODEL_PRICING overrides applied.
+
+    Never mutates MODEL_PRICING, and never raises: a malformed override is
+    logged and ignored, because breaking all pricing would be worse than
+    ignoring one bad setting.
+    """
+    raw = os.environ.get(MODEL_PRICING_ENV_VAR)
+    if not raw:
+        return MODEL_PRICING
+
+    try:
+        overrides = json.loads(raw)
+        if not isinstance(overrides, dict):
+            raise ValueError(f"expected an object, got {type(overrides).__name__}")
+        clean = {
+            model: {"input": float(p["input"]), "output": float(p["output"])}
+            for model, p in overrides.items()
+        }
+    except (json.JSONDecodeError, ValueError, TypeError, KeyError) as exc:
+        logger.warning(
+            "Ignoring malformed %s (%s). Using built-in pricing.",
+            MODEL_PRICING_ENV_VAR,
+            exc,
+        )
+        return MODEL_PRICING
+
+    return {**MODEL_PRICING, **clean}
 
 # Regex to strip -YYYYMMDD date suffixes from Anthropic API model names
 # (e.g., "claude-sonnet-4-5-20250514" → "claude-sonnet-4-5")
@@ -74,13 +124,15 @@ def normalize_model_name(raw_model: str) -> str:
     Returns:
         Normalized model name (e.g., 'claude-sonnet-4-5')
     """
+    table = _pricing_table()
+
     # If it already matches a known model, return as-is
-    if raw_model in MODEL_PRICING:
+    if raw_model in table:
         return raw_model
 
     # Try stripping date suffix (8 digits at the end)
     stripped = _DATE_SUFFIX_RE.sub("", raw_model)
-    if stripped in MODEL_PRICING:
+    if stripped in table:
         return stripped
 
     # Unknown model - return as-is
@@ -117,17 +169,14 @@ class MetricsTracker:
         self.db = db
 
     @staticmethod
-    def calculate_cost(model_name: str, input_tokens: int, output_tokens: int) -> float:
+    def calculate_cost(
+        model_name: str, input_tokens: int, output_tokens: int
+    ) -> Optional[float]:
         """Calculate estimated cost in USD for an LLM call.
 
-        Uses current Anthropic pricing (as of 2025-11):
-        - Claude Sonnet 4.5: $3.00 input / $15.00 output per MTok
-        - Claude Opus 4: $15.00 input / $75.00 output per MTok
-        - Claude Haiku 4: $0.80 input / $4.00 output per MTok
-
-        Handles model names with date suffixes (e.g., 'claude-sonnet-4-5-20250514')
-        by normalizing them first. Unknown models return $0.00 cost instead of
-        raising, to avoid crashing the agent during recording.
+        Rates come from ``MODEL_PRICING``, overridable per-deployment via the
+        ``CODEFRAME_MODEL_PRICING`` environment variable. Model names with date
+        suffixes ('claude-sonnet-4-5-20250514') are normalized first.
 
         Args:
             model_name: Model identifier (e.g., "claude-sonnet-4-5" or "claude-sonnet-4-5-20250514")
@@ -135,7 +184,11 @@ class MetricsTracker:
             output_tokens: Number of output tokens
 
         Returns:
-            Estimated cost in USD (rounded to 6 decimal places), or 0.0 for unknown models
+            Estimated cost in USD (rounded to 6 decimal places), or **None** when
+            the model has no pricing. ``None`` and ``0.0`` mean different things:
+            ``0.0`` is a priced-at-free call, ``None`` is "we cannot say".
+            Callers must not coerce ``None`` to ``0.0`` — that is the
+            silent under-reporting this signature exists to prevent (#932).
 
         Example:
             >>> cost = MetricsTracker.calculate_cost(
@@ -144,16 +197,20 @@ class MetricsTracker:
             >>> print(f"${cost:.4f}")
             $0.0105
         """
+        table = _pricing_table()
         normalized = normalize_model_name(model_name)
 
-        if normalized not in MODEL_PRICING:
+        if normalized not in table:
             logger.warning(
-                f"Unknown model '{model_name}' (normalized: '{normalized}'). "
-                f"Returning $0.00 cost. Supported: {', '.join(MODEL_PRICING.keys())}"
+                f"No pricing for model '{model_name}' (normalized: '{normalized}'). "
+                f"Recording as UNPRICED, not $0.00. Known: {', '.join(sorted(table))}. "
+                f"Set {MODEL_PRICING_ENV_VAR} to supply a rate."
             )
-            return 0.0
+            # None, not 0.0 (#932): summing an unknown model as free under-reports
+            # spend silently. $0.00 must mean free, never "we don't know".
+            return None
 
-        prices = MODEL_PRICING[normalized]
+        prices = table[normalized]
 
         # Calculate cost: (tokens * price_per_mtok) / 1,000,000
         input_cost = (input_tokens * prices["input"]) / 1_000_000
@@ -193,7 +250,11 @@ class MetricsTracker:
             Database ID of the created token usage record
 
         Raises:
-            ValueError: If model_name is unknown or token counts are negative
+            ValueError: If input_tokens or output_tokens is negative.
+                An unknown ``model_name`` does NOT raise — the docstring used to
+                claim it did (#932). It is stored with
+                ``estimated_cost_usd = None`` (SQL NULL) instead, so unpriced
+                usage is excluded from cost sums rather than counted as free.
 
         Example:
             >>> usage_id = await tracker.record_token_usage(
@@ -210,7 +271,8 @@ class MetricsTracker:
         if input_tokens < 0 or output_tokens < 0:
             raise ValueError("Token counts cannot be negative")
 
-        # Calculate cost (returns 0.0 for unknown models)
+        # None when the model has no pricing — stored as NULL so it is excluded
+        # from cost sums rather than counted as free (#932).
         estimated_cost = self.calculate_cost(model_name, input_tokens, output_tokens)
 
         # Create TokenUsage model
@@ -233,7 +295,8 @@ class MetricsTracker:
 
         logger.info(
             f"Recorded token usage: agent={agent_id}, model={model_name}, "
-            f"tokens={input_tokens + output_tokens}, cost=${estimated_cost:.6f}"
+            f"tokens={input_tokens + output_tokens}, "
+            f"cost={'UNPRICED' if estimated_cost is None else f'${estimated_cost:.6f}'}"
         )
 
         return usage_id
@@ -293,7 +356,8 @@ class MetricsTracker:
 
         logger.info(
             f"Recorded token usage (sync): agent={agent_id}, model={model_name}, "
-            f"tokens={input_tokens + output_tokens}, cost=${estimated_cost:.6f}"
+            f"tokens={input_tokens + output_tokens}, "
+            f"cost={'UNPRICED' if estimated_cost is None else f'${estimated_cost:.6f}'}"
         )
 
         return usage_id

--- a/codeframe/lib/metrics_tracker.py
+++ b/codeframe/lib/metrics_tracker.py
@@ -106,6 +106,17 @@ def _pricing_table() -> Dict[str, Dict[str, float]]:
 
     return {**MODEL_PRICING, **clean}
 
+
+def _priced(cost: Optional[float]) -> float:
+    """Coerce an unpriced (None) cost to 0.0 **for summation only**.
+
+    An unpriced call must not crash an aggregator, and must not be counted as
+    spend either. Callers pair this with an ``unpriced_calls`` counter so the
+    gap is reported rather than hidden (#932).
+    """
+    return 0.0 if cost is None else cost
+
+
 # Regex to strip -YYYYMMDD date suffixes from Anthropic API model names
 # (e.g., "claude-sonnet-4-5-20250514" → "claude-sonnet-4-5")
 _DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
@@ -570,6 +581,10 @@ class MetricsTracker:
             "total_cost_usd": 0.0,
             "total_tokens": 0,
             "total_calls": len(usage_records),
+            # Calls whose model has no pricing: excluded from total_cost_usd
+            # rather than counted as free, and surfaced so the UI can say so
+            # instead of under-reporting silently (#932).
+            "unpriced_calls": 0,
             "by_agent": [],
             "by_model": [],
         }
@@ -582,7 +597,10 @@ class MetricsTracker:
         model_stats: Dict[str, Dict[str, Any]] = {}
 
         for record in usage_records:
-            cost = record["estimated_cost_usd"]
+            raw_cost = record["estimated_cost_usd"]
+            if raw_cost is None:
+                result["unpriced_calls"] = result.get("unpriced_calls", 0) + 1
+            cost = _priced(raw_cost)
             tokens = record["input_tokens"] + record["output_tokens"]
             agent_id = record["agent_id"]
             model_name = record["model_name"]
@@ -676,7 +694,10 @@ class MetricsTracker:
         project_stats: Dict[int, Dict[str, Any]] = {}
 
         for record in usage_records:
-            cost = record["estimated_cost_usd"]
+            raw_cost = record["estimated_cost_usd"]
+            if raw_cost is None:
+                result["unpriced_calls"] = result.get("unpriced_calls", 0) + 1
+            cost = _priced(raw_cost)
             tokens = record["input_tokens"] + record["output_tokens"]
             call_type = record["call_type"]
             project_id = record["project_id"]
@@ -770,7 +791,9 @@ class MetricsTracker:
 
         # Aggregate totals
         for record in usage_records:
-            result["total_cost_usd"] += record["estimated_cost_usd"]
+            if record["estimated_cost_usd"] is None:
+                result["unpriced_calls"] = result.get("unpriced_calls", 0) + 1
+            result["total_cost_usd"] += _priced(record["estimated_cost_usd"])
             result["total_tokens"] += record["input_tokens"] + record["output_tokens"]
 
         # Round cost
@@ -869,7 +892,7 @@ class MetricsTracker:
             buckets[bucket_key]["total_tokens"] += (
                 record["input_tokens"] + record["output_tokens"]
             )
-            buckets[bucket_key]["cost_usd"] += record["estimated_cost_usd"]
+            buckets[bucket_key]["cost_usd"] += _priced(record["estimated_cost_usd"])
 
         # Round costs and sort by timestamp
         result = []

--- a/codeframe/lib/metrics_tracker.py
+++ b/codeframe/lib/metrics_tracker.py
@@ -576,7 +576,7 @@ class MetricsTracker:
         )
 
         # Initialize result
-        result = {
+        result: Dict[str, Any] = {
             "project_id": project_id,
             "total_cost_usd": 0.0,
             "total_tokens": 0,
@@ -596,10 +596,11 @@ class MetricsTracker:
         agent_stats: Dict[str, Dict[str, Any]] = {}
         model_stats: Dict[str, Dict[str, Any]] = {}
 
+        unpriced_calls = 0
         for record in usage_records:
             raw_cost = record["estimated_cost_usd"]
             if raw_cost is None:
-                result["unpriced_calls"] = result.get("unpriced_calls", 0) + 1
+                unpriced_calls += 1
             cost = _priced(raw_cost)
             tokens = record["input_tokens"] + record["output_tokens"]
             agent_id = record["agent_id"]
@@ -635,6 +636,7 @@ class MetricsTracker:
 
         # Convert to lists and round costs
         result["total_cost_usd"] = round(result["total_cost_usd"], 6)  # type: ignore[call-overload]
+        result["unpriced_calls"] = unpriced_calls
         result["by_agent"] = [
             {**stats, "cost_usd": round(stats["cost_usd"], 6)}
             for stats in agent_stats.values()
@@ -677,7 +679,7 @@ class MetricsTracker:
         usage_records = self.db.get_token_usage(agent_id=agent_id)
 
         # Initialize result
-        result = {
+        result: Dict[str, Any] = {
             "agent_id": agent_id,
             "total_cost_usd": 0.0,
             "total_tokens": 0,
@@ -693,10 +695,11 @@ class MetricsTracker:
         call_type_stats: Dict[str, Dict[str, Any]] = {}
         project_stats: Dict[int, Dict[str, Any]] = {}
 
+        unpriced_calls = 0
         for record in usage_records:
             raw_cost = record["estimated_cost_usd"]
             if raw_cost is None:
-                result["unpriced_calls"] = result.get("unpriced_calls", 0) + 1
+                unpriced_calls += 1
             cost = _priced(raw_cost)
             tokens = record["input_tokens"] + record["output_tokens"]
             call_type = record["call_type"]
@@ -723,6 +726,7 @@ class MetricsTracker:
 
         # Convert to lists and round costs
         result["total_cost_usd"] = round(result["total_cost_usd"], 6)  # type: ignore[call-overload]
+        result["unpriced_calls"] = unpriced_calls
         result["by_call_type"] = [
             {**stats, "cost_usd": round(stats["cost_usd"], 6)}
             for stats in call_type_stats.values()
@@ -775,7 +779,7 @@ class MetricsTracker:
         )
 
         # Initialize result
-        result = {
+        result: Dict[str, Any] = {
             "project_id": project_id,
             "total_cost_usd": 0.0,
             "total_tokens": 0,
@@ -790,14 +794,16 @@ class MetricsTracker:
             return result
 
         # Aggregate totals
+        unpriced_calls = 0
         for record in usage_records:
             if record["estimated_cost_usd"] is None:
-                result["unpriced_calls"] = result.get("unpriced_calls", 0) + 1
+                unpriced_calls += 1
             result["total_cost_usd"] += _priced(record["estimated_cost_usd"])
             result["total_tokens"] += record["input_tokens"] + record["output_tokens"]
 
         # Round cost
         result["total_cost_usd"] = round(result["total_cost_usd"], 6)  # type: ignore[call-overload]
+        result["unpriced_calls"] = unpriced_calls
 
         return result
 

--- a/tests/core/test_cost_accounting_932.py
+++ b/tests/core/test_cost_accounting_932.py
@@ -1,0 +1,225 @@
+"""Cost accounting must not report $0.00 by default (#932).
+
+Three separate ways the shipped product under-reported spend:
+
+1. `MODEL_PRICING` had three entries and `DEFAULT_GENERATION_MODEL`
+   ("claude-haiku-4-5") was not one of them, so the default generation path
+   priced every call at $0.
+2. `calculate_cost` returned 0.0 for anything unpriced, so a gpt-4o/ollama call
+   summed into totals as if it were free rather than as unknown.
+3. The builtin (react/plan) adapters never populated `AgentResult.token_usage`,
+   so engine stats and the Costs page showed 0 tokens for the *default* engine.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeframe.adapters.llm import base as llm_base
+from codeframe.lib.metrics_tracker import MODEL_PRICING, MetricsTracker
+
+pytestmark = pytest.mark.v2
+
+
+DEFAULT_MODEL_CONSTANTS = [
+    name for name in dir(llm_base)
+    if name.startswith("DEFAULT_") and name.endswith("_MODEL")
+]
+
+
+class TestShippedDefaultsArePriced:
+    def test_every_default_model_constant_exists(self):
+        """Guard the guard: if the constants are renamed this test must not pass vacuously."""
+        assert len(DEFAULT_MODEL_CONSTANTS) >= 5, DEFAULT_MODEL_CONSTANTS
+
+    @pytest.mark.parametrize("const_name", DEFAULT_MODEL_CONSTANTS)
+    def test_default_model_has_a_real_price(self, const_name):
+        """Every shipped default must price non-zero — including future bumps."""
+        model = getattr(llm_base, const_name)
+
+        cost = MetricsTracker.calculate_cost(model, 1_000_000, 1_000_000)
+
+        assert cost is not None, f"{const_name} = {model!r} has no pricing entry"
+        assert cost > 0, f"{const_name} = {model!r} priced at ${cost}"
+
+    def test_default_generation_model_specifically(self):
+        """The one named in the issue."""
+        cost = MetricsTracker.calculate_cost(llm_base.DEFAULT_GENERATION_MODEL, 1000, 500)
+
+        assert cost is not None and cost > 0
+
+
+class TestUnknownModelsAreUnpricedNotFree:
+    def test_unknown_model_returns_none(self):
+        assert MetricsTracker.calculate_cost("totally-made-up-model", 1000, 500) is None
+
+    def test_known_model_still_returns_a_float(self):
+        cost = MetricsTracker.calculate_cost("claude-sonnet-4-5", 1000, 500)
+
+        assert isinstance(cost, float)
+        assert cost == pytest.approx(0.0105, abs=1e-6)
+
+    def test_date_suffix_still_normalizes(self):
+        assert MetricsTracker.calculate_cost("claude-sonnet-4-5-20250514", 1000, 500) is not None
+
+    def test_zero_tokens_on_a_priced_model_is_zero_not_none(self):
+        """$0.00 must mean 'free', never 'unknown'."""
+        assert MetricsTracker.calculate_cost("claude-sonnet-4-5", 0, 0) == 0.0
+
+
+class TestPricingIsConfigurable:
+    def test_env_override_adds_a_model(self, monkeypatch):
+        monkeypatch.setenv(
+            "CODEFRAME_MODEL_PRICING",
+            json.dumps({"my-local-model": {"input": 1.0, "output": 2.0}}),
+        )
+
+        cost = MetricsTracker.calculate_cost("my-local-model", 1_000_000, 1_000_000)
+
+        assert cost == pytest.approx(3.0)
+
+    def test_env_override_can_replace_a_builtin_rate(self, monkeypatch):
+        monkeypatch.setenv(
+            "CODEFRAME_MODEL_PRICING",
+            json.dumps({"claude-sonnet-4-5": {"input": 0.0, "output": 0.0}}),
+        )
+
+        assert MetricsTracker.calculate_cost("claude-sonnet-4-5", 1000, 500) == 0.0
+
+    def test_malformed_override_is_ignored_not_fatal(self, monkeypatch, caplog):
+        monkeypatch.setenv("CODEFRAME_MODEL_PRICING", "{not json")
+
+        cost = MetricsTracker.calculate_cost("claude-sonnet-4-5", 1000, 500)
+
+        assert cost is not None, "a bad override must not break pricing entirely"
+
+    def test_builtin_table_is_not_mutated_by_an_override(self, monkeypatch):
+        monkeypatch.setenv(
+            "CODEFRAME_MODEL_PRICING",
+            json.dumps({"ephemeral-model": {"input": 1.0, "output": 1.0}}),
+        )
+        MetricsTracker.calculate_cost("ephemeral-model", 10, 10)
+
+        assert "ephemeral-model" not in MODEL_PRICING
+
+
+class TestBuiltinAdapterReportsTokens:
+    def test_react_adapter_attaches_token_usage(self, tmp_path: Path):
+        """AC2 — the default engine must not report 0 tokens."""
+        from codeframe.core.adapters.builtin import BuiltinReactAdapter
+        from codeframe.core.agent import AgentStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        workspace = create_or_load_workspace(tmp_path)
+        adapter = BuiltinReactAdapter(workspace=workspace, llm_provider=MagicMock())
+
+        fake_agent = MagicMock()
+        fake_agent.run.return_value = AgentStatus.COMPLETED
+        fake_agent.get_total_tokens.return_value = {
+            "input_tokens": 1200,
+            "output_tokens": 340,
+            "total_tokens": 1540,
+            "estimated_cost_usd": 0.0123,
+        }
+        fake_agent.get_token_usage.return_value = [
+            {"model": "claude-sonnet-4-5", "input_tokens": 1200, "output_tokens": 340}
+        ]
+
+        with patch(
+            "codeframe.core.react_agent.ReactAgent", return_value=fake_agent
+        ):
+            result = adapter.run("task-1", "do the thing", tmp_path)
+
+        assert result.status == "completed"
+        assert result.token_usage is not None, "builtin react adapter reported no tokens"
+        assert result.token_usage.input_tokens == 1200
+        assert result.token_usage.output_tokens == 340
+        assert result.token_usage.total_tokens == 1540
+        assert result.token_usage.cost_usd == pytest.approx(0.0123)
+
+    def test_token_usage_absent_when_the_agent_recorded_nothing(self, tmp_path: Path):
+        from codeframe.core.adapters.builtin import BuiltinReactAdapter
+        from codeframe.core.agent import AgentStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        workspace = create_or_load_workspace(tmp_path)
+        adapter = BuiltinReactAdapter(workspace=workspace, llm_provider=MagicMock())
+
+        fake_agent = MagicMock()
+        fake_agent.run.return_value = AgentStatus.COMPLETED
+        fake_agent.get_total_tokens.return_value = {
+            "input_tokens": 0, "output_tokens": 0,
+            "total_tokens": 0, "estimated_cost_usd": 0.0,
+        }
+        fake_agent.get_token_usage.return_value = []
+
+        with patch("codeframe.core.react_agent.ReactAgent", return_value=fake_agent):
+            result = adapter.run("task-1", "do the thing", tmp_path)
+
+        assert result.token_usage is None, "a zero-token run should not claim usage"
+
+
+class TestRecordTokenUsageDocstring:
+    """AC4 — the docstring must match behaviour.
+
+    Checked structurally (no `Raises:` section) *and* behaviourally (it really
+    does not raise), so the pair cannot drift apart again.
+    """
+
+    def test_documented_valueerror_is_actually_raised(self):
+        """The docstring's ValueError must be real, and only for what it says."""
+        doc = MetricsTracker.record_token_usage.__doc__ or ""
+
+        assert "negative" in doc, "the ValueError's real trigger is not documented"
+
+    @pytest.mark.asyncio
+    async def test_negative_tokens_raise_as_documented(self):
+        tracker = MetricsTracker(MagicMock())
+
+        with pytest.raises(ValueError, match="negative"):
+            await tracker.record_token_usage(
+                task_id="t1", agent_id="a1", project_id=1,
+                model_name="claude-sonnet-4-5",
+                input_tokens=-1, output_tokens=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_does_not_raise_and_stores_null_cost(self):
+        db = MagicMock()
+        db.save_token_usage = MagicMock(return_value=42)
+        tracker = MetricsTracker(db)
+
+        usage_id = await tracker.record_token_usage(
+            task_id="t1",
+            agent_id="a1",
+            project_id=1,
+            model_name="totally-made-up-model",
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+        assert usage_id == 42
+        recorded = db.save_token_usage.call_args.args[0]
+        assert recorded.estimated_cost_usd is None, (
+            "an unpriced call must store NULL, not 0.0 — otherwise it sums as free"
+        )
+
+    @pytest.mark.asyncio
+    async def test_priced_model_stores_a_real_cost(self):
+        db = MagicMock()
+        db.save_token_usage = MagicMock(return_value=7)
+        tracker = MetricsTracker(db)
+
+        await tracker.record_token_usage(
+            task_id="t1",
+            agent_id="a1",
+            project_id=1,
+            model_name="claude-haiku-4-5",
+            input_tokens=1_000_000,
+            output_tokens=0,
+        )
+
+        recorded = db.save_token_usage.call_args.args[0]
+        assert recorded.estimated_cost_usd == pytest.approx(1.00)

--- a/tests/core/test_cost_accounting_932.py
+++ b/tests/core/test_cost_accounting_932.py
@@ -223,3 +223,65 @@ class TestRecordTokenUsageDocstring:
 
         recorded = db.save_token_usage.call_args.args[0]
         assert recorded.estimated_cost_usd == pytest.approx(1.00)
+
+
+class TestAggregatorsToleratNullCosts:
+    """Raised by `codex review`: unpriced rows now persist NULL, and the Python
+    aggregators added the raw value — so viewing metrics after an ollama run
+    raised TypeError instead of excluding the unknown spend."""
+
+    @pytest.fixture
+    def tracker_with_mixed_records(self):
+        from codeframe.core.models import CallType
+
+        db = MagicMock()
+        db.get_token_usage = MagicMock(return_value=[
+            {"estimated_cost_usd": 0.01, "input_tokens": 100, "output_tokens": 50,
+             "agent_id": "a1", "model_name": "claude-sonnet-4-5", "project_id": 1,
+             "call_type": CallType.OTHER.value, "timestamp": "2026-08-01T00:00:00+00:00"},
+            {"estimated_cost_usd": None, "input_tokens": 200, "output_tokens": 80,
+             "agent_id": "a1", "model_name": "some-local-model", "project_id": 1,
+             "call_type": CallType.OTHER.value, "timestamp": "2026-08-01T00:00:00+00:00"},
+        ])
+        return MetricsTracker(db)
+
+    @pytest.mark.asyncio
+    async def test_project_costs_excludes_unpriced_and_counts_it(
+        self, tracker_with_mixed_records
+    ):
+        result = await tracker_with_mixed_records.get_project_costs(project_id=1)
+
+        assert result["total_cost_usd"] == pytest.approx(0.01), (
+            "unpriced spend must be excluded, not summed as free"
+        )
+        assert result["total_tokens"] == 430, "tokens are still counted"
+        assert result.get("unpriced_calls") == 1, (
+            "the gap must be reported so the UI can render 'unpriced'"
+        )
+
+
+class TestExplicitlyFreePricingIsMeasured:
+    """Raised by `codex review`: a local model priced 0/0 is measured at $0,
+    which is different from having no pricing — the cost cap must not abort."""
+
+    def test_zero_priced_model_is_not_unpriced(self, monkeypatch, tmp_path):
+        from codeframe.core.react_agent import ReactAgent
+        from codeframe.core.workspace import create_or_load_workspace
+
+        monkeypatch.setenv(
+            "CODEFRAME_MODEL_PRICING",
+            json.dumps({"my-free-local": {"input": 0.0, "output": 0.0}}),
+        )
+        agent = ReactAgent(
+            workspace=create_or_load_workspace(tmp_path), llm_provider=MagicMock()
+        )
+        agent._max_cost_usd = 5.0
+        agent._token_records.append({
+            "model": "my-free-local", "input_tokens": 100000,
+            "output_tokens": 50000, "call_type": "execution", "iteration": 1,
+        })
+
+        assert agent._has_unpriced_records() is False
+        assert agent._cost_cap_message() is None, (
+            "an explicitly free model was treated as unmeasurable and aborted"
+        )

--- a/tests/core/test_cost_accounting_932.py
+++ b/tests/core/test_cost_accounting_932.py
@@ -285,3 +285,34 @@ class TestExplicitlyFreePricingIsMeasured:
         assert agent._cost_cap_message() is None, (
             "an explicitly free model was treated as unmeasurable and aborted"
         )
+
+
+class TestUnpricedCallsIsAlwaysReported:
+    """The bot review noted the key was emitted inconsistently across
+    aggregators — present only when an unpriced record existed in two of them,
+    zero-initialized in the third. A caller should not have to guess."""
+
+    @pytest.mark.asyncio
+    async def test_project_costs_reports_zero_when_all_priced(self):
+        from codeframe.core.models import CallType
+
+        db = MagicMock()
+        db.get_token_usage = MagicMock(return_value=[
+            {"estimated_cost_usd": 0.02, "input_tokens": 10, "output_tokens": 5,
+             "agent_id": "a1", "model_name": "claude-sonnet-4-5", "project_id": 1,
+             "call_type": CallType.OTHER.value,
+             "timestamp": "2026-08-01T00:00:00+00:00"},
+        ])
+
+        result = await MetricsTracker(db).get_project_costs(project_id=1)
+
+        assert result["unpriced_calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_project_costs_reports_zero_with_no_records_at_all(self):
+        db = MagicMock()
+        db.get_token_usage = MagicMock(return_value=[])
+
+        result = await MetricsTracker(db).get_project_costs(project_id=1)
+
+        assert result["unpriced_calls"] == 0

--- a/tests/core/test_cost_cap_enforced_911.py
+++ b/tests/core/test_cost_cap_enforced_911.py
@@ -287,10 +287,35 @@ def test_an_unknown_task_has_no_prior_spend(workspace):
 def test_a_cap_on_an_unpriced_model_refuses_rather_than_never_firing(
     workspace, monkeypatch
 ):
-    """calculate_cost returns $0.00 for unknown models, so with e.g.
-    --llm-provider openai the guard would see $0.00 forever and never fire —
-    the same silently-inert control this issue is about, one layer down."""
+    """A cap we cannot measure is not a cap: refuse instead of never firing.
+
+    The model here was `gpt-4o` until #932 added pricing for the advertised
+    providers — so the example had to change to one that is genuinely unpriced.
+    The behaviour under test is unchanged; only the stand-in moved.
+    """
     _set_cap(workspace, 1.0)
+    agent = _agent(workspace)
+    agent._max_cost_usd = agent._resolve_cost_cap()
+
+    agent._token_records.append(
+        {"model": "some-unlisted-local-model", "input_tokens": 100000,
+         "output_tokens": 50000, "call_type": "execution", "iteration": 1}
+    )
+
+    message = agent._cost_cap_message()
+
+    assert message is not None, "an unmeasurable cap silently allowed unbounded spend"
+    assert "some-unlisted-local-model" in message
+    assert "pricing" in message
+
+
+def test_an_advertised_openai_model_is_priced_and_does_not_refuse(workspace):
+    """#932 AC4: pricing covers the advertised providers.
+
+    gpt-4o used to hit the "no pricing data" refusal above, which meant a cap
+    made the whole OpenAI path unusable rather than bounded.
+    """
+    _set_cap(workspace, 100.0)
     agent = _agent(workspace)
     agent._max_cost_usd = agent._resolve_cost_cap()
 
@@ -299,11 +324,30 @@ def test_a_cap_on_an_unpriced_model_refuses_rather_than_never_firing(
          "call_type": "execution", "iteration": 1}
     )
 
+    assert agent._cost_cap_message() is None
+    assert agent._estimate_total_cost() == pytest.approx(0.75)  # 0.25 in + 0.50 out
+
+
+def test_an_unpriced_model_is_refused_even_when_a_priced_one_also_ran(workspace):
+    """A mixed run must not hide the unmeasurable part behind a measurable one."""
+    _set_cap(workspace, 100.0)
+    agent = _agent(workspace)
+    agent._max_cost_usd = agent._resolve_cost_cap()
+
+    agent._token_records.append(
+        {"model": "claude-sonnet-4-5", "input_tokens": 1000, "output_tokens": 500,
+         "call_type": "execution", "iteration": 1}
+    )
+    agent._token_records.append(
+        {"model": "some-unlisted-local-model", "input_tokens": 1000,
+         "output_tokens": 500, "call_type": "execution", "iteration": 2}
+    )
+
     message = agent._cost_cap_message()
 
-    assert message is not None, "an unmeasurable cap silently allowed unbounded spend"
-    assert "gpt-4o" in message
-    assert "pricing" in message
+    assert message is not None, (
+        "spend on an unpriced model was masked by a priced call in the same run"
+    )
 
 
 def test_a_priced_model_under_the_cap_still_runs(workspace):


### PR DESCRIPTION
Closes #932.

## The product sells spend visibility and reported $0 by default

Four independent defects, all in the same direction — under-report.

### 1. The shipped default model had no price (AC1)

`MODEL_PRICING` had three entries. `DEFAULT_GENERATION_MODEL` is `claude-haiku-4-5`, which was not one of them — so **the default generation path priced every call at $0**.

Added the current Anthropic models plus the advertised OpenAI ones. The guard is a parametrized test over **every** `DEFAULT_*_MODEL` constant, so the next default bump cannot silently reintroduce this:

```
  before                                    after
  !! DEFAULT_GENERATION_MODEL  $0.0    ->   OK DEFAULT_GENERATION_MODEL  $6.0
```

### 2. Unknown was indistinguishable from free (AC3)

`calculate_cost` returned `0.0` for anything unpriced, so a gpt-4o/ollama call summed into totals as if it cost nothing. It now returns `Optional[float]` — `None` means "no pricing", `0.0` means "priced at free". `TokenUsage.estimated_cost_usd` is `Optional`, so unpriced usage stores SQL NULL, which the existing `COALESCE(SUM(...))` queries already skip.

The Python-side aggregators coalesce for summation and report the gap:

```
  total_cost_usd : $0.5500   (unpriced excluded, not zeroed in)
  total_tokens   : 1450
  unpriced_calls : 1         <- the UI can render "unpriced"
```

### 3. The default engine reported 0 tokens (AC2)

`BuiltinReactAdapter._map_status` built its `AgentResult` without `token_usage`, so engine stats and the Costs page showed 0 for **the default engine** while delegated adapters reported real figures. `ReactAgent` already had the numbers.

```
AgentResult.token_usage : AdapterTokenUsage(input_tokens=12000, output_tokens=3400,
                                            model='claude-haiku-4-5', cost_usd=0.0529)
```

A zero-token run reports `None` rather than claiming it was free. A run that used several models reports no single `model` rather than guessing one.

### 4. Configurable pricing + an honest docstring (AC4)

`CODEFRAME_MODEL_PRICING` (JSON) merges over the built-in table, so a new model or a negotiated rate needs no release. A malformed value is logged and ignored rather than breaking all pricing. Explicit `0/0` is supported and meaningful — local models are legitimately free, which is **not** the same as unpriced.

`record_token_usage`'s docstring promised a `ValueError` for unknown models that it never raised, while omitting the one it does raise (negative tokens). Corrected — and pinned behaviourally, not by text match. (Writing that test is what revealed my first correction was itself wrong.)

## Knock-on: #911's cost-cap workaround existed because of this bug

`react_agent._check_cost_cap` inferred "unpriced" from the *outcome* — tokens recorded but $0 spent — with a comment explaining that a `MODEL_PRICING` membership test false-fired on the shipped default. That is precisely the bug fixed here, so the cap now asks `_has_unpriced_records()` directly.

The #911 test used `gpt-4o` as its unpriced stand-in; AC4 prices gpt-4o, so it moved to a genuinely unlisted model. Its *intent* is unchanged and two tests were added: the newly-priced gpt-4o path, and a mixed priced/unpriced run (an unpriced call must not be masked by a priced one).

## Acceptance criteria

- [x] The shipped default generation model resolves to a real price; a test asserts non-zero cost for `DEFAULT_GENERATION_MODEL`
- [x] Builtin adapters populate `AgentResult.token_usage`
- [x] Unknown models are stored as unpriced and rendered as such rather than summing as $0
- [x] `record_token_usage`'s docstring matches behaviour; pricing covers the advertised providers **and** is configurable

## Third-party review

`codex review --base main` found **two P2 regressions this PR introduced**, both fixed:

1. Four Python aggregators added the raw DB value, so viewing metrics after an unpriced run raised `TypeError`. Now coalesced, with `unpriced_calls` reported.
2. Keeping `spent == 0.0 and tokens > 0` as an "unmeasurable" fallback contradicted the new explicit-zero pricing — a local model priced `0/0` is measured, and the cap aborted the run anyway. Dropped; `None` is the sentinel now.

## Tests

40 tests across the two files (7 RED before the fix, plus 2 more for each codex finding). Regression sweep: **714 passed** across `tests/ -k "cost or token or metrics or adapter or engine_stats"`. `ruff check` clean.

## Known limitations

- Rates are point-in-time and will drift; `CODEFRAME_MODEL_PRICING` is the escape hatch rather than a promise that the table stays current.
- `_load_prior_task_cost` sums prior recorded spend, and a prior *unpriced* run stored NULL — so a resumed task's cap sees only the priced part of earlier runs. Detecting that needs the prior-run query to report NULL rows too; out of scope here.
- The Costs page now receives `unpriced_calls` but this PR does not add the frontend badge for it — the API reports the gap, the UI change is a follow-up.
