### PR TITLE
fix(api): harden the v2 surface — AI tier, payload caps, no leaks, CORS (#934)

### DIFF
--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -50,6 +50,7 @@ _AUTH_FALSY = {"0", "false", "no", "off"}
 _QUERY_TICKET_PATHS = (
     re.compile(r"^/api/v2/tasks/[^/]+/stream$"),  # task event stream (SSE)
     re.compile(r"^/api/v2/prd/stress-test$"),  # PRD stress-test stream (SSE)
+    re.compile(r"^/api/v2/tasks/[^/]+/output$"),  # raw task output stream (SSE, #934)
 )
 
 

--- a/codeframe/ui/response_models.py
+++ b/codeframe/ui/response_models.py
@@ -203,3 +203,35 @@ def retrieved_message(resource: str, count: Optional[int] = None) -> str:
     if count is not None:
         return f"Retrieved {count} {resource}(s)"
     return f"{resource} retrieved successfully"
+
+
+def internal_error(exc: BaseException, *, operation: str, logger=None) -> dict:
+    """Log an unexpected exception and return a client-safe error body (#934).
+
+    ``str(exc)`` on an unexpected exception leaks host filesystem paths, SQL,
+    library internals and sometimes credentials in connection strings — to any
+    authenticated tenant, and inside SSE ``error`` events too. The client gets a
+    generic message plus a correlation id; the id is what ties their report to
+    the full traceback in the operator's logs.
+
+    Args:
+        exc: The caught exception. Never rendered into the response.
+        operation: Short human description, e.g. "generate PRD".
+        logger: Logger to record against; falls back to this module's.
+
+    Returns:
+        A standard error dict carrying only the correlation id as detail.
+    """
+    import logging as _logging
+    import uuid as _uuid
+
+    correlation_id = str(_uuid.uuid4())
+    (logger or _logging.getLogger(__name__)).error(
+        "[%s] Failed to %s: %s", correlation_id, operation, exc, exc_info=True
+    )
+    return {
+        "error": f"Failed to {operation}",
+        "code": ErrorCodes.EXECUTION_FAILED,
+        "detail": f"An internal error occurred. Reference: {correlation_id}",
+        "correlation_id": correlation_id,
+    }

--- a/codeframe/ui/routers/environment_v2.py
+++ b/codeframe/ui/routers/environment_v2.py
@@ -16,6 +16,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
+from codeframe.auth.api_keys import SCOPE_ADMIN
+from codeframe.auth.dependencies import require_scope
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_standard
 from codeframe.core.environment import EnvironmentValidator, ValidationResult, ToolInfo
@@ -189,6 +191,9 @@ async def install_tool(
     request: Request,
     body: InstallToolRequest,
     workspace: Workspace = Depends(get_v2_workspace),
+    # Installing a package on the HOST is machine-wide and irreversible from the
+    # app's side — it is administration, not ordinary write access (#934).
+    _auth: dict = Depends(require_scope(SCOPE_ADMIN)),
 ) -> InstallResultResponse:
     """Install a missing tool.
 

--- a/codeframe/ui/routers/git_v2.py
+++ b/codeframe/ui/routers/git_v2.py
@@ -113,7 +113,6 @@ async def get_git_status(
         logger.error(f"Git status failed: {e}")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Failed to get git status: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             # Generic body + correlation id: str(e) here leaked host paths and
@@ -165,7 +164,6 @@ async def list_commits(
         logger.error(f"List commits failed: {e}")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Failed to list commits: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             # Generic body + correlation id: str(e) here leaked host paths and
@@ -211,7 +209,6 @@ async def create_commit(
         logger.error(f"Create commit failed: {e}")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Failed to create commit: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             # Generic body + correlation id: str(e) here leaked host paths and
@@ -248,7 +245,6 @@ async def get_diff(
         logger.error(f"Get diff failed: {e}")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Failed to get diff: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             # Generic body + correlation id: str(e) here leaked host paths and
@@ -279,7 +275,6 @@ async def get_current_branch(
         logger.error(f"Get branch failed: {e}")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Failed to get current branch: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             # Generic body + correlation id: str(e) here leaked host paths and
@@ -310,7 +305,6 @@ async def check_clean(
         logger.error(f"Check clean failed: {e}")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Failed to check if clean: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             # Generic body + correlation id: str(e) here leaked host paths and

--- a/codeframe/ui/routers/git_v2.py
+++ b/codeframe/ui/routers/git_v2.py
@@ -17,6 +17,7 @@ from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_standard
 from codeframe.core import git
 from codeframe.ui.dependencies import get_v2_workspace
+from codeframe.ui.response_models import internal_error
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,12 @@ async def get_git_status(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to get git status: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            # Generic body + correlation id: str(e) here leaked host paths and
+            # git internals to any authenticated tenant (#934).
+            detail=internal_error(e, operation="get git status", logger=logger),
+        )
 
 
 @router.get("/commits", response_model=CommitListResponse)
@@ -160,7 +166,12 @@ async def list_commits(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to list commits: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            # Generic body + correlation id: str(e) here leaked host paths and
+            # git internals to any authenticated tenant (#934).
+            detail=internal_error(e, operation="list commits", logger=logger),
+        )
 
 
 @router.post("/commit", response_model=CommitResultResponse, status_code=201)
@@ -201,7 +212,12 @@ async def create_commit(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to create commit: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            # Generic body + correlation id: str(e) here leaked host paths and
+            # git internals to any authenticated tenant (#934).
+            detail=internal_error(e, operation="create commit", logger=logger),
+        )
 
 
 @router.get("/diff", response_model=DiffResponse)
@@ -233,7 +249,12 @@ async def get_diff(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to get diff: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            # Generic body + correlation id: str(e) here leaked host paths and
+            # git internals to any authenticated tenant (#934).
+            detail=internal_error(e, operation="get diff", logger=logger),
+        )
 
 
 @router.get("/branch")
@@ -259,7 +280,12 @@ async def get_current_branch(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to get current branch: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            # Generic body + correlation id: str(e) here leaked host paths and
+            # git internals to any authenticated tenant (#934).
+            detail=internal_error(e, operation="get current branch", logger=logger),
+        )
 
 
 @router.get("/clean")
@@ -285,4 +311,9 @@ async def check_clean(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to check if clean: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            # Generic body + correlation id: str(e) here leaked host paths and
+            # git internals to any authenticated tenant (#934).
+            detail=internal_error(e, operation="check if clean", logger=logger),
+        )

--- a/codeframe/ui/routers/prd_v2.py
+++ b/codeframe/ui/routers/prd_v2.py
@@ -18,7 +18,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import AsyncGenerator, Optional
+from typing import Annotated, AsyncGenerator, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
@@ -44,6 +44,11 @@ MAX_PRD_CONTENT_CHARS = 200_000
 MAX_ANSWER_CHARS = 10_000
 #: How many ambiguities one refine request may carry.
 MAX_REFINE_ANSWERS = 100
+#: A single restated question, and how many may accompany one answer. These are
+#: joined into the refine prompt too, so capping only `answer` left the same
+#: billing/DoS vector open through `questions` (codex review on #934).
+MAX_QUESTION_CHARS = 2_000
+MAX_QUESTIONS_PER_AMBIGUITY = 20
 
 logger = logging.getLogger(__name__)
 
@@ -131,8 +136,14 @@ class AmbiguityAnswer(BaseModel):
     label: str = Field(
         ..., min_length=1, max_length=500, description="Short ambiguity label"
     )
-    questions: list[str] = Field(
-        default_factory=list, description="The unanswered questions"
+    questions: list[Annotated[str, Field(max_length=MAX_QUESTION_CHARS)]] = Field(
+        default_factory=list,
+        max_length=MAX_QUESTIONS_PER_AMBIGUITY,
+        description=(
+            "The unanswered questions. At most "
+            f"{MAX_QUESTIONS_PER_AMBIGUITY}, each up to {MAX_QUESTION_CHARS} "
+            "characters — these are joined into the refine prompt (#934)."
+        ),
     )
     answer: str = Field(
         ...,
@@ -324,14 +335,12 @@ async def _stress_test_event_stream(
         # has already sent 200 OK by the time this generator runs, so the app-level
         # 400 handler can never fire here — letting it escape would kill the
         # EventSource with no frame and no explanation.
-        # A generic message + correlation id, not str(exc): SSE error events
-        # are rendered in the browser and used to leak host paths (#934).
-        _err = internal_error(exc, operation="run the stress test", logger=logger)
-        yield _sse({
-            "type": "error",
-            "message": _err["detail"],
-            "correlation_id": _err["correlation_id"],
-        })
+        # str(exc) is kept HERE on purpose (#934). These are configuration
+        # errors with messages authored for the operator ("ANTHROPIC_API_KEY
+        # environment variable required", an untrusted base_url) — actionable,
+        # and they contain no internals. The generic-message rule applies to
+        # *unexpected* exceptions, handled below.
+        yield _sse({"type": "error", "message": str(exc)})
         return
 
     # Latched so the *recursion* can see it, not just this loop. Breaking here
@@ -378,6 +387,17 @@ async def _stress_test_event_stream(
                 disconnected = True
                 break
             yield _sse(event)
+    except Exception as exc:  # noqa: BLE001 - the stream is already 200 OK
+        # There was no except here at all: an unexpected failure mid-stream
+        # killed the EventSource with no frame and no explanation. Emit a
+        # generic error event with a correlation id — unlike the configuration
+        # errors above, str(exc) here is arbitrary internals (#934).
+        _err = internal_error(exc, operation="run the stress test", logger=logger)
+        yield _sse({
+            "type": "error",
+            "message": _err["detail"],
+            "correlation_id": _err["correlation_id"],
+        })
     finally:
         if watcher is not None:
             disconnected = True  # stops the poll loop on the normal path too
@@ -584,9 +604,9 @@ async def create_prd(
         return _prd_to_response(record)
 
     except Exception as e:
-        logger.error(f"Failed to create PRD: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
+            # internal_error logs the traceback under the correlation id.
             detail=internal_error(e, operation="create PRD", logger=logger),
         )
 
@@ -716,9 +736,9 @@ async def create_prd_version(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to create PRD version: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
+            # internal_error logs the traceback under the correlation id.
             detail=internal_error(e, operation="create version", logger=logger),
         )
 

--- a/codeframe/ui/routers/prd_v2.py
+++ b/codeframe/ui/routers/prd_v2.py
@@ -29,6 +29,10 @@ from codeframe.core.llm_resolution import UntrustedBaseURLError
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
 from codeframe.core import prd
 
+from codeframe.core.prd import PrdHasDependentTasksError
+from codeframe.ui.dependencies import get_v2_workspace
+from codeframe.ui.response_models import api_error, internal_error, ErrorCodes
+
 # Payload caps (#934). Every value below is fed into an LLM prompt, so an
 # uncapped request body is an unbounded provider bill and a DoS vector. Pydantic
 # enforces these before the handler runs, so overflow is a 422 with a field-level
@@ -40,9 +44,6 @@ MAX_PRD_CONTENT_CHARS = 200_000
 MAX_ANSWER_CHARS = 10_000
 #: How many ambiguities one refine request may carry.
 MAX_REFINE_ANSWERS = 100
-from codeframe.core.prd import PrdHasDependentTasksError
-from codeframe.ui.dependencies import get_v2_workspace
-from codeframe.ui.response_models import api_error, internal_error, ErrorCodes
 
 logger = logging.getLogger(__name__)
 

--- a/codeframe/ui/routers/prd_v2.py
+++ b/codeframe/ui/routers/prd_v2.py
@@ -26,11 +26,23 @@ from pydantic import BaseModel, Field, field_validator
 
 from codeframe.core.workspace import Workspace
 from codeframe.core.llm_resolution import UntrustedBaseURLError
-from codeframe.lib.rate_limiter import rate_limit_standard
+from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
 from codeframe.core import prd
+
+# Payload caps (#934). Every value below is fed into an LLM prompt, so an
+# uncapped request body is an unbounded provider bill and a DoS vector. Pydantic
+# enforces these before the handler runs, so overflow is a 422 with a field-level
+# message rather than work the operator pays for.
+#: ~200k characters is roughly 50k tokens — comfortably above a real PRD and far
+#: below a context-window-filling upload.
+MAX_PRD_CONTENT_CHARS = 200_000
+#: A single stress-test answer.
+MAX_ANSWER_CHARS = 10_000
+#: How many ambiguities one refine request may carry.
+MAX_REFINE_ANSWERS = 100
 from codeframe.core.prd import PrdHasDependentTasksError
 from codeframe.ui.dependencies import get_v2_workspace
-from codeframe.ui.response_models import api_error, ErrorCodes
+from codeframe.ui.response_models import api_error, internal_error, ErrorCodes
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +90,16 @@ class PrdListResponse(BaseModel):
 class CreatePrdRequest(BaseModel):
     """Request for creating a PRD."""
 
-    content: str = Field(..., min_length=1, description="PRD content (markdown)")
+    content: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_PRD_CONTENT_CHARS,
+        description=(
+            "PRD content (markdown). Capped at "
+            f"{MAX_PRD_CONTENT_CHARS} characters — this text is fed to an LLM, "
+            "so an uncapped body is an unbounded bill. Overflow returns 422."
+        ),
+    )
     title: Optional[str] = Field(None, description="Optional title (extracted from content if not provided)")
     metadata: Optional[dict] = Field(None, description="Optional metadata")
 
@@ -86,7 +107,12 @@ class CreatePrdRequest(BaseModel):
 class CreateVersionRequest(BaseModel):
     """Request for creating a new PRD version."""
 
-    content: str = Field(..., min_length=1, description="New PRD content")
+    content: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_PRD_CONTENT_CHARS,
+        description=f"New PRD content. Capped at {MAX_PRD_CONTENT_CHARS} characters (#934).",
+    )
     change_summary: str = Field(..., min_length=1, description="Description of changes")
 
 
@@ -101,11 +127,18 @@ class PrdDiffResponse(BaseModel):
 class AmbiguityAnswer(BaseModel):
     """A single answered ambiguity from the stress-test results view (#562)."""
 
-    label: str = Field(..., min_length=1, description="Short ambiguity label")
+    label: str = Field(
+        ..., min_length=1, max_length=500, description="Short ambiguity label"
+    )
     questions: list[str] = Field(
         default_factory=list, description="The unanswered questions"
     )
-    answer: str = Field(..., min_length=1, description="The user's answer")
+    answer: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_ANSWER_CHARS,
+        description=f"The user's answer. Capped at {MAX_ANSWER_CHARS} characters (#934).",
+    )
 
     @field_validator("answer")
     @classmethod
@@ -127,7 +160,13 @@ class StressTestRefineRequest(BaseModel):
 
     prd_id: str = Field(..., description="ID of the PRD to refine")
     answers: list[AmbiguityAnswer] = Field(
-        ..., min_length=1, description="Resolved ambiguities to fold into the PRD"
+        ...,
+        min_length=1,
+        max_length=MAX_REFINE_ANSWERS,
+        description=(
+            "Resolved ambiguities to fold into the PRD. At most "
+            f"{MAX_REFINE_ANSWERS} — each one lengthens the LLM prompt (#934)."
+        ),
     )
 
 
@@ -284,7 +323,14 @@ async def _stress_test_event_stream(
         # has already sent 200 OK by the time this generator runs, so the app-level
         # 400 handler can never fire here — letting it escape would kill the
         # EventSource with no frame and no explanation.
-        yield _sse({"type": "error", "message": str(exc)})
+        # A generic message + correlation id, not str(exc): SSE error events
+        # are rendered in the browser and used to leak host paths (#934).
+        _err = internal_error(exc, operation="run the stress test", logger=logger)
+        yield _sse({
+            "type": "error",
+            "message": _err["detail"],
+            "correlation_id": _err["correlation_id"],
+        })
         return
 
     # Latched so the *recursion* can see it, not just this loop. Breaking here
@@ -338,7 +384,9 @@ async def _stress_test_event_stream(
 
 
 @router.get("/stress-test")
-@rate_limit_standard()
+# LLM route -> AI tier (#934). On the standard tier one tenant burned the
+# operator's provider budget five times faster than any other LLM endpoint.
+@rate_limit_ai()
 async def stress_test_prd_stream_endpoint(
     request: Request,
     max_depth: int = Query(3, ge=1, le=10, description="Maximum recursion depth"),
@@ -375,7 +423,8 @@ async def stress_test_prd_stream_endpoint(
 # NOTE: registered before the "/{prd_id}" catch-all so FastAPI does not match
 # "stress-test/refine" as a PRD id.
 @router.post("/stress-test/refine", response_model=PrdResponse)
-@rate_limit_standard()
+# LLM route -> AI tier (#934), same reason as the stream above.
+@rate_limit_ai()
 async def refine_prd_from_stress_test(
     request: Request,
     body: StressTestRefineRequest,
@@ -471,12 +520,9 @@ async def refine_prd_from_stress_test(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to refine PRD: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=api_error(
-                "Failed to refine PRD", ErrorCodes.EXECUTION_FAILED, str(e)
-            ),
+            detail=internal_error(e, operation="refine PRD", logger=logger),
         )
 
 
@@ -540,7 +586,7 @@ async def create_prd(
         logger.error(f"Failed to create PRD: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=api_error("Failed to create PRD", ErrorCodes.EXECUTION_FAILED, str(e)),
+            detail=internal_error(e, operation="create PRD", logger=logger),
         )
 
 
@@ -672,7 +718,7 @@ async def create_prd_version(
         logger.error(f"Failed to create PRD version: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=api_error("Failed to create version", ErrorCodes.EXECUTION_FAILED, str(e)),
+            detail=internal_error(e, operation="create version", logger=logger),
         )
 
 

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -1211,6 +1211,9 @@ async def stream_task_output_lines(
 
 
 @router.get("/{task_id}/stream")
+# An unlimited SSE route lets one client hold open arbitrarily many server-side
+# subscriptions; every other streaming route here is limited (#934).
+@rate_limit_standard()
 async def stream_task_events(
     request: Request,
     task_id: str,

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -723,8 +723,20 @@ cors_origins_env = os.environ.get("CORS_ALLOWED_ORIGINS", "")
 # Parse comma-separated origins
 if cors_origins_env:
     allowed_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
+elif os.environ.get("CODEFRAME_DEPLOYMENT_MODE", "self_hosted").strip().lower() == "hosted":
+    # Fail closed (#934). The localhost fallback below is paired with
+    # allow_credentials=True, so on a multi-tenant deployment an unset
+    # CORS_ALLOWED_ORIGINS would let a page served from any localhost origin —
+    # including one an attacker persuades a logged-in operator to open — make
+    # credentialed cross-origin calls. A hosted deploy that has not declared its
+    # origins gets none, not convenient ones.
+    allowed_origins = []
+    logger.error(
+        "CORS_ALLOWED_ORIGINS is unset in hosted mode — refusing all cross-origin "
+        "requests. Set it to your public origin(s)."
+    )
 else:
-    # Fallback to development defaults if not configured
+    # Self-hosted/local default: the dev servers, on the same machine as the API.
     allowed_origins = [
         "http://localhost:3000",  # Next.js dev server
         "http://localhost:3001",  # Next.js E2E test server

--- a/tests/ui/test_api_hardening_934.py
+++ b/tests/ui/test_api_hardening_934.py
@@ -1,0 +1,241 @@
+"""v2 API surface hardening (#934).
+
+Five independent weaknesses on the public API:
+
+1. prd_v2's stress-test SSE and refine used the *standard* rate-limit tier while
+   every other LLM route uses the AI tier — one tenant could burn the operator's
+   provider budget five times faster.
+2. PRD content and refine answers had no size cap before entering an LLM prompt.
+3. prd_v2 and git_v2 returned raw `str(exc)` to clients — host paths, SQL and
+   library internals — including inside SSE `error` events rendered in a browser.
+4. With CORS_ALLOWED_ORIGINS unset, allow_origins fell back to localhost while
+   allow_credentials=True.
+5. GET /{task_id}/stream carried no rate limit; GET /{task_id}/output had no
+   browser-usable auth path; and the HOST package install needed only write scope.
+"""
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _source(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text()
+
+
+class TestLlmRoutesUseTheAiTier:
+    """AC1 — an LLM route on the standard tier is a budget hole."""
+
+    @pytest.mark.parametrize(
+        "route", ['@router.get("/stress-test")', '@router.post("/stress-test/refine"']
+    )
+    def test_route_is_decorated_with_rate_limit_ai(self, route: str):
+        source = _source("codeframe/ui/routers/prd_v2.py")
+        start = source.index(route)
+        # The decorators sit between the route decorator and its handler.
+        block = source[start : source.index("async def", start)]
+
+        assert "@rate_limit_ai()" in block, f"{route} is not on the AI tier"
+        assert "@rate_limit_standard()" not in block
+
+    def test_task_event_stream_is_rate_limited(self):
+        source = _source("codeframe/ui/routers/tasks_v2.py")
+        start = source.index('@router.get("/{task_id}/stream")')
+        block = source[start : source.index("async def", start)]
+
+        assert "@rate_limit" in block, "the SSE event stream carries no rate limit"
+
+
+class TestPayloadCaps:
+    """AC2 — anything entering an LLM prompt must be bounded."""
+
+    def test_prd_content_is_capped(self):
+        from codeframe.ui.routers.prd_v2 import MAX_PRD_CONTENT_CHARS, CreatePrdRequest
+
+        field = CreatePrdRequest.model_fields["content"]
+        assert any(
+            getattr(m, "max_length", None) == MAX_PRD_CONTENT_CHARS
+            for m in field.metadata
+        ), "PRD content has no max_length"
+
+    def test_oversized_prd_content_is_rejected_with_422(self):
+        from pydantic import ValidationError
+
+        from codeframe.ui.routers.prd_v2 import MAX_PRD_CONTENT_CHARS, CreatePrdRequest
+
+        with pytest.raises(ValidationError):
+            CreatePrdRequest(content="x" * (MAX_PRD_CONTENT_CHARS + 1))
+
+    def test_content_at_the_cap_is_accepted(self):
+        from codeframe.ui.routers.prd_v2 import MAX_PRD_CONTENT_CHARS, CreatePrdRequest
+
+        assert CreatePrdRequest(content="x" * MAX_PRD_CONTENT_CHARS)
+
+    def test_refine_answer_is_capped(self):
+        from pydantic import ValidationError
+
+        from codeframe.ui.routers.prd_v2 import MAX_ANSWER_CHARS, AmbiguityAnswer
+
+        with pytest.raises(ValidationError):
+            AmbiguityAnswer(label="l", answer="x" * (MAX_ANSWER_CHARS + 1))
+
+    def test_refine_answer_count_is_capped(self):
+        from pydantic import ValidationError
+
+        from codeframe.ui.routers.prd_v2 import (
+            MAX_REFINE_ANSWERS,
+            AmbiguityAnswer,
+            StressTestRefineRequest,
+        )
+
+        one = AmbiguityAnswer(label="l", answer="a")
+        with pytest.raises(ValidationError):
+            StressTestRefineRequest(
+                prd_id="p", answers=[one] * (MAX_REFINE_ANSWERS + 1)
+            )
+
+    def test_the_cap_is_documented_in_the_field_description(self):
+        from codeframe.ui.routers.prd_v2 import CreatePrdRequest
+
+        description = CreatePrdRequest.model_fields["content"].description or ""
+        assert "Capped" in description or "capped" in description
+
+
+class TestNoRawExceptionText:
+    """AC3 — str(exc) reaches the client with host paths and internals."""
+
+    def test_internal_error_hides_the_exception_text(self):
+        from codeframe.ui.response_models import internal_error
+
+        body = internal_error(
+            RuntimeError("/home/operator/.ssh/id_rsa could not be read"),
+            operation="do a thing",
+        )
+
+        assert "/home/operator" not in str(body)
+        assert "id_rsa" not in str(body)
+
+    def test_internal_error_returns_a_correlation_id(self):
+        from codeframe.ui.response_models import internal_error
+
+        body = internal_error(RuntimeError("boom"), operation="do a thing")
+
+        assert body["correlation_id"]
+        assert body["correlation_id"] in body["detail"], (
+            "the id must be visible to the client so they can quote it"
+        )
+
+    def test_two_failures_get_distinct_ids(self):
+        from codeframe.ui.response_models import internal_error
+
+        a = internal_error(RuntimeError("x"), operation="op")
+        b = internal_error(RuntimeError("x"), operation="op")
+
+        assert a["correlation_id"] != b["correlation_id"]
+
+    def test_internal_error_logs_the_real_exception(self, caplog):
+        import logging
+
+        from codeframe.ui.response_models import internal_error
+
+        with caplog.at_level(logging.ERROR):
+            body = internal_error(
+                RuntimeError("/secret/path exploded"), operation="do a thing"
+            )
+
+        assert "/secret/path exploded" in caplog.text, "the operator loses the detail"
+        assert body["correlation_id"] in caplog.text, "the id must tie the two together"
+
+    @pytest.mark.parametrize(
+        "module", ["codeframe/ui/routers/prd_v2.py", "codeframe/ui/routers/git_v2.py"]
+    )
+    def test_no_500_handler_returns_str_of_the_exception(self, module: str):
+        source = _source(module)
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if re.search(r"status_code=500.*str\(e", line)
+            or re.search(r"EXECUTION_FAILED,\s*str\(e\)", line)
+        ]
+
+        assert not offenders, "raw exception text is returned to the client:\n" + "\n".join(
+            offenders
+        )
+
+    def test_sse_error_events_do_not_carry_exception_text(self):
+        source = _source("codeframe/ui/routers/prd_v2.py")
+
+        assert '"message": str(exc)' not in source, (
+            "the SSE error event leaks exception text into the browser"
+        )
+
+
+class TestCorsFailsClosedInHostedMode:
+    """AC4 — a credentialed localhost default on a multi-tenant deploy."""
+
+    def _origins(self, monkeypatch, *, mode: str, cors: str | None):
+        monkeypatch.setenv("CODEFRAME_DEPLOYMENT_MODE", mode)
+        if cors is None:
+            monkeypatch.delenv("CORS_ALLOWED_ORIGINS", raising=False)
+        else:
+            monkeypatch.setenv("CORS_ALLOWED_ORIGINS", cors)
+        import codeframe.ui.server as server
+
+        importlib.reload(server)
+        return server.allowed_origins
+
+    def test_hosted_mode_without_cors_allows_nothing(self, monkeypatch):
+        assert self._origins(monkeypatch, mode="hosted", cors=None) == []
+
+    def test_hosted_mode_with_cors_uses_it(self, monkeypatch):
+        assert self._origins(
+            monkeypatch, mode="hosted", cors="https://app.example.com"
+        ) == ["https://app.example.com"]
+
+    def test_self_hosted_keeps_the_localhost_defaults(self, monkeypatch):
+        origins = self._origins(monkeypatch, mode="self_hosted", cors=None)
+
+        assert "http://localhost:3000" in origins, (
+            "local development must not be broken by the hosted-mode guard"
+        )
+
+    def test_unset_deployment_mode_is_treated_as_self_hosted(self, monkeypatch):
+        monkeypatch.delenv("CODEFRAME_DEPLOYMENT_MODE", raising=False)
+        monkeypatch.delenv("CORS_ALLOWED_ORIGINS", raising=False)
+        import codeframe.ui.server as server
+
+        importlib.reload(server)
+
+        assert "http://localhost:3000" in server.allowed_origins
+
+
+class TestStreamAuthAndAdminScope:
+    """AC5 — browser auth for /output, admin scope for host installs."""
+
+    def test_task_output_stream_accepts_a_query_ticket(self):
+        from codeframe.auth.dependencies import _query_ticket_allowed
+
+        assert _query_ticket_allowed("/api/v2/tasks/abc-123/output")
+
+    def test_the_ticket_allowlist_stays_tight(self):
+        """The fallback must not spread to the rest of the API."""
+        from codeframe.auth.dependencies import _query_ticket_allowed
+
+        assert not _query_ticket_allowed("/api/v2/tasks")
+        assert not _query_ticket_allowed("/api/v2/settings/keys")
+        assert not _query_ticket_allowed("/api/v2/tasks/abc-123")
+
+    def test_install_route_requires_admin_scope(self):
+        source = _source("codeframe/ui/routers/environment_v2.py")
+        start = source.index('@router.post("/install"')
+        block = source[start : source.index("\"\"\"", start)]
+
+        assert "require_scope(SCOPE_ADMIN)" in block, (
+            "installing a host package needs admin, not plain write scope"
+        )

--- a/tests/ui/test_api_hardening_934.py
+++ b/tests/ui/test_api_hardening_934.py
@@ -100,6 +100,30 @@ class TestPayloadCaps:
                 prd_id="p", answers=[one] * (MAX_REFINE_ANSWERS + 1)
             )
 
+    def test_restated_questions_are_capped(self):
+        """Raised by codex review: `questions` is joined into the refine prompt
+        too, so capping only `answer` left the same vector open."""
+        from pydantic import ValidationError
+
+        from codeframe.ui.routers.prd_v2 import (
+            MAX_QUESTION_CHARS,
+            MAX_QUESTIONS_PER_AMBIGUITY,
+            AmbiguityAnswer,
+        )
+
+        with pytest.raises(ValidationError):
+            AmbiguityAnswer(
+                label="l", answer="a", questions=["x" * (MAX_QUESTION_CHARS + 1)]
+            )
+        with pytest.raises(ValidationError):
+            AmbiguityAnswer(
+                label="l", answer="a", questions=["q"] * (MAX_QUESTIONS_PER_AMBIGUITY + 1)
+            )
+
+        assert AmbiguityAnswer(
+            label="l", answer="a", questions=["q"] * MAX_QUESTIONS_PER_AMBIGUITY
+        )
+
     def test_the_cap_is_documented_in_the_field_description(self):
         from codeframe.ui.routers.prd_v2 import CreatePrdRequest
 
@@ -168,12 +192,34 @@ class TestNoRawExceptionText:
             offenders
         )
 
-    def test_sse_error_events_do_not_carry_exception_text(self):
+    def test_unexpected_sse_failures_use_a_correlation_id(self):
+        """The stream had NO except clause: an unexpected failure killed the
+        EventSource with no frame. It now emits a generic error event.
+
+        The *configuration* branch above it deliberately keeps `str(exc)` —
+        "ANTHROPIC_API_KEY environment variable required" is operator guidance,
+        not an internal leak, and the AC scopes the rule to *unexpected*
+        exceptions. An earlier revision of this fix genericized both and
+        swallowed that guidance; a router test caught it.
+        """
+        source = _source("codeframe/ui/routers/prd_v2.py")
+        generator = source[
+            source.index("async def _stress_test_event_stream") if
+            "async def _stress_test_event_stream" in source else 0
+            : source.index('@router.get("/stress-test")')
+        ]
+
+        assert "except Exception as exc" in generator, (
+            "an unexpected mid-stream failure still has no handler"
+        )
+        assert "internal_error(exc" in generator
+        assert "correlation_id" in generator
+
+    def test_configuration_errors_keep_their_actionable_message(self):
+        """Genericizing these would hide 'ANTHROPIC_API_KEY required' from the operator."""
         source = _source("codeframe/ui/routers/prd_v2.py")
 
-        assert '"message": str(exc)' not in source, (
-            "the SSE error event leaks exception text into the browser"
-        )
+        assert 'yield _sse({"type": "error", "message": str(exc)})' in source
 
 
 class TestCorsFailsClosedInHostedMode:


### PR DESCRIPTION
Closes #934. (Blocked-by #898 is closed.)

Five independent weaknesses on the public v2 surface.

## 1. LLM routes were on the wrong rate-limit tier

`prd_v2`'s stress-test SSE and refine used `@rate_limit_standard` while every other LLM route uses `@rate_limit_ai` — so one tenant could burn the operator's provider budget **five times faster** through these two endpoints than through any other. Both moved to `@rate_limit_ai`.

`GET /tasks/{id}/stream` carried no rate limit at all; an unlimited SSE route lets one client hold arbitrarily many server-side subscriptions open. Added.

## 2. Nothing capped what reached an LLM prompt

| Field | Cap |
|---|---|
| PRD `content` (create + new version) | 200,000 chars (~50k tokens) |
| a single stress-test `answer` | 10,000 chars |
| `answers` per refine request | 100 |

Pydantic enforces these before the handler runs, so overflow is a **422** with a field-level message rather than work the operator pays for. Each cap is stated in its field description, so it appears in the OpenAPI schema.

## 3. Raw exception text was returned to clients

`prd_v2` and `git_v2` returned `str(exc)` on unexpected failures — host filesystem paths, SQL, library internals — to any authenticated tenant, **including inside SSE `error` events rendered in the browser**.

New `response_models.internal_error(exc, operation=..., logger=...)`:

```python
{
  "error": "Failed to refine PRD",
  "code": "EXECUTION_FAILED",
  "detail": "An internal error occurred. Reference: 2a4094a7-…",
  "correlation_id": "2a4094a7-…"
}
```

The real exception and traceback go to the operator's log under the same id, so a user report stays actionable. Applied to every 500 handler in both routers and to the stress-test SSE error event.

`ValueError` → 400 branches keep their messages: those are authored validation text, not internals.

## 4. CORS fell back to credentialed localhost

With `CORS_ALLOWED_ORIGINS` unset, `allow_origins` defaulted to three localhost origins **while `allow_credentials=True`**. On a multi-tenant deploy that lets a page served from any localhost origin — including one an attacker persuades a logged-in operator to open — make credentialed cross-origin calls.

Now fails closed **in hosted mode only**: `CODEFRAME_DEPLOYMENT_MODE=hosted` with no `CORS_ALLOWED_ORIGINS` allows nothing and logs an error. Self-hosted (the default) keeps the dev-server defaults, so local development is untouched. A test pins both halves.

## 5. Stream auth and admin scope

- `GET /tasks/{id}/output` joins `_QUERY_TICKET_PATHS`. A browser `EventSource` cannot send an `Authorization` header, so without this the route had no browser-usable auth path at all. Tests assert the allowlist stays tight (`/api/v2/tasks`, `/api/v2/settings/keys` and `/api/v2/tasks/{id}` are still refused).
- `POST /environment/install` now requires **admin** scope. Installing a package on the *host* is machine-wide and irreversible from the app's side — administration, not ordinary write access.

## Acceptance criteria

- [x] prd_v2 stress-test and refine use `@rate_limit_ai`; `GET /{task_id}/stream` carries a rate limit
- [x] PRD content and refine answers are length-capped with 422 on overflow, documented
- [x] No endpoint returns `str(exc)` of an unexpected exception; a generic message plus correlation id is returned and the detail logged
- [x] `CORS_ALLOWED_ORIGINS` unset in hosted mode fails closed rather than defaulting to credentialed localhost
- [x] `GET /{task_id}/output` is added to `_QUERY_TICKET_PATHS`; the install route requires admin scope

## Tests

23 tests in `tests/ui/test_api_hardening_934.py`. Two are worth calling out as generalizing guards rather than point checks:

- a scanner over `prd_v2.py` and `git_v2.py` that fails if **any** 500 handler returns `str(e)` — so a new leak fails the build
- `internal_error` is asserted to both hide the exception text from the client *and* log it with the matching correlation id, so the two cannot drift apart

`ruff` and `mypy codeframe/` (197 files) clean.

## Known limitations

- The 413 alternative in the AC was not used: pydantic's `max_length` produces 422, which is the same class of answer and keeps the field-level message. A true 413 would need a body-size middleware ahead of parsing — worth doing, but broader than this issue.
- `internal_error` is applied to `prd_v2` and `git_v2`, the two routers the issue names. Other routers still return `str(e)` in places; the test scanner is scoped to these two so it does not fail on untouched files. Widening it is a follow-up.
- The CORS guard keys on `CODEFRAME_DEPLOYMENT_MODE`. A self-hosted instance exposed to the internet with `CORS_ALLOWED_ORIGINS` unset still gets the localhost defaults — documented behaviour, not silently changed here.
