### PR TITLE
fix(web): replace the CSP unsafe-inline script policy with a per-request nonce (#936)

### DIFF
--- a/web-ui/security-headers.d.ts
+++ b/web-ui/security-headers.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Types for the CommonJS security-headers.js (#936).
+ *
+ * The implementation stays CommonJS because next.config.js `require()`s it and
+ * must remain dependency-free; this declaration lets src/proxy.ts import it with
+ * ESM syntax, which the lint gate requires.
+ */
+export interface CspOptions {
+  /** Per-request nonce. Omit for the non-document fallback policy. */
+  nonce?: string;
+}
+
+export function buildCsp(env?: NodeJS.ProcessEnv, options?: CspOptions): string;
+export function buildConnectSrc(sources?: { apiUrl?: string; wsUrl?: string }): string;
+export function buildScriptSrc(options?: { nonce?: string; isDev?: boolean }): string;
+export function securityHeaders(): Array<{ key: string; value: string }>;

--- a/web-ui/security-headers.js
+++ b/web-ui/security-headers.js
@@ -94,7 +94,7 @@ function buildCsp(env = process.env, { nonce } = {}) {
  * intersected by the browser, so leaving the static one in place would have
  * re-imposed the weaker policy's absence of a nonce and blocked every script.
  */
-function securityHeaders(env = process.env) {
+function securityHeaders() {
   return [
     { key: 'X-Content-Type-Options', value: 'nosniff' },
     { key: 'X-Frame-Options', value: 'DENY' },

--- a/web-ui/security-headers.js
+++ b/web-ui/security-headers.js
@@ -25,26 +25,54 @@ function buildConnectSrc({ apiUrl, wsUrl } = {}) {
   return Array.from(sources).join(' ');
 }
 
-function buildCsp(env = process.env) {
+/**
+ * Build the script-src directive.
+ *
+ * With a per-request nonce (the production path, set by proxy.ts) this is
+ * `'self' 'nonce-<n>' 'strict-dynamic'` and contains NO 'unsafe-inline', so an
+ * injected inline script simply does not execute — which is what protects the
+ * localStorage JWT (#936). 'strict-dynamic' lets Next.js's nonced bootstrap
+ * load the chunks it needs without enumerating them.
+ *
+ * Browsers that understand 'strict-dynamic' ignore 'self' for scripts; it is
+ * kept for older ones, which then fall back to a host allow-list rather than
+ * to nothing.
+ *
+ * Without a nonce we cannot serve a working App Router page, so the nonce-less
+ * form keeps 'unsafe-inline'. That form must only ever reach responses that are
+ * not HTML documents — see next.config.js.
+ */
+function buildScriptSrc({ nonce, isDev } = {}) {
+  // unsafe-eval is only needed by the Next.js dev runtime (React Refresh /
+  // eval source maps); production bundles never eval, so it ships dev-only.
+  const devEval = isDev ? " 'unsafe-eval'" : '';
+  if (nonce) {
+    return `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${devEval}`;
+  }
+  return `script-src 'self' 'unsafe-inline'${devEval}`;
+}
+
+function buildCsp(env = process.env, { nonce } = {}) {
   const connectSrc = buildConnectSrc({
     apiUrl: env.NEXT_PUBLIC_API_URL,
     wsUrl: env.NEXT_PUBLIC_WS_URL,
   });
-  // unsafe-eval is only needed by the Next.js dev runtime (React Refresh /
-  // eval source maps); production bundles never eval, so it ships dev-only.
-  const scriptSrc = env.NODE_ENV === 'development'
-    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-    : "script-src 'self' 'unsafe-inline'";
+  const scriptSrc = buildScriptSrc({
+    nonce,
+    isDev: env.NODE_ENV === 'development',
+  });
   return [
     "default-src 'self'",
-    // ponytail: 'unsafe-inline' is required by the Next.js App Router without
-    // a per-request nonce middleware (a much larger change). Residual risk
-    // (#783): with the JWT in localStorage and inline scripts allowed, an
-    // injected inline script can read the token. connect-src/img-src/
-    // object-src below close the fetch/XHR/img/plugin exfil channels, but NOT
-    // top-level navigation (`window.location = attacker + token`) — CSP has
-    // no deployable navigate-to directive, so that channel stays open until
-    // the real fix: nonce middleware and/or an httpOnly-cookie token.
+    // script-src carries a per-request nonce in production (#936), so an
+    // injected inline script does not run and cannot read the localStorage
+    // JWT. That closes the top-level-navigation exfil channel too
+    // (`window.location = attacker + token`), which no CSP directive could
+    // block once the script was already executing — the residual risk this
+    // comment used to concede (#783).
+    //
+    // style-src deliberately keeps 'unsafe-inline': Tailwind and React set
+    // style attributes directly, and a stolen *style* is not a stolen session.
+    // The threat this addresses is script execution.
     scriptSrc,
     "style-src 'self' 'unsafe-inline'",
     `img-src 'self' data: blob: ${AVATAR_HOST}`,
@@ -57,13 +85,21 @@ function buildCsp(env = process.env) {
   ].join('; ');
 }
 
+/**
+ * Static headers for next.config.js.
+ *
+ * NOTE (#936): no Content-Security-Policy here. HTML documents get their CSP
+ * from proxy.ts, which mints a per-request nonce; a static CSP cannot carry one
+ * and would have to keep 'unsafe-inline'. Two CSP headers on one response are
+ * intersected by the browser, so leaving the static one in place would have
+ * re-imposed the weaker policy's absence of a nonce and blocked every script.
+ */
 function securityHeaders(env = process.env) {
   return [
-    { key: 'Content-Security-Policy', value: buildCsp(env) },
     { key: 'X-Content-Type-Options', value: 'nosniff' },
     { key: 'X-Frame-Options', value: 'DENY' },
     { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   ];
 }
 
-module.exports = { buildCsp, buildConnectSrc, securityHeaders };
+module.exports = { buildCsp, buildConnectSrc, buildScriptSrc, securityHeaders };

--- a/web-ui/src/__tests__/security-headers.test.js
+++ b/web-ui/src/__tests__/security-headers.test.js
@@ -49,15 +49,107 @@ describe('security headers (#657)', () => {
     expect(buildCsp({ NODE_ENV: 'development' })).toContain("'unsafe-eval'");
   });
 
-  test('securityHeaders ships the CSP plus the hardening header set', () => {
+  test('securityHeaders ships the hardening header set', () => {
+    // The CSP moved OUT of this static set in #936: HTML documents get it from
+    // proxy.ts, which mints a per-request nonce. A static CSP cannot carry one,
+    // and two CSP headers on a response are intersected — so leaving it here
+    // would have blocked every script. Asserted explicitly below.
     const keys = securityHeaders({}).map((h) => h.key);
     expect(keys).toEqual(
       expect.arrayContaining([
-        'Content-Security-Policy',
         'X-Content-Type-Options',
         'X-Frame-Options',
         'Referrer-Policy',
       ])
     );
+  });
+});
+
+describe('production CSP carries a nonce, not unsafe-inline (#936)', () => {
+  const PROD = { NODE_ENV: 'production' };
+
+  /** The AC's CI check: the production policy must not allow inline script. */
+  test('script-src has no unsafe-inline in production', () => {
+    const scriptSrc = buildCsp(PROD, { nonce: 'test-nonce' })
+      .split('; ')
+      .find((d) => d.startsWith('script-src'));
+
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  test('script-src carries the request nonce and strict-dynamic', () => {
+    const scriptSrc = buildCsp(PROD, { nonce: 'abc123' })
+      .split('; ')
+      .find((d) => d.startsWith('script-src'));
+
+    expect(scriptSrc).toContain("'nonce-abc123'");
+    expect(scriptSrc).toContain("'strict-dynamic'");
+  });
+
+  test('production never ships unsafe-eval', () => {
+    expect(buildCsp(PROD, { nonce: 'n' })).not.toContain("'unsafe-eval'");
+  });
+
+  test('development keeps unsafe-eval for the Next.js dev runtime', () => {
+    const csp = buildCsp({ NODE_ENV: 'development' }, { nonce: 'n' });
+    expect(csp).toContain("'unsafe-eval'");
+    // ...but still no unsafe-inline: the nonce works in dev too.
+    const scriptSrc = csp.split('; ').find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  test('style-src deliberately keeps unsafe-inline', () => {
+    // Documented decision: Tailwind/React set style attributes directly, and a
+    // stolen style is not a stolen session. If this ever changes it should be a
+    // conscious edit, not a silent one.
+    const styleSrc = buildCsp(PROD, { nonce: 'n' })
+      .split('; ')
+      .find((d) => d.startsWith('style-src'));
+    expect(styleSrc).toContain("'unsafe-inline'");
+  });
+
+  test('the static header set no longer carries a CSP', () => {
+    // Two CSP headers are intersected by the browser, so a static (nonce-less)
+    // one alongside the proxy's would block every script.
+    const keys = securityHeaders(PROD).map((h) => h.key);
+    expect(keys).not.toContain('Content-Security-Policy');
+    expect(keys).toContain('X-Content-Type-Options');
+  });
+
+  test('a missing nonce still produces a working policy', () => {
+    // Non-document responses fall back to this; it must not be empty or broken.
+    const scriptSrc = buildCsp(PROD)
+      .split('; ')
+      .find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toContain("'self'");
+  });
+});
+
+describe('the nonce requires dynamic rendering (#936)', () => {
+  const fs = require('fs');
+  const path = require('path');
+
+  test('the root layout forces dynamic rendering', () => {
+    // Next.js can only stamp a per-request nonce onto a document it renders at
+    // request time. Measured on a statically prerendered route: 0 of 21 scripts
+    // carried the nonce — with 'strict-dynamic' and no 'unsafe-inline' that is a
+    // blank page. Deleting this export would reintroduce that silently, since
+    // the build still succeeds.
+    const layout = fs.readFileSync(
+      path.join(__dirname, '..', 'app', 'layout.tsx'),
+      'utf8'
+    );
+    expect(layout).toMatch(/export const dynamic = 'force-dynamic'/);
+  });
+
+  test('proxy.ts sets the CSP on both request and response headers', () => {
+    const proxy = fs.readFileSync(path.join(__dirname, '..', 'proxy.ts'), 'utf8');
+    // The REQUEST header is what Next.js reads to nonce its own scripts; the
+    // RESPONSE header is what the browser enforces. Both are required — with
+    // only the response header set, the policy blocks the page's own scripts.
+    expect(proxy).toMatch(/requestHeaders\.set\(\s*'Content-Security-Policy'/);
+    expect(proxy).toMatch(/response\.headers\.set\(\s*'Content-Security-Policy'/);
+    expect(proxy).toContain('getRandomValues');
   });
 });

--- a/web-ui/src/__tests__/security-headers.test.js
+++ b/web-ui/src/__tests__/security-headers.test.js
@@ -5,6 +5,9 @@
  * object-src / base-uri / frame-ancestors — these tests pin that lockdown so a
  * future edit can't silently widen it (e.g. to `connect-src *`).
  */
+import fs from 'fs';
+import path from 'path';
+
 import { buildCsp, buildConnectSrc, securityHeaders } from '../../security-headers';
 
 describe('security headers (#657)', () => {
@@ -127,9 +130,6 @@ describe('production CSP carries a nonce, not unsafe-inline (#936)', () => {
 });
 
 describe('the nonce requires dynamic rendering (#936)', () => {
-  const fs = require('fs');
-  const path = require('path');
-
   test('the root layout forces dynamic rendering', () => {
     // Next.js can only stamp a per-request nonce onto a document it renders at
     // request time. Measured on a statically prerendered route: 0 of 21 scripts

--- a/web-ui/src/app/layout.tsx
+++ b/web-ui/src/app/layout.tsx
@@ -10,6 +10,23 @@ const nunitoSans = Nunito_Sans({
   variable: '--font-nunito-sans',
 });
 
+/**
+ * Every page is server-rendered per request (#936).
+ *
+ * The CSP nonce in `src/proxy.ts` is minted per request, and Next.js can only
+ * stamp it onto a document it renders at request time — a statically
+ * prerendered page keeps whatever was baked in at build time, i.e. no nonce.
+ * Measured before adding this: on a static route 0 of 21 scripts carried the
+ * nonce (with 'strict-dynamic' and no 'unsafe-inline' that is a blank page);
+ * on a dynamic route, 22 of 22 did.
+ *
+ * The cost is small here because these pages are `'use client'` shells whose
+ * prerender is an empty loading skeleton — the data is fetched client-side
+ * either way, and the JS/CSS chunks are still served statically from
+ * /_next/static, which the proxy matcher skips.
+ */
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: 'CodeFRAME',
   description: 'AI-powered development workflow orchestration',

--- a/web-ui/src/proxy.ts
+++ b/web-ui/src/proxy.ts
@@ -1,0 +1,59 @@
+/**
+ * Per-request CSP nonce (#936).
+ *
+ * The production CSP used to ship `script-src 'self' 'unsafe-inline'`, and the
+ * security-headers comment conceded the consequence: with the JWT in
+ * localStorage and inline scripts allowed, any future HTML-injection bug became
+ * full session theft. connect-src/img-src closed fetch/XHR/img exfiltration, but
+ * nothing could close top-level navigation (`window.location = attacker + token`)
+ * once the injected script was already running.
+ *
+ * A nonce fixes the actual problem rather than the exfil channels: an injected
+ * inline script has no nonce, so it never executes.
+ *
+ * This must be a proxy (not a static `headers()` entry) because the nonce has to
+ * differ per request — a constant nonce is worth exactly as much as
+ * 'unsafe-inline'.
+ */
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { buildCsp } = require('../security-headers');
+
+export function proxy(request: NextRequest) {
+  // crypto.getRandomValues: available on the Edge runtime, unlike node:crypto.
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const nonce = btoa(String.fromCharCode(...bytes));
+
+  const csp = buildCsp(process.env, { nonce });
+
+  // Set on the REQUEST headers too: Next.js reads the nonce from the CSP header
+  // it receives and stamps it onto the framework's own inline bootstrap scripts.
+  // Without this the page's own scripts would be blocked by the policy we just
+  // set — the failure mode is a blank page, so it is not subtle.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', csp);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set('Content-Security-Policy', csp);
+  return response;
+}
+
+export const config = {
+  matcher: [
+    {
+      // Everything except API routes, static assets and the favicon. Those are
+      // not HTML documents, so they need no nonce; next.config.js still applies
+      // the non-CSP hardening headers to them.
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      // Prefetches are not rendered, so nonce-ing them only costs work.
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};

--- a/web-ui/src/proxy.ts
+++ b/web-ui/src/proxy.ts
@@ -18,8 +18,9 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { buildCsp } = require('../security-headers');
+// security-headers.js is CommonJS (next.config.js requires it); the bundler
+// handles the interop. ESM here because the lint gate forbids require().
+import { buildCsp } from '../security-headers';
 
 export function proxy(request: NextRequest) {
   // crypto.getRandomValues: available on the Edge runtime, unlike node:crypto.


### PR DESCRIPTION
Closes #936.

## The problem, in the file's own words

Production shipped `script-src 'self' 'unsafe-inline'`, and `security-headers.js` conceded what that meant:

> with the JWT in localStorage and inline scripts allowed, an injected inline script can read the token. connect-src/img-src/object-src below close the fetch/XHR/img/plugin exfil channels, but **NOT** top-level navigation (`window.location = attacker + token`) — CSP has no deployable navigate-to directive, so that channel stays open until the real fix.

Closing exfiltration channels one at a time is a losing game once arbitrary script is already running. A nonce fixes the cause: **an injected inline script has no nonce, so it never executes.**

## What changed

- **`src/proxy.ts`** mints a nonce per request (`crypto.getRandomValues`, Edge-runtime safe) and sets the CSP on **both** the request headers — which is how Next.js knows to stamp the nonce onto its own bootstrap scripts — and the response headers, which is what the browser enforces.
- **`buildScriptSrc()`** emits `'self' 'nonce-<n>' 'strict-dynamic'`, with **no `'unsafe-inline'`**. `unsafe-eval` remains dev-only.
- **`securityHeaders()` no longer carries a CSP.** Two CSP headers on one response are *intersected* by the browser, so leaving a static nonce-less policy alongside the proxy's would have blocked every script.
- **`layout.tsx` sets `export const dynamic = 'force-dynamic'`** — see below.

`style-src` deliberately keeps `'unsafe-inline'`: Tailwind and React set style attributes directly, and a stolen *style* is not a stolen session. The threat here is script execution. A test pins that decision so changing it has to be deliberate.

## The part the build does not catch

Next.js can only stamp a per-request nonce onto a document it renders **at request time**. A statically prerendered page keeps whatever was baked in at build time — nothing.

Measured against a real `next start`, before adding `force-dynamic`:

| Route | Rendering | Scripts carrying the nonce |
|---|---|---|
| `/login` | ○ static | **0 / 21** → blank page |
| `/sessions/[id]` | ƒ dynamic | 22 / 22 ✅ |

**The build succeeded in both cases.** Shipping the proxy without `force-dynamic` would have produced a white screen on 14 of 17 routes with a green CI.

After `force-dynamic`, every route is `ƒ` and every script and preload is nonced:

```
/login     scripts=20  nonced=22
/tasks     scripts=21  nonced=23
/settings  scripts=20  nonced=22
```

(Nonced exceeds the `<script` count because Next stamps preload `<link>` tags too.)

Distinct nonce per request, confirmed on two consecutive requests:
```
script-src 'self' 'nonce-3OYI/yCrBNhOtpIzsF/NIg==' 'strict-dynamic'
script-src 'self' 'nonce-PgTBsISXjlWvMYjNLQKOQg==' 'strict-dynamic'
```

### Cost of `force-dynamic`

These pages are `'use client'` shells — the static prerender was an empty loading skeleton, and the data is fetched client-side either way. JS/CSS chunks are still served statically from `/_next/static`, which the proxy matcher skips. So the cost is rendering an empty shell per document request, not per-request data work.

If that trade is unwanted, the AC's other option (moving the token to an httpOnly cookie) removes the need for the nonce entirely — but it is a much larger change: login response, axios interceptor, SSE stream tickets, WebSocket auth, the CLI API client, and CSRF protection.

## Acceptance criteria

- [x] Production CSP no longer contains `'unsafe-inline'` in `script-src` (per-request nonce middleware)
- [x] A CI check asserts the production CSP string has no `'unsafe-inline'` in `script-src` — `security-headers.test.js`, which the `frontend-tests` job runs
- [x] The residual-risk comment reflects the shipped mitigation

## Tests

15 CSP tests. Two guard the coupling that the build cannot: the root layout must keep `force-dynamic`, and `proxy.ts` must set the CSP on *both* header sets. One pre-existing test asserted the static header list contained a CSP; it is updated with a comment explaining why the CSP moved.

Full web-ui suite: **1083 passed** across 96 suites. `npm run build` clean.

## Known limitations

- `style-src 'unsafe-inline'` stays, as above.
- `force-dynamic` is applied at the root layout, so it covers every route. A per-route opt-in would preserve static generation for any page that genuinely does not need the nonce — but every page in this app serves the authenticated shell, so there is nothing to exempt today.
- The nonce is not threaded to `next/script` or any inline `<script>` a future component might add; those would need `nonce={await headers().get('x-nonce')}`. The proxy already exposes it as `x-nonce` for that purpose.
