### PR TITLE
feat(audit): actually emit the security events the taxonomy promised (#937)

### DIFF
--- a/codeframe/auth/api_key_router.py
+++ b/codeframe/auth/api_key_router.py
@@ -29,6 +29,7 @@ from codeframe.auth.api_keys import (
 )
 from codeframe.core.api_key_service import ApiKeyService
 from codeframe.platform_store.database import Database
+from codeframe.lib.audit_logger import AuditEventType, audit_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,17 @@ async def create_api_key(
         expires_at=body.expires_at,
     )
 
+    # Minting a credential is a security-relevant event; the scopes matter as
+    # much as the fact, since an admin-scoped key can store credentials and
+    # merge PRs (#937).
+    audit_from_request(
+        request,
+        AuditEventType.API_KEY_CREATED,
+        user_id=current_user.id,
+        resource_type="api_key",
+        metadata={"name": body.name, "scopes": list(body.scopes or [])},
+    )
+
     return CreateApiKeyResponse(
         key=result.key,
         id=result.id,
@@ -260,5 +272,13 @@ async def revoke_api_key(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="API key not found",
         )
+
+    audit_from_request(
+        request,
+        AuditEventType.API_KEY_REVOKED,
+        user_id=auth["user_id"],
+        resource_type="api_key",
+        metadata={"key_id": key_id},
+    )
 
     return RevokeApiKeyResponse(id=key_id, revoked=True)

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -183,11 +183,24 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
         point that sees both the submitted identity and the outcome.
         """
         user = await super().authenticate(credentials)
-        if user is None:
+
+        # `user is not None` is not the same as "logged in": fastapi-users'
+        # generated route rejects an inactive account with the same 400
+        # BAD_CREDENTIALS *after* authenticate() returns. Auditing only the None
+        # case made repeated correct-password attempts against a disabled or
+        # compromised account invisible — which is precisely the
+        # credential-stuffing signal this exists to capture (PR review on #937).
+        if user is None or not user.is_active:
             audit_from_request(
                 current_audit_request(),
                 AuditEventType.AUTH_LOGIN_FAILED,
+                user_id=getattr(user, "id", None),
                 email=getattr(credentials, "username", None),
+                metadata=(
+                    {"reason": "inactive_account"}
+                    if user is not None
+                    else {"reason": "bad_credentials"}
+                ),
             )
         return user
 

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -14,6 +14,11 @@ from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
 from codeframe.auth.models import User
+from codeframe.lib.audit_logger import (
+    AuditEventType,
+    audit_from_request,
+    current_audit_request,
+)
 
 # Re-exported, never redefined. The placeholder password for the seeded
 # bootstrap admin (id=1) is owned by the layer that writes it
@@ -169,11 +174,31 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
     reset_password_token_secret = SECRET
     verification_token_secret = SECRET
 
+    async def authenticate(self, credentials):
+        """Authenticate, recording failures (#937).
+
+        fastapi-users exposes `on_after_login` but has no failed-login hook, and
+        a failed login is the event an audit trail exists for — repeated ones are
+        the signature of credential stuffing. This is the documented extension
+        point that sees both the submitted identity and the outcome.
+        """
+        user = await super().authenticate(credentials)
+        if user is None:
+            audit_from_request(
+                current_audit_request(),
+                AuditEventType.AUTH_LOGIN_FAILED,
+                email=getattr(credentials, "username", None),
+            )
+        return user
+
     async def on_after_register(self, user: User, request: Optional[Request] = None):
         """Called after successful registration."""
         logger.info(
             "User registered",
             extra={"user_id": user.id, "email": user.email}
+        )
+        audit_from_request(
+            request, AuditEventType.USER_CREATED, user_id=user.id, email=user.email
         )
         await self._promote_if_bootstrap_user(user)
 
@@ -235,6 +260,9 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
         """Called after successful login."""
         # Only log user_id on login (avoid excessive email logging)
         logger.info("User logged in", extra={"user_id": user.id})
+        audit_from_request(
+            request, AuditEventType.AUTH_LOGIN_SUCCESS, user_id=user.id
+        )
 
 
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:

--- a/codeframe/auth/router.py
+++ b/codeframe/auth/router.py
@@ -20,6 +20,11 @@ from codeframe.auth.manager import (
 from codeframe.auth.models import User
 from codeframe.auth.api_key_router import router as api_key_router
 from codeframe.auth.dependencies import require_auth
+from codeframe.lib.audit_logger import (
+    AuditEventType,
+    audit_from_request,
+    capture_audit_request,
+)
 from codeframe.auth.stream_tickets import TICKET_TTL_SECONDS, mint_ticket
 from codeframe.lib.rate_limiter import enforce_auth_rate_limit
 
@@ -216,13 +221,36 @@ async def allow_registration(request: Request):
         yield
 
 
+
+async def audit_logout(request: Request) -> None:
+    """Record a logout (#937).
+
+    fastapi-users has no ``on_after_logout`` hook, and this dependency runs on
+    the whole /auth/jwt include, so it filters by path. It fires *before* the
+    handler: with the JWT strategy, logout for an authenticated caller does not
+    fail, so "attempted" and "succeeded" are the same event. The alternative —
+    wrapping the generated route's endpoint — means rebuilding FastAPI's
+    dependant graph, which is far more fragile than one path check.
+    """
+    if not request.url.path.endswith("/logout"):
+        return
+    audit_from_request(request, AuditEventType.AUTH_LOGOUT)
+
+
 # Authentication routes (login, logout) - JWT endpoints at /auth/jwt/*
 # enforce_auth_rate_limit throttles credential brute-force (#644).
 router.include_router(
     fastapi_users.get_auth_router(auth_backend),
     prefix="/auth/jwt",
     tags=["auth"],
-    dependencies=[Depends(enforce_auth_rate_limit)],
+    # capture_audit_request exposes the Request to UserManager.authenticate,
+    # which fastapi-users calls with only the credentials — so a failed login
+    # can still be audited with its client IP (#937).
+    dependencies=[
+        Depends(enforce_auth_rate_limit),
+        Depends(capture_audit_request),
+        Depends(audit_logout),
+    ],
 )
 
 # Registration route at /auth/register (bootstrap-first-user only).
@@ -231,7 +259,11 @@ router.include_router(
     fastapi_users.get_register_router(UserRead, UserCreate),
     prefix="/auth",
     tags=["auth"],
-    dependencies=[Depends(enforce_auth_rate_limit), Depends(allow_registration)],
+    dependencies=[
+        Depends(enforce_auth_rate_limit),
+        Depends(allow_registration),
+        Depends(capture_audit_request),
+    ],
 )
 
 # User management routes (get me, update me) at /users/*

--- a/codeframe/lib/audit_logger.py
+++ b/codeframe/lib/audit_logger.py
@@ -267,7 +267,8 @@ class AuditLogger:
         except Exception:  # noqa: BLE001 - see comment
             logger.warning(
                 "Audit write failed for %s (user_id=%s) — the event happened but "
-                "was NOT recorded.",
+                "was NOT recorded. (audit_logs.user_id is a foreign key: passing "
+                "an id with no users row fails the whole insert.)",
                 event_type.value,
                 user_id,
                 exc_info=True,

--- a/codeframe/lib/audit_logger.py
+++ b/codeframe/lib/audit_logger.py
@@ -9,11 +9,17 @@ This module provides centralized audit logging for security-relevant events incl
 All audit logs are stored in the database with timestamps, user context, and event metadata.
 """
 
+import logging
 from datetime import datetime, UTC
+from contextvars import ContextVar
+
+from starlette.requests import Request
 from typing import Optional, Dict, Any
 from enum import Enum
 
 from codeframe.platform_store.database import Database
+
+logger = logging.getLogger(__name__)
 
 
 class AuditEventType(Enum):
@@ -43,6 +49,11 @@ class AuditEventType(Enum):
     USER_UPDATED = "user.updated"
     USER_DELETED = "user.deleted"
     USER_ROLE_CHANGED = "user.role.changed"
+
+    # API key lifecycle (#937). Minting and revoking a credential are the
+    # security-relevant events here; a key's *use* is covered by the auth events.
+    API_KEY_CREATED = "api_key.created"
+    API_KEY_REVOKED = "api_key.revoked"
 
     # Rate limiting events
     RATE_LIMIT_EXCEEDED = "rate_limit.exceeded"
@@ -237,12 +248,90 @@ class AuditLogger:
             ip_address: Client IP address
             metadata: Additional event metadata
         """
-        self.db.create_audit_log(
-            event_type=event_type.value,
-            user_id=user_id,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            ip_address=ip_address,
-            metadata=metadata,
-            timestamp=datetime.now(UTC),
-        )
+        # Never raise: an audit write must not fail the operation being audited
+        # — refusing a login because the audit table is unavailable would be a
+        # self-inflicted outage. But it is logged at WARNING, not debug: a
+        # silently missing audit trail is indistinguishable from "nothing
+        # happened", which is exactly what an audit trail exists to rule out
+        # (#937).
+        try:
+            self.db.create_audit_log(
+                event_type=event_type.value,
+                user_id=user_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                ip_address=ip_address,
+                metadata=metadata,
+                timestamp=datetime.now(UTC),
+            )
+        except Exception:  # noqa: BLE001 - see comment
+            logger.warning(
+                "Audit write failed for %s (user_id=%s) — the event happened but "
+                "was NOT recorded.",
+                event_type.value,
+                user_id,
+                exc_info=True,
+            )
+
+
+def audit_from_request(
+    request,
+    event_type: "AuditEventType",
+    *,
+    user_id: Optional[int] = None,
+    email: Optional[str] = None,
+    resource_type: str = "auth",
+    resource_id: Optional[int] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Write one audit event using the Database on the app state (#937).
+
+    A single funnel for the call sites that only have a ``Request``: it resolves
+    the store, records the client IP, and is guarded end to end so no caller
+    needs its own try/except. Returns quietly when there is no database (unit
+    tests build routers without app state) but logs when a write is attempted
+    and fails.
+    """
+    db = getattr(getattr(getattr(request, "app", None), "state", None), "db", None)
+    if db is None:
+        return
+
+    client = getattr(request, "client", None)
+    AuditLogger(db)._log_event(
+        event_type=event_type,
+        user_id=user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        ip_address=getattr(client, "host", None),
+        metadata={**(metadata or {}), **({"email": email} if email else {})},
+    )
+
+
+#: The in-flight Request, for audit call sites that cannot receive one.
+#: ``UserManager.authenticate`` is the motivating case: fastapi-users calls it
+#: with only the submitted credentials, but a failed login is precisely the
+#: event worth auditing, and the row needs the client IP. Set by the
+#: ``capture_audit_request`` dependency on the auth routes (#937).
+_current_request: ContextVar[Optional[Any]] = ContextVar(
+    "codeframe_audit_request", default=None
+)
+
+
+async def capture_audit_request(request: Request):
+    """FastAPI dependency: expose this request to request-less audit call sites.
+
+    The annotation is load-bearing: without it FastAPI reads ``request`` as a
+    query parameter and every login 422s.
+    """
+    token = _current_request.set(request)
+    try:
+        yield
+    finally:
+        # Reset rather than clear: ContextVar state leaking between requests on a
+        # reused worker task would attribute one user's IP to another's event.
+        _current_request.reset(token)
+
+
+def current_audit_request():
+    """The in-flight Request, or None outside a captured route."""
+    return _current_request.get()

--- a/codeframe/lib/audit_logger.py
+++ b/codeframe/lib/audit_logger.py
@@ -297,7 +297,7 @@ def audit_from_request(
         return
 
     client = getattr(request, "client", None)
-    AuditLogger(db)._log_event(
+    kwargs = dict(
         event_type=event_type,
         user_id=user_id,
         resource_type=resource_type,
@@ -305,6 +305,16 @@ def audit_from_request(
         ip_address=getattr(client, "host", None),
         metadata={**(metadata or {}), **({"email": email} if email else {})},
     )
+
+    queue = _pending.get()
+    if queue is not None:
+        # Inside a captured route: flush after the other dependencies close, so
+        # the write never contends with an open auth transaction on the same
+        # SQLite file (#937).
+        queue.append((db, kwargs))
+        return
+
+    AuditLogger(db)._log_event(**kwargs)
 
 
 #: The in-flight Request, for audit call sites that cannot receive one.
@@ -316,20 +326,41 @@ _current_request: ContextVar[Optional[Any]] = ContextVar(
     "codeframe_audit_request", default=None
 )
 
+#: Events queued for after the request's other dependencies have torn down.
+_pending: ContextVar[Optional[list]] = ContextVar(
+    "codeframe_audit_pending", default=None
+)
+
 
 async def capture_audit_request(request: Request):
-    """FastAPI dependency: expose this request to request-less audit call sites.
+    """FastAPI dependency: expose this request to request-less audit call sites,
+    and defer their writes until the rest of the request has torn down.
 
     The annotation is load-bearing: without it FastAPI reads ``request`` as a
     query parameter and every login 422s.
+
+    Deferral matters on the auth routes (codex review on #937). fastapi-users'
+    async SQLAlchemy session and ``app.state.db`` are two connections to the SAME
+    SQLite file, and ``authenticate()`` can leave a write open (it rewrites a
+    legacy password hash). Writing the audit row inline would then queue behind
+    that transaction on ``busy_timeout = 5000`` — a 5s stall on every failed
+    login, and then a lost audit row when the wait expires. Router-level
+    dependencies tear down LAST, after the route's session dependency has
+    closed, so flushing here writes against an uncontended file.
     """
-    token = _current_request.set(request)
+    request_token = _current_request.set(request)
+    pending_token = _pending.set([])
     try:
         yield
     finally:
+        queued = _pending.get() or []
+        # Reset BEFORE flushing so a failure below cannot strand the context.
         # Reset rather than clear: ContextVar state leaking between requests on a
         # reused worker task would attribute one user's IP to another's event.
-        _current_request.reset(token)
+        _pending.reset(pending_token)
+        _current_request.reset(request_token)
+        for db, kwargs in queued:
+            AuditLogger(db)._log_event(**kwargs)
 
 
 def current_audit_request():

--- a/tests/api/test_audit_events_937.py
+++ b/tests/api/test_audit_events_937.py
@@ -1,0 +1,226 @@
+"""Security events actually reach audit_logs (#937).
+
+`AuditLogger` documented "all security-relevant events ... for compliance,
+security monitoring, and incident investigation" and defined AUTH_*, AUTHZ_* and
+USER_* types; the store created `audit_logs` plus three indexes. The only call
+site in the whole package was the rate-limit handler, wrapped in
+`except Exception: logger.debug`. No test referenced AuditLogger or
+AuditRepository at all.
+
+So the schema implied controls that were not in force: a failed login, a logout,
+a bootstrap registration and every API-key mint or revocation wrote nothing.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.lib.audit_logger import AuditEventType, AuditLogger, audit_from_request
+from codeframe.platform_store.database import Database
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def db():
+    database = Database(":memory:")
+    database.initialize()
+    return database
+
+
+def _rows(database, event_type=None):
+    conn = database.conn if hasattr(database, "conn") else database._conn
+    sql = "SELECT event_type, user_id, ip_address, metadata FROM audit_logs"
+    params = ()
+    if event_type:
+        sql += " WHERE event_type = ?"
+        params = (event_type,)
+    return conn.execute(sql, params).fetchall()
+
+
+class TestAuditRepositoryDirectly:
+    """AC2 — create_audit_log had no direct test."""
+
+    def test_create_audit_log_persists_a_row(self, db):
+        from datetime import UTC, datetime
+
+        row_id = db.create_audit_log(
+            event_type="auth.login.failed",
+            user_id=None,
+            resource_type="auth",
+            resource_id=None,
+            ip_address="203.0.113.7",
+            metadata={"email": "someone@example.com"},
+            timestamp=datetime.now(UTC),
+        )
+
+        assert row_id
+        rows = _rows(db, "auth.login.failed")
+        assert len(rows) == 1
+        assert rows[0]["ip_address"] == "203.0.113.7"
+
+    def test_metadata_round_trips_as_json(self, db):
+        from datetime import UTC, datetime
+        import json
+
+        db.create_audit_log(
+            event_type="api_key.created",
+            user_id=1,
+            resource_type="api_key",
+            resource_id=None,
+            ip_address=None,
+            metadata={"scopes": ["read", "write"], "name": "ci"},
+            timestamp=datetime.now(UTC),
+        )
+
+        stored = json.loads(_rows(db, "api_key.created")[0]["metadata"])
+        assert stored["scopes"] == ["read", "write"]
+        assert stored["name"] == "ci"
+
+    def test_null_user_is_allowed(self, db):
+        """A failed login has no user id — the row must still be writable."""
+        from datetime import UTC, datetime
+
+        assert db.create_audit_log(
+            event_type="auth.login.failed",
+            user_id=None,
+            resource_type="auth",
+            resource_id=None,
+            ip_address=None,
+            metadata=None,
+            timestamp=datetime.now(UTC),
+        )
+
+
+class TestAuditWriteFailureIsLoud:
+    """AC3 — the failure path logged at debug, so a missing trail was invisible."""
+
+    def test_write_failure_logs_at_warning(self, caplog):
+        import logging
+
+        class BrokenDb:
+            def create_audit_log(self, **_kwargs):
+                raise RuntimeError("audit table is gone")
+
+        with caplog.at_level(logging.WARNING):
+            AuditLogger(BrokenDb())._log_event(
+                event_type=AuditEventType.AUTH_LOGIN_FAILED,
+                user_id=None,
+                resource_type="auth",
+                resource_id=None,
+                ip_address=None,
+                metadata=None,
+            )
+
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+        assert "auth.login.failed" in caplog.text
+
+    def test_write_failure_does_not_raise(self):
+        """Refusing a login because auditing broke would be a self-inflicted outage."""
+
+        class BrokenDb:
+            def create_audit_log(self, **_kwargs):
+                raise RuntimeError("boom")
+
+        AuditLogger(BrokenDb())._log_event(
+            event_type=AuditEventType.AUTH_LOGOUT,
+            user_id=1,
+            resource_type="auth",
+            resource_id=None,
+            ip_address=None,
+            metadata=None,
+        )
+
+
+class TestAuditFromRequest:
+    def test_writes_using_the_app_database(self, db):
+        app = FastAPI()
+        app.state.db = db
+
+        class FakeRequest:
+            def __init__(self, application):
+                self.app = application
+                self.client = type("C", (), {"host": "198.51.100.9"})()
+
+        audit_from_request(
+            FakeRequest(app),
+            AuditEventType.AUTH_LOGIN_FAILED,
+            email="attacker@example.com",
+        )
+
+        rows = _rows(db, "auth.login.failed")
+        assert len(rows) == 1
+        assert rows[0]["ip_address"] == "198.51.100.9"
+
+    def test_no_database_is_a_quiet_no_op(self):
+        """Routers built without app state (unit tests) must not blow up."""
+        app = FastAPI()
+
+        class FakeRequest:
+            def __init__(self, application):
+                self.app = application
+                self.client = None
+
+        audit_from_request(FakeRequest(app), AuditEventType.AUTH_LOGOUT)
+
+
+class TestFailedLoginProducesAnAuditRow:
+    """AC2 — the router-level assertion the issue asks for."""
+
+    @pytest.fixture
+    def client(self, db, monkeypatch):
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        from codeframe.auth import router as auth_router
+
+        app = FastAPI()
+        app.state.db = db
+        app.include_router(auth_router.router)
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_bad_credentials_are_recorded(self, client, db):
+        response = client.post(
+            "/auth/jwt/login",
+            data={"username": "nobody@example.com", "password": "nope"},
+        )
+
+        assert response.status_code in (400, 401), response.text
+        rows = _rows(db, "auth.login.failed")
+        assert len(rows) == 1, "a failed login wrote no audit row"
+
+    def test_the_recorded_row_names_the_attempted_identity(self, client, db):
+        client.post(
+            "/auth/jwt/login",
+            data={"username": "target@example.com", "password": "wrong"},
+        )
+
+        import json
+
+        rows = _rows(db, "auth.login.failed")
+        assert rows, "no audit row"
+        assert "target@example.com" in json.loads(rows[0]["metadata"])["email"]
+
+    def test_repeated_failures_each_produce_a_row(self, client, db):
+        """One row per attempt is what makes credential stuffing visible."""
+        for _ in range(3):
+            client.post(
+                "/auth/jwt/login",
+                data={"username": "target@example.com", "password": "wrong"},
+            )
+
+        assert len(_rows(db, "auth.login.failed")) == 3
+
+
+class TestTaxonomyCoversTheWiredEvents:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "AUTH_LOGIN_SUCCESS",
+            "AUTH_LOGIN_FAILED",
+            "AUTH_LOGOUT",
+            "USER_CREATED",
+            "API_KEY_CREATED",
+            "API_KEY_REVOKED",
+        ],
+    )
+    def test_event_type_exists(self, name):
+        assert hasattr(AuditEventType, name)

--- a/tests/api/test_audit_events_937.py
+++ b/tests/api/test_audit_events_937.py
@@ -28,6 +28,12 @@ def db():
     return database
 
 
+def _seeded_user_id(database):
+    """The bootstrap account's id. audit_logs.user_id is a foreign key."""
+    conn = database.conn if hasattr(database, "conn") else database._conn
+    return conn.execute("SELECT id FROM users LIMIT 1").fetchone()["id"]
+
+
 def _rows(database, event_type=None):
     conn = database.conn if hasattr(database, "conn") else database._conn
     sql = "SELECT event_type, user_id, ip_address, metadata FROM audit_logs"
@@ -208,6 +214,128 @@ class TestFailedLoginProducesAnAuditRow:
             )
 
         assert len(_rows(db, "auth.login.failed")) == 3
+
+
+class TestForeignKeyOnUserId:
+    """Found while writing the inactive-account test: a user_id with no `users`
+    row fails the INSERT outright, and the guard then swallows it — so the event
+    is lost rather than partially recorded. Worth pinning so the behaviour is a
+    known constraint on call sites, not a surprise."""
+
+    def test_an_unknown_user_id_loses_the_row_and_warns(self, db, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            AuditLogger(db)._log_event(
+                event_type=AuditEventType.AUTH_LOGIN_FAILED,
+                user_id=999999,  # no such users row
+                resource_type="auth",
+                resource_id=None,
+                ip_address=None,
+                metadata=None,
+            )
+
+        assert _rows(db, "auth.login.failed") == []
+        assert "foreign key" in caplog.text.lower()
+
+    def test_a_null_user_id_always_works(self, db):
+        """Which is why the bad-credentials path passes None."""
+        AuditLogger(db)._log_event(
+            event_type=AuditEventType.AUTH_LOGIN_FAILED,
+            user_id=None,
+            resource_type="auth",
+            resource_id=None,
+            ip_address=None,
+            metadata=None,
+        )
+
+        assert len(_rows(db, "auth.login.failed")) == 1
+
+
+class TestInactiveAccountLoginIsAudited:
+    """Raised by the PR bot.
+
+    fastapi-users' route rejects an inactive account with the same 400
+    BAD_CREDENTIALS *after* authenticate() returns the user. Auditing only the
+    None case made repeated correct-password attempts against a disabled or
+    compromised account invisible — the exact credential-stuffing signal this
+    feature exists to capture.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_inactive_user_with_the_right_password_is_audited(self, db):
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi_users import BaseUserManager
+
+        from codeframe.auth.manager import UserManager
+        from codeframe.lib.audit_logger import _current_request
+
+        # A REAL user row: audit_logs.user_id is a foreign key, so a fabricated
+        # id would make the write fail and the guard would swallow it — the test
+        # would then pass for the wrong reason once the code was fixed.
+        real_id = _seeded_user_id(db)
+        inactive = type(
+            "U", (), {"id": real_id, "is_active": False, "email": "x@y.z"}
+        )()
+
+        class FakeRequest:
+            def __init__(self):
+                self.app = type("A", (), {"state": type("S", (), {"db": db})()})()
+                self.client = None
+
+        manager = UserManager.__new__(UserManager)
+        token = _current_request.set(FakeRequest())
+        try:
+            with patch.object(
+                BaseUserManager, "authenticate", AsyncMock(return_value=inactive)
+            ):
+                result = await manager.authenticate(
+                    type("C", (), {"username": "x@y.z", "password": "pw"})()
+                )
+        finally:
+            _current_request.reset(token)
+
+        assert result is inactive, "authenticate must still return what it returned"
+        rows = _rows(db, "auth.login.failed")
+        assert len(rows) == 1, "an inactive-account login wrote no audit row"
+
+        import json
+
+        assert json.loads(rows[0]["metadata"])["reason"] == "inactive_account"
+
+    @pytest.mark.asyncio
+    async def test_an_active_user_is_not_audited_as_a_failure(self, db):
+        """on_after_login records the success; a duplicate failure row would lie."""
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi_users import BaseUserManager
+
+        from codeframe.auth.manager import UserManager
+        from codeframe.lib.audit_logger import _current_request
+
+        active = type(
+            "U", (), {"id": _seeded_user_id(db), "is_active": True, "email": "x@y.z"}
+        )()
+
+        class FakeRequest:
+            def __init__(self):
+                self.app = type("A", (), {"state": type("S", (), {"db": db})()})()
+                self.client = None
+
+        manager = UserManager.__new__(UserManager)
+        token = _current_request.set(FakeRequest())
+        try:
+            with patch.object(
+                BaseUserManager, "authenticate", AsyncMock(return_value=active)
+            ):
+                await manager.authenticate(
+                    type("C", (), {"username": "x@y.z", "password": "pw"})()
+                )
+        finally:
+            _current_request.reset(token)
+
+        assert _rows(db, "auth.login.failed") == []
 
 
 class TestWritesAreDeferredPastTheAuthSession:

--- a/tests/api/test_audit_events_937.py
+++ b/tests/api/test_audit_events_937.py
@@ -210,6 +210,74 @@ class TestFailedLoginProducesAnAuditRow:
         assert len(_rows(db, "auth.login.failed")) == 3
 
 
+class TestWritesAreDeferredPastTheAuthSession:
+    """Raised by `codex review` as a P1.
+
+    fastapi-users' async SQLAlchemy session and app.state.db are two connections
+    to the SAME SQLite file, and authenticate() can leave a write open (it
+    rewrites a legacy password hash). An inline audit write would queue behind
+    that transaction on busy_timeout=5000 — a 5s stall on every failed login,
+    and a LOST audit row once the wait expires.
+    """
+
+    def test_events_are_queued_not_written_during_the_request(self, db):
+        from codeframe.lib.audit_logger import _pending
+
+        class FakeRequest:
+            def __init__(self):
+                self.app = type("A", (), {"state": type("S", (), {"db": db})()})()
+                self.client = None
+
+        token = _pending.set([])
+        try:
+            audit_from_request(FakeRequest(), AuditEventType.AUTH_LOGIN_FAILED)
+            assert _rows(db) == [], "the row was written inline, not deferred"
+            assert len(_pending.get()) == 1, "the event was not queued"
+        finally:
+            _pending.reset(token)
+
+    def test_without_a_capture_context_the_write_is_immediate(self, db):
+        """Call sites outside a captured route must still work."""
+
+        class FakeRequest:
+            def __init__(self):
+                self.app = type("A", (), {"state": type("S", (), {"db": db})()})()
+                self.client = None
+
+        audit_from_request(FakeRequest(), AuditEventType.AUTH_LOGOUT)
+
+        assert len(_rows(db, "auth.logout")) == 1
+
+    def test_the_context_is_reset_even_if_a_flush_fails(self):
+        """A stranded ContextVar would leak one request's identity into the next."""
+        import asyncio
+
+        from codeframe.lib.audit_logger import _pending, capture_audit_request
+
+        class BrokenDb:
+            def create_audit_log(self, **_kwargs):
+                raise RuntimeError("boom")
+
+        async def drive():
+            gen = capture_audit_request(
+                type("R", (), {"app": None, "client": None})()
+            )
+            await gen.asend(None)
+            _pending.get().append((BrokenDb(), {
+                "event_type": AuditEventType.AUTH_LOGOUT,
+                "user_id": None, "resource_type": "auth",
+                "resource_id": None, "ip_address": None, "metadata": None,
+            }))
+            try:
+                await gen.asend(None)
+            except StopAsyncIteration:
+                pass
+
+        asyncio.run(drive())
+
+        assert _pending.get() is None, "the pending buffer leaked past the request"
+
+
 class TestTaxonomyCoversTheWiredEvents:
     @pytest.mark.parametrize(
         "name",


### PR DESCRIPTION
Closes #937. (Blocked-by #919 is closed.)

## Dead schema implying controls that were not in force

`AuditLogger` documented *"all security-relevant events ... for compliance, security monitoring, and incident investigation"*, defined `AUTH_*`, `AUTHZ_*` and `USER_*` event types, and the store created `audit_logs` plus three indexes.

The only call site in the entire package was the rate-limit handler — wrapped in `except Exception: logger.debug`. No test referenced `AuditLogger` or `AuditRepository`.

So a failed login, a logout, a bootstrap registration and every API-key mint or revocation wrote **nothing**, while the schema advertised otherwise.

The issue offered "or delete the taxonomy". Wiring it is the right call for a SaaS beta — these are the events an incident investigation starts from.

## Events now written

| Event | Seam |
|---|---|
| `auth.login.failed` | `UserManager.authenticate` override |
| `auth.login.success` | `on_after_login` |
| `auth.logout` | path-filtered dependency on `/auth/jwt` |
| `user.created` | `on_after_register` |
| `api_key.created` / `api_key.revoked` | `api_key_router` (new event types) |

### Why `authenticate()` for the failure case

fastapi-users exposes `on_after_login` but **no failed-login hook** — and a failed login is the event an audit trail exists for; repeated ones are the signature of credential stuffing. `authenticate()` is the documented extension point that sees both the submitted identity and the outcome.

It receives only the credentials, though, and the row needs the client IP. So `capture_audit_request` — a `ContextVar` dependency on the `/auth/jwt` routes — exposes the in-flight `Request`. It uses `reset(token)` rather than clearing, because leaked context between requests on a reused worker task would attribute one user's IP to another's event.

The dependency's `request: Request` annotation is load-bearing: without it FastAPI reads `request` as a *query parameter* and every login 422s. That was caught by the router test, not by review.

### Why a dependency for logout

There is no `on_after_logout` in fastapi-users (`BaseUserManager` has `on_after_login`, `on_after_register`, `on_after_delete`, … and nothing for logout). The alternative — wrapping the generated route's endpoint — means rebuilding FastAPI's dependant graph, which is far more fragile than one path check. It fires before the handler; with the JWT strategy, logout for an authenticated caller does not fail, so "attempted" and "succeeded" are the same event. Stated in the docstring.

## AC3: the failure path is now loud

The guard moved **into** `AuditLogger._log_event` and logs at **WARNING**:

```
Audit write failed for auth.login.failed (user_id=None) — the event happened but was NOT recorded.
```

A silently missing audit trail is indistinguishable from "nothing happened", which is precisely what an audit trail exists to rule out. It still never raises — refusing a login because the audit table is unavailable would be a self-inflicted outage.

Putting the guard in `_log_event` also means no call site needs its own `try`, so a new one cannot forget it.

## Acceptance criteria

- [x] Login success/failure, logout, registration and API-key create/revoke are written to `audit_logs`
- [x] `AuditRepository.create_audit_log` has a direct test; a router-level test asserts a failed login produces an audit row
- [x] The audit write failure path logs at WARNING or above

## Tests

16 tests, in a file that did not exist because **nothing tested this subsystem at all**:

- `create_audit_log` directly — persistence, JSON metadata round-trip, and a NULL `user_id` (a failed login has no user, so the row must still be writable)
- the WARNING failure path, and that it does not raise
- router-level: a bad-credentials POST writes **exactly one** row naming the attempted identity, and three attempts write three rows — one row per attempt is what makes credential stuffing visible

`tests/api` + `tests/auth` + `tests/unit`: **250 passed**. `ruff` and `mypy` clean.

## Known limitations

- `AUTHZ_ACCESS_DENIED` is still unwired. Scope denials happen inside `require_scope`, which runs on many routers; emitting there needs a decision about volume (every 403 on a polling client would flood the table) that is worth making separately.
- The logout event records intent rather than a confirmed token invalidation — with the stateless JWT strategy there is nothing to invalidate server-side.
- `audit_from_request` no-ops when the app has no `state.db`, which is how unit-test routers are built. That keeps this from breaking existing tests, but it also means a misconfigured deploy would silently write nothing; the WARNING only covers a *failed* write, not an absent store.
