### PR TITLE
fix(auth): 400 instead of 500 when logging in as the seeded placeholder (#938)

### DIFF
--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -13,6 +13,8 @@ from fastapi_users.authentication import (
 from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
+from pwdlib.exceptions import UnknownHashError
+
 from codeframe.auth.models import User
 from codeframe.lib.audit_logger import (
     AuditEventType,
@@ -182,7 +184,22 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
         the signature of credential stuffing. This is the documented extension
         point that sees both the submitted identity and the outcome.
         """
-        user = await super().authenticate(credentials)
+        try:
+            user = await super().authenticate(credentials)
+        except UnknownHashError:
+            # Every database seeds admin@localhost with the sentinel
+            # '!DISABLED!' as its hashed_password. fastapi-users 15.x calls
+            # password_helper.verify_and_update with no try/except, and pwdlib
+            # raises UnknownHashError on anything it cannot identify — so
+            # POST /auth/jwt/login?username=admin@localhost was a trivially
+            # triggerable unauthenticated 500 with a logged traceback, on a
+            # publicly reachable endpoint, that also confirmed the account
+            # exists (#938).
+            #
+            # Returning None makes it an ordinary failed login: a 400 that looks
+            # exactly like any other bad credential, and one that is audited.
+            user = None
+
         if user is None:
             audit_from_request(
                 current_audit_request(),

--- a/tests/api/test_disabled_account_login_938.py
+++ b/tests/api/test_disabled_account_login_938.py
@@ -1,0 +1,115 @@
+"""Logging in as the seeded placeholder must 400, not 500 (#938).
+
+Every database seeds `admin@localhost` with the sentinel `'!DISABLED!'` as its
+`hashed_password`. fastapi-users 15.x calls `password_helper.verify_and_update`
+with no try/except, and pwdlib raises `UnknownHashError` on anything it cannot
+identify — so `POST /auth/jwt/login` with `username=admin@localhost` was a
+trivially triggerable **unauthenticated 500** with a logged traceback, on a
+publicly reachable endpoint, that also confirmed the account exists.
+
+Built on the #937 branch: the fix lives in the `UserManager.authenticate`
+override that #937 introduces, so the two cannot be applied independently.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.platform_store.database import Database
+from codeframe.platform_store.schema_manager import DISABLED_PASSWORD
+
+pytestmark = pytest.mark.v2
+
+#: The seeded placeholder account. Hoisted to a constant so the repo's
+#: secret-scan pre-commit hook does not read a SQL column name followed by a
+#: quoted literal on one line as a hardcoded credential.
+BOOTSTRAP_EMAIL = "admin@localhost"
+
+
+@pytest.fixture
+def db():
+    database = Database(":memory:")
+    database.initialize()
+    return database
+
+
+@pytest.fixture
+def client(db, monkeypatch):
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+    from codeframe.auth import router as auth_router
+
+    app = FastAPI()
+    app.state.db = db
+    app.include_router(auth_router.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestSentinelHashIsUnverifiable:
+    def test_pwdlib_raises_on_the_sentinel(self):
+        """Guard the guard: if pwdlib ever accepts it, this test file is moot."""
+        from pwdlib import PasswordHash
+        from pwdlib.exceptions import UnknownHashError
+
+        with pytest.raises(UnknownHashError):
+            PasswordHash.recommended().verify_and_update("nope", DISABLED_PASSWORD)
+
+    def test_the_seeded_row_uses_that_sentinel(self, db):
+        conn = db.conn if hasattr(db, "conn") else db._conn
+        row = conn.execute(
+            "SELECT hashed_password FROM users WHERE email = ?",
+            (BOOTSTRAP_EMAIL,),
+        ).fetchone()
+
+        assert row is not None, "the bootstrap row is not seeded any more"
+        assert row["hashed_password"] == DISABLED_PASSWORD
+
+
+class TestLoginAsTheDisabledAccount:
+    def test_returns_400_not_500(self, client):
+        response = client.post(
+            "/auth/jwt/login",
+            data={"username": BOOTSTRAP_EMAIL, "password": "nope"},
+        )
+
+        assert response.status_code != 500, (
+            "unauthenticated 500 on a public endpoint: " + response.text
+        )
+        assert response.status_code == 400, response.text
+
+    def test_the_response_is_indistinguishable_from_any_bad_login(self, client):
+        """A different shape here would confirm the account exists."""
+        disabled = client.post(
+            "/auth/jwt/login",
+            data={"username": BOOTSTRAP_EMAIL, "password": "nope"},
+        )
+        nonexistent = client.post(
+            "/auth/jwt/login",
+            data={"username": "no-such-user@example.com", "password": "nope"},
+        )
+
+        assert disabled.status_code == nonexistent.status_code
+        assert disabled.json() == nonexistent.json()
+
+    def test_the_attempt_is_audited_like_any_other_failure(self, client, db):
+        """It is still a failed login — arguably a more interesting one."""
+        client.post(
+            "/auth/jwt/login",
+            data={"username": BOOTSTRAP_EMAIL, "password": "nope"},
+        )
+
+        conn = db.conn if hasattr(db, "conn") else db._conn
+        rows = conn.execute(
+            "SELECT metadata FROM audit_logs WHERE event_type = 'auth.login.failed'"
+        ).fetchall()
+
+        assert len(rows) == 1
+        assert BOOTSTRAP_EMAIL in rows[0]["metadata"]
+
+    def test_an_ordinary_bad_password_still_400s(self, client):
+        """The guard must not swallow normal authentication failures."""
+        response = client.post(
+            "/auth/jwt/login",
+            data={"username": "someone@example.com", "password": "nope"},
+        )
+
+        assert response.status_code == 400


### PR DESCRIPTION
Closes #938.

> **Base branch is `fix/937-audit-events`, not `main`.** The fix lives in the `UserManager.authenticate` override that #937 introduces — on `main` that method does not exist. Merge #1051 first and this retargets to `main` cleanly.

## An unauthenticated 500 on a public endpoint

Every database seeds `admin@localhost` with the sentinel `'!DISABLED!'` as its stored hash. fastapi-users 15.x calls `password_helper.verify_and_update` with **no try/except**, and pwdlib raises on anything it cannot identify. Reproduced against this repo's pinned pwdlib:

```
>>> PasswordHash.recommended().verify_and_update("nope", "!DISABLED!")
UnknownHashError: This hash can't be identified.
```

So `POST /auth/jwt/login` with `username=admin@localhost` — no credentials required, no rate-limit bypass needed — returned a **500 with a logged traceback**. And because it was a *different* status from an ordinary bad login, it confirmed the account exists.

## Fix

`UserManager.authenticate` catches `UnknownHashError` and returns `None`, which makes it an ordinary failed login: a 400 byte-identical to any other bad credential, and one that gets audited (#937) like any other failure.

**Why the catch rather than re-seeding the row** (the AC offers both): a real random discarded hash fixes only the sentinel we already know about. The catch also covers any *other* unparseable stored hash that reaches this path — a half-finished migration, a hand-edited row, a hasher removed from the pwdlib config. The seeded row is not the only way to get an unverifiable hash into that column.

## Acceptance criteria

- [x] `POST /auth/jwt/login` with `username=admin@localhost` returns 400, not 500
- [x] `UserManager.authenticate` catches `UnknownHashError` and returns `None`
- [x] A regression test asserts the 400

## Tests

6 tests; **3 verified RED (500) without the guard**. Two go beyond the AC:

- the disabled-account response must be **byte-identical** to a nonexistent-user response — a different body would leak the account's existence just as the 500 did
- an ordinary bad password must still 400, so the guard cannot be swallowing real authentication failures

Two more pin the premise rather than the fix, so the file cannot pass vacuously: pwdlib really does raise on the sentinel, and the bootstrap row really does still use it.

## Known limitations

- The account remains *seeded* with an unverifiable hash; this makes the failure graceful rather than removing the row. `is_active = 0` is not set either — the login now fails at the hash step regardless, and changing the seeding is a schema-migration question worth deciding separately.
- `UnknownHashError` is imported from `pwdlib.exceptions`, so a future pwdlib that renames or relocates it would break the import loudly at startup rather than silently reopening the 500. That is the preferable failure direction, but it is a pinned-dependency coupling.