### PR TITLE
fix(ratelimit): make the 429 parseable and stop blocking the loop (#939)

### DIFF
--- a/codeframe/lib/rate_limiter.py
+++ b/codeframe/lib/rate_limiter.py
@@ -21,6 +21,7 @@ Security:
 
 import asyncio
 import logging
+import threading
 from typing import Any, Callable, Optional
 
 from fastapi import Request
@@ -183,6 +184,52 @@ def get_rate_limiter() -> Optional[Limiter]:
     return _limiter
 
 
+#: Cap on audit writes queued but not yet committed. Writes serialize behind the
+#: store's single sqlite3 connection, so under a distributed 429 flood — the very
+#: scenario this handler exists for — an unbounded executor queue grows faster
+#: than it drains and takes process memory with it (PR review on #939). Past the
+#: cap the event is dropped and counted: losing some audit rows during a flood is
+#: strictly better than losing the process.
+_AUDIT_MAX_PENDING = 256
+_audit_pending = 0
+_audit_dropped = 0
+_audit_lock = threading.Lock()
+
+
+def _submit_audit(fn) -> None:
+    """Run ``fn`` off the event loop, bounded. Never raises."""
+    global _audit_pending, _audit_dropped
+
+    with _audit_lock:
+        if _audit_pending >= _AUDIT_MAX_PENDING:
+            _audit_dropped += 1
+            dropped = _audit_dropped
+            if dropped == 1 or dropped % 100 == 0:
+                logger.warning(
+                    "Audit queue full (%d pending): dropped %d rate-limit "
+                    "event(s). The 429s were still served.",
+                    _AUDIT_MAX_PENDING,
+                    dropped,
+                )
+            return
+        _audit_pending += 1
+
+    def _run() -> None:
+        global _audit_pending
+        try:
+            fn()
+        finally:
+            with _audit_lock:
+                _audit_pending -= 1
+
+    try:
+        asyncio.get_running_loop().run_in_executor(None, _run)
+    except RuntimeError:
+        # No loop (sync test client / direct call): write inline rather than
+        # drop the event.
+        _run()
+
+
 def _limit_object(exc):
     """The underlying ``limits`` object behind slowapi's Limit wrapper."""
     return getattr(getattr(exc, "limit", None), "limit", None)
@@ -277,12 +324,7 @@ async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) 
                 metadata={"limit": limit_str, "retry_after": retry_after},
             )
 
-        try:
-            asyncio.get_running_loop().run_in_executor(None, _write_audit)
-        except RuntimeError:
-            # No loop (sync test client / direct call): write inline rather than
-            # drop the event.
-            _write_audit()
+        _submit_audit(_write_audit)
 
     # RFC 9110 delta-seconds: an integer number of seconds, nothing else.
     headers = {"Retry-After": str(retry_after)}

--- a/codeframe/lib/rate_limiter.py
+++ b/codeframe/lib/rate_limiter.py
@@ -19,6 +19,7 @@ Security:
 - Configure RATE_LIMIT_TRUSTED_PROXIES to define trusted proxy networks
 """
 
+import asyncio
 import logging
 from typing import Any, Callable, Optional
 
@@ -182,6 +183,51 @@ def get_rate_limiter() -> Optional[Limiter]:
     return _limiter
 
 
+def _limit_object(exc):
+    """The underlying ``limits`` object behind slowapi's Limit wrapper."""
+    return getattr(getattr(exc, "limit", None), "limit", None)
+
+
+def retry_after_seconds(exc, default: int = 60) -> int:
+    """Seconds until the window resets — RFC 9110 delta-seconds (#939).
+
+    The handler used ``str(exc.detail)``, but slowapi sets ``detail`` to
+    ``str(limit.limit)`` — the human description, e.g. "100 per 1 minute". So
+    every 429 sent ``Retry-After: 100 per 1 minute``, which no client can parse,
+    and the same string appeared in the body's ``retry_after``.
+
+    The window is derived from the limit instead: GRANULARITY.seconds times
+    multiples, so "2 per 5 minutes" yields 300.
+    """
+    limit = _limit_object(exc)
+    seconds = getattr(getattr(limit, "GRANULARITY", None), "seconds", None)
+    if not seconds:
+        return default
+    try:
+        return int(seconds) * max(1, int(getattr(limit, "multiples", 1) or 1))
+    except (TypeError, ValueError):
+        return default
+
+
+def limit_string(exc) -> Optional[str]:
+    """The limit as '100/minute' for X-RateLimit-Limit (#939).
+
+    ``exc.limit`` is slowapi's Limit *wrapper*, which defines no ``__str__`` —
+    so ``str(exc.limit)`` leaked an object repr like
+    ``<slowapi.wrappers.Limit object at 0x7f...>`` into the response header.
+    """
+    limit = _limit_object(exc)
+    if limit is None:
+        return None
+    amount = getattr(limit, "amount", None)
+    name = getattr(getattr(limit, "GRANULARITY", None), "name", None)
+    if amount is None or not name:
+        return str(limit)
+    multiples = int(getattr(limit, "multiples", 1) or 1)
+    return f"{amount}/{name}" if multiples == 1 else f"{amount}/{multiples}{name}"
+
+
+
 async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
     """Custom exception handler for rate limit exceeded errors.
 
@@ -206,44 +252,51 @@ async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) 
         f"ip={client_ip}, user_id={user_id}"
     )
 
-    # Log to audit log for security monitoring
-    try:
-        db = getattr(getattr(request, "app", None), "state", None)
-        db = getattr(db, "db", None) if db else None
-        if db:
-            from codeframe.lib.audit_logger import AuditLogger, AuditEventType
+    retry_after = retry_after_seconds(exc)
+    limit_str = limit_string(exc)
 
-            audit = AuditLogger(db)
-            audit.log_rate_limit_event(
+    # Offloaded to a worker thread (#939). This is a synchronous SQLite
+    # INSERT+COMMIT, and running it inline blocks the event loop for every
+    # rejected request — during a burst or a brute-force attempt, which is
+    # precisely when the handler is hot and when the write can sit on the 5s
+    # busy_timeout. Fire-and-forget: the 429 must not wait on an audit row.
+    db = getattr(getattr(request, "app", None), "state", None)
+    db = getattr(db, "db", None) if db else None
+    if db is not None:
+        from codeframe.lib.audit_logger import AuditEventType, AuditLogger
+
+        def _write_audit() -> None:
+            # AuditLogger._log_event already guards and logs at WARNING (#937);
+            # a silently missing audit trail is the failure mode that matters.
+            AuditLogger(db).log_rate_limit_event(
                 event_type=AuditEventType.RATE_LIMIT_EXCEEDED,
                 user_id=user_id,
                 ip_address=client_ip,
                 endpoint=endpoint,
                 limit_category=None,  # Not easily determinable from exception
-                metadata={
-                    "limit": str(exc.limit) if hasattr(exc, "limit") else None,
-                    "retry_after": str(exc.detail) if hasattr(exc, "detail") else "60",
-                },
+                metadata={"limit": limit_str, "retry_after": retry_after},
             )
-    except Exception as e:
-        # Don't let audit logging failure affect the rate limit response
-        logger.debug(f"Failed to log rate limit event to audit log: {e}")
 
-    # Build response headers
-    headers = {
-        "Retry-After": str(exc.detail) if hasattr(exc, "detail") else "60",
-    }
+        try:
+            asyncio.get_running_loop().run_in_executor(None, _write_audit)
+        except RuntimeError:
+            # No loop (sync test client / direct call): write inline rather than
+            # drop the event.
+            _write_audit()
 
-    # Add rate limit info headers if available
-    if hasattr(exc, "limit"):
-        headers["X-RateLimit-Limit"] = str(exc.limit)
+    # RFC 9110 delta-seconds: an integer number of seconds, nothing else.
+    headers = {"Retry-After": str(retry_after)}
+    if limit_str:
+        headers["X-RateLimit-Limit"] = limit_str
 
     response = JSONResponse(
         status_code=429,
         content={
             "error": "rate_limit_exceeded",
             "detail": "Too many requests. Please try again later.",
-            "retry_after": headers.get("Retry-After", "60"),
+            # int, not str: the header is a string by protocol, but a JSON body
+            # field typed as a string invites clients to concatenate it.
+            "retry_after": retry_after,
         },
         headers=headers,
     )

--- a/codeframe/platform_store/repositories/audit_repository.py
+++ b/codeframe/platform_store/repositories/audit_repository.py
@@ -43,8 +43,12 @@ class AuditRepository(BaseRepository):
             ID of the created audit log entry
         """
 
-        cursor = self.conn.cursor()
-        cursor.execute(
+        # _execute/_commit, not self.conn.cursor(): the base class serializes
+        # sync access to the shared sqlite3 connection behind a threading lock,
+        # and this repository was the one place bypassing it (#939). The 429
+        # handler writes here from the event loop during a burst, which is
+        # exactly when an unsynchronized write races another thread's.
+        cursor = self._execute(
             """
             INSERT INTO audit_logs (
                 event_type, user_id, resource_type, resource_id,
@@ -62,6 +66,6 @@ class AuditRepository(BaseRepository):
                 timestamp.isoformat(),
             ),
         )
-        self.conn.commit()
+        self._commit()
         return cursor.lastrowid
 

--- a/tests/api/test_rate_limit_429_939.py
+++ b/tests/api/test_rate_limit_429_939.py
@@ -1,0 +1,213 @@
+"""The 429 response must be parseable and cheap to produce (#939).
+
+Three defects in `rate_limit_exceeded_handler`, all from misreading slowapi:
+
+1. `exc.detail` is the limit *description* ("100 per 1 minute"), not a delay —
+   so every 429 sent `Retry-After: 100 per 1 minute`, which is unparseable per
+   RFC 9110, and the same junk appeared in the body's `retry_after`.
+2. `exc.limit` is slowapi's `Limit` *wrapper*, which defines no `__str__`, so
+   `X-RateLimit-Limit` leaked an object repr.
+3. The handler ran a synchronous SQLite INSERT+COMMIT on the event loop, using
+   `self.conn.cursor()` directly rather than the base repository's locked path —
+   a per-rejected-request DB write with a 5s busy_timeout ceiling, during
+   exactly the burst or brute-force that triggered it.
+"""
+
+import re
+
+import pytest
+from limits import parse
+from slowapi.errors import RateLimitExceeded
+from slowapi.wrappers import Limit
+
+from codeframe.lib.rate_limiter import (
+    limit_string,
+    rate_limit_exceeded_handler,
+    retry_after_seconds,
+)
+
+pytestmark = pytest.mark.v2
+
+#: RFC 9110 delta-seconds: "a non-negative decimal integer, representing time in
+#: seconds". Nothing else parses.
+DELTA_SECONDS = re.compile(r"^\d+$")
+
+
+def _exc(spec: str) -> RateLimitExceeded:
+    limit = Limit(parse(spec), lambda: "", None, False, None, None, 1, False, False)
+    return RateLimitExceeded(limit)
+
+
+class TestRetryAfterIsDeltaSeconds:
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [
+            ("100/minute", 60),
+            ("20/second", 1),
+            ("10/hour", 3600),
+            ("5/day", 86400),
+            # Multi-window: the multiplier must be applied, not dropped.
+            ("2/5minute", 300),
+        ],
+    )
+    def test_window_is_derived_from_the_limit(self, spec: str, expected: int):
+        assert retry_after_seconds(_exc(spec)) == expected
+
+    @pytest.mark.parametrize("spec", ["100/minute", "20/second", "2/5minute"])
+    def test_header_parses_as_delta_seconds(self, spec: str):
+        assert DELTA_SECONDS.match(str(retry_after_seconds(_exc(spec))))
+
+    def test_the_old_value_would_not_have_parsed(self):
+        """Guard the guard: exc.detail really is the human description."""
+        assert _exc("100/minute").detail == "100 per 1 minute"
+        assert not DELTA_SECONDS.match(_exc("100/minute").detail)
+
+    def test_an_unrecognizable_limit_falls_back_to_a_valid_default(self):
+        class Bare:
+            limit = None
+
+        assert retry_after_seconds(Bare()) == 60
+        assert DELTA_SECONDS.match(str(retry_after_seconds(Bare())))
+
+
+class TestLimitHeaderIsAString:
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [
+            ("100/minute", "100/minute"),
+            ("20/second", "20/second"),
+            ("10/hour", "10/hour"),
+            ("2/5minute", "2/5minute"),
+        ],
+    )
+    def test_limit_renders_as_amount_per_window(self, spec: str, expected: str):
+        assert limit_string(_exc(spec)) == expected
+
+    def test_no_object_repr_leaks(self):
+        rendered = limit_string(_exc("100/minute"))
+
+        assert "object at 0x" not in rendered
+        assert "<" not in rendered and ">" not in rendered
+
+    def test_the_wrapper_really_has_no_str(self):
+        """Guard the guard: str(exc.limit) is what leaked the repr."""
+        assert "object at 0x" in str(_exc("100/minute").limit)
+
+    def test_a_missing_limit_yields_none_not_a_broken_header(self):
+        class Bare:
+            limit = None
+
+        assert limit_string(Bare()) is None
+
+
+class TestHandlerResponse:
+    @pytest.fixture
+    def request_obj(self):
+        class FakeUrl:
+            path = "/api/v2/tasks"
+
+        class FakeRequest:
+            url = FakeUrl()
+            client = type("C", (), {"host": "203.0.113.5"})()
+            headers: dict = {}
+            app = None
+            state = None
+
+        return FakeRequest()
+
+    @pytest.mark.asyncio
+    async def test_headers_are_wire_valid(self, request_obj):
+        response = await rate_limit_exceeded_handler(request_obj, _exc("100/minute"))
+
+        assert response.status_code == 429
+        assert response.headers["Retry-After"] == "60"
+        assert DELTA_SECONDS.match(response.headers["Retry-After"])
+        assert response.headers["X-RateLimit-Limit"] == "100/minute"
+
+    @pytest.mark.asyncio
+    async def test_body_retry_after_matches_the_header(self, request_obj):
+        import json
+
+        response = await rate_limit_exceeded_handler(request_obj, _exc("10/hour"))
+        body = json.loads(response.body)
+
+        assert body["retry_after"] == 3600
+        assert str(body["retry_after"]) == response.headers["Retry-After"]
+
+    @pytest.mark.asyncio
+    async def test_no_app_state_is_not_fatal(self, request_obj):
+        """The handler must produce a 429 even with nowhere to audit."""
+        response = await rate_limit_exceeded_handler(request_obj, _exc("100/minute"))
+
+        assert response.status_code == 429
+
+
+class TestAuditWriteUsesTheLockedPath:
+    def test_create_audit_log_goes_through_execute(self):
+        """AC3 — audit_repository was the one place bypassing the base class's
+        lock, which serializes access to the shared sqlite3 connection."""
+        import inspect
+
+        from codeframe.platform_store.repositories.audit_repository import (
+            AuditRepository,
+        )
+
+        # Comments stripped: the fix's own comment names the old call, and a raw
+        # substring check would fail on the explanation of what was fixed.
+        source = "\n".join(
+            line.split("#")[0]
+            for line in inspect.getsource(AuditRepository.create_audit_log).splitlines()
+        )
+
+        assert "self._execute(" in source
+        assert "self.conn.cursor()" not in source, (
+            "still bypassing the base repository's threading lock"
+        )
+        assert "self._commit()" in source
+        assert "self.conn.commit()" not in source
+
+    def test_the_handler_offloads_the_write(self):
+        """A synchronous INSERT+COMMIT on the event loop, per rejected request,
+        during exactly the burst that triggered it."""
+        import inspect
+
+        from codeframe.lib import rate_limiter
+
+        source = inspect.getsource(rate_limiter.rate_limit_exceeded_handler)
+
+        assert "run_in_executor" in source
+
+    @pytest.mark.asyncio
+    async def test_the_audit_row_is_still_written(self):
+        """Offloading must not mean dropping."""
+        import asyncio
+
+        from codeframe.platform_store.database import Database
+
+        db = Database(":memory:")
+        db.initialize()
+
+        class FakeUrl:
+            path = "/api/v2/tasks"
+
+        class FakeRequest:
+            url = FakeUrl()
+            client = type("C", (), {"host": "203.0.113.5"})()
+            headers: dict = {}
+            app = type("A", (), {"state": type("S", (), {"db": db})()})()
+            state = None
+
+        await rate_limit_exceeded_handler(FakeRequest(), _exc("100/minute"))
+        # The executor call is fire-and-forget; yield until it lands.
+        for _ in range(50):
+            await asyncio.sleep(0.02)
+            rows = db.conn.execute(
+                "SELECT metadata FROM audit_logs WHERE event_type = 'rate_limit.exceeded'"
+            ).fetchall()
+            if rows:
+                break
+
+        assert rows, "the rate-limit event was never audited"
+        assert "100/minute" in rows[0]["metadata"], (
+            "the audited limit should be the readable string, not an object repr"
+        )

--- a/tests/api/test_rate_limit_429_939.py
+++ b/tests/api/test_rate_limit_429_939.py
@@ -142,6 +142,61 @@ class TestHandlerResponse:
         assert response.status_code == 429
 
 
+class TestAuditQueueIsBounded:
+    """Raised by the PR bot: fire-and-forget run_in_executor uses the default
+    executor's UNBOUNDED queue, so a distributed 429 flood — this handler's
+    whole reason to exist — grows pending writes and process memory without
+    limit, because writes serialize behind the store's single connection."""
+
+    def setup_method(self):
+        from codeframe.lib import rate_limiter
+
+        rate_limiter._audit_pending = 0
+        rate_limiter._audit_dropped = 0
+
+    def test_writes_past_the_cap_are_dropped_not_queued(self, caplog):
+        import logging
+
+        from codeframe.lib import rate_limiter
+
+        calls = []
+        rate_limiter._audit_pending = rate_limiter._AUDIT_MAX_PENDING
+
+        with caplog.at_level(logging.WARNING):
+            rate_limiter._submit_audit(lambda: calls.append(1))
+
+        assert calls == [], "the write ran despite a full queue"
+        assert rate_limiter._audit_dropped == 1
+        assert "Audit queue full" in caplog.text
+
+    def test_the_cap_does_not_block_normal_operation(self):
+        from codeframe.lib import rate_limiter
+
+        calls = []
+        rate_limiter._submit_audit(lambda: calls.append(1))
+
+        assert calls == [1], "an ordinary write was dropped"
+
+    def test_pending_returns_to_zero_after_a_write(self):
+        from codeframe.lib import rate_limiter
+
+        rate_limiter._submit_audit(lambda: None)
+
+        assert rate_limiter._audit_pending == 0, "the counter leaked"
+
+    def test_pending_returns_to_zero_when_the_write_raises(self):
+        """A leaked counter would silently shrink the cap to zero over time."""
+        from codeframe.lib import rate_limiter
+
+        def boom():
+            raise RuntimeError("nope")
+
+        with pytest.raises(RuntimeError):
+            rate_limiter._submit_audit(boom)
+
+        assert rate_limiter._audit_pending == 0
+
+
 class TestAuditWriteUsesTheLockedPath:
     def test_create_audit_log_goes_through_execute(self):
         """AC3 — audit_repository was the one place bypassing the base class's
@@ -173,9 +228,11 @@ class TestAuditWriteUsesTheLockedPath:
 
         from codeframe.lib import rate_limiter
 
-        source = inspect.getsource(rate_limiter.rate_limit_exceeded_handler)
-
-        assert "run_in_executor" in source
+        # The offload moved into _submit_audit, which bounds the queue.
+        assert "_submit_audit(" in inspect.getsource(
+            rate_limiter.rate_limit_exceeded_handler
+        )
+        assert "run_in_executor" in inspect.getsource(rate_limiter._submit_audit)
 
     @pytest.mark.asyncio
     async def test_the_audit_row_is_still_written(self):


### PR DESCRIPTION
Closes #939. (Blocked-by #937 is merged.)

Three defects in `rate_limit_exceeded_handler`, all from misreading slowapi internals.

## 1. `Retry-After` was unparseable

slowapi sets `exc.detail` to `str(limit.limit)` — the *human description*, not a delay. So every 429 sent:

```
Retry-After: 100 per 1 minute
```

RFC 9110 requires delta-seconds: "a non-negative decimal integer". Nothing parses that, and the same string went into the body's `retry_after`.

`retry_after_seconds()` derives the window from the limit — `GRANULARITY.seconds × multiples`:

| limit | old `Retry-After` | new |
|---|---|---|
| `100/minute` | `'100 per 1 minute'` | `60` |
| `20/second` | `'20 per 1 second'` | `1` |
| `10/hour` | `'10 per 1 hour'` | `3600` |
| `2/5minute` | `'2 per 5 minute'` | `300` |

The last row matters: the multiplier is the easy part to drop, and a 5-minute window reporting 60s tells every client to retry four minutes early — turning a rate limit into a retry storm.

The body's `retry_after` is now an **int**; a string invites clients to concatenate rather than compute.

## 2. `X-RateLimit-Limit` leaked an object repr

`exc.limit` is slowapi's `Limit` **wrapper**, which defines no `__str__`:

```
X-RateLimit-Limit: <slowapi.wrappers.Limit object at 0x7f3c...>
```

`limit_string()` renders `100/minute` from the underlying `limits` object.

## 3. The audit write blocked the event loop and bypassed the lock

The handler ran a synchronous SQLite `INSERT` + `COMMIT` **inline, per rejected request** — during exactly the burst or brute-force that triggered the 429, against a 5s `busy_timeout`.

- Offloaded via `run_in_executor`, falling back to an inline write when there is no running loop rather than dropping the event.
- `AuditRepository.create_audit_log` now uses the base class's `_execute`/`_commit`, which serialize access to the shared `sqlite3` connection behind a threading lock. That repository was **the one place bypassing it** — and it is the one written to from the event loop under contention.

## Acceptance criteria

- [x] `Retry-After` is an integer number of seconds derived from the limit window; a test asserts it parses as delta-seconds
- [x] `X-RateLimit-Limit` contains the limit string (e.g. `100/minute`), asserted by a test
- [x] The audit write is offloaded and uses the same locked connection path as other repositories

## Tests

23 tests. Two are "guard the guard": they assert `exc.detail` really *is* the human description and `str(exc.limit)` really *does* leak a repr — so the file cannot pass vacuously if slowapi changes those shapes. One asserts the audit row still lands after offloading, because "offloaded" must not quietly mean "dropped".

`ruff`, `mypy codeframe/` (197 files), and `tests/api + tests/unit -k "rate or audit or limit"` (48 passed) clean.

## Known limitations

- `Retry-After` is the **full window**, not the time remaining in the current one — slowapi's exception does not carry the window start, so a client told 60s may wait longer than strictly necessary. Erring long is the safe direction for a rate limiter; the true reset would need the storage backend's `get_window_stats`.
- The executor write is fire-and-forget: if the process dies between emitting the 429 and the write landing, that event is lost. Awaiting it would reintroduce the blocking this fixes.
