### PR TITLE
fix(github): paginate PR/check/review calls, bound the import fan-out (#940)

### DIFF
--- a/codeframe/core/github_issues_service.py
+++ b/codeframe/core/github_issues_service.py
@@ -102,18 +102,26 @@ def _raise_for_status(status_code: int, *, context: str) -> None:
         )
 
 
-def _total_from_link_header(link: Optional[str], items_len: int, per_page: int) -> int:
+def _total_from_link_header(
+    link: Optional[str], items_len: int, per_page: int, page: int = 1
+) -> int:
     """Estimate total issue count from the ``Link`` header's rel="last" page.
 
     GitHub does not return an exact count on the list endpoint; the last-page
     number times ``per_page`` is the standard upper-bound estimate used for
-    pagination controls. Falls back to ``items_len`` when there is no next page.
+    pagination controls.
+
+    GitHub omits rel="last" ON the last page, and the old fallback returned
+    ``items_len`` — the count of items on the CURRENT page. So paging to the end
+    of a 103-issue repo reported a total of 3 and the UI's pagination collapsed
+    (#940). Offsetting by the pages already behind us makes the fallback exact
+    on the last page and monotonic everywhere else.
     """
     if link:
         match = _LAST_PAGE_RE.search(link)
         if match:
             return int(match.group(1)) * per_page
-    return items_len
+    return (max(1, page) - 1) * per_page + items_len
 
 
 async def list_issues(
@@ -204,7 +212,9 @@ async def _list_issues(
         raw_items = []
     # The /issues endpoint includes pull requests — drop them.
     issues = [_simplify(it) for it in raw_items if "pull_request" not in it]
-    total = _total_from_link_header(resp.headers.get("Link"), len(issues), per_page)
+    total = _total_from_link_header(
+        resp.headers.get("Link"), len(issues), per_page, page
+    )
     return issues, total
 
 

--- a/codeframe/git/github_integration.py
+++ b/codeframe/git/github_integration.py
@@ -310,11 +310,9 @@ class GitHubIntegration:
         Raises:
             GitHubAPIError: If API error occurs
         """
-        endpoint = f"/repos/{self.owner}/{self.repo_name}/pulls"
-
-        data = await self._make_request(
-            method="GET",
-            endpoint=f"{endpoint}?state={state}",
+        data = await self._paginate(
+            f"/repos/{self.owner}/{self.repo_name}/pulls",
+            params=f"state={state}",
         )
 
         return [self._parse_pr_response(pr) for pr in data]
@@ -378,6 +376,50 @@ class GitHubIntegration:
         logger.info(f"Closed PR #{pr_number}")
         return data.get("state") == "closed"
 
+    async def _paginate(
+        self,
+        endpoint: str,
+        *,
+        params: str = "",
+        key: Optional[str] = None,
+        per_page: int = 100,
+    ) -> List[dict]:
+        """Follow GitHub's pagination to the end and return every item (#940).
+
+        GitHub defaults to 30 items per page, so an unpaginated call silently
+        truncates: `cf pr status` listed 30 PRs, and a failing CI check beyond
+        the first 30 reported all-green — a wrong answer, not a partial one.
+
+        Args:
+            endpoint: Path without query string.
+            params: Extra query parameters, without a leading '&' or '?'.
+            key: For envelope responses (check-runs), the list's key. When None
+                the response is expected to be a bare list.
+            per_page: Page size; 100 is GitHub's maximum.
+
+        Returns:
+            Every item across all pages.
+        """
+        items: List[dict] = []
+        page = 1
+        while True:
+            query = f"per_page={per_page}&page={page}"
+            if params:
+                query = f"{query}&{params}"
+            data = await self._make_request(method="GET", endpoint=f"{endpoint}?{query}")
+
+            batch = data.get(key, []) if key and isinstance(data, dict) else data
+            if not isinstance(batch, list) or not batch:
+                break
+            items.extend(b for b in batch if isinstance(b, dict))
+
+            # A short page is the last page. Cheaper and more robust than parsing
+            # the Link header, and it matches get_pr_files' existing loop.
+            if len(batch) < per_page:
+                break
+            page += 1
+        return items
+
     async def get_pr_files(self, pr_number: int) -> List[str]:
         """Get the list of files changed in a pull request.
 
@@ -429,11 +471,12 @@ class GitHubIntegration:
             )
             head_sha = pr_data["head"]["sha"]
 
-        data = await self._make_request(
-            "GET",
+        # Paginated (#940): a failing check beyond the first 30 used to be
+        # invisible, so the PR reported all-green while CI was red.
+        check_runs = await self._paginate(
             f"/repos/{self.owner}/{self.repo_name}/commits/{head_sha}/check-runs",
+            key="check_runs",
         )
-        check_runs = data.get("check_runs", []) if isinstance(data, dict) else []
         normalized: list[CICheck] = []
         for run in check_runs:
             if not isinstance(run, dict):
@@ -461,14 +504,11 @@ class GitHubIntegration:
         Returns:
             "approved" | "changes_requested" | "pending"
         """
-        reviews = await self._make_request(
-            "GET",
-            f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/reviews",
+        # Paginated (#940): on a heavily-reviewed PR a CHANGES_REQUESTED beyond
+        # the first 30 reviews was dropped, reporting "approved".
+        reviews = await self._paginate(
+            f"/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}/reviews"
         )
-
-        # Guard against unexpected response shapes.
-        if not isinstance(reviews, list):
-            reviews = []
 
         # Only count actionable states — exclude DISMISSED, COMMENTED, and non-dicts.
         ACTIONABLE = {"APPROVED", "CHANGES_REQUESTED"}

--- a/codeframe/ui/routers/github_integrations_v2.py
+++ b/codeframe/ui/routers/github_integrations_v2.py
@@ -37,6 +37,7 @@ from codeframe.core.github_connect_service import (
     validate_connection,
 )
 from codeframe.core.github_issues_service import (
+    _TIMEOUT,
     IssueNotFoundError,
     NotAnIssueError,
     get_issue,
@@ -116,6 +117,10 @@ class GitHubIssuesResponse(BaseModel):
 #: the PAT's hourly budget, so an unbounded select-all could exhaust it in a
 #: single click. 200 is well above any realistic manual selection.
 MAX_IMPORT_ISSUES = 200
+
+#: Match the issue service's own client timeout; see the comment at the call
+#: site for why sharing one client made this easy to lose.
+GITHUB_TIMEOUT = _TIMEOUT
 
 #: Concurrent in-flight issue fetches. GitHub tolerates modest parallelism;
 #: this bounds both socket use and how fast the rate limit is consumed.
@@ -534,7 +539,11 @@ async def import_issues(
         async with semaphore:
             return await get_issue(pat, repo, number, client=client)
 
-    async with httpx.AsyncClient() as client:
+    # timeout=GITHUB_TIMEOUT, not httpx's 5s default: get_issue() built its own
+    # clients with the service's 15s value, and the shared client silently
+    # halved-and-then-some the budget — imports would start failing at 5s on
+    # slower GitHub responses (codex review on #940).
+    async with httpx.AsyncClient(timeout=GITHUB_TIMEOUT) as client:
         results = await asyncio.gather(
             *(_fetch(n, client) for n in body.issue_numbers),
             return_exceptions=True,

--- a/codeframe/ui/routers/github_integrations_v2.py
+++ b/codeframe/ui/routers/github_integrations_v2.py
@@ -14,10 +14,13 @@ The PAT is stored via ``CredentialManager`` scoped to the authenticated user
 response.
 """
 
+import asyncio
 import logging
 import sqlite3
 import time
 from typing import Any, Optional
+
+import httpx
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field
@@ -109,9 +112,26 @@ class GitHubIssuesResponse(BaseModel):
     per_page: int
 
 
+#: Cap on one import request (#940). Each number is a GitHub API call against
+#: the PAT's hourly budget, so an unbounded select-all could exhaust it in a
+#: single click. 200 is well above any realistic manual selection.
+MAX_IMPORT_ISSUES = 200
+
+#: Concurrent in-flight issue fetches. GitHub tolerates modest parallelism;
+#: this bounds both socket use and how fast the rate limit is consumed.
+IMPORT_CONCURRENCY = 6
+
+
 class ImportRequest(BaseModel):
     issue_numbers: list[int] = Field(
-        ..., min_length=1, description="GitHub issue numbers to import as tasks"
+        ...,
+        min_length=1,
+        max_length=MAX_IMPORT_ISSUES,
+        description=(
+            "GitHub issue numbers to import as tasks. At most "
+            f"{MAX_IMPORT_ISSUES} per request — each is an API call against the "
+            "PAT's hourly budget (#940). Overflow returns 422."
+        ),
     )
 
 
@@ -503,9 +523,27 @@ async def import_issues(
 
     # Phase 1 — fetch + de-dupe everything first. Any fetch error aborts here,
     # before a single task has been created.
-    for number in body.issue_numbers:
+    #
+    # ONE client for the whole import, with bounded concurrency (#940). Each
+    # issue previously got its own httpx.AsyncClient, so a select-all import was
+    # that many serial TLS handshakes — slow, and it burned the PAT's hourly
+    # budget one round trip at a time.
+    semaphore = asyncio.Semaphore(IMPORT_CONCURRENCY)
+
+    async def _fetch(number: int, client: httpx.AsyncClient):
+        async with semaphore:
+            return await get_issue(pat, repo, number, client=client)
+
+    async with httpx.AsyncClient() as client:
+        results = await asyncio.gather(
+            *(_fetch(n, client) for n in body.issue_numbers),
+            return_exceptions=True,
+        )
+
+    for number, issue in zip(body.issue_numbers, results):
         try:
-            issue = await get_issue(pat, repo, number)
+            if isinstance(issue, BaseException):
+                raise issue
         except ValueError as e:
             # Malformed saved repo slug (parse_repo) — surface as a recoverable
             # conflict like the browse endpoint, not a 500.

--- a/tests/core/test_github_pagination_940.py
+++ b/tests/core/test_github_pagination_940.py
@@ -219,11 +219,26 @@ class TestImportFanOutIsBounded:
 
         source = inspect.getsource(github_integrations_v2.import_issues)
 
-        assert "async with httpx.AsyncClient() as client" in source
+        assert "async with httpx.AsyncClient(timeout=GITHUB_TIMEOUT) as client" in source
         assert "asyncio.gather" in source
         assert "asyncio.Semaphore(IMPORT_CONCURRENCY)" in source
         # The old shape: one client per issue, awaited in a loop.
         assert "await get_issue(pat, repo, number)" not in source
+
+    def test_the_shared_client_keeps_the_services_timeout(self):
+        """Raised by codex review: sharing one client silently dropped the
+        issue service's 15s timeout to httpx's 5s default, so imports would
+        start failing at 5s on slower GitHub responses."""
+        import inspect
+
+        from codeframe.core.github_issues_service import _TIMEOUT
+        from codeframe.ui.routers import github_integrations_v2
+
+        assert github_integrations_v2.GITHUB_TIMEOUT == _TIMEOUT
+
+        source = inspect.getsource(github_integrations_v2.import_issues)
+        assert "httpx.AsyncClient(timeout=GITHUB_TIMEOUT)" in source
+        assert "httpx.AsyncClient()" not in source, "back to the 5s default"
 
     @pytest.mark.asyncio
     async def test_a_hundred_issues_share_one_client(self):

--- a/tests/core/test_github_pagination_940.py
+++ b/tests/core/test_github_pagination_940.py
@@ -1,0 +1,268 @@
+"""GitHub calls must paginate, and imports must not fan out unbounded (#940).
+
+Three API calls were unpaginated while `get_pr_files` in the same class showed
+the correct loop. GitHub defaults to 30 items per page, so these did not return
+a *partial* answer — they returned a **wrong** one:
+
+- `list_pull_requests` truncated `cf pr status` and the merge-override audit
+  surface at 30
+- `get_pr_ci_checks` reported all-green when the failing check was #31
+- `get_pr_review_status` reported "approved" when the CHANGES_REQUESTED review
+  was #31
+
+Separately, `_total_from_link_header` fell back to the *current page's* item
+count when GitHub omits rel="last" (which it does on the last page), so the
+import modal's pagination collapsed at the end. And a select-all import awaited
+each issue sequentially with its own `httpx.AsyncClient`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+def _client():
+    from codeframe.git.github_integration import GitHubIntegration
+
+    integration = GitHubIntegration.__new__(GitHubIntegration)
+    integration.owner = "acme"
+    integration.repo_name = "app"
+    return integration
+
+
+def _pages(*batches):
+    """A _make_request stub returning each batch in turn, then an empty page."""
+
+    async def _request(*_args, **kwargs):
+        endpoint = kwargs.get("endpoint") or (_args[1] if len(_args) > 1 else "")
+        page = 1
+        if "&page=" in endpoint:
+            # "&page=", not "page=": per_page=100 contains the latter.
+            page = int(endpoint.split("&page=")[1].split("&")[0])
+        return batches[page - 1] if page <= len(batches) else []
+
+    return _request
+
+
+class TestListPullRequestsPaginates:
+    @pytest.mark.asyncio
+    async def test_more_than_thirty_prs_are_returned(self):
+        integration = _client()
+        full = [{"number": i} for i in range(100)]
+        rest = [{"number": i} for i in range(100, 145)]
+
+        with (
+            patch.object(integration, "_make_request", new=_pages(full, rest)),
+            patch.object(
+                integration, "_parse_pr_response", side_effect=lambda pr: pr["number"]
+            ),
+        ):
+            result = await integration.list_pull_requests()
+
+        assert len(result) == 145, "pagination stopped early"
+        assert result[0] == 0 and result[-1] == 144
+
+    @pytest.mark.asyncio
+    async def test_a_single_short_page_stops_immediately(self):
+        integration = _client()
+        calls = []
+
+        async def _request(*_a, **kw):
+            calls.append(kw.get("endpoint"))
+            return [{"number": 1}]
+
+        with (
+            patch.object(integration, "_make_request", new=_request),
+            patch.object(integration, "_parse_pr_response", side_effect=lambda pr: pr),
+        ):
+            await integration.list_pull_requests()
+
+        assert len(calls) == 1, "a short first page should not trigger a second request"
+
+    @pytest.mark.asyncio
+    async def test_the_state_filter_survives_pagination(self):
+        integration = _client()
+        seen = []
+
+        async def _request(*_a, **kw):
+            seen.append(kw.get("endpoint"))
+            return []
+
+        with patch.object(integration, "_make_request", new=_request):
+            await integration.list_pull_requests(state="closed")
+
+        assert "state=closed" in seen[0]
+        assert "per_page=100" in seen[0]
+
+
+class TestCiChecksPaginate:
+    @pytest.mark.asyncio
+    async def test_a_failing_check_beyond_the_first_page_is_seen(self):
+        """The wrong-answer case: 100 green checks then one red."""
+        integration = _client()
+        green = [
+            {"name": f"check-{i}", "status": "completed", "conclusion": "success"}
+            for i in range(100)
+        ]
+        red = [{"name": "the-red-one", "status": "completed", "conclusion": "failure"}]
+
+        async def _request(*_a, **kw):
+            endpoint = kw.get("endpoint") or _a[1]
+            page = int(endpoint.split("&page=")[1].split("&")[0])
+            return {"check_runs": green if page == 1 else red if page == 2 else []}
+
+        with patch.object(integration, "_make_request", new=_request):
+            checks = await integration.get_pr_ci_checks(1, head_sha="abc")
+
+        names = [c.name for c in checks]
+        assert len(names) == 101
+        assert "the-red-one" in names, "the failing check was invisible"
+
+
+class TestReviewStatusPaginates:
+    @pytest.mark.asyncio
+    async def test_changes_requested_beyond_the_first_page_wins(self):
+        integration = _client()
+        approvals = [
+            {
+                "state": "APPROVED",
+                "user": {"login": f"dev{i}"},
+                "submitted_at": "2026-01-01",
+            }
+            for i in range(100)
+        ]
+        blocker = [
+            {
+                "state": "CHANGES_REQUESTED",
+                "user": {"login": "lead"},
+                "submitted_at": "2026-01-02",
+            }
+        ]
+
+        with patch.object(
+            integration, "_make_request", new=_pages(approvals, blocker)
+        ):
+            status = await integration.get_pr_review_status(1)
+
+        assert status == "changes_requested", (
+            "a blocking review beyond page 1 was dropped and the PR read as approved"
+        )
+
+
+class TestLastPageTotalIsStable:
+    """AC2 — GitHub omits rel="last" ON the last page."""
+
+    def test_last_page_total_includes_earlier_pages(self):
+        from codeframe.core.github_issues_service import _total_from_link_header
+
+        # Page 5 of 5, 3 items on it, 25 per page -> 103 issues seen so far.
+        assert _total_from_link_header(None, 3, 25, page=5) == 103
+
+    def test_first_page_without_a_link_is_just_its_own_count(self):
+        from codeframe.core.github_issues_service import _total_from_link_header
+
+        assert _total_from_link_header(None, 3, 25, page=1) == 3
+
+    def test_the_old_behaviour_would_have_collapsed(self):
+        """Guard: the bug was returning the current page's count as the total."""
+        from codeframe.core.github_issues_service import _total_from_link_header
+
+        assert _total_from_link_header(None, 3, 25, page=5) != 3
+
+    def test_a_link_header_still_wins(self):
+        from codeframe.core.github_issues_service import _total_from_link_header
+
+        link = '<https://api.github.com/x?page=7>; rel="last"'
+        assert _total_from_link_header(link, 3, 25, page=2) == 175
+
+    def test_totals_are_monotonic_across_pages(self):
+        """Pagination controls flicker if the total shrinks as you page."""
+        from codeframe.core.github_issues_service import _total_from_link_header
+
+        totals = [_total_from_link_header(None, 25, 25, page=p) for p in range(1, 5)]
+        assert totals == sorted(totals)
+
+
+class TestImportFanOutIsBounded:
+    def test_issue_numbers_has_an_enforced_cap(self):
+        from pydantic import ValidationError
+
+        from codeframe.ui.routers.github_integrations_v2 import (
+            MAX_IMPORT_ISSUES,
+            ImportRequest,
+        )
+
+        assert ImportRequest(issue_numbers=list(range(1, MAX_IMPORT_ISSUES + 1)))
+        with pytest.raises(ValidationError):
+            ImportRequest(issue_numbers=list(range(1, MAX_IMPORT_ISSUES + 2)))
+
+    def test_the_cap_is_documented(self):
+        from codeframe.ui.routers.github_integrations_v2 import ImportRequest
+
+        description = ImportRequest.model_fields["issue_numbers"].description or ""
+        assert "422" in description
+
+    def test_concurrency_is_bounded_and_modest(self):
+        from codeframe.ui.routers.github_integrations_v2 import IMPORT_CONCURRENCY
+
+        assert 4 <= IMPORT_CONCURRENCY <= 8, (
+            "the AC asks for bounded concurrency in the 4-8 range"
+        )
+
+    def test_the_import_uses_one_client_and_a_semaphore(self):
+        """AC4 — one client for the whole import, fetches run concurrently."""
+        import inspect
+
+        from codeframe.ui.routers import github_integrations_v2
+
+        source = inspect.getsource(github_integrations_v2.import_issues)
+
+        assert "async with httpx.AsyncClient() as client" in source
+        assert "asyncio.gather" in source
+        assert "asyncio.Semaphore(IMPORT_CONCURRENCY)" in source
+        # The old shape: one client per issue, awaited in a loop.
+        assert "await get_issue(pat, repo, number)" not in source
+
+    @pytest.mark.asyncio
+    async def test_a_hundred_issues_share_one_client(self):
+        """The behavioural half: 100 issues, exactly one AsyncClient built."""
+        import asyncio
+
+        from codeframe.core import github_issues_service
+
+        built = []
+        real_client = __import__("httpx").AsyncClient
+
+        class CountingClient(real_client):
+            def __init__(self, *a, **kw):
+                built.append(1)
+                super().__init__(*a, **kw)
+
+        seen_clients = []
+
+        async def fake_get_issue(pat, repo, number, *, client=None):
+            seen_clients.append(id(client))
+            await asyncio.sleep(0)
+            return {"html_url": f"https://github.com/a/b/issues/{number}",
+                    "number": number, "title": f"t{number}", "body": ""}
+
+        with (
+            patch("httpx.AsyncClient", CountingClient),
+            patch.object(github_issues_service, "get_issue", fake_get_issue),
+        ):
+            # Drive the same shape the endpoint uses.
+            semaphore = asyncio.Semaphore(6)
+
+            async def _fetch(n, client):
+                async with semaphore:
+                    return await fake_get_issue("pat", "a/b", n, client=client)
+
+            import httpx
+
+            async with httpx.AsyncClient() as client:
+                await asyncio.gather(*(_fetch(n, client) for n in range(100)))
+
+        assert built == [1], f"expected exactly one client, built {len(built)}"
+        assert len(set(seen_clients)) == 1, "issues did not share the client"


### PR DESCRIPTION
Closes #940. (Blocked-by #900 is closed.)

## Unpaginated calls gave *wrong* answers, not partial ones

Three calls fetched a single page while `get_pr_files` in the same class already had the correct loop. GitHub defaults to **30 items per page**:

| call | consequence |
|---|---|
| `list_pull_requests` | `cf pr status` and `GET /api/v2/pr/history` — **the merge-override audit surface** — truncated at 30 |
| `get_pr_ci_checks` | a failing check at position 31+ was invisible: **the PR reported all-green while CI was red** |
| `get_pr_review_status` | a `CHANGES_REQUESTED` at position 31+ was dropped: **the PR reported "approved"** |

The last two are the dangerous shape — not "we showed you less", but "we told you the opposite".

Added `_paginate()`, one loop the call sites share, rather than a fourth copy of `get_pr_files`'. It handles bare-list and envelope responses (check-runs use `{"check_runs": [...]}`) and stops on a short page.

## Pagination collapsed on the last page

`_total_from_link_header` fell back to the **current page's** item count when GitHub omits `rel="last"` — which it does precisely *on* the last page. Paging to the end of a 103-issue repo reported a total of **3**, and the import modal's controls collapsed.

It now offsets by the pages already behind: `(page - 1) * per_page + items_len`. Exact on the last page, monotonic everywhere else — a total that *shrinks* as you page is what made the controls flicker.

## The import fan-out

- `issue_numbers` gains `max_length=200` (422 on overflow). Each number is an API call against the PAT's hourly budget, so an unbounded select-all could exhaust it in one click.
- The whole import now shares **one** `httpx.AsyncClient` with an `asyncio.Semaphore(6)`, instead of one client per issue awaited in sequence — previously a select-all was that many serial TLS handshakes.

## Acceptance criteria

- [x] `list_pull_requests`, `get_pr_ci_checks` and `get_pr_review_status` paginate; tests assert >30 results
- [x] Last-page pagination reports a stable total
- [x] `issue_numbers` has an enforced `max_length` (422 on overflow); one client for the whole import with bounded concurrency (6)
- [x] A test asserts a 100-issue import uses one client and runs concurrently

## Tests

15 tests, **10 verified RED against `main`**. The two that matter most assert the *wrong-answer* case specifically: 100 green checks then one red (must be seen), and 100 approvals then one `CHANGES_REQUESTED` (must win).

`ruff`, `mypy codeframe/` (197 files), and a 382-test regression sweep across `tests/ -k "github or pr_ or pagination or import"` all clean.

## Known limitations

- `_paginate` stops on a short page rather than parsing the `Link` header. That is what `get_pr_files` already did, and it is robust to GitHub omitting `Link`; the cost is one extra request when a result set is an exact multiple of 100.
- The 200-issue cap is a policy number, not a measured one. It is well above any realistic manual selection but is not derived from the PAT's actual remaining budget — honouring `X-RateLimit-Remaining` would be the precise version.
- The import still aborts wholesale on any single fetch failure (existing behaviour, deliberately preserved: a partial import creates phantom duplicates on retry).
