### PR TITLE
fix(notifications): mask the webhook URL, delete the SSRF-bypassing path (#941)

### DIFF
--- a/codeframe/core/notifications_config.py
+++ b/codeframe/core/notifications_config.py
@@ -226,14 +226,20 @@ def is_webhook_active(workspace: Workspace) -> Optional[str]:
     if not _is_safe_webhook_url(url):
         logger.warning(
             "Refusing to dispatch webhook to unsafe URL: %s",
-            _redact_url_for_log(url),
+            redact_webhook_url(url),
         )
         return None
     return url
 
 
-def _redact_url_for_log(url: str) -> str:
-    """Return a logging-safe representation of a webhook URL.
+def redact_webhook_url(url: str) -> str:
+    """Return a display-safe representation of a webhook URL.
+
+    Used for logs AND for the settings API response (#941): Slack/Discord/
+    GitHub webhook URLs are bearer credentials — anyone holding the full URL can
+    post to the channel — so the path and query must never reach a read-scope
+    caller. Sibling secret material in this codebase is admin-gated and never
+    echoed; this brings the webhook URL in line.
 
     Slack/Discord/GitHub-style webhook URLs commonly embed secrets in:
 

--- a/codeframe/notifications/webhook.py
+++ b/codeframe/notifications/webhook.py
@@ -19,7 +19,6 @@ from urllib.parse import urlparse
 
 import aiohttp
 
-from codeframe.core.models import BlockerType
 from codeframe.core.notifications_config import (
     UnsafeWebhookHostError,
     allow_private_webhook_hosts,
@@ -136,7 +135,7 @@ def format_test_payload() -> dict:
 class WebhookNotificationService:
     """Async outbound webhook service.
 
-    Originally built for SYNC blocker alerts (``send_blocker_notification``);
+    Originally built for SYNC blocker alerts (that path is gone, #941);
     now also powers the issue #560 outbound event webhooks (batch / blocker /
     PR / test) via ``send_event``. Delivery is fire-and-forget with a
     configurable timeout — failures are logged but never break the triggering
@@ -168,124 +167,23 @@ class WebhookNotificationService:
         """
         return self.webhook_url is not None and self.webhook_url.strip() != ""
 
-    def format_payload(
-        self,
-        blocker_id: int,
-        question: str,
-        agent_id: str,
-        task_id: int,
-        blocker_type: BlockerType,
-        created_at: datetime,
-    ) -> dict:
-        """Format webhook payload with blocker details.
+    # send_blocker_notification() and format_payload() were DELETED (#941).
+    #
+    # They had no production callers, but remained public and POSTed with a
+    # plain aiohttp session: no host vetting, no pinned resolver, and
+    # allow_redirects defaulting to True. That bypassed every guard send_event
+    # implements (#656/#746), so the first future caller would have silently
+    # reopened the metadata-endpoint hole (169.254.169.254) those issues closed.
+    # Use send_event / send_event_background.
 
-        Args:
-            blocker_id: Blocker database ID
-            question: Blocker question text
-            agent_id: Agent that created the blocker
-            task_id: Associated task ID
-            blocker_type: SYNC or ASYNC
-            created_at: Blocker creation timestamp
 
-        Returns:
-            Dictionary payload ready for JSON serialization
-        """
-        dashboard_url = f"{self.dashboard_base_url}/#blocker-{blocker_id}"
-
-        return {
-            "blocker_id": blocker_id,
-            "question": question,
-            "agent_id": agent_id,
-            "task_id": task_id,
-            "type": blocker_type.value,
-            "created_at": created_at.isoformat(),
-            "dashboard_url": dashboard_url,
-        }
-
-    async def send_blocker_notification(
-        self,
-        blocker_id: int,
-        question: str,
-        agent_id: str,
-        task_id: int,
-        blocker_type: BlockerType,
-        created_at: datetime,
-    ) -> bool:
-        """Send async webhook notification for a blocker.
-
-        Fire-and-forget delivery with timeout. Logs errors but doesn't block execution.
-        Only sends notifications for SYNC blockers.
-
-        Args:
-            blocker_id: Blocker database ID
-            question: Blocker question text
-            agent_id: Agent that created the blocker
-            task_id: Associated task ID
-            blocker_type: SYNC or ASYNC
-            created_at: Blocker creation timestamp
-
-        Returns:
-            True if notification sent successfully, False on failure
-        """
-        # Only send notifications for SYNC blockers
-        if blocker_type != BlockerType.SYNC:
-            logger.debug(f"Skipping webhook notification for ASYNC blocker {blocker_id}")
-            return False
-
-        # Check if webhooks are enabled
-        if not self.is_enabled():
-            logger.debug(f"Webhook notifications disabled, skipping blocker {blocker_id}")
-            return False
-
-        # Format payload
-        payload = self.format_payload(
-            blocker_id=blocker_id,
-            question=question,
-            agent_id=agent_id,
-            task_id=task_id,
-            blocker_type=blocker_type,
-            created_at=created_at,
-        )
-
-        try:
-            # Send HTTP POST with timeout
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    self.webhook_url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=self.timeout),
-                ) as response:
-                    response.raise_for_status()
-
-                    logger.info(
-                        f"Webhook notification sent for blocker {blocker_id} "
-                        f"(status: {response.status})"
-                    )
-                    return True
-
-        except asyncio.TimeoutError:
-            logger.error(
-                f"Webhook notification timeout for blocker {blocker_id} "
-                f"(exceeded {self.timeout}s)"
-            )
-            return False
-
-        except aiohttp.ClientError as e:
-            logger.error(f"Webhook notification failed for blocker {blocker_id}: {e}")
-            return False
-
-        except Exception as e:
-            logger.error(
-                f"Unexpected error sending webhook for blocker {blocker_id}: {e}", exc_info=True
-            )
-            return False
 
     async def send_event(
         self, payload: dict, url: Optional[str] = None
     ) -> WebhookSendResult:
         """Generic webhook POST for outbound event notifications (issue #560).
 
-        Unlike ``send_blocker_notification``, this method:
+        This method (the only send path since #941):
 
         * Accepts an arbitrary JSON payload (the caller composes the event).
         * Returns rich status information so the Settings ``Test`` endpoint

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -72,6 +72,7 @@ from codeframe.ui.models import (
     VerifyKeyResponse,
 )
 from codeframe.ui.response_models import ErrorCodes, api_error
+from codeframe.core.notifications_config import redact_webhook_url
 
 logger = logging.getLogger(__name__)
 
@@ -440,7 +441,12 @@ async def verify_key(
 
 
 class NotificationSettingsResponse(BaseModel):
+    #: MASKED to scheme://host[:port] — never the full URL (#941). The path and
+    #: query of a Slack/Discord/GitHub webhook carry its token.
     webhook_url: Optional[str] = None
+    #: Whether a URL is stored, so the UI can distinguish "unset" from "set but
+    #: not shown" without the value itself.
+    webhook_url_set: bool = False
     webhook_enabled: bool = False
 
 
@@ -464,10 +470,20 @@ async def get_notification_settings(
     request: Request,
     workspace: Workspace = Depends(get_v2_workspace),
 ) -> NotificationSettingsResponse:
-    """Load outbound webhook config for this workspace."""
+    """Load outbound webhook config for this workspace.
+
+    The URL is MASKED to scheme://host[:port] (#941). A Slack/Discord/GitHub
+    webhook URL is a bearer credential — its path and query carry the token, and
+    anyone holding the full URL can post to the channel. Returning it verbatim
+    to any read-scope caller was inconsistent with every other secret here,
+    which is admin-gated and never echoed. `webhook_url_set` tells the UI whether
+    one is configured without disclosing it.
+    """
     cfg = load_notifications_config(workspace)
+    stored = cfg["webhook_url"]
     return NotificationSettingsResponse(
-        webhook_url=cfg["webhook_url"],
+        webhook_url=redact_webhook_url(stored) if stored else None,
+        webhook_url_set=bool(stored),
         webhook_enabled=cfg["webhook_enabled"],
     )
 
@@ -548,6 +564,15 @@ async def update_notification_settings(
     the saved URL. The URL is validated for ``http(s)`` scheme to avoid
     ``file://`` / ``ftp://`` SSRF on local resources.
     """
+    # GET now returns the URL MASKED (#941), so a client that round-trips what
+    # it was shown would otherwise overwrite the real URL with "https://host".
+    # Treat a submitted value identical to the current mask as "unchanged" —
+    # server-side, so it protects any client, not just our own UI.
+    existing = load_notifications_config(workspace)["webhook_url"]
+    submitted = (body.webhook_url or "").strip()
+    if existing and submitted and submitted == redact_webhook_url(existing):
+        body = body.model_copy(update={"webhook_url": existing})
+
     # Off the event loop: _validate_webhook_url may do a blocking DNS lookup.
     url = await run_in_threadpool(_validate_webhook_url, body.webhook_url)
     try:

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -590,8 +590,14 @@ async def update_notification_settings(
                 str(e),
             ),
         )
+    # Masked here too (#941). Masking only GET left the credential flowing out
+    # of the SAME handler's sibling response — and this one is what the UI holds
+    # in state after a save, so the full URL would sit in the browser until the
+    # next reload.
     return NotificationSettingsResponse(
-        webhook_url=url, webhook_enabled=body.webhook_enabled
+        webhook_url=redact_webhook_url(url) if url else None,
+        webhook_url_set=bool(url),
+        webhook_enabled=body.webhook_enabled,
     )
 
 

--- a/tests/core/test_notifications_config.py
+++ b/tests/core/test_notifications_config.py
@@ -173,23 +173,23 @@ def test_unsafe_url_log_does_not_leak_basic_auth(workspace, caplog):
     assert "admin:" not in log_text
 
 
-def test_redact_url_for_log_preserves_port():
+def testredact_webhook_url_preserves_port():
     """Port is non-secret and useful in logs (which environment), so keep it."""
-    from codeframe.core.notifications_config import _redact_url_for_log
+    from codeframe.core.notifications_config import redact_webhook_url
 
-    assert _redact_url_for_log("https://hooks.example.com:8443/path/x?q=1") == (
+    assert redact_webhook_url("https://hooks.example.com:8443/path/x?q=1") == (
         "https://hooks.example.com:8443"
     )
 
 
-def test_redact_url_for_log_handles_malformed_port():
+def testredact_webhook_url_handles_malformed_port():
     """``parsed.port`` raises ValueError for invalid ports — the redaction
     helper must convert that into <unparseable> rather than letting it bubble
     out and turn ``is_webhook_active``'s fail-safe branch into an exception.
     """
-    from codeframe.core.notifications_config import _redact_url_for_log
+    from codeframe.core.notifications_config import redact_webhook_url
 
-    assert _redact_url_for_log("https://host:not-a-port/path") == "<unparseable>"
+    assert redact_webhook_url("https://host:not-a-port/path") == "<unparseable>"
 
 
 def test_is_webhook_active_returns_none_for_malformed_port(workspace):

--- a/tests/core/test_notifications_config.py
+++ b/tests/core/test_notifications_config.py
@@ -173,7 +173,7 @@ def test_unsafe_url_log_does_not_leak_basic_auth(workspace, caplog):
     assert "admin:" not in log_text
 
 
-def testredact_webhook_url_preserves_port():
+def test_redact_webhook_url_preserves_port():
     """Port is non-secret and useful in logs (which environment), so keep it."""
     from codeframe.core.notifications_config import redact_webhook_url
 
@@ -182,7 +182,7 @@ def testredact_webhook_url_preserves_port():
     )
 
 
-def testredact_webhook_url_handles_malformed_port():
+def test_redact_webhook_url_handles_malformed_port():
     """``parsed.port`` raises ValueError for invalid ports — the redaction
     helper must convert that into <unparseable> rather than letting it bubble
     out and turn ``is_webhook_active``'s fail-safe branch into an exception.

--- a/tests/notifications/test_webhook_notifications.py
+++ b/tests/notifications/test_webhook_notifications.py
@@ -1,13 +1,8 @@
 """Tests for webhook notification service (049-human-in-loop, Phase 7)."""
 
-import asyncio
-from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
 
-from codeframe.core.models import BlockerType
 from codeframe.notifications.webhook import WebhookNotificationService
 
 
@@ -50,262 +45,20 @@ class TestWebhookNotificationService:
         service = WebhookNotificationService(webhook_url="   ", timeout=5)
         assert service.is_enabled() is False
 
-    def test_format_payload(self, webhook_service):
-        """Test payload formatting includes all required fields."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-        payload = webhook_service.format_payload(
-            blocker_id=123,
-            question="What API key should I use?",
-            agent_id="backend-worker-abc123",
-            task_id=456,
-            blocker_type=BlockerType.SYNC,
-            created_at=created_at,
-        )
+    # The format_payload / send_blocker_notification tests were removed with the
+    # methods they covered (#941). Those methods had no production callers and
+    # POSTed with a plain aiohttp session — no host vetting, no pinned resolver,
+    # redirects enabled — bypassing the SSRF guards send_event implements.
+    # Deleting the tests alongside the code is deliberate: keeping them would
+    # have required keeping the unsafe path alive to test.
 
-        assert payload["blocker_id"] == 123
-        assert payload["question"] == "What API key should I use?"
-        assert payload["agent_id"] == "backend-worker-abc123"
-        assert payload["task_id"] == 456
-        assert payload["type"] == "SYNC"
-        assert payload["created_at"] == "2025-11-08T14:30:00"
-        assert payload["dashboard_url"] == "http://localhost:3000/#blocker-123"
 
-    def test_format_payload_async_type(self, webhook_service):
-        """Test payload formatting with ASYNC blocker type."""
-        created_at = datetime(2025, 11, 8, 15, 0, 0)
-        payload = webhook_service.format_payload(
-            blocker_id=789,
-            question="Should we use light or dark theme?",
-            agent_id="frontend-worker-xyz789",
-            task_id=101,
-            blocker_type=BlockerType.ASYNC,
-            created_at=created_at,
-        )
 
-        assert payload["type"] == "ASYNC"
 
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_sync_success(self, webhook_service):
-        """Test successful webhook notification for SYNC blocker."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
 
-        # Mock aiohttp response
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.raise_for_status = MagicMock()
 
-        # Create proper async context manager mock
-        mock_post_context = AsyncMock()
-        mock_post_context.__aenter__.return_value = mock_response
-        mock_post_context.__aexit__.return_value = None
 
-        mock_session = MagicMock()
-        mock_session.post.return_value = mock_post_context
-        mock_session.__aenter__.return_value = mock_session
-        mock_session.__aexit__.return_value = None
 
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            result = await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="Critical blocker",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
 
-        assert result is True
-        mock_session.post.assert_called_once()
 
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_async_skipped(self, webhook_service):
-        """Test webhook notification skipped for ASYNC blocker."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
 
-        result = await webhook_service.send_blocker_notification(
-            blocker_id=123,
-            question="Non-critical question",
-            agent_id="backend-worker-1",
-            task_id=456,
-            blocker_type=BlockerType.ASYNC,
-            created_at=created_at,
-        )
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_disabled(self, webhook_service_no_url):
-        """Test webhook notification skipped when webhooks disabled."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        result = await webhook_service_no_url.send_blocker_notification(
-            blocker_id=123,
-            question="Critical blocker",
-            agent_id="backend-worker-1",
-            task_id=456,
-            blocker_type=BlockerType.SYNC,
-            created_at=created_at,
-        )
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_timeout(self, webhook_service):
-        """Test webhook notification handles timeout gracefully."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        mock_session = AsyncMock()
-        mock_session.post.side_effect = asyncio.TimeoutError()
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            result = await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="Critical blocker",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_client_error(self, webhook_service):
-        """Test webhook notification handles HTTP client errors."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        mock_response = AsyncMock()
-        mock_response.raise_for_status.side_effect = aiohttp.ClientError("Connection failed")
-
-        mock_session = AsyncMock()
-        mock_session.post.return_value.__aenter__.return_value = mock_response
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            result = await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="Critical blocker",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_unexpected_error(self, webhook_service):
-        """Test webhook notification handles unexpected exceptions."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        mock_session = AsyncMock()
-        mock_session.post.side_effect = RuntimeError("Unexpected error")
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            result = await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="Critical blocker",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_http_error_status(self, webhook_service):
-        """Test webhook notification handles HTTP error status codes."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        mock_response = AsyncMock()
-        mock_response.status = 500
-        mock_response.raise_for_status.side_effect = aiohttp.ClientError(
-            "500 Internal Server Error"
-        )
-
-        mock_session = AsyncMock()
-        mock_session.post.return_value.__aenter__.return_value = mock_response
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            result = await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="Critical blocker",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_correct_payload(self, webhook_service):
-        """Test webhook notification sends correct JSON payload."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.raise_for_status = MagicMock()
-
-        # Create proper async context manager mock
-        mock_post_context = AsyncMock()
-        mock_post_context.__aenter__.return_value = mock_response
-        mock_post_context.__aexit__.return_value = None
-
-        mock_session = MagicMock()
-        mock_session.post.return_value = mock_post_context
-        mock_session.__aenter__.return_value = mock_session
-        mock_session.__aexit__.return_value = None
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="What API key?",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
-
-        # Verify POST was called with correct arguments
-        call_args = mock_session.post.call_args
-        assert call_args[0][0] == "https://hooks.example.com/webhook/12345"
-        assert call_args[1]["json"]["blocker_id"] == 123
-        assert call_args[1]["json"]["question"] == "What API key?"
-        assert call_args[1]["json"]["agent_id"] == "backend-worker-1"
-        assert call_args[1]["json"]["task_id"] == 456
-        assert call_args[1]["json"]["type"] == "SYNC"
-        assert call_args[1]["json"]["dashboard_url"] == "http://localhost:3000/#blocker-123"
-
-    @pytest.mark.asyncio
-    async def test_send_blocker_notification_timeout_configured(self, webhook_service):
-        """Test webhook notification uses configured timeout."""
-        created_at = datetime(2025, 11, 8, 14, 30, 0)
-
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.raise_for_status = MagicMock()
-
-        # Create proper async context manager mock
-        mock_post_context = AsyncMock()
-        mock_post_context.__aenter__.return_value = mock_response
-        mock_post_context.__aexit__.return_value = None
-
-        mock_session = MagicMock()
-        mock_session.post.return_value = mock_post_context
-        mock_session.__aenter__.return_value = mock_session
-        mock_session.__aexit__.return_value = None
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            await webhook_service.send_blocker_notification(
-                blocker_id=123,
-                question="Critical blocker",
-                agent_id="backend-worker-1",
-                task_id=456,
-                blocker_type=BlockerType.SYNC,
-                created_at=created_at,
-            )
-
-        # Verify timeout was passed
-        call_args = mock_session.post.call_args
-        assert call_args[1]["timeout"].total == 5

--- a/tests/ui/test_settings_notifications.py
+++ b/tests/ui/test_settings_notifications.py
@@ -60,7 +60,11 @@ class TestGetNotificationSettings:
         r = client.get("/api/v2/settings/notifications")
         assert r.status_code == 200
         data = r.json()
-        assert data == {"webhook_url": None, "webhook_enabled": False}
+        # webhook_url_set added in #941; assert the fields, not an exact dict,
+        # so a new non-secret field does not fail this.
+        assert data["webhook_url"] is None
+        assert data["webhook_enabled"] is False
+        assert data["webhook_url_set"] is False
 
 
 class TestUpdateNotificationSettings:
@@ -84,7 +88,11 @@ class TestUpdateNotificationSettings:
         )
         r = client.get("/api/v2/settings/notifications")
         data = r.json()
-        assert data["webhook_url"] == "https://x.test/h"
+        # MASKED since #941 — the path/query of a webhook URL carries its token,
+        # so a read-scope caller gets scheme://host and a "set" flag, not the
+        # credential. Round-tripping the mask through PUT is a no-op by design.
+        assert data["webhook_url"] == "https://x.test"
+        assert data["webhook_url_set"] is True
         assert data["webhook_enabled"] is False
 
     def test_empty_url_clears_value(self, client):

--- a/tests/ui/test_settings_notifications.py
+++ b/tests/ui/test_settings_notifications.py
@@ -78,7 +78,11 @@ class TestUpdateNotificationSettings:
         )
         assert r.status_code == 200
         data = r.json()
-        assert data["webhook_url"] == "https://hooks.example.com/abc"
+        # MASKED since #941 — the PUT response is what the UI holds in state
+        # after a save, so returning the full URL kept the credential in the
+        # browser until the next reload.
+        assert data["webhook_url"] == "https://hooks.example.com"
+        assert data["webhook_url_set"] is True
         assert data["webhook_enabled"] is True
 
     def test_roundtrip_get_after_put(self, client):

--- a/tests/ui/test_webhook_masking_941.py
+++ b/tests/ui/test_webhook_masking_941.py
@@ -138,3 +138,27 @@ class TestRoundTrippingTheMaskDoesNotDestroyTheUrl:
         assert new != redact_webhook_url(old), (
             "a real new URL must not be mistaken for the mask"
         )
+
+
+class TestPutResponseIsMaskedToo:
+    """Raised by the PR bot: masking only GET left the credential flowing out of
+    the SAME handler's sibling response — and the PUT response is what the UI
+    holds in state after a save, so the full URL sat in the browser until the
+    next reload."""
+
+    def test_the_put_handler_masks_its_response(self):
+        from codeframe.ui.routers import settings_v2
+
+        source = inspect.getsource(settings_v2.update_notification_settings)
+
+        assert "redact_webhook_url(url)" in source
+        assert "webhook_url=url," not in source, "the PUT response returns the raw URL"
+
+    def test_the_put_response_sets_the_flag(self):
+        from codeframe.ui.routers import settings_v2
+
+        source = inspect.getsource(settings_v2.update_notification_settings)
+
+        assert "webhook_url_set=bool(url)" in source, (
+            "webhook_url_set was left at its False default after a successful save"
+        )

--- a/tests/ui/test_webhook_masking_941.py
+++ b/tests/ui/test_webhook_masking_941.py
@@ -1,0 +1,140 @@
+"""The stored webhook URL is a secret, and the unsafe send path is gone (#941).
+
+`GET /api/v2/settings/notifications` returned the stored webhook URL **verbatim
+to any read-scope caller** — while the codebase itself treats these as secrets
+(`redact_webhook_url` exists precisely because Slack/Discord/GitHub webhook URLs
+embed tokens in their path). Every sibling secret here is admin-gated and never
+echoed.
+
+Separately, `send_blocker_notification` + `format_payload` had no production
+callers but remained public and POSTed with a plain aiohttp session — no host
+vetting, no pinned resolver, `allow_redirects` defaulting to True — bypassing
+the #656/#746 hardening that `send_event` implements.
+"""
+
+import inspect
+
+import pytest
+
+from codeframe.core.notifications_config import redact_webhook_url
+
+pytestmark = pytest.mark.v2
+
+#: A Slack-shaped URL: the token is in the PATH, which is the whole problem.
+SECRET_URL = "https://hooks.slack.com/services/T00000000/B11111111/XXXXsecretTOKEN"
+
+
+class TestUrlIsMasked:
+    def test_path_and_query_never_survive(self):
+        masked = redact_webhook_url(SECRET_URL + "?signature=deadbeef")
+
+        assert "XXXXsecretTOKEN" not in masked
+        assert "T00000000" not in masked
+        assert "deadbeef" not in masked
+        assert masked == "https://hooks.slack.com"
+
+    def test_basic_auth_credentials_are_stripped(self):
+        masked = redact_webhook_url("https://user:hunter2@hooks.example.com/x")
+
+        assert "hunter2" not in masked
+        assert "user" not in masked
+
+    def test_the_port_survives_because_it_is_not_secret(self):
+        assert redact_webhook_url("https://h.example.com:8443/p?q=1") == (
+            "https://h.example.com:8443"
+        )
+
+    def test_unparseable_input_does_not_leak_it_back(self):
+        assert redact_webhook_url("not a url") == "<unparseable>"
+
+
+class TestSettingsResponseDoesNotDiscloseTheUrl:
+    def test_the_handler_masks_before_responding(self):
+        from codeframe.ui.routers import settings_v2
+
+        source = inspect.getsource(settings_v2.get_notification_settings)
+
+        assert "redact_webhook_url(" in source
+        assert 'webhook_url=cfg["webhook_url"]' not in source, (
+            "the raw stored URL is still returned"
+        )
+
+    def test_the_response_model_exposes_a_set_flag(self):
+        """So the UI can say 'configured' without being told the value."""
+        from codeframe.ui.routers.settings_v2 import NotificationSettingsResponse
+
+        assert "webhook_url_set" in NotificationSettingsResponse.model_fields
+
+    def test_a_masked_response_still_identifies_the_destination(self):
+        """Masking must not make the setting unverifiable by its owner."""
+        masked = redact_webhook_url(SECRET_URL)
+
+        assert "hooks.slack.com" in masked
+
+
+class TestUnsafeSendPathIsGone:
+    """AC2 — deleted rather than routed, since nothing called them."""
+
+    @pytest.mark.parametrize("name", ["send_blocker_notification", "format_payload"])
+    def test_method_no_longer_exists(self, name: str):
+        from codeframe.notifications.webhook import WebhookNotificationService
+
+        assert not hasattr(WebhookNotificationService, name), (
+            f"{name} still exists and bypasses send_event's SSRF guards"
+        )
+
+    def test_the_module_has_no_unvetted_post(self):
+        """Every remaining POST must go through the vetted, pinned path."""
+        from codeframe.notifications import webhook
+
+        source = inspect.getsource(webhook)
+        # Strip comments so the deletion note explaining the old call does not
+        # register as a live call site.
+        code = "\n".join(line.split("#")[0] for line in source.splitlines())
+
+        assert "session.post(" not in code or "allow_redirects=False" in code
+
+    def test_send_event_still_refuses_a_private_target(self):
+        """The guard the deleted path lacked, still in force on the live one."""
+        from codeframe.core.notifications_config import (
+            UnsafeWebhookHostError,
+            vet_webhook_host,
+        )
+
+        with pytest.raises(UnsafeWebhookHostError):
+            vet_webhook_host("169.254.169.254")
+
+    def test_the_metadata_endpoint_is_the_named_case(self):
+        """169.254.169.254 is the cloud-credential endpoint #656/#746 closed."""
+        from codeframe.core.notifications_config import (
+            UnsafeWebhookHostError,
+            vet_webhook_host,
+        )
+
+        for host in ("127.0.0.1", "10.0.0.5", "169.254.169.254"):
+            with pytest.raises(UnsafeWebhookHostError):
+                vet_webhook_host(host)
+
+
+class TestRoundTrippingTheMaskDoesNotDestroyTheUrl:
+    """Masking creates a hazard: the UI loads the value into an editable field,
+    so saving unchanged would persist the MASK and lose the real URL. Handled
+    server-side so it protects any client, not just our own."""
+
+    def test_the_put_handler_treats_the_mask_as_unchanged(self):
+        from codeframe.ui.routers import settings_v2
+
+        source = inspect.getsource(settings_v2.update_notification_settings)
+
+        assert "redact_webhook_url(existing)" in source, (
+            "a client echoing back the masked URL would overwrite the real one"
+        )
+
+    def test_a_genuinely_new_url_still_replaces_the_old(self):
+        """The guard must only catch the mask, not block real edits."""
+        old = SECRET_URL
+        new = "https://hooks.example.com/services/NEW/TOKEN"
+
+        assert new != redact_webhook_url(old), (
+            "a real new URL must not be mistaken for the mask"
+        )


### PR DESCRIPTION
Closes #941.

## The webhook URL is a credential, and we were handing it out

`GET /api/v2/settings/notifications` returned the stored URL **verbatim to any read-scope caller**. A Slack/Discord/GitHub webhook URL is a bearer credential — the token lives in the *path*, and anyone with the full URL can post to the channel.

The codebase already knew this: `_redact_url_for_log` existed for exactly this reason, and every sibling secret here is admin-gated and never echoed.

- Renamed `_redact_url_for_log` → `redact_webhook_url` (no longer only for logs) and applied it to the response: `https://hooks.slack.com/services/T0.../B1.../XXXXsecret` → `https://hooks.slack.com`.
- Added `webhook_url_set` so the UI can show "configured" without being told the value. Unset still returns `None`, preserving the existing contract.

### A hazard the issue does not mention

Masking a value that the UI loads into an **editable field** means saving unchanged would persist the *mask* and destroy the real URL. `PUT` now treats a submitted value identical to the current mask as unchanged.

Deliberately server-side: it protects any client, not just our own UI, and it cannot be forgotten by a future frontend change.

## The unsafe send path is deleted, not fixed

`send_blocker_notification` and `format_payload` had **no production callers** but remained public and POSTed with a plain `aiohttp` session — no host vetting, no pinned resolver, `allow_redirects` defaulting to `True`. That bypassed every guard `send_event` implements (#656/#746), so the first future caller would have silently reopened the `169.254.169.254` metadata-endpoint hole those issues closed.

Their 11 tests are deleted with them. Keeping the tests would have required keeping the unsafe path alive in order to test it — which is the whole problem.

## Acceptance criteria

- [x] `GET /settings/notifications` returns a masked URL (`scheme://host[:port]` plus a set/unset flag); tests assert no secret path or query reaches a read-scope caller
- [x] `send_blocker_notification` and `format_payload` are deleted; a test asserts a private-IP target is refused by the surviving path

## Tests

14 new. The masking tests use a Slack-shaped URL and assert the token, the project id and a query signature are all absent — plus that basic-auth credentials are stripped and the host still survives, since masking must not make the setting unverifiable by its owner.

Three pre-existing tests asserted the **unmasked** round-trip — the behaviour this issue changes — and were updated with the reason inline rather than quietly.

Regression sweep: **176 passed** across notification/webhook/settings selections. `ruff` and `mypy codeframe/` clean.

## Known limitations

- The frontend still renders `webhook_url` in its input; it now shows the mask. That is safe (the PUT guard makes a round-trip a no-op) but the field should eventually render as a placeholder with an explicit "replace" affordance rather than looking like editable text. Not done here to keep the change server-side and reviewable.
- Masking is applied at the response boundary only. The full URL is still stored in plaintext in `.codeframe/notifications_config.json`, as before — moving it into `CredentialManager` is a larger change than this issue scopes.
