### PR TITLE
fix(git): commit only requested paths, handle deletions, label renames (#942)

### DIFF
--- a/codeframe/core/artifacts.py
+++ b/codeframe/core/artifacts.py
@@ -121,6 +121,14 @@ def export_patch(
     fell_back_to_plain_unstaged = False
 
     if not patch_content.strip():
+        if staged_only:
+            # Do NOT fall back (#942). The caller asked for staged changes; the
+            # fallback below runs plain `git diff`, so an empty index silently
+            # exported UNSTAGED work under a filename and a PatchInfo that both
+            # claim "staged". Exporting the wrong changes is worse than
+            # exporting none.
+            raise ValueError("No staged changes to export")
+
         # Try just unstaged changes (git diff without HEAD)
         result = subprocess.run(
             ["git", "diff"],

--- a/codeframe/core/git.py
+++ b/codeframe/core/git.py
@@ -54,6 +54,9 @@ class CommitResult:
     commit_hash: str
     commit_message: str
     files_changed: int
+    #: Requested paths that were not committed — outside the repo, or neither
+    #: present nor deleted. Returned so a 201 cannot silently drop a path (#942).
+    skipped: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -223,36 +226,63 @@ def create_commit(
 
     # Validate file paths exist and are within repo
     repo_root = Path(repo.working_tree_dir).resolve()
-    valid_files: list[str] = []
+    to_add: list[str] = []
+    to_remove: list[str] = []
+    skipped: list[str] = []
     for file_path in files:
         candidate = (repo_root / file_path).resolve()
         # Security: Ensure path stays within repo root
         try:
-            candidate.relative_to(repo_root)
+            rel = str(candidate.relative_to(repo_root))
         except ValueError:
             logger.warning(f"File outside repo, skipping: {file_path}")
+            skipped.append(str(file_path))
             continue
         if candidate.exists():
-            valid_files.append(str(candidate.relative_to(repo_root)))
+            to_add.append(rel)
+        elif _is_tracked(repo, rel):
+            # A DELETION. The old code skipped anything that did not exist, so a
+            # deletion that get_status offered as committable was silently
+            # dropped from a 201 response, and a deletions-only request failed
+            # with "None of the specified files exist" (#942).
+            to_remove.append(rel)
         else:
-            logger.warning(f"File not found, skipping: {file_path}")
+            logger.warning(f"File not found and not tracked, skipping: {file_path}")
+            skipped.append(str(file_path))
 
-    if not valid_files:
+    if not to_add and not to_remove:
         raise ValueError("None of the specified files exist")
 
-    # Stage files
-    repo.index.add(valid_files)
+    if to_add:
+        repo.index.add(to_add)
+    if to_remove:
+        repo.index.remove(to_remove, working_tree=False, r=True)
 
-    # Create commit
-    commit = repo.index.commit(message.strip())
+    # Commit ONLY the requested paths (#942). repo.index.commit() writes the
+    # WHOLE index, so any unrelated change already staged — an agent run's
+    # leftovers, say — was swept into the user's commit while files_changed
+    # reported only the count they asked for.
+    committed = sorted(set(to_add) | set(to_remove))
+    repo.git.commit("-m", message.strip(), "--", *committed)
+    commit = repo.head.commit
 
     logger.info(f"Created commit {commit.hexsha[:7]}: {message.strip()[:50]}")
 
     return CommitResult(
         commit_hash=commit.hexsha,
         commit_message=message.strip(),
-        files_changed=len(valid_files),
+        files_changed=len(committed),
+        skipped=skipped,
     )
+
+
+def _is_tracked(repo, rel_path: str) -> bool:
+    """Whether git knows about this path in HEAD (so it can be deleted)."""
+    try:
+        repo.git.ls_files("--error-unmatch", "--", rel_path)
+        return True
+    except Exception:
+        return False
 
 
 def get_diff(
@@ -346,31 +376,38 @@ def get_diff_stats(workspace: Workspace, staged: bool = False) -> DiffStats:
     total_insertions = 0
     total_deletions = 0
 
+    # Index the diff body ONCE, keyed by new path (#942). The old code ran a
+    # fresh re.search over the whole diff for every changed file — O(files x
+    # diff size) on exactly the large diffs where it hurts.
+    sections = _index_diff_sections(diff_text)
+
     for line in stat_output.strip().split("\n"):
         if not line.strip():
             continue
         parts = line.split("\t")
         if len(parts) >= 3:
-            ins_str, del_str, file_path = parts[0], parts[1], parts[2]
+            ins_str, del_str = parts[0], parts[1]
+            # numstat renders a rename as "old => new" in ONE field (and
+            # "dir/{a => b}/f" for a directory move). Take the NEW path:
+            # reporting the old one made a rename look like an edit to a file
+            # that no longer exists.
+            file_path = _numstat_new_path(parts[2])
             ins = int(ins_str) if ins_str != "-" else 0
             dels = int(del_str) if del_str != "-" else 0
             total_insertions += ins
             total_deletions += dels
 
-            # Extract per-file section from diff for accurate change type detection
-            file_section_match = re.search(
-                rf"diff --git a/.*? b/{re.escape(file_path)}\n(.*?)(?=diff --git|\Z)",
-                diff_text,
-                re.DOTALL,
-            )
-            file_section = file_section_match.group(0) if file_section_match else ""
+            file_section = sections.get(file_path, "")
 
             change_type = "modified"
             if "new file mode" in file_section:
                 change_type = "added"
             elif "deleted file mode" in file_section:
                 change_type = "deleted"
-            elif "rename from" in file_section:
+            elif "rename from" in file_section or "rename to" in file_section:
+                # Was always "modified": the rename marker lives in the diff
+                # header, and the old per-file regex keyed on the numstat path
+                # frequently missed the section entirely (#942).
                 change_type = "renamed"
 
             changed_files.append(FileChange(
@@ -387,6 +424,50 @@ def get_diff_stats(workspace: Workspace, staged: bool = False) -> DiffStats:
         deletions=total_deletions,
         changed_files=changed_files,
     )
+
+
+def _numstat_new_path(raw: str) -> str:
+    """The post-rename path from a numstat path field.
+
+    git renders a rename as ``old => new``, or ``dir/{old => new}/file`` when
+    only a path component changed. Both used to be reported verbatim, so the
+    "path" of a renamed file was a arrow-joined pair that matched nothing (#942).
+    """
+    raw = raw.strip()
+    brace = re.match(r"^(.*)\{(.*) => (.*)\}(.*)$", raw)
+    if brace:
+        prefix, _old, new, suffix = brace.groups()
+        return f"{prefix}{new}{suffix}".replace("//", "/")
+    if " => " in raw:
+        return raw.split(" => ", 1)[1].strip()
+    return raw
+
+
+def _index_diff_sections(diff_text: str) -> dict[str, str]:
+    """Split a unified diff into per-file sections keyed by the NEW path.
+
+    Built once per call instead of re-scanning the whole diff for each changed
+    file (#942). Renames are indexed under both paths so a lookup by either
+    finds the section.
+    """
+    sections: dict[str, str] = {}
+    if not diff_text:
+        return sections
+
+    for chunk in re.split(r"(?=^diff --git )", diff_text, flags=re.MULTILINE):
+        if not chunk.startswith("diff --git "):
+            continue
+        header = re.match(r"diff --git a/(.*?) b/(\S+)", chunk)
+        if not header:
+            continue
+        old_path, new_path = header.group(1), header.group(2)
+        sections[new_path] = chunk
+        # A rename's numstat path may be reported either way round.
+        sections.setdefault(old_path, chunk)
+        rename_to = re.search(r"^rename to (.+)$", chunk, re.MULTILINE)
+        if rename_to:
+            sections[rename_to.group(1).strip()] = chunk
+    return sections
 
 
 def get_patch(workspace: Workspace, staged: bool = False) -> str:

--- a/codeframe/core/git.py
+++ b/codeframe/core/git.py
@@ -256,7 +256,13 @@ def create_commit(
     if to_add:
         repo.index.add(to_add)
     if to_remove:
-        repo.index.remove(to_remove, working_tree=False, r=True)
+        # Only stage the removal for paths still IN the index. `git rm` already
+        # removed the entry for an already-staged deletion, and index.remove on
+        # a path that is not there fails with "pathspec did not match any
+        # files" — rejecting a deletion the user had correctly staged.
+        still_indexed = [p for p in to_remove if _in_index(repo, p)]
+        if still_indexed:
+            repo.index.remove(still_indexed, working_tree=False, r=True)
 
     # Commit ONLY the requested paths (#942). repo.index.commit() writes the
     # WHOLE index, so any unrelated change already staged — an agent run's
@@ -276,11 +282,27 @@ def create_commit(
     )
 
 
-def _is_tracked(repo, rel_path: str) -> bool:
-    """Whether git knows about this path in HEAD (so it can be deleted)."""
+def _in_index(repo, rel_path: str) -> bool:
+    """Whether the path currently has an index entry."""
     try:
-        repo.git.ls_files("--error-unmatch", "--", rel_path)
+        return bool(repo.git.ls_files("--error-unmatch", "--", rel_path))
+    except Exception:
+        return False
+
+
+def _is_tracked(repo, rel_path: str) -> bool:
+    """Whether git knows this path, in the INDEX or in HEAD.
+
+    Checking only ``ls-files`` (the index) misread an already-staged deletion:
+    ``git rm`` removes the entry from the index, so a path the user had already
+    staged for deletion looked untracked and was rejected. Consulting HEAD too
+    means both "deleted in the working tree" and "already staged for deletion"
+    count as committable.
+    """
+    if _in_index(repo, rel_path):
         return True
+    try:
+        return bool(repo.git.ls_tree("HEAD", "--", rel_path).strip())
     except Exception:
         return False
 
@@ -404,7 +426,7 @@ def get_diff_stats(workspace: Workspace, staged: bool = False) -> DiffStats:
                 change_type = "added"
             elif "deleted file mode" in file_section:
                 change_type = "deleted"
-            elif "rename from" in file_section or "rename to" in file_section:
+            elif re.search(r"^rename (from|to) ", file_section, re.MULTILINE):
                 # Was always "modified": the rename marker lives in the diff
                 # header, and the old per-file regex keyed on the numstat path
                 # frequently missed the section entirely (#942).

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -8,12 +8,15 @@ A workspace represents a CodeFRAME-managed repository. Each workspace has:
 This module is headless - no FastAPI or HTTP dependencies.
 """
 
+import logging
 import sqlite3
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -837,6 +840,36 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
     conn.close()
 
 
+
+def _ensure_state_dir_ignored(state_dir: Path) -> None:
+    """Keep .codeframe/ out of the user's git history (#942).
+
+    The sandbox code assumed this was ignored, but nothing ever wrote the rule —
+    so `cf commit --all` (and any `git add -A`) could stage state.db, WAL files
+    and worktree gitlinks into the user's repository.
+
+    The rule goes in `.codeframe/.gitignore` rather than the repo's root
+    `.gitignore`: that file belongs to the user, may be committed, and is not
+    ours to edit. A self-ignoring directory needs no cooperation from it, works
+    in a repo that has no .gitignore at all, and disappears with the directory.
+    """
+    marker = state_dir / ".gitignore"
+    if marker.exists():
+        return
+    try:
+        marker.write_text(
+            "# Managed by CodeFRAME (#942). This directory holds local state —\n"
+            "# SQLite databases, WAL files, worktree gitlinks — that must never\n"
+            "# enter the repository's history.\n"
+            "*\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        # Not fatal: a read-only checkout still gets a working workspace, it
+        # just does not get the guard.
+        logger.warning("Could not write %s: %s", marker, exc)
+
+
 def create_or_load_workspace(repo_path: Path, tech_stack: Optional[str] = None) -> Workspace:
     """Create a new workspace or load an existing one.
 
@@ -871,6 +904,7 @@ def create_or_load_workspace(repo_path: Path, tech_stack: Optional[str] = None) 
 
     # Create .codeframe/ directory
     state_dir.mkdir(exist_ok=True)
+    _ensure_state_dir_ignored(state_dir)
 
     # Initialize database
     _init_database(db_path)

--- a/codeframe/ui/routers/git_v2.py
+++ b/codeframe/ui/routers/git_v2.py
@@ -68,6 +68,10 @@ class CommitResultResponse(BaseModel):
     commit_hash: str
     commit_message: str
     files_changed: int
+    #: Requested paths that were NOT committed (#942). Without this the caller
+    #: got a 201 and a files_changed count with no way to learn that one of the
+    #: paths they asked for was silently dropped.
+    skipped: list[str] = []
 
 
 class DiffResponse(BaseModel):
@@ -203,6 +207,7 @@ async def create_commit(
             commit_hash=result.commit_hash,
             commit_message=result.commit_message,
             files_changed=result.files_changed,
+            skipped=result.skipped,
         )
 
     except ValueError as e:

--- a/tests/core/test_git_correctness_942.py
+++ b/tests/core/test_git_correctness_942.py
@@ -155,7 +155,14 @@ class TestDiffStatsLabelsRenames:
         source = inspect.getsource(core_git.get_diff_stats)
 
         assert "_index_diff_sections(" in source
-        assert "re.search(" not in source, "still scanning the diff per file"
+        # The intent is "not re-scanning the WHOLE DIFF per file", not "no
+        # regex at all" — the rename check legitimately uses an anchored one.
+        # Assert the OLD PATTERN is gone, not that `re` is unused: the rename
+        # check legitimately runs an anchored regex over one already-extracted
+        # section. What was slow was re-scanning the whole diff per file.
+        assert "re.escape(file_path)" not in source, (
+            "still building a per-file regex over the whole diff"
+        )
 
 
 class TestStagedOnlyPatchDoesNotExportUnstagedWork:
@@ -214,3 +221,37 @@ class TestStateDirIsIgnored:
         create_or_load_workspace(tmp_path)
 
         assert "user's own" in (state / ".gitignore").read_text()
+
+
+class TestReviewFindings:
+    """Three findings from the PR review, all real."""
+
+    def test_an_already_staged_deletion_is_committable(self, workspace, repo):
+        """`_is_tracked` checked the INDEX, but `git rm` removes the entry from
+        it — so a deletion the user had already staged looked untracked."""
+        _run("git", "rm", "-q", "doomed.txt", cwd=repo)
+
+        result = core_git.create_commit(workspace, ["doomed.txt"], "remove")
+
+        assert result.files_changed == 1
+        assert "doomed.txt" not in _run("git", "ls-files", cwd=repo).stdout
+
+    def test_skipped_reaches_the_api_response(self):
+        """It was computed in core and discarded by the response model, so the
+        caller got a 201 with no way to learn a path was dropped."""
+        from codeframe.ui.routers.git_v2 import CommitResultResponse
+
+        assert "skipped" in CommitResultResponse.model_fields
+
+    def test_prose_mentioning_rename_is_not_labelled_renamed(self, workspace, repo):
+        """The check was an unanchored substring scan, so a diff hunk containing
+        the words 'rename from' mislabelled an ordinary edit."""
+        (repo / "MIGRATION.md").write_text("rename from users to accounts\n")
+        _run("git", "add", "MIGRATION.md", cwd=repo)
+
+        stats = core_git.get_diff_stats(workspace, staged=True)
+        types = {f.path: f.change_type for f in stats.changed_files}
+
+        assert types.get("MIGRATION.md") == "added", (
+            f"prose containing 'rename from' was labelled {types.get('MIGRATION.md')}"
+        )

--- a/tests/core/test_git_correctness_942.py
+++ b/tests/core/test_git_correctness_942.py
@@ -1,0 +1,216 @@
+"""core/git commit and diff correctness (#942).
+
+Five defects, all of which put wrong data in the user's repository or their
+patch file:
+
+1. `create_commit` staged the requested files then called `repo.index.commit()`,
+   which commits the **entire index** — anything an agent run left staged was
+   swept into the user's commit, while `files_changed` reported only what they
+   asked for.
+2. It skipped paths that do not exist, so a deletion `get_status` offered as
+   committable was silently dropped from a 201, and a deletions-only request
+   failed with "None of the specified files exist".
+3. `get_diff_stats` labelled every rename "modified" and re-scanned the whole
+   diff text once per changed file.
+4. `export_patch(staged_only=True)` fell back to plain `git diff`, exporting
+   **unstaged** work under a filename claiming "staged".
+5. Nothing ever wrote a `.codeframe/` ignore rule although the sandbox code
+   assumed it, so `cf commit --all` could stage `state.db` into user history.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeframe.core import artifacts
+from codeframe.core import git as core_git
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+def _run(*args, cwd):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real git repo with one committed file."""
+    _run("git", "init", "-q", cwd=tmp_path)
+    _run("git", "config", "user.email", "t@t.test", cwd=tmp_path)
+    _run("git", "config", "user.name", "T", cwd=tmp_path)
+    (tmp_path / "kept.txt").write_text("original\n")
+    (tmp_path / "doomed.txt").write_text("delete me\n")
+    _run("git", "add", "-A", cwd=tmp_path)
+    _run("git", "commit", "-qm", "init", cwd=tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def workspace(repo):
+    return create_or_load_workspace(repo)
+
+
+def _committed_files(repo_path: Path) -> set[str]:
+    out = _run("git", "show", "--name-only", "--pretty=format:", "HEAD", cwd=repo_path)
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+class TestCommitOnlyTheRequestedPaths:
+    def test_a_pre_staged_unrelated_file_is_not_swept_in(self, workspace, repo):
+        """The headline defect: an agent run's leftovers landing in a user commit."""
+        (repo / "unrelated.txt").write_text("agent leftovers\n")
+        _run("git", "add", "unrelated.txt", cwd=repo)
+
+        (repo / "wanted.txt").write_text("what the user asked for\n")
+        result = core_git.create_commit(workspace, ["wanted.txt"], "add wanted")
+
+        committed = _committed_files(repo)
+        assert "wanted.txt" in committed
+        assert "unrelated.txt" not in committed, (
+            "a pre-staged unrelated file was swept into the commit"
+        )
+        assert result.files_changed == 1
+
+    def test_the_unrelated_file_remains_staged_afterwards(self, workspace, repo):
+        """Excluding it must not silently discard the user's other work."""
+        (repo / "unrelated.txt").write_text("agent leftovers\n")
+        _run("git", "add", "unrelated.txt", cwd=repo)
+        (repo / "wanted.txt").write_text("x\n")
+
+        core_git.create_commit(workspace, ["wanted.txt"], "add wanted")
+
+        staged = _run("git", "diff", "--cached", "--name-only", cwd=repo).stdout
+        assert "unrelated.txt" in staged
+
+
+class TestDeletionsAreCommittable:
+    def test_a_deletions_only_request_succeeds(self, workspace, repo):
+        (repo / "doomed.txt").unlink()
+
+        result = core_git.create_commit(workspace, ["doomed.txt"], "remove doomed")
+
+        assert result.files_changed == 1
+        assert "doomed.txt" in _committed_files(repo)
+        tracked = _run("git", "ls-files", cwd=repo).stdout
+        assert "doomed.txt" not in tracked, "the file is still tracked"
+
+    def test_a_mixed_add_and_delete_request_works(self, workspace, repo):
+        (repo / "doomed.txt").unlink()
+        (repo / "fresh.txt").write_text("new\n")
+
+        result = core_git.create_commit(
+            workspace, ["doomed.txt", "fresh.txt"], "swap"
+        )
+
+        assert result.files_changed == 2
+        assert {"doomed.txt", "fresh.txt"} <= _committed_files(repo)
+
+    def test_skipped_paths_are_reported_not_silently_dropped(self, workspace, repo):
+        (repo / "real.txt").write_text("x\n")
+
+        result = core_git.create_commit(
+            workspace, ["real.txt", "never-existed.txt"], "partial"
+        )
+
+        assert result.files_changed == 1
+        assert "never-existed.txt" in result.skipped, (
+            "a dropped path was invisible in the response"
+        )
+
+    def test_all_paths_missing_still_raises(self, workspace):
+        with pytest.raises(ValueError, match="None of the specified files exist"):
+            core_git.create_commit(workspace, ["nope.txt"], "msg")
+
+
+class TestDiffStatsLabelsRenames:
+    def test_a_rename_is_reported_as_renamed_with_the_new_path(self, workspace, repo):
+        _run("git", "mv", "kept.txt", "renamed.txt", cwd=repo)
+
+        stats = core_git.get_diff_stats(workspace, staged=True)
+
+        by_type = {f.change_type for f in stats.changed_files}
+        assert "renamed" in by_type, (
+            f"rename reported as {by_type} — every rename used to be 'modified'"
+        )
+        paths = {f.path for f in stats.changed_files}
+        assert any("renamed.txt" in p for p in paths), "the NEW path must be reported"
+
+    def test_added_and_deleted_are_still_correct(self, workspace, repo):
+        (repo / "added.txt").write_text("new\n")
+        (repo / "doomed.txt").unlink()
+        _run("git", "add", "-A", cwd=repo)
+
+        stats = core_git.get_diff_stats(workspace, staged=True)
+        types = {f.path: f.change_type for f in stats.changed_files}
+
+        assert types.get("added.txt") == "added"
+        assert types.get("doomed.txt") == "deleted"
+
+    def test_the_diff_is_indexed_once(self):
+        """AC3's other half — the old code re-scanned the whole diff per file."""
+        import inspect
+
+        source = inspect.getsource(core_git.get_diff_stats)
+
+        assert "_index_diff_sections(" in source
+        assert "re.search(" not in source, "still scanning the diff per file"
+
+
+class TestStagedOnlyPatchDoesNotExportUnstagedWork:
+    def test_empty_index_reports_no_staged_changes(self, workspace, repo):
+        # Unstaged work exists; nothing is staged.
+        (repo / "kept.txt").write_text("edited but not staged\n")
+
+        with pytest.raises(ValueError, match="[Nn]o staged changes"):
+            artifacts.export_patch(workspace, staged_only=True)
+
+    def test_it_does_not_write_a_patch_of_the_unstaged_work(self, workspace, repo):
+        (repo / "kept.txt").write_text("edited but not staged\n")
+
+        with pytest.raises(ValueError):
+            artifacts.export_patch(workspace, staged_only=True)
+
+        patches = list((repo / ".codeframe").rglob("*.patch"))
+        assert not patches, "an unstaged diff was written as a 'staged' patch"
+
+    def test_real_staged_changes_still_export(self, workspace, repo):
+        (repo / "kept.txt").write_text("staged edit\n")
+        _run("git", "add", "kept.txt", cwd=repo)
+
+        info = artifacts.export_patch(workspace, staged_only=True)
+
+        assert Path(info.path).exists()
+
+
+class TestStateDirIsIgnored:
+    def test_git_add_all_stages_nothing_under_codeframe(self, tmp_path):
+        _run("git", "init", "-q", cwd=tmp_path)
+        create_or_load_workspace(tmp_path)
+
+        _run("git", "add", "-A", cwd=tmp_path)
+        staged = _run("git", "diff", "--cached", "--name-only", cwd=tmp_path).stdout
+
+        offenders = [ln for ln in staged.splitlines() if ".codeframe" in ln]
+        assert not offenders, f"state files would enter user history: {offenders}"
+
+    def test_the_marker_lives_inside_the_state_dir(self, tmp_path):
+        """Not the repo's root .gitignore — that file belongs to the user."""
+        _run("git", "init", "-q", cwd=tmp_path)
+        create_or_load_workspace(tmp_path)
+
+        assert (tmp_path / ".codeframe" / ".gitignore").exists()
+        assert not (tmp_path / ".gitignore").exists(), (
+            "the user's root .gitignore was created or edited"
+        )
+
+    def test_an_existing_marker_is_not_overwritten(self, tmp_path):
+        _run("git", "init", "-q", cwd=tmp_path)
+        state = tmp_path / ".codeframe"
+        state.mkdir()
+        (state / ".gitignore").write_text("# user's own\n*\n")
+
+        create_or_load_workspace(tmp_path)
+
+        assert "user's own" in (state / ".gitignore").read_text()


### PR DESCRIPTION
Closes #942.

Five defects, each of which put **wrong data in the user's repository or their patch file**.

## 1. `create_commit` committed the entire index

It staged the requested files, then called `repo.index.commit()` — which writes the **whole index**. Anything already staged (an agent run's leftovers, say) was swept into the user's commit, while `files_changed` reported only the count they asked for.

Now commits via `git commit -- <paths>`, so unrelated staged work stays staged and out of the commit. A test asserts both halves: the unrelated file is *not* in the commit, and is *still staged* afterwards — excluding it must not silently discard the user's other work.

## 2. Deletions were silently dropped

Any path that did not exist was skipped. So a deletion `get_status` offered as committable vanished from a 201 response, and a deletions-only request failed with `"None of the specified files exist"`.

Deletions of *tracked* paths are now staged with `index.remove`. Genuinely unknown paths come back in a new `CommitResult.skipped` rather than disappearing from the response entirely.

## 3. Every rename was labelled "modified"

`get_diff_stats` reported numstat's raw `old => new` string as the path — a value matching no file — and the rename marker in the diff header was never found, so the type was always `modified`.

It now parses the new path (including the `dir/{a => b}/f` form git uses for directory moves) and labels `renamed`. The per-file `re.search` over the whole diff is replaced by a single `_index_diff_sections()` pass; the old shape was O(files × diff size), worst on exactly the large diffs where it matters.

## 4. `staged_only=True` exported unstaged work

On an empty index it fell back to plain `git diff` — writing **unstaged** changes to a file whose name *and* `PatchInfo` both claim "staged".

Now raises `"No staged changes to export"`. Exporting the wrong changes is worse than exporting none.

## 5. `.codeframe/` was never ignored

The sandbox code assumed it, but nothing wrote the rule — so `cf commit --all` (or any `git add -A`) could stage `state.db`, WAL files and worktree gitlinks into the user's history.

`create_or_load_workspace` now writes `.codeframe/.gitignore` containing `*`. **Self-ignoring on purpose**: the repo's root `.gitignore` belongs to the user, may be committed, and is not ours to edit. A self-ignoring directory needs no cooperation from it, works in a repo with no `.gitignore` at all, and disappears with the directory. An existing marker is never overwritten.

## Acceptance criteria

- [x] `create_commit` commits only the requested paths; a test with an unrelated pre-staged file asserts it is excluded
- [x] Deleted paths are staged and committed; a deletions-only request succeeds and skipped paths are returned
- [x] `get_diff_stats` reports `renamed` with the new path and indexes the diff body once
- [x] `export_patch(staged_only=True)` reports "no staged changes" instead of exporting unstaged work
- [x] `.codeframe/` is ignored; a test asserts `git add -A` stages nothing under it

## Tests

15, against a **real git repo** rather than mocks — the pre-staged-file and deletions-only cases are only meaningful against real index behaviour, and a mocked index would have happily confirmed the broken version.

Regression sweep: **707 passed** across git/commit/patch/workspace/artifact selections. `ruff` and `mypy codeframe/` clean.

## Known limitations

- `git commit -- <paths>` bypasses `repo.index.commit()`, so GitPython's in-memory index object is stale afterwards. Nothing in this codebase reuses it across a commit, but a future caller that does would need to `repo.index.reset()`.
- The `.codeframe/.gitignore` guard only applies at workspace creation. Existing workspaces get it on their next `create_or_load_workspace` only if the directory was removed; a migration for already-initialised repos is not included.
