### PR TITLE
fix(web): restore the PR merge panel on reload, unify the WS base URL (#944)

### DIFF
--- a/web-ui/src/__tests__/lib/pickOpenPr.test.ts
+++ b/web-ui/src/__tests__/lib/pickOpenPr.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The restored PR panel must show THIS branch's PR (#944).
+ *
+ * Raised as a major on the PR: the first cut took `pull_requests[0]` — the
+ * newest open PR in the connected repo, not this workspace's branch. With more
+ * than one open PR (several feature branches, dependabot, a stale one), the
+ * panel restored the wrong PR, and its Merge button — the only merge surface in
+ * the web UI — would then merge it.
+ */
+import { pickOpenPr } from '@/lib/pickOpenPr';
+import type { PRResponse } from '@/types';
+
+const pr = (number: number, head_branch: string): PRResponse =>
+  ({
+    number,
+    head_branch,
+    url: `https://github.com/o/r/pull/${number}`,
+    state: 'open',
+    title: `PR ${number}`,
+    body: null,
+    created_at: '2026-01-01T00:00:00Z',
+    merged_at: null,
+    base_branch: 'main',
+  }) as PRResponse;
+
+// Newest first, as the API returns them. #99 is somebody else's.
+const OPEN = [pr(99, 'dependabot/npm/lodash'), pr(42, 'fix/944-web-ui-defects')];
+
+describe('pickOpenPr (#944)', () => {
+  it('picks the PR whose head is the current branch, not the newest', () => {
+    expect(pickOpenPr(OPEN, 'fix/944-web-ui-defects')?.number).toBe(42);
+  });
+
+  it('does not return the newest PR when it belongs to another branch', () => {
+    // The exact failure: merging #99 from a page showing #42's diff.
+    expect(pickOpenPr(OPEN, 'fix/944-web-ui-defects')?.number).not.toBe(99);
+  });
+
+  it('returns nothing when this branch has no open PR', () => {
+    expect(pickOpenPr(OPEN, 'fix/some-other-work')).toBeUndefined();
+  });
+
+  it('returns nothing on a detached HEAD rather than guessing', () => {
+    expect(pickOpenPr(OPEN, undefined)).toBeUndefined();
+    expect(pickOpenPr(OPEN, '')).toBeUndefined();
+  });
+
+  it('tolerates a missing list', () => {
+    expect(pickOpenPr(undefined, 'main')).toBeUndefined();
+  });
+
+  it('still works when the branch has the only open PR', () => {
+    expect(pickOpenPr([pr(7, 'main')], 'main')?.number).toBe(7);
+  });
+
+  it('matches exactly, not by prefix', () => {
+    // 'fix/944' must not claim 'fix/944-web-ui-defects'.
+    expect(pickOpenPr(OPEN, 'fix/944')).toBeUndefined();
+  });
+});

--- a/web-ui/src/__tests__/lib/wsBase.test.ts
+++ b/web-ui/src/__tests__/lib/wsBase.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Both sockets must resolve the same base URL (#944).
+ *
+ * `AgentTerminal` derived its base from `NEXT_PUBLIC_API_URL` when
+ * `NEXT_PUBLIC_WS_URL` was unset; `useAgentChat` hardcoded
+ * `ws://localhost:8000`. A deployment setting only `NEXT_PUBLIC_API_URL` — the
+ * documented single-origin setup — therefore had a working terminal and a
+ * silently dead chat socket, with no error to explain the difference.
+ */
+import { wsBase } from '@/lib/wsBase';
+
+describe('wsBase (#944)', () => {
+  it('derives the ws base from NEXT_PUBLIC_API_URL alone', () => {
+    // The AC's exact scenario: one variable set, both sockets must agree.
+    expect(wsBase({ NEXT_PUBLIC_API_URL: 'http://api.example.com' })).toBe(
+      'ws://api.example.com'
+    );
+  });
+
+  it('upgrades https to wss, never downgrading a TLS deployment', () => {
+    expect(wsBase({ NEXT_PUBLIC_API_URL: 'https://app.example.com' })).toBe(
+      'wss://app.example.com'
+    );
+  });
+
+  it('prefers an explicit NEXT_PUBLIC_WS_URL', () => {
+    expect(
+      wsBase({
+        NEXT_PUBLIC_API_URL: 'https://app.example.com',
+        NEXT_PUBLIC_WS_URL: 'wss://sockets.example.com',
+      })
+    ).toBe('wss://sockets.example.com');
+  });
+
+  it('falls back to localhost when nothing is configured', () => {
+    expect(wsBase({})).toBe('ws://localhost:8000');
+  });
+
+  it('never returns the old hardcoded value when an API URL is set', () => {
+    // The chat hook's old constant. If this ever comes back, the chat socket
+    // is dead on every real deployment.
+    expect(wsBase({ NEXT_PUBLIC_API_URL: 'https://app.example.com' })).not.toBe(
+      'ws://localhost:8000'
+    );
+  });
+});

--- a/web-ui/src/__tests__/lib/wsBase.test.ts
+++ b/web-ui/src/__tests__/lib/wsBase.test.ts
@@ -7,9 +7,31 @@
  * documented single-origin setup — therefore had a working terminal and a
  * silently dead chat socket, with no error to explain the difference.
  */
+import fs from 'fs';
+import path from 'path';
+
 import { wsBase } from '@/lib/wsBase';
 
 describe('wsBase (#944)', () => {
+  const ENV_KEYS = ['NEXT_PUBLIC_WS_URL', 'NEXT_PUBLIC_API_URL'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // The overrides are meant to be read INSTEAD of the ambient environment;
+    // a CI runner that exports either variable must not change any assertion.
+    ENV_KEYS.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    ENV_KEYS.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
   it('derives the ws base from NEXT_PUBLIC_API_URL alone', () => {
     // The AC's exact scenario: one variable set, both sockets must agree.
     expect(wsBase({ NEXT_PUBLIC_API_URL: 'http://api.example.com' })).toBe(
@@ -42,5 +64,40 @@ describe('wsBase (#944)', () => {
     expect(wsBase({ NEXT_PUBLIC_API_URL: 'https://app.example.com' })).not.toBe(
       'ws://localhost:8000'
     );
+  });
+
+  describe('reads the environment the way Next can actually inline', () => {
+    // The first cut took `env: Record<string, string|undefined> = process.env`
+    // and read `env.NEXT_PUBLIC_API_URL`. That looks equivalent and is not:
+    // Next's build-time substitution is TEXTUAL on `process.env.NEXT_PUBLIC_X`,
+    // so an indirect read compiles to a lookup on the client's empty
+    // `process.env` stub — undefined, always the localhost fallback. Both
+    // callers are client components, so it would have shipped broken.
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/wsBase.ts'),
+      'utf8'
+    );
+
+    it.each(ENV_KEYS)('reads %s as a literal process.env expression', (key) => {
+      expect(source).toContain(`process.env.${key}`);
+    });
+
+    it('does not read the env through an indirect reference', () => {
+      expect(source).not.toMatch(/=\s*process\.env\b(?!\.)/);
+    });
+
+    it('picks up the ambient variable with no override supplied', () => {
+      process.env.NEXT_PUBLIC_API_URL = 'https://ambient.example.com';
+
+      expect(wsBase()).toBe('wss://ambient.example.com');
+    });
+
+    it('lets an override win over the ambient variable', () => {
+      process.env.NEXT_PUBLIC_API_URL = 'https://ambient.example.com';
+
+      expect(wsBase({ NEXT_PUBLIC_API_URL: 'http://explicit.example.com' })).toBe(
+        'ws://explicit.example.com'
+      );
+    });
   });
 });

--- a/web-ui/src/app/review/page.tsx
+++ b/web-ui/src/app/review/page.tsx
@@ -6,6 +6,7 @@ import { reviewApi, gatesApi, gitApi, prApi, tasksApi } from '@/lib/api';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
 import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import { parseDiff, getFilePath } from '@/lib/diffParser';
+import { pickOpenPr } from '@/lib/pickOpenPr';
 import type {
   DiffStatsResponse,
   TaskListResponse,
@@ -58,17 +59,21 @@ export default function ReviewPage() {
   // normal case — permanently hid PRStatusPanel, which is the ONLY web surface
   // carrying the Merge button and the PROOF9 merge-gate display. Ship then had
   // to be finished from the CLI.
+  //
+  // Match on head_branch, NOT pull_requests[0]. That is the newest open PR in
+  // the whole repo — with several feature branches, or a dependabot PR, or a
+  // stale one, the panel would restore someone else's PR and its Merge button
+  // would merge it.
   useEffect(() => {
     if (!workspacePath || prNumber > 0) return;
     let cancelled = false;
-    prApi
-      .list(workspacePath, 'open')
-      .then((res) => {
+    Promise.all([gitApi.getStatus(workspacePath), prApi.list(workspacePath, 'open')])
+      .then(([status, res]) => {
         if (cancelled) return;
-        const open = res.pull_requests?.[0];
-        if (open?.number) {
-          setPrNumber(open.number);
-          if (open.url) setPrUrl(open.url);
+        const mine = pickOpenPr(res.pull_requests, status.current_branch);
+        if (mine?.number) {
+          setPrNumber(mine.number);
+          if (mine.url) setPrUrl(mine.url);
         }
       })
       .catch(() => {

--- a/web-ui/src/app/review/page.tsx
+++ b/web-ui/src/app/review/page.tsx
@@ -53,6 +53,33 @@ export default function ReviewPage() {
   const [prUrl, setPrUrl] = useState('');
   const [prNumber, setPrNumber] = useState(0);
 
+  // Restore the open PR on load (#944). prNumber lived only in local state set
+  // by handleCreatePR, so reloading or navigating away while CI ran — the
+  // normal case — permanently hid PRStatusPanel, which is the ONLY web surface
+  // carrying the Merge button and the PROOF9 merge-gate display. Ship then had
+  // to be finished from the CLI.
+  useEffect(() => {
+    if (!workspacePath || prNumber > 0) return;
+    let cancelled = false;
+    prApi
+      .list(workspacePath, 'open')
+      .then((res) => {
+        if (cancelled) return;
+        const open = res.pull_requests?.[0];
+        if (open?.number) {
+          setPrNumber(open.number);
+          if (open.url) setPrUrl(open.url);
+        }
+      })
+      .catch(() => {
+        // No repo connection / no remote: leave the panel hidden rather than
+        // surfacing an error on a page whose main job is the diff.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath, prNumber]);
+
   // Feedback
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 

--- a/web-ui/src/components/sessions/AgentTerminal.tsx
+++ b/web-ui/src/components/sessions/AgentTerminal.tsx
@@ -4,14 +4,13 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useTerminalSocket, type TerminalSocketStatus } from '@/hooks/useTerminalSocket';
 import { fetchStreamTicket } from '@/lib/api';
 
+import { wsBase } from '@/lib/wsBase';
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function wsBase(): string {
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-  return process.env.NEXT_PUBLIC_WS_URL || apiBase.replace(/^http/, 'ws');
-}
+
 
 // ---------------------------------------------------------------------------
 // ReconnectingOverlay

--- a/web-ui/src/hooks/useAgentChat.ts
+++ b/web-ui/src/hooks/useAgentChat.ts
@@ -3,12 +3,15 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { fetchStreamTicket, verifyAuthAfterStreamFailure } from '@/lib/api';
 import type { AgentChatState, ChatMessage, MessageRole } from '@/types';
+import { wsBase } from '@/lib/wsBase';
 
 export type { AgentChatState, ChatMessage, MessageRole };
 
 // ── Constants ─────────────────────────────────────────────────────────
 
-const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000';
+// One shared resolver (#944) — this used to hardcode ws://localhost:8000,
+// so a deployment setting only NEXT_PUBLIC_API_URL had a dead chat socket.
+const WS_BASE_URL = wsBase();
 
 const MAX_RETRIES = 5;
 const BASE_RETRY_DELAY_MS = 1000;

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -57,6 +57,7 @@ import type {
   ProofRunSummary,
   ProofRunDetail,
   PRHistoryResponse,
+  PRListResponse,
   PRFilesResponse,
   Session,
   SessionState,
@@ -928,6 +929,18 @@ export const prApi = {
       },
       { params: { workspace_path: workspacePath } }
     );
+    return response.data;
+  },
+
+  /**
+   * Open (or closed/all) PRs. Used by /review to restore the merge panel after
+   * a reload — getHistory only returns MERGED PRs, so it cannot answer
+   * "is there a PR open right now?" (#944).
+   */
+  list: async (workspacePath: string, state = 'open'): Promise<PRListResponse> => {
+    const response = await api.get<PRListResponse>('/api/v2/pr', {
+      params: { workspace_path: workspacePath, state },
+    });
     return response.data;
   },
 

--- a/web-ui/src/lib/pickOpenPr.ts
+++ b/web-ui/src/lib/pickOpenPr.ts
@@ -1,0 +1,20 @@
+import type { PRResponse } from '@/types';
+
+/**
+ * The open PR for `branch`, or undefined (#944).
+ *
+ * `/review` restores its PR panel on load by listing open PRs. The first cut
+ * took `pull_requests[0]` — the newest open PR in the whole repo. With several
+ * feature branches, a dependabot PR, or a stale one, that restores someone
+ * else's PR, and the panel's Merge button then merges it.
+ *
+ * A falsy branch (detached HEAD) matches nothing on purpose: a hidden panel
+ * beats an arbitrary PR.
+ */
+export function pickOpenPr(
+  prs: PRResponse[] | undefined,
+  branch: string | undefined
+): PRResponse | undefined {
+  if (!branch) return undefined;
+  return prs?.find((pr) => pr.head_branch === branch);
+}

--- a/web-ui/src/lib/wsBase.ts
+++ b/web-ui/src/lib/wsBase.ts
@@ -2,17 +2,28 @@
  * The single source of truth for the WebSocket base URL (#944).
  *
  * There were two. `AgentTerminal` derived its base from `NEXT_PUBLIC_API_URL`
- * when `NEXT_PUBLIC_WS_URL` was unset; `useAgentChat` hardcoded
- * `ws://localhost:8000`. So a deployment that set only `NEXT_PUBLIC_API_URL` —
- * the documented single-origin setup — got a working terminal and a silently
- * dead chat socket, with no error to explain it.
+ * when `NEXT_PUBLIC_WS_URL` was unset; `useAgentChat` hardcoded a loopback
+ * address. So a deployment that set only `NEXT_PUBLIC_API_URL` — the documented
+ * single-origin setup — got a working terminal and a silently dead chat socket,
+ * with no error to explain it.
+ *
+ * Both reads are written as literal `process.env.NEXT_PUBLIC_*` expressions.
+ * Next inlines only that exact textual form at build time; reading the same key
+ * off a `process.env` *reference* (a defaulted parameter, a destructure) yields
+ * `undefined` in the client bundle — which is where both callers run.
  */
-export function wsBase(env: Record<string, string | undefined> = process.env): string {
-  const explicit = env.NEXT_PUBLIC_WS_URL;
+export interface WsEnvOverrides {
+  NEXT_PUBLIC_WS_URL?: string;
+  NEXT_PUBLIC_API_URL?: string;
+}
+
+export function wsBase(overrides: WsEnvOverrides = {}): string {
+  const explicit = overrides.NEXT_PUBLIC_WS_URL || process.env.NEXT_PUBLIC_WS_URL;
   if (explicit) return explicit;
 
   // Derive from the API origin: same host, ws(s) scheme. https -> wss, so a
   // TLS deployment does not fall back to an insecure socket.
-  const apiBase = env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  // prettier-ignore -- one line so the env-var-before-fallback CI check matches.
+  const apiBase = overrides.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   return apiBase.replace(/^http/, 'ws');
 }

--- a/web-ui/src/lib/wsBase.ts
+++ b/web-ui/src/lib/wsBase.ts
@@ -1,0 +1,18 @@
+/**
+ * The single source of truth for the WebSocket base URL (#944).
+ *
+ * There were two. `AgentTerminal` derived its base from `NEXT_PUBLIC_API_URL`
+ * when `NEXT_PUBLIC_WS_URL` was unset; `useAgentChat` hardcoded
+ * `ws://localhost:8000`. So a deployment that set only `NEXT_PUBLIC_API_URL` —
+ * the documented single-origin setup — got a working terminal and a silently
+ * dead chat socket, with no error to explain it.
+ */
+export function wsBase(env: Record<string, string | undefined> = process.env): string {
+  const explicit = env.NEXT_PUBLIC_WS_URL;
+  if (explicit) return explicit;
+
+  // Derive from the API origin: same host, ws(s) scheme. https -> wss, so a
+  // TLS deployment does not fall back to an insecure socket.
+  const apiBase = env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  return apiBase.replace(/^http/, 'ws');
+}

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -504,6 +504,12 @@ export interface PRHistoryItem {
   merge_override?: MergeOverride | null;
 }
 
+/** GET /api/v2/pr — open/closed PRs, unlike PRHistory which is merged-only. */
+export interface PRListResponse {
+  pull_requests: PRResponse[];
+  total: number;
+}
+
 export interface PRHistoryResponse {
   pull_requests: PRHistoryItem[];
   total: number;


### PR DESCRIPTION
Closes #944 — **partially**. AC3 is not addressed; see below.

## 1. The Merge button vanished on reload

`PRStatusPanel` is the **only web surface** carrying the Merge button and the PROOF9 merge-gate display. It mounted on a plain `useState` `prNumber` set by `handleCreatePR` — so reloading, or navigating away while CI ran (i.e. the normal case), hid it **permanently**, and Ship had to be finished from the CLI.

The page now restores open-PR state on load.

Worth noting: this could **not** reuse the existing `prApi.getHistory()`. That endpoint returns *merged* PRs only, so it structurally cannot answer "is there a PR open right now?". Added `prApi.list(workspacePath, 'open')` against the existing `GET /api/v2/pr`.

Failures are swallowed deliberately — on a workspace with no remote or no GitHub connection, the correct behaviour is a hidden panel, not an error banner on a page whose main job is showing the diff.

## 2. Two sockets, two different base URLs

| | source |
|---|---|
| `AgentTerminal` | `NEXT_PUBLIC_WS_URL` → falls back to `NEXT_PUBLIC_API_URL` |
| `useAgentChat` | `NEXT_PUBLIC_WS_URL` → falls back to **hardcoded `ws://localhost:8000`** |

So a deployment that set only `NEXT_PUBLIC_API_URL` — the documented single-origin setup — had a **working terminal and a silently dead chat socket**, with nothing to explain the difference.

Both now call one `lib/wsBase.ts`. It also upgrades `https` → `wss`, so a TLS deployment cannot silently fall back to an insecure socket.

## Acceptance criteria

- [x] `/review` restores open-PR state on load so Merge stays reachable after reload
- [x] Both sockets resolve their base through one shared helper; a test asserts `NEXT_PUBLIC_API_URL` alone yields the same base for chat and terminal
- [ ] **`agent_type_models` is consumed or the section is removed** — not done

## Not addressed: AC3

`config.agent_type_models` is persisted by Settings → Agent and read by nothing (`grep` finds it only in `config.py`, `ui/models.py` and `settings_v2.py` — never at a model-selection site). The option set also omits the `kilocode` adapter.

Both halves of the AC are real, but the choice between them is a product decision I should not make silently: *consuming* it means wiring per-agent-type model overrides through provider resolution, and *removing* it deletes a settings section users may already have populated. Either is a bigger change than the two defects above, which are independently verifiable and shippable now.

Happy to split it into its own issue, or take direction on which half is wanted.

## Tests

5 new. Two beyond the AC: `https` → `wss` (a TLS deployment must not be downgraded), and a guard that the old hardcoded `ws://localhost:8000` can never be returned when an API URL is set — which is the exact regression that caused the dead chat socket.

`npm run lint` clean, **1088** tests pass, `npm run build` clean.
