### PR TITLE
test: make the default `uv run pytest` offline and free (#946)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -400,10 +400,13 @@ jobs:
 
       - name: Run E2E backend tests
         run: |
+          # "and not e2e_llm" is load-bearing (#946): a -m on the command line
+          # REPLACES the one in pytest.ini's addopts, so a bare -m "e2e" would
+          # re-select the paid real-LLM Golden Path tests here.
           uv run pytest tests/e2e/ \
             -v \
             --tb=short \
-            -m "e2e"
+            -m "e2e and not e2e_llm"
 
       - name: Stop FastAPI server
         if: always()

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,6 +29,14 @@ addopts =
     --strict-config
     # Show durations of slowest tests
     --durations=10
+    # Deselect the two markers that spend real money by default (#946). Both
+    # make live Anthropic calls, and e2e_llm additionally rmtree's .codeframe/
+    # inside an EXTERNAL project (~/projects/cf-test). `uv run pytest` is the
+    # documented quality command, so its default must not do either.
+    # Opt back in explicitly — a -m on the command line replaces this one:
+    #   uv run pytest -m e2e_llm
+    #   scripts/lifecycle --mode all      (which passes -m lifecycle)
+    -m "not e2e_llm and not lifecycle"
 
 # Markers for test categorization
 markers =

--- a/tests/e2e/cli/conftest.py
+++ b/tests/e2e/cli/conftest.py
@@ -22,22 +22,12 @@ CODEFRAME_ROOT = Path(
 )
 
 
-def _ensure_api_key() -> None:
-    """Eagerly load ANTHROPIC_API_KEY from .env if not already set."""
-    if os.environ.get("ANTHROPIC_API_KEY"):
-        return
-    env_file = CODEFRAME_ROOT / ".env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if line.startswith("ANTHROPIC_API_KEY="):
-                key = line.split("=", 1)[1].strip().strip('"').strip("'")
-                os.environ["ANTHROPIC_API_KEY"] = key
-                return
-
-
-# Load API key at import time so subprocesses inherit it
-_ensure_api_key()
+# The production key used to be copied out of the repo's .env into os.environ
+# at IMPORT time (#946), so merely COLLECTING `pytest tests/` mutated the
+# ambient environment of the whole run — which also flipped every
+# requires_api_key gate from skip to run. Nothing needed it there: the
+# `anthropic_api_key` fixture below loads it for tests that ask, and
+# GoldenPathRunner._build_env reads .env itself for the subprocesses it spawns.
 
 
 def pytest_collection_modifyitems(config, items):
@@ -67,11 +57,17 @@ def codeframe_root() -> Path:
 
 
 @pytest.fixture(scope="session")
-def anthropic_api_key() -> str:
-    """Load ANTHROPIC_API_KEY from codeframe .env or environment."""
+def anthropic_api_key():
+    """Load ANTHROPIC_API_KEY from the environment or the repo's .env.
+
+    The only place the key enters os.environ (#946), and it is removed again
+    when the last requesting test finishes — so a run that also collects other
+    suites cannot inherit it and silently un-skip their requires_api_key gates.
+    """
     key = os.environ.get("ANTHROPIC_API_KEY")
     if key:
-        return key
+        yield key
+        return
 
     env_file = CODEFRAME_ROOT / ".env"
     if env_file.exists():
@@ -81,7 +77,11 @@ def anthropic_api_key() -> str:
                 key = line.split("=", 1)[1].strip().strip('"').strip("'")
                 if key:
                     os.environ["ANTHROPIC_API_KEY"] = key
-                    return key
+                    try:
+                        yield key
+                    finally:
+                        os.environ.pop("ANTHROPIC_API_KEY", None)
+                    return
 
     pytest.skip("ANTHROPIC_API_KEY not available")
 

--- a/tests/e2e/cli/validators.py
+++ b/tests/e2e/cli/validators.py
@@ -2,6 +2,12 @@
 
 Each validator returns a (passed: bool, detail: str) tuple so results
 can be aggregated into a report.
+
+Every subprocess here passes ``timeout=``, so every one must also catch
+``subprocess.TimeoutExpired`` (#946). It is a ``SubprocessError``, NOT an
+``OSError``, so the "tool not available" handlers never covered it: a hanging
+command propagated out of the validator and killed the whole module fixture
+instead of being recorded as the failed check it is.
 """
 
 from __future__ import annotations
@@ -27,6 +33,8 @@ def validate_ruff_lint(project_path: Path) -> tuple[bool, str]:
             return True, "0 lint errors"
         error_count = proc.stdout.count("\n")
         return False, f"{error_count} lint errors:\n{proc.stdout[:500]}"
+    except subprocess.TimeoutExpired as exc:
+        return False, f"ruff timed out after {exc.timeout}s"
     except OSError as exc:
         return False, f"ruff not available: {exc}"
 
@@ -60,6 +68,8 @@ def validate_tests_pass(project_path: Path) -> tuple[bool, str]:
             return True, f"All tests passed\n{proc.stdout[-300:]}"
         combined = proc.stdout[-300:] + "\n--- stderr ---\n" + proc.stderr[-200:]
         return False, f"Tests failed (exit {proc.returncode}):\n{combined}"
+    except subprocess.TimeoutExpired as exc:
+        return False, f"the project's test suite timed out after {exc.timeout}s"
     except OSError as exc:
         return False, f"uv/pytest not available: {exc}"
 
@@ -77,6 +87,8 @@ def validate_cli_works(project_path: Path) -> tuple[bool, str]:
         if proc.returncode == 0:
             return True, "CLI --help works"
         return False, f"CLI --help failed (exit {proc.returncode}):\n{proc.stderr[:300]}"
+    except subprocess.TimeoutExpired as exc:
+        return False, f"CLI --help timed out after {exc.timeout}s"
     except OSError as exc:
         return False, f"uv not available: {exc}"
 
@@ -95,6 +107,8 @@ def validate_no_import_errors(project_path: Path) -> tuple[bool, str]:
         if proc.returncode == 0 and "OK" in proc.stdout:
             return True, "Package imports cleanly"
         return False, f"Import error:\n{proc.stderr[:300]}"
+    except subprocess.TimeoutExpired as exc:
+        return False, f"the import check timed out after {exc.timeout}s"
     except OSError as exc:
         return False, f"uv/python not available: {exc}"
 

--- a/tests/test_offline_default_946.py
+++ b/tests/test_offline_default_946.py
@@ -1,0 +1,223 @@
+"""`uv run pytest` must not spend money or touch an external project (#946).
+
+Three defects, all reachable by running the repo's own documented quality
+command on a developer machine:
+
+1. `pytest.ini` had `testpaths = tests` and no marker deselection, so plain
+   `uv run pytest` collected and RAN `test_react_engine_validation.py` — a full
+   Golden Path with `timeout_per_task=600` making real Anthropic calls, whose
+   `clean_cf_test` fixture `rmtree`s `.codeframe/` inside the EXTERNAL
+   `~/projects/cf-test`.
+2. `tests/e2e/cli/conftest.py` called `_ensure_api_key()` at import time,
+   copying the production key out of the repo's `.env` into `os.environ` during
+   COLLECTION of any `pytest tests/` run. That also flipped `requires_api_key`
+   gates from skip to run.
+3. Every validator passes `timeout=` but caught only `OSError`.
+   `subprocess.TimeoutExpired` is a `SubprocessError`, so a hanging command
+   escaped the validator and aborted the module fixture instead of being
+   recorded as a failed check.
+
+These live at the tests root, not under `tests/e2e/`, because CI's gate runs
+`--ignore=tests/e2e` — a regression test inside that tree would never run.
+"""
+
+import configparser
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+E2E_CLI = REPO_ROOT / "tests" / "e2e" / "cli"
+
+
+def _addopts() -> list[str]:
+    parser = configparser.ConfigParser()
+    parser.read(REPO_ROOT / "pytest.ini")
+    return shlex.split(parser["pytest"]["addopts"], comments=True)
+
+
+class TestExpensiveMarkersAreDeselectedByDefault:
+    def test_addopts_carries_a_marker_expression(self):
+        assert "-m" in _addopts(), (
+            "nothing deselects the paid markers, so plain `pytest` runs them"
+        )
+
+    @pytest.mark.parametrize("marker", ["e2e_llm", "lifecycle"])
+    def test_the_expression_excludes_the_marker(self, marker: str):
+        opts = _addopts()
+        expr = opts[opts.index("-m") + 1]
+
+        assert f"not {marker}" in expr, f"{marker} is not deselected: {expr!r}"
+
+    def test_a_bare_run_collects_zero_expensive_tests(self):
+        """AC2, measured — the ini could say anything; this asks pytest."""
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "-q", "tests/e2e"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+        # "N/M tests collected (K deselected)" — the paid ones must be in K.
+        assert "e2e_llm" not in proc.stdout, proc.stdout[-2000:]
+        assert "test_react_engine_validation" not in proc.stdout, (
+            "the paid Golden Path test is still collected by a default run"
+        )
+
+    def test_an_explicit_opt_in_still_selects_them(self):
+        """The deselection must be a default, not a wall."""
+        proc = subprocess.run(
+            [
+                sys.executable, "-m", "pytest",
+                "--collect-only", "-q", "-m", "e2e_llm", "tests/e2e",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+        assert "test_react_engine_validation" in proc.stdout, (
+            "`-m e2e_llm` no longer reaches the tests it names"
+        )
+
+
+class TestCollectionDoesNotLeakTheApiKey:
+    def test_the_conftest_does_not_load_the_key_at_import_time(self):
+        source = E2E_CLI / "conftest.py"
+        code = "\n".join(
+            line.split("#")[0] for line in source.read_text().splitlines()
+        )
+
+        assert "_ensure_api_key()" not in code, (
+            "the key is still copied into os.environ during collection"
+        )
+
+    def test_importing_the_conftest_leaves_the_environment_alone(self):
+        """AC3, measured in a child process so this test cannot poison itself.
+
+        Importing the conftest is exactly what collection does. Run with the
+        variable explicitly unset; if the import puts it back, the child says
+        LEAKED. This fails against the previous conftest.
+        """
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        probe = (
+            "import os, sys, importlib;"
+            "importlib.import_module('tests.e2e.cli.conftest');"
+            "sys.stdout.write("
+            "'LEAKED' if os.environ.get('ANTHROPIC_API_KEY') else 'CLEAN')"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+        assert proc.stdout.endswith("CLEAN"), (
+            f"importing the conftest wrote ANTHROPIC_API_KEY into os.environ: "
+            f"{proc.stdout!r} {proc.stderr[-500:]!r}"
+        )
+
+    def test_the_key_fixture_puts_it_back_the_way_it_found_it(self):
+        """It is a generator fixture with a finally, not a plain return."""
+        source = (E2E_CLI / "conftest.py").read_text()
+        body = source.split("def anthropic_api_key(")[1].split("\n@pytest")[0]
+
+        assert "yield" in body, "the fixture cannot clean up after a bare return"
+        assert 'os.environ.pop("ANTHROPIC_API_KEY", None)' in body
+
+
+class TestValidatorsSurviveAHangingCommand:
+    """AC4. `subprocess.TimeoutExpired` subclasses `SubprocessError`, so the
+    existing `except OSError` never caught it."""
+
+    @pytest.fixture
+    def hang(self, monkeypatch):
+        """Make every subprocess.run in validators time out."""
+        from tests.e2e.cli import validators
+
+        def _timeout(argv, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout", 1))
+
+        monkeypatch.setattr(validators.subprocess, "run", _timeout)
+        return validators
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "validate_ruff_lint",
+            "validate_tests_pass",
+            "validate_cli_works",
+            "validate_no_import_errors",
+        ],
+    )
+    def test_a_timeout_is_a_failed_check_not_an_exception(self, hang, name, tmp_path):
+        passed, detail = getattr(hang, name)(tmp_path)
+
+        assert passed is False
+        assert "timed out" in detail, f"{name} reported {detail!r}"
+
+    def test_the_report_still_aggregates_when_everything_hangs(self, hang, tmp_path):
+        """The point of the tuple contract: one hung tool must not cost the
+        results of the seven other checks."""
+        run = type("R", (), {"task_results": []})()
+
+        results = hang.run_all_validators(tmp_path, run, original_pyproject_hash="x")
+
+        assert len(results) == 8
+        assert all(isinstance(v, tuple) for v in results.values())
+
+    def test_the_non_subprocess_validators_are_unaffected(self, hang, tmp_path):
+        """They never call subprocess, so a hang must not change their verdict."""
+        run = type("R", (), {"task_results": []})()
+
+        assert hang.validate_iteration_counts(run)[0] is True
+
+    def test_a_genuinely_hanging_command(self, monkeypatch, tmp_path):
+        """AC4 verbatim: a real process that really outlives its timeout, not a
+        raised exception. The monkeypatched cases above prove the handler; this
+        proves the handler is reached by the thing it was written for."""
+        from tests.e2e.cli import validators
+
+        real_run = subprocess.run
+        monkeypatch.setattr(
+            validators.subprocess,
+            "run",
+            lambda argv, **kw: real_run(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                **{**kw, "timeout": 1},
+            ),
+        )
+
+        passed, detail = validators.validate_ruff_lint(tmp_path)
+
+        assert passed is False
+        assert "timed out" in detail
+
+
+class TestTheCiSelectorDoesNotReSelectThem:
+    """A `-m` on the command line REPLACES the one in addopts rather than
+    combining with it, so every CI invocation that passes its own -m has to
+    exclude the paid markers itself."""
+
+    def test_the_e2e_job_excludes_e2e_llm(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text()
+
+        assert '-m "e2e and not e2e_llm"' in workflow, (
+            "the E2E job's -m re-selects the paid real-LLM tests"
+        )
+
+    def test_the_backend_job_ignores_the_e2e_tree_entirely(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text()
+
+        assert "--ignore=tests/e2e" in workflow


### PR DESCRIPTION
Closes #946.

## The repo's own quality command spent money and reached outside the repo

`CLAUDE.md` documents `uv run pytest` as the quality check. On a developer machine with `ANTHROPIC_API_KEY` set and `~/projects/cf-test` present, it collected and **ran** `test_react_engine_validation.py` — a full Golden Path with `timeout_per_task=600` making real Anthropic calls, whose `clean_cf_test` fixture `rmtree`s `.codeframe/` inside that **external** project.

## Three fixes

### 1. `pytest.ini` deselects the paid markers by default (AC1, AC2)

`addopts` now carries `-m "not e2e_llm and not lifecycle"`.

```
$ uv run pytest --collect-only -q | tail -1
5323/5349 tests collected (26 deselected)
```

A `-m` on the command line **replaces** this one rather than combining with it, so the opt-ins are unchanged — but that also meant auditing every CI invocation that passes its own `-m`. **One was wrong**: the E2E Backend job ran `-m "e2e"`, and the paid tests are marked `[e2e, e2e_llm]`, so it selected them. Now `-m "e2e and not e2e_llm"`.

`scripts/lifecycle` (`-m lifecycle`) and the backend gate (`--ignore=tests/e2e -m "not lifecycle"`) were already correct; the gate collects the same 5300 tests as before.

### 2. The key no longer enters `os.environ` during collection (AC3)

`tests/e2e/cli/conftest.py` called `_ensure_api_key()` at **import** time. Reproduced before the fix:

```
$ env -u ANTHROPIC_API_KEY .venv/bin/python -c "
import os, pytest
pytest.main(['--collect-only','-q','tests/e2e'])
print('after:', bool(os.environ.get('ANTHROPIC_API_KEY')))"
after: True
```

**Deleted rather than moved** — nothing needed it there. The `anthropic_api_key` fixture already loads it for the tests that ask, and `GoldenPathRunner._build_env` reads `.env` itself for the subprocesses it spawns. That fixture is now a generator that pops the key again on teardown, so even the opt-in path leaves the environment as it found it.

### 3. Validators survive a hanging command (AC4)

`subprocess.TimeoutExpired` is a `SubprocessError`, **not** an `OSError` — so every `except OSError` ("tool not available") missed it, and a hang propagated out of the validator and killed the module fixture instead of being recorded as the failed check it is. All four now catch it and report the timeout.

## Tests

17, at the **tests root** — not under `tests/e2e/`, because CI's gate runs `--ignore=tests/e2e` and a regression test in that tree would never run.

They assert measured behaviour, not just file contents: a real `pytest --collect-only` subprocess for both the default and the `-m e2e_llm` opt-in, a child-process probe for the env leak, and — for AC4's "test with a hanging command" — a real `time.sleep(30)` against a 1s timeout, alongside the monkeypatched cases that cover all four validators.

**12 of the 17 fail against the pre-fix tree** (`git stash` + rerun). The other 5 are guards that must hold in both states: the `-m e2e_llm` opt-in still selecting, the non-subprocess validators being unaffected, and the two CI-selector checks.

`ruff` and `mypy codeframe/` clean.

## Known limitations

- **`os.environ` is still mutated by importing the CLI.** `codeframe/cli/app.py:42` calls `load_env_files()` at module import, so `from codeframe.cli.app import app` — which most CLI tests do — loads `.env` into the ambient environment. That is correct behaviour for `cf` itself and is governed by #904's precedence rules; making it lazy is a separate change, filed as **#1064 (P2.21)**. AC3 is therefore met for the mechanism this issue cites (`tests/e2e/cli/conftest.py:39`) and explicitly not for that one.
- `golden_path_runner.py` already caught `TimeoutExpired` at both of its `subprocess.run` sites, so it needed no change.
