### PR TITLE
docs: bring the root documentation in line with the shipped product (#950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,119 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+Over 200 commits since v0.9.1. `SECURITY.md` supports only the latest release, so the
+security section below is the one to read before deploying anything older.
+
+### Security
+
+Several of these change defaults and will require configuration on an existing deploy.
+
+- **`WORKSPACE_ROOT` has one meaning and fails closed (#896).** It is an
+  `os.pathsep`-separated allowlist of permitted workspace roots, never a location, and
+  nothing creates it. The server now **refuses to start** when auth is enforced and no
+  allowlist is set — an empty allowlist let any authenticated user open a session, and
+  therefore a terminal shell, in any host directory. `CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES=1`
+  is the documented single-operator local escape hatch.
+- **Bootstrap registration is gated (#897).** `POST /auth/register` is unauthenticated by
+  design for the first account. It now requires `CODEFRAME_BOOTSTRAP_TOKEN` as an
+  `X-Bootstrap-Token` header, or a genuinely host-local request. **Required for any deploy
+  reachable over a network**: without it, a fresh instance is claimable as admin by
+  whoever reaches the route first.
+- **Scopes are real, not decorative (#898).** A JWT principal's scopes derive from its
+  user row — `read`/`write` always, `admin` only for a superuser — so
+  `require_scope(SCOPE_ADMIN)` now genuinely refuses a non-superuser browser session on
+  credential storage and PR merge. Only a superuser may mint an admin-scoped API key.
+  Workspace-registry ownership is write-once, so one user can no longer take over
+  another's registered `repo_path`.
+- **Untrusted-repository boundaries closed.** A cloned repo can commit files that used to
+  steer the process: lifecycle hooks now require a recorded trust decision (#905), a
+  repo-supplied `llm.base_url` is refused unless it is loopback or explicitly opted into
+  (#903), every `.env` variant is ignored rather than an enumeration (#895), and a
+  repository `.env` can no longer override the operator's environment or supply
+  security-steering keys (#904).
+- **Subprocess containment.** Plan-engine and gate subprocesses run with one allowlisted
+  environment (#907), plan-engine file operations are confined to the workspace (#906),
+  `review_files()` likewise (#899), and secrets are stripped from the LLM `run_command`
+  environment (#721). Delegated coding CLIs run with a sandboxed `$HOME` by default
+  (#996) — 69 inherited environment variables including 5 API keys, down to 12 and none.
+- **Streams no longer carry JWTs in URLs (#745).** An authenticated
+  `POST /auth/stream-ticket` mints a 60-second single-use ticket, accepted as `?ticket=`
+  on the two SSE and two WebSocket routes only. `?token=<JWT>` is no longer accepted
+  anywhere.
+- **Outbound webhook SSRF is blocked at dispatch, not only at save (#746, #656).**
+  `send_event` resolves the host, rejects private/loopback/link-local/metadata/CGNAT
+  addresses, and pins the vetted IPs into the connector — defeating a hand-edited config
+  and DNS rebinding (e.g. `169.254.169.254`).
+- **Credential handling (#772).** `CODEFRAME_CREDENTIAL_SECRET` mixes into the PBKDF2 KDF
+  for the encrypted-file fallback; unset, the key derives from the non-secret machine id
+  alone, which is obfuscation and not confidentiality. Credentials are per-user scoped in
+  hosted mode (#790), and sharing them across trust domains is blocked (#718).
+- **Hosted multi-tenancy.** Session REST endpoints are owner-scoped with TOCTOU path
+  revalidation (#704), GitHub PR endpoints are scoped to the caller's credential and repo
+  (#900), `GET /workspaces/exists` enforces the allowlist (#719), and registry
+  list/delete are owner-scoped (#720).
+- **Auth hardening.** The server hard-fails on a default `AUTH_SECRET` whenever auth is
+  enabled (#643); `/auth/jwt/login` and `/auth/register` are rate-limited (#644); the JWT
+  lifetime dropped from 7 days to 24 hours and the web UI ships a CSP (#657); the
+  security-event taxonomy is actually emitted rather than merely defined (#937); a
+  disabled account cannot log in (#938); and the test-only `/test/broadcast` route is
+  behind `CODEFRAME_ENABLE_TEST_ENDPOINTS` (#753).
+- The server warns at startup when in-memory rate limiting is used with multiple workers,
+  where each worker keeps its own counters and the effective limit multiplies (#678).
+
 ### Added
-- Server-side PROOF9 merge gate (#731): `POST /api/v2/pr/{n}/merge` now blocks while open (non-waived) requirements exist. An explicit `override: true` + `override_reason` bypasses the gate and records an audit entry (actor, reason, bypassed requirements, timestamp), surfaced as `merge_override` in `GET /api/v2/pr/history`. A proof-ledger failure blocks the merge (explicit 500) rather than silently allowing it.
-- The same gate applies to `cf pr merge`: open requirements in the cwd workspace block the merge unless `--override --reason "..."` is given, which persists the same audit record.
+
+- **Phase 5.5 — GitHub Issues import.** Connect a repo with a PAT from Settings →
+  Integrations (#563), browse its open issues with search, label filter and pagination
+  (#564), and import selected issues as tasks with `github_issue_number`/`external_url`
+  traceability, atomic dedupe, and opt-in auto-close when the task reaches DONE (#565).
+- **Phase 5.4 — PRD stress-test in the web UI.** An SSE endpoint streams goal analysis
+  live (#561); results render as severity-tagged ambiguity cards, and answering the
+  blocking ones folds them into a new PRD version (#562).
+- **Phase 5.3 — Async notifications.** A browser + in-app notification centre with
+  workspace-scoped persistence (#559), a cross-page watcher so batch completions and new
+  blockers fire even when the execution page is unmounted (#652), and an outbound webhook
+  with a test button (#560).
+- **Phase 5.2 — Cost visibility.** Spend summary (#557) plus per-task and per-agent
+  breakdowns, with an inline cost badge on task cards (#558).
+- **Phase 5.1 — Settings.** Working Agent, API Keys and PROOF9-defaults tabs (#554–#556);
+  `run_proof()` honours `enabled_gates` and `strictness`.
+- **Server-side PROOF9 merge gate (#731).** `POST /api/v2/pr/{n}/merge` blocks while open
+  (non-waived) requirements exist. An explicit `override: true` + `override_reason`
+  bypasses it and records an audit entry (actor, reason, bypassed requirements,
+  timestamp), surfaced as `merge_override` in `GET /api/v2/pr/history`. A proof-ledger
+  failure blocks the merge with an explicit 500 rather than silently allowing it. `cf pr
+  merge` enforces the same gate with `--override --reason "..."`.
+- **Worktree isolation with real merge-back (#787)**, so parallel agents no longer share a
+  tree.
+- **Per-user credential scoping for hosted mode (#790).**
+- **A rewritten Playwright browser suite for the Phase-3+ UI (#684)**, with the config
+  starting both servers itself.
+- **A proactive web-UI auth guard plus an SSE/WebSocket token-expiry re-auth path (#651).**
+
+### Fixed
+
+- Token/cost data was silently dropped: `react_agent` int-cast UUID task ids and stored
+  NULL in `token_usage` (#712, #558).
+- A bad GitHub PAT returned 401, which the web UI treated as session expiry and logged the
+  user out; upstream GitHub 401s are now remapped to 400/502 with typed errors (#734).
+- `cf init` no longer runs a cloned repository's `after_init` hook without a trust
+  decision (#905).
+- The default-`AUTH_SECRET` warning no longer prints on every `cf` command.
+- Numerous correctness fixes across the conductor, PROOF9 ledger, CLI, task store and web
+  UI — see the commit log for the full list.
+
+### Changed
+
+- **Coverage is enforced (#948).** `.coveragerc` sets `fail_under = 80`; the README badge
+  and the contribution rule were corrected from an 88%/85% that nothing measured and that
+  was not true (the real figure is 81.9%).
+- **`uv run pytest` is offline and free by default (#946).** `e2e_llm` and `lifecycle` are
+  deselected unless explicitly requested; collection no longer copies the repository's
+  `ANTHROPIC_API_KEY` into the process environment.
+- **`scripts/lifecycle --mode api|web` exits 3** instead of reporting success for stubs
+  that only ever raised `NotImplementedError` (#948).
+- Root documentation was brought back in line with the shipped product (#950).
 
 ## [0.9.1] - 2026-06-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,65 +78,97 @@ uv run ruff check codeframe tests
 
 ## Architecture Documentation
 
-Before contributing, review relevant architecture documentation in [`docs/architecture/`](docs/architecture/):
+Before contributing, read the documents that actually govern the codebase:
 
-- **Task Identifiers**: Understand the dual-identifier system (`id` vs `task_number`) and dependency semantics
-- **Design Decisions**: Review existing patterns before introducing new ones
+- [`CLAUDE.md`](CLAUDE.md) — the non-negotiable architecture rules (core is headless, the
+  CLI never requires a server, agent state transitions flow through the runtime)
+- [`docs/GOLDEN_PATH.md`](docs/GOLDEN_PATH.md) — the CLI-first workflow contract
+- [`docs/CLI_WIREFRAME.md`](docs/CLI_WIREFRAME.md) — command → module mapping
+- [`docs/AGENT_SYSTEM_REFERENCE.md`](docs/AGENT_SYSTEM_REFERENCE.md) — components and execution flows
+- [`docs/PHASE_2_DEVELOPER_GUIDE.md`](docs/PHASE_2_DEVELOPER_GUIDE.md) — the server layer and v2 router patterns
+- [`docs/PHASE_3_UI_ARCHITECTURE.md`](docs/PHASE_3_UI_ARCHITECTURE.md) — the Next.js web UI
 
-Add new architecture documentation when introducing cross-cutting patterns or data model changes.
+Add documentation when introducing a cross-cutting pattern or a data-model change.
 
 ## Authentication & Security
 
-CodeFRAME uses FastAPI Users for authentication and implements comprehensive authorization checks.
-
-### Authentication Requirements
-
-Authentication is **always required** for all API endpoints. All requests must include a valid JWT Bearer token in the Authorization header. Requests without valid tokens receive 401 Unauthorized.
-
-For testing, test fixtures automatically create JWT tokens. See `tests/api/conftest.py` for examples.
-
-### Adding Protected Endpoints
-
-When creating new API endpoints that access project resources:
+Auth is enforced centrally, not per handler. `codeframe/ui/server.py` mounts every v2
+router with a router-level dependency:
 
 ```python
-from fastapi import HTTPException, Depends
-from codeframe.platform_store.database import Database
-from codeframe.ui.dependencies import get_db, get_current_user, User
-
-@router.get("/api/projects/{project_id}/resource")
-async def get_resource(
-    project_id: int,
-    db: Database = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    # 1. Verify project exists
-    project = db.get_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    # 2. Authorization check
-    if not db.user_has_project_access(current_user.id, project_id):
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    # 3. Proceed with operation
-    return {"resource": "data"}
+_AUTH = [Depends(require_method_scope)]
+app.include_router(tasks_v2.router, dependencies=_AUTH)   # /api/v2/tasks
 ```
 
-**Key Requirements**:
-- Add `current_user: User = Depends(get_current_user)` parameter
-- Check project existence before authorization check
-- Use `db.user_has_project_access()` for authorization
-- Return 403 Forbidden (not 404) for unauthorized access
+So **a new router is protected by mounting it that way, and by nothing else.** A router
+added without `dependencies=_AUTH` is publicly reachable.
+A companion suite enumerates `app.routes` and fails when any `/api/v2` route is missing
+the dependency, so that mistake cannot reach `main`.
 
-**See Also**: [docs/authentication.md](docs/authentication.md) for complete guide.
+### What a caller must present
+
+`require_auth` accepts either a JWT `Authorization: Bearer <token>` or an `X-API-Key`
+header, and resolves both to a principal dict. Enforcement is gated by
+`CODEFRAME_AUTH_REQUIRED`, read **at request time**, default **on**; set it to `false`
+for local development. With auth disabled the dependency yields a synthetic principal
+carrying every scope — the single-operator local opt-out.
+
+Streams never carry a JWT in the URL. `POST /auth/stream-ticket` mints a 60-second
+single-use ticket, redeemed as `?ticket=` on the two SSE routes and the two WebSocket
+routes only.
+
+### Scopes
+
+A JWT principal's scopes come from its user row: `read` and `write` always, plus `admin`
+only when `is_superuser`. Use `require_scope(SCOPE_ADMIN)` for anything that stores a
+credential or merges a PR:
+
+```python
+@router.post("/{pr_number}/merge")
+async def merge_pull_request(
+    request: Request,
+    pr_number: int,
+    workspace: Workspace = Depends(get_v2_workspace),
+    auth: dict = Depends(require_auth),
+    _: None = Depends(require_scope(SCOPE_ADMIN)),
+) -> MergeResponse:
+    ...
+```
+
+### Tenancy
+
+Handlers do not hand-roll ownership checks. `get_v2_workspace` resolves the caller's
+workspace and enforces the `WORKSPACE_ROOT` allowlist, returning 403 for a path outside
+it; in hosted mode each user is further confined to `<root>/<user_id>`. Take the
+workspace from that dependency rather than from a client-supplied path.
+
+### Writing tests for a protected endpoint
+
+`tests/conftest.py` sets `CODEFRAME_AUTH_REQUIRED=false` for the suite, so most tests
+need nothing. Tests that exercise auth opt back in explicitly — see
+`tests/ui/test_v2_auth_enforcement.py` for the app fixture, and its companion for a real
+register → login → authorized-request round-trip.
+
+**See also**: the "Environment Variables" section of [`CLAUDE.md`](CLAUDE.md) documents
+every auth-related switch (`CODEFRAME_AUTH_REQUIRED`, `AUTH_SECRET`,
+`CODEFRAME_BOOTSTRAP_TOKEN`, `WORKSPACE_ROOT`, `JWT_LIFETIME_SECONDS`) and what happens
+when each is unset.
 
 ## Testing
 
-- Write unit tests for new features
-- Maintain >85% code coverage
-- Run `uv run pytest` before submitting PRs
-- Include authentication/authorization tests for protected endpoints
+- Write tests for new behaviour, before the code where you can
+- Coverage is gated in CI at the floor in `.coveragerc` (currently 80%)
+- Run the full check before submitting a PR:
+
+  ```bash
+  uv run pytest && uv run ruff check . && uv run mypy codeframe/
+  cd web-ui && npm test && npm run build
+  ```
+
+- Include an auth test for a protected endpoint
+- Real-LLM lifecycle tests are opt-in and cost money: `scripts/lifecycle --mode cli`
+
+See [`TESTING.md`](TESTING.md) for how the suites are laid out and which markers exist.
 
 ## Pull Request Process
 
@@ -147,24 +179,21 @@ async def get_resource(
 5. Run tests and linting
 6. Submit PR with description of changes
 
-## Adding New Providers
+## Adding an LLM Provider
 
-See `codeframe/providers/base.py` for the provider interface.
+Implement [`codeframe/adapters/llm/base.py`](codeframe/adapters/llm/base.py)'s
+`LLMProvider`, alongside the existing `anthropic.py`, `openai.py` and `mock.py`, then
+register it in the resolution chain (`codeframe/core/llm_resolution.py`). Any
+OpenAI-compatible endpoint already works without new code — use
+`--llm-provider openai --llm-model <name>` with `OPENAI_BASE_URL`.
 
-Example:
-```python
-from codeframe.providers.base import AgentProvider
+## Adding a Coding-Agent Adapter
 
-class GeminiProvider(AgentProvider):
-    def initialize(self, config: dict) -> None:
-        # Implementation
-        pass
-    # etc.
-```
-
-## Adding New Language Support
-
-See `codeframe/tasks/test_runner.py` for test runner configuration.
+Implement [`codeframe/core/adapters/agent_adapter.py`](codeframe/core/adapters/agent_adapter.py)'s
+interface, alongside `claude_code.py`, `codex.py`, `opencode.py` and `kilocode.py`. Declare
+the credentials your CLI needs (`credential_env_vars`) and its login directory
+(`home_passthrough`): delegated agents run with a sandboxed `$HOME` by default, so a CLI
+that keeps state elsewhere will not find it.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ THE CLOSED LOOP
 ---
 
 > [!NOTE]
-> **CodeFRAME is in public beta (`0.9.0`).** The vision and the Golden Path CLI
+> **CodeFRAME is in public beta (`0.9.1`).** The vision and the Golden Path CLI
 > (`cf init/prd/tasks/work/proof/pr`) and v2 API are stable enough to build on;
 > the web UI and anything marked "in progress" in
 > [`docs/PRODUCT_ROADMAP.md`](docs/PRODUCT_ROADMAP.md) are still moving, and
@@ -340,12 +340,12 @@ CodeFRAME delivers the full Think-Build-Prove-Ship loop from the CLI and browser
 - [x] PROOF9 -- 9-gate evidence-based quality system
 - [x] `cf proof capture` -- Glitch-to-requirement closed loop
 - [x] Quality compounding: every failure becomes a permanent proof obligation
-- [ ] Run gates from the web UI (backend ready, frontend pending)
-- [ ] Glitch capture web UI
+- [x] Run gates from the web UI -- live progress, per-gate evidence, run history
+- [x] Glitch capture web UI -- `CaptureGlitchModal` plus the REQ detail view at `/proof/[req_id]`
 - [x] Merge gating on PROOF9 pass -- enforced server-side at the merge API, with an explicit audited override (actor + reason)
 
 ### SHIP (delivery confidence)
-- [ ] PR status tracking + CI check display in web UI
+- [x] PR status tracking + CI check display in web UI (`PRStatusPanel` on `/review`)
 - [ ] Post-merge glitch capture loop
 
 ### Web UI
@@ -357,7 +357,7 @@ CodeFRAME delivers the full Think-Build-Prove-Ship loop from the CLI and browser
 - [x] PROOF9 requirements list, detail, evidence history, sort/filter controls, waiver with audit trail
 - [x] Interactive Agent Sessions — chat panel (tool calls, thinking blocks), XTerm.js terminal, SplitPane layout
 - [x] Run gates button, live gate progress, per-gate evidence display, run history panel (PROOF9 page)
-- [ ] Glitch capture form and REQ detail view
+- [x] Glitch capture form and REQ detail view (markdown description, scope metadata, obligations table, sortable evidence history)
 - [x] PR status panel with PROOF9-gated merge button (gate also enforced server-side)
 
 ---
@@ -376,7 +376,7 @@ export OPENAI_BASE_URL=http://localhost:11434/v1  # for Ollama, vLLM, LM Studio,
 # Per-workspace: .codeframe/config.yaml supports an `llm:` block for the same options
 
 # Optional
-export DATABASE_PATH=./codeframe.db         # Default: in-memory SQLite
+export DATABASE_PATH=./codeframe.db         # Default: ./.codeframe/state.db
 export RATE_LIMIT_ENABLED=true              # API rate limiting
 export RATE_LIMIT_DEFAULT=100/minute        # Default limit
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,411 +1,123 @@
-# CodeFRAME Testing Guide
-
-> Sprint 1 manual testing checklist (historical). For current test organization and
-> commands see [`README.md`](README.md) and [`CLAUDE.md`](CLAUDE.md); for sprint
-> history see [`legacydocs/SPRINTS.md`](legacydocs/SPRINTS.md).
-
-## Sprint 1 Manual Test Checklist
-
-### Setup Requirements
-
-#### Environment Setup
-- [ ] Clone repository: `git clone https://github.com/frankbria/codeframe.git`
-- [ ] Navigate to project: `cd codeframe`
-- [ ] Create virtual environment: `python -m venv venv`
-- [ ] Activate virtual environment: `source venv/bin/activate`
-- [ ] Install Python dependencies: `pip install -e .`
-- [ ] Install Node dependencies: `cd web-ui && npm install && cd ..`
-
-#### Configuration
-- [ ] Create `.env` file in project root
-- [ ] Add ANTHROPIC_API_KEY: `ANTHROPIC_API_KEY=your-key-here`
-- [ ] Verify `.env` is in `.gitignore`
-
-#### Service Startup
-- [ ] Start Status Server: `python -m codeframe.ui.server`
-  - Expected: Server starts on port 8000
-  - Expected: "Status Server running on http://localhost:8000" message
-- [ ] Start Web UI (new terminal): `cd web-ui && npm run dev`
-  - Expected: UI starts on port 3000
-  - Expected: "Local: http://localhost:3000" message
-
----
-
-### Test 1: Project Creation (cf-8, cf-11)
-
-#### 1.1 Basic Project Initialization
-- [ ] Run: `codeframe init test-project`
-- [ ] Verify: Project directory created at `./test-project`
-- [ ] Verify: `.codeframe/` directory exists in `test-project/`
-- [ ] Verify: Database file created: `.codeframe/state.db`
-- [ ] Verify: Success message displayed
-
-#### 1.2 Database Verification
-- [ ] Open database: `sqlite3 test-project/.codeframe/state.db`
-- [ ] Run: `.tables`
-- [ ] Verify: All tables exist: projects, tasks, agents, blockers, memory, context_items, checkpoints, changelog
-- [ ] Run: `SELECT * FROM projects;`
-- [ ] Verify: Project entry exists with name='test-project', status='init'
-- [ ] Exit sqlite: `.exit`
-
-#### 1.3 Dashboard Integration
-- [ ] Open browser: http://localhost:3000
-- [ ] Verify: "test-project" appears in projects list
-- [ ] Verify: Status shows "init"
-- [ ] Verify: Created timestamp is recent
-
----
-
-### Test 2: Database CRUD Operations (cf-8)
-
-#### 2.1 Project Operations
-- [ ] Create second project: `codeframe init project2`
-- [ ] Verify: Both projects appear in dashboard
-- [ ] Verify: Both have separate `.codeframe/state.db` files
-- [ ] Update project status (via API or direct DB): `UPDATE projects SET status='planning' WHERE name='test-project'`
-- [ ] Refresh dashboard
-- [ ] Verify: Status updated to "planning"
-
-#### 2.2 Agent Creation
-- [ ] Use Python REPL or script:
-  ```python
-  from codeframe.platform_store.database import Database
-  db = Database("test-project/.codeframe/state.db")
-  db.initialize()
-  agent_id = db.create_agent("lead-1", "lead", "claude", "directive")
-  agent = db.get_agent("lead-1")
-  print(agent)
-  ```
-- [ ] Verify: Agent created successfully
-- [ ] Verify: Agent details correct (type=lead, provider=claude, maturity=directive)
-
-#### 2.3 Memory Storage
-- [ ] Continue in Python REPL:
-  ```python
-  project = db.get_project(1)
-  memory_id = db.create_memory(
-      project_id=project['id'],
-      category='pattern',
-      key='auth_pattern',
-      value='JWT with refresh tokens'
-  )
-  memories = db.get_project_memories(project['id'])
-  print(memories)
-  ```
-- [ ] Verify: Memory entry created
-- [ ] Verify: Can retrieve memory by project_id
-
----
-
-### Test 3: Anthropic Provider Integration (cf-9)
-
-#### 3.1 Provider Initialization
-- [ ] Test provider creation:
-  ```python
-  from codeframe.agents.providers.anthropic_provider import AnthropicProvider
-  provider = AnthropicProvider(api_key="test-key")
-  ```
-- [ ] Verify: Provider initializes without error
-- [ ] Verify: Model defaults to "claude-3-5-sonnet-20241022"
-
-#### 3.2 Message Sending (Mock/Test)
-- [ ] Run unit tests: `ANTHROPIC_API_KEY="test-key" pytest tests/test_anthropic_provider.py -v`
-- [ ] Verify: All 17 tests pass
-- [ ] Verify: Message formatting tests pass
-- [ ] Verify: Error handling tests pass
-
----
-
-### Test 4: Lead Agent Lifecycle (cf-9, cf-10)
-
-#### 4.1 Lead Agent Creation
-- [ ] Test Lead Agent initialization:
-  ```python
-  from codeframe.agents.lead_agent import LeadAgent
-  from codeframe.platform_store.database import Database
-
-  db = Database("test-project/.codeframe/state.db")
-  db.initialize()
-
-  lead = LeadAgent(
-      agent_id="lead-test-1",
-      provider_name="anthropic",
-      api_key="test-key",
-      database=db
-  )
-  ```
-- [ ] Verify: Lead Agent creates successfully
-- [ ] Verify: Agent entry created in database
-- [ ] Verify: Default maturity level is "directive"
-
-#### 4.2 Agent Status Management
-- [ ] Update agent status:
-  ```python
-  lead.update_status("working")
-  agent = db.get_agent("lead-test-1")
-  print(agent['status'])
-  ```
-- [ ] Verify: Status updates to "working"
-- [ ] Verify: Database reflects change
-
----
-
-### Test 5: Project Creation API (cf-11)
-
-#### 5.1 API Endpoint Testing
-- [ ] Send POST request to create project:
-  ```bash
-  curl -X POST http://localhost:8000/api/projects \
-    -H "Content-Type: application/json" \
-    -d '{"name": "api-test-project", "description": "Test via API"}'
-  ```
-- [ ] Verify: 200 OK response
-- [ ] Verify: Response includes project_id and status
-- [ ] Verify: Project directory created
-- [ ] Verify: Database initialized
-
-#### 5.2 Project Listing API
-- [ ] Send GET request:
-  ```bash
-  curl http://localhost:8000/api/projects
-  ```
-- [ ] Verify: Returns JSON array
-- [ ] Verify: Contains all created projects
-- [ ] Verify: Each project has id, name, status, created_at
-
-#### 5.3 WebSocket Real-Time Updates
-- [ ] Open browser developer console on dashboard
-- [ ] Create new project via CLI: `codeframe init websocket-test`
-- [ ] Verify: Dashboard updates automatically (no refresh needed)
-- [ ] Verify: Console shows WebSocket message received
-- [ ] Check WebSocket connection: Network tab → WS → Messages
-- [ ] Verify: `project_created` event appears
-
----
-
-### Test 6: Agent Lifecycle Management (cf-10)
-
-#### 6.1 Agent State Transitions
-- [ ] Test agent lifecycle:
-  ```python
-  from codeframe.agents.lead_agent import LeadAgent
-  from codeframe.platform_store.database import Database
-  from codeframe.core.models import AgentMaturity
-
-  db = Database("test-project/.codeframe/state.db")
-  db.initialize()
-
-  lead = LeadAgent("lead-lifecycle", "anthropic", "test-key", db)
-
-  # Test state transitions
-  lead.update_status("idle")
-  lead.update_status("working")
-  lead.update_status("blocked")
-  lead.update_status("completed")
-
-  # Test maturity progression
-  lead.update_maturity(AgentMaturity.D2)
-  lead.update_maturity(AgentMaturity.D3)
-  ```
-- [ ] Verify: All status transitions succeed
-- [ ] Verify: Maturity level updates correctly
-- [ ] Verify: Database reflects all changes
-
-#### 6.2 Agent Error Handling
-- [ ] Test invalid transitions:
-  ```python
-  lead.update_status("invalid_status")  # Should handle gracefully
-  ```
-- [ ] Verify: Error handled without crash
-- [ ] Verify: Agent remains in valid state
-
----
-
-### Test 7: End-to-End Integration
-
-#### 7.1 Complete Project Workflow
-- [ ] Initialize new project: `codeframe init e2e-test`
-- [ ] Verify: Project appears in dashboard immediately
-- [ ] Verify: Database created with all tables
-- [ ] Create Lead Agent programmatically
-- [ ] Store memory entry
-- [ ] Update project status to "planning"
-- [ ] Verify: All changes visible in dashboard
-- [ ] Verify: WebSocket events fire for all updates
-
-#### 7.2 Multi-Project Handling
-- [ ] Create 3 projects simultaneously:
-  ```bash
-  codeframe init project-a &
-  codeframe init project-b &
-  codeframe init project-c &
-  wait
-  ```
-- [ ] Verify: All 3 projects created successfully
-- [ ] Verify: Each has independent database
-- [ ] Verify: Dashboard shows all 3 projects
-- [ ] Verify: No database conflicts
-
----
-
-### Test 8: Error Conditions & Edge Cases
-
-#### 8.1 Database Errors
-- [ ] Test duplicate project: `codeframe init test-project` (already exists)
-- [ ] Verify: Error message displayed
-- [ ] Verify: No corruption of existing project
-
-#### 8.2 API Errors
-- [ ] Send invalid JSON to API:
-  ```bash
-  curl -X POST http://localhost:8000/api/projects \
-    -H "Content-Type: application/json" \
-    -d 'invalid json'
-  ```
-- [ ] Verify: 400 Bad Request response
-- [ ] Verify: Helpful error message
-
-#### 8.3 Missing Configuration
-- [ ] Remove ANTHROPIC_API_KEY from `.env`
-- [ ] Try to create Lead Agent
-- [ ] Verify: Clear error about missing API key
-- [ ] Restore API key
-
----
-
-### Test 9: Performance Verification
-
-#### 9.1 Response Times
-- [ ] Measure API response time:
-  ```bash
-  time curl http://localhost:8000/api/projects
-  ```
-- [ ] Verify: Response time < 500ms (p95 requirement)
-
-#### 9.2 Database Performance
-- [ ] Create 100 memory entries:
-  ```python
-  for i in range(100):
-      db.create_memory(1, 'test', f'key_{i}', f'value_{i}')
-  ```
-- [ ] Query all memories: `db.get_project_memories(1)`
-- [ ] Verify: Query completes in < 1 second
-
----
-
-### Test 10: Automated Test Suite Verification
-
-#### 10.1 Run All Tests
-- [ ] Run complete test suite:
-  ```bash
-  ANTHROPIC_API_KEY="test-key" pytest -v
-  ```
-- [ ] Verify: 111 tests pass (100% pass rate)
-- [ ] Verify: No warnings or errors
-
-#### 10.2 Test Coverage
-- [ ] Run with coverage:
-  ```bash
-  ANTHROPIC_API_KEY="test-key" pytest --cov=codeframe --cov-report=html
-  ```
-- [ ] Verify: Overall coverage > 90%
-- [ ] Verify: Database module > 92%
-- [ ] Open `htmlcov/index.html` to review
-
----
-
-## Definition of Done Verification
-
-### Sprint 1 Completion Criteria
-- [ ] ✅ All 9 tasks complete (cf-8 through cf-13)
-- [ ] ✅ 111 automated tests passing at 100%
-- [ ] ✅ Zero mock data in production code
-- [ ] ✅ Database operations tested at >80% coverage (actual: 92%)
-- [ ] ✅ API response time <500ms (p95)
-- [ ] ✅ WebSocket reconnect works automatically
-- [ ] ✅ Can run `codeframe init` and see project in dashboard
-- [ ] ✅ Lead Agent can be created with valid API key
-- [ ] ✅ No critical bugs blocking sprint review
-
-### Code Quality Checks
-- [ ] ✅ All code follows Python PEP 8 style guide
-- [ ] ✅ No hardcoded API keys or secrets in code
-- [ ] ✅ All database operations use parameterized queries
-- [ ] ✅ Error handling implemented for all external calls
-- [ ] ✅ TDD followed for all features (RED-GREEN-REFACTOR)
-
-### Documentation Complete
-- [ ] ✅ TESTING.md created with manual test checklist
-- [ ] ✅ README.md updated with setup instructions
-- [ ] ✅ AGILE_SPRINTS.md reflects actual progress
-- [ ] ✅ All API endpoints documented
-
----
-
-## Test Results Template
-
-```markdown
-## Sprint 1 Manual Test Execution Results
-**Date**: YYYY-MM-DD
-**Tester**: [Name]
-**Environment**: [OS, Python version, Node version]
-
-### Setup
-- [ ] All setup steps completed successfully
-- Issues found: [None | List issues]
-
-### Test 1: Project Creation
-- [ ] Passed | [ ] Failed
-- Issues found: [None | List issues]
-- Notes:
-
-### Test 2: Database CRUD
-- [ ] Passed | [ ] Failed
-- Issues found: [None | List issues]
-- Notes:
-
-[Continue for all tests...]
-
-### Overall Assessment
-- Total Tests Run: X
-- Tests Passed: Y
-- Tests Failed: Z
-- Critical Issues: [List]
-- Sprint 1 Ready for Demo: [ ] Yes | [ ] No
+# Testing CodeFRAME
+
+> This file used to be a ~400-line Sprint-1 manual checklist that imported modules
+> which no longer exist (`codeframe.agents.providers.anthropic_provider`,
+> `codeframe.providers.base`) and told you to start the server with a command that
+> was renamed several releases ago. It has been replaced with what the suite
+> actually is today (#950). Sprint history lives in [`legacydocs/SPRINTS.md`](legacydocs/SPRINTS.md).
+
+## The one command
+
+```bash
+uv run pytest && uv run ruff check . && uv run mypy codeframe/
+cd web-ui && npm test && npm run build
 ```
 
----
+That is the same gate [CI](.github/workflows/test.yml) runs. If it passes locally it should pass on a PR.
 
-## Troubleshooting Guide
+## What a bare `uv run pytest` runs
 
-### Common Issues
+Everything under `tests/` **except** the two markers that cost real money:
 
-**Issue**: Database file not found
-- **Solution**: Ensure you're in the correct project directory, run `codeframe init` first
+```ini
+# pytest.ini
+addopts = ... -m "not e2e_llm and not lifecycle"
+```
 
-**Issue**: WebSocket connection fails
-- **Solution**: Check Status Server is running on port 8000, check browser console for errors
+A `-m` on the command line **replaces** that one rather than combining with it — so
+`uv run pytest -m integration` also re-enables the paid tests. Add
+`and not e2e_llm and not lifecycle` when you narrow by marker.
 
-**Issue**: API key error
-- **Solution**: Verify `.env` file exists with valid ANTHROPIC_API_KEY
+## Layout
 
-**Issue**: Import errors
-- **Solution**: Activate virtual environment, reinstall with `pip install -e .`
+| Directory | What lives there |
+|---|---|
+| `tests/core/` | Headless domain + orchestration (`tasks`, `conductor`, `prd`, `proof`, `git`, …) |
+| `tests/ui/` | FastAPI router tests, via `TestClient` over a fresh app |
+| `tests/cli/` | Typer commands, via `CliRunner` — in-process, no server |
+| `tests/adapters/` | LLM providers and the E2B sandbox |
+| `tests/unit/` | Narrow units that fit none of the above (e.g. the GitHub client) |
+| `tests/integration/` | Cross-module flows |
+| `tests/agents/` | Dependency resolution |
+| `tests/e2e/` | CLI end-to-end (`tests/e2e/cli`) and Playwright browser (`tests/e2e/*.spec.ts`) |
+| `tests/lifecycle/` | Full Think → Build → Prove loop against a real LLM |
 
-**Issue**: Dashboard doesn't update
-- **Solution**: Check WebSocket connection in browser DevTools, restart Status Server
+## Markers
 
----
+Registered in `pytest.ini`. The ones that change what runs:
 
-## Next Steps (Sprint 2)
+| Marker | Effect |
+|---|---|
+| `e2e_llm` | **Deselected by default.** Real Anthropic calls, and the fixtures `rmtree` `.codeframe/` inside an external project. Opt in with `-m e2e_llm`. |
+| `lifecycle` | **Deselected by default.** Real Anthropic calls, 10–30 minutes. Run via `scripts/lifecycle`, never directly. |
+| `slow`, `integration`, `edge_case` | Selection conveniences; all run by default. |
+| `v2` | Registered for back-compat and ad-hoc selection. **Not** a CI gate — anything non-e2e and non-lifecycle runs by default (#669). |
 
-After completing Sprint 1 manual testing:
-1. Document any critical bugs and fix before demo
-2. Prepare sprint demo showing working features
-3. Review Sprint 2 tasks: Socratic Discovery phase
-4. Plan Sprint 2 implementation starting with CLI foundation
+## Coverage
 
-**Sprint 1 Status**: COMPLETE ✅
-**Total Test Cases**: 111 automated + 10 manual test scenarios
-**Pass Rate**: 100%
-**Ready for Production**: Foundation components ready for Sprint 2 integration
+Gated, not decorative. [`.coveragerc`](.coveragerc) sets `fail_under = 80`, which `pytest --cov`
+enforces on the CI gate and which the README badge mirrors.
+
+```bash
+uv run pytest --cov=codeframe --cov-report=term
+```
+
+Note that `fail_under` applies to **any** run that asks for coverage, so measuring a
+subset (`pytest tests/core --cov=codeframe`) exits 1 on the threshold. That is stock
+`pytest-cov` behaviour, not a misconfiguration.
+
+## Real-LLM lifecycle tests
+
+These cost money and are not part of any automated gate. Run the CLI mode locally
+before opening a PR that touches the execution path:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+scripts/lifecycle --mode cli            # ~$0.50–1.00 with the default haiku model
+scripts/lifecycle --mode cli --dry-run  # show what would run, spend nothing
+```
+
+`--mode api` and `--mode web` **exit 3**: they are not implemented (#1068). They used
+to collect only skipped stubs and exit 0, which read as a pass.
+
+## Browser E2E
+
+[`tests/e2e/playwright.config.ts`](tests/e2e/playwright.config.ts) starts both servers itself (`uv uvicorn` for the
+backend, `next build && next start` for the frontend) and `global-setup.ts` seeds a
+workspace and a login user. You do not start anything by hand.
+
+```bash
+cd tests/e2e && npx playwright test
+```
+
+## Web UI
+
+```bash
+cd web-ui
+npm test              # Jest
+npm run lint          # eslint --max-warnings 0
+npm run build         # must succeed; the frontend-tests CI job enforces it
+```
+
+## Writing tests
+
+- **No mocking at integration boundaries.** Use a real SQLite workspace, a real git
+  repository, the real core modules. Substitute only what would spend money, spawn an
+  agent, or reach the network — and say so in a comment.
+- **Assert outcomes, not status codes.** A `201` from the commit endpoint means little;
+  reading the commit back out of `git log` means something.
+- **Give a destructive path a negative case too.** "Returns 400" and "did not corrupt
+  anything" are different claims.
+- **A new `/api/v2` router is protected by how it is mounted**, and by nothing else.
+  [`tests/ui/test_v2_auth_enforcement.py`](tests/ui/test_v2_auth_enforcement.py) asserts
+  the 401 responses, and a companion suite enumerates `app.routes` so a router mounted
+  without the auth dependency fails rather than shipping.
+- Tests run with `CODEFRAME_AUTH_REQUIRED=false` (set in [`tests/conftest.py`](tests/conftest.py)); opt back
+  in explicitly when auth is what you are testing.
+
+## Demoing against a sample project
+
+When verifying agent behaviour end to end against something like `cf-test/`, you are
+**observing the agent's work, not doing it**. Do not fix its errors or write code on its
+behalf — that is the data. Report what worked, what failed, and the final state against
+the acceptance criteria.

--- a/tests/test_root_docs_950.py
+++ b/tests/test_root_docs_950.py
@@ -1,0 +1,264 @@
+"""The root docs described a product that no longer exists (#950).
+
+`CONTRIBUTING.md` taught the dead v1 auth model — `db.user_has_project_access()`,
+`/api/projects/{id}`, `get_current_user` — and linked four paths that did not
+exist. The README's roadmap contradicted itself (PROVE and SHIP listed web gates,
+glitch capture and PR status tracking as pending while the Web UI section marked
+the same things shipped) and cited a version `pyproject.toml` disagreed with.
+`TESTING.md` was ~400 lines of Sprint-1 instructions importing modules that were
+deleted releases ago.
+
+AC5 asks for a link/import check that runs in CI. These are it: every relative
+link in a root doc must resolve, every module path a doc names must be importable,
+and the claims that drifted last time — version, coverage floor, roadmap
+consistency — are pinned so they cannot drift silently again.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The docs a first-time user or contributor actually opens.
+ROOT_DOCS = [
+    "README.md",
+    "CONTRIBUTING.md",
+    "TESTING.md",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "LICENSING.md",
+    "CLAUDE.md",
+]
+
+#: [text](target) — skip external URLs, mailto, and pure in-page anchors.
+LINK = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:|#)([^)]+)\)")
+
+#: A fenced ```python block.
+PY_BLOCK = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+#: `from codeframe.x.y import Z` / `import codeframe.x.y` inside one.
+IMPORT = re.compile(
+    r"^\s*(?:from\s+(codeframe[\w.]*)\s+import|import\s+(codeframe[\w.]*))", re.MULTILINE
+)
+
+
+def _links(doc: str) -> list[str]:
+    text = (REPO_ROOT / doc).read_text()
+    # Drop the fragment: a link to a heading resolves against the file.
+    return [m.split("#", 1)[0] for m in LINK.findall(text) if m.split("#", 1)[0]]
+
+
+class TestEveryRelativeLinkResolves:
+    """AC5. The four dead ones in CONTRIBUTING were `docs/architecture/`,
+    `docs/authentication.md`, `codeframe/providers/base.py` and
+    `codeframe/tasks/test_runner.py`."""
+
+    @pytest.mark.parametrize("doc", ROOT_DOCS)
+    def test_the_doc_has_links_to_check(self, doc: str):
+        """Guard against a vacuous pass: "all zero links resolve" is true."""
+        if doc in ("SECURITY.md", "CHANGELOG.md"):
+            pytest.skip("these legitimately link almost entirely externally")
+        if doc == "CLAUDE.md":
+            pytest.skip("its doc table uses backticked paths, covered below")
+        assert _links(doc), f"{doc} has no relative links — did the parser break?"
+
+    @pytest.mark.parametrize("doc", ROOT_DOCS)
+    def test_no_link_points_at_a_missing_path(self, doc: str):
+        broken = [t for t in _links(doc) if not (REPO_ROOT / t).exists()]
+
+        assert not broken, f"{doc} links to paths that do not exist: {broken}"
+
+
+class TestClaudeMdPathsResolve:
+    """CLAUDE.md's documentation table names paths in backticks rather than
+    markdown links, so the link check above cannot see them — and it is the file
+    an agent working in this repo is told to follow."""
+
+    def test_every_backticked_doc_path_exists(self):
+        text = (REPO_ROOT / "CLAUDE.md").read_text()
+        paths = set(re.findall(r"`(docs/[\w/]+\.md)`", text))
+
+        assert paths, "the doc table stopped parsing"
+        missing = [p for p in sorted(paths) if not (REPO_ROOT / p).exists()]
+        assert not missing, f"CLAUDE.md names docs that do not exist: {missing}"
+
+
+class TestEveryDocumentedImportResolves:
+    """AC5's other half. TESTING.md told contributors to run
+    `from codeframe.agents.providers.anthropic_provider import AnthropicProvider`
+    against a module deleted releases ago."""
+
+    @pytest.mark.parametrize("doc", ROOT_DOCS)
+    def test_every_codeframe_module_named_in_a_python_block_is_importable(
+        self, doc: str
+    ):
+        import importlib.util
+
+        text = (REPO_ROOT / doc).read_text()
+        missing = []
+        for block in PY_BLOCK.findall(text):
+            for from_mod, import_mod in IMPORT.findall(block):
+                module = from_mod or import_mod
+                try:
+                    if importlib.util.find_spec(module) is None:
+                        missing.append(module)
+                except (ImportError, ModuleNotFoundError, ValueError):
+                    missing.append(module)
+
+        assert not missing, f"{doc} imports modules that do not exist: {missing}"
+
+    def test_the_check_would_catch_a_deleted_module(self):
+        """The old TESTING.md's exact import. If this ever resolves, the guard
+        above is testing nothing."""
+        import importlib.util
+
+        with pytest.raises((ImportError, ModuleNotFoundError)):
+            importlib.util.find_spec("codeframe.agents.providers.anthropic_provider")
+
+
+class TestTheVersionAgrees:
+    def _pyproject_version(self) -> str:
+        with open(REPO_ROOT / "pyproject.toml", "rb") as fh:
+            return tomllib.load(fh)["project"]["version"]
+
+    def test_the_readme_beta_banner_matches_pyproject(self):
+        """It said 0.9.0 against a 0.9.1 package."""
+        readme = (REPO_ROOT / "README.md").read_text()
+
+        assert f"public beta (`{self._pyproject_version()}`)" in readme
+
+    def test_the_changelog_has_a_section_for_that_version(self):
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text()
+
+        assert f"## [{self._pyproject_version()}]" in changelog
+
+
+class TestTheRoadmapDoesNotContradictItself:
+    """PROVE and SHIP listed as pending exactly what the Web UI section listed as
+    shipped. A reader cannot tell which half is true."""
+
+    def _readme(self) -> str:
+        return (REPO_ROOT / "README.md").read_text()
+
+    @pytest.mark.parametrize(
+        "claim,component",
+        [
+            ("Run gates from the web UI", "web-ui/src/components/proof/GateRunPanel.tsx"),
+            ("Glitch capture web UI", "web-ui/src/components/proof/CaptureGlitchModal.tsx"),
+            (
+                "PR status tracking + CI check display in web UI",
+                "web-ui/src/components/review/PRStatusPanel.tsx",
+            ),
+        ],
+    )
+    def test_a_shipped_feature_is_not_still_listed_as_pending(
+        self, claim: str, component: str
+    ):
+        """Each pairs a roadmap line with the file that proves it shipped, so the
+        checkbox cannot be flipped back without deleting the component."""
+        assert (REPO_ROOT / component).exists(), (
+            f"{component} is gone — the roadmap claim for {claim!r} needs revisiting"
+        )
+        assert f"- [ ] {claim}" not in self._readme(), (
+            f"{claim!r} is marked pending although {component} ships it"
+        )
+
+    def test_the_req_detail_route_exists_as_the_roadmap_claims(self):
+        assert (REPO_ROOT / "web-ui/src/app/proof/[req_id]").is_dir()
+
+    def test_every_checkbox_is_one_of_the_two_valid_forms(self):
+        """A typo'd `- [X]` or `- []` silently renders as plain text, which is
+        how a stale entry survives review."""
+        # `- [` followed by exactly one character and `]` is a checkbox; a
+        # markdown link list item (`- [Vision](docs/VISION.md)`) is not, and
+        # matching those was this test's own first bug.
+        bad = [
+            line
+            for line in self._readme().splitlines()
+            if re.match(r"^\s*-\s*\[.\]", line) and not re.match(r"^\s*- \[[ x]\] ", line)
+        ]
+
+        assert not bad, f"malformed roadmap checkboxes: {bad}"
+
+
+class TestContributingTeachesTheRealAuthModel:
+    def _contributing(self) -> str:
+        return (REPO_ROOT / "CONTRIBUTING.md").read_text()
+
+    @pytest.mark.parametrize(
+        "dead",
+        [
+            "user_has_project_access",
+            "get_current_user",
+            "/api/projects/{project_id}",
+            "db.get_project(",
+        ],
+    )
+    def test_the_v1_auth_model_is_gone(self, dead: str):
+        assert dead not in self._contributing(), (
+            f"CONTRIBUTING still teaches {dead!r}, which no longer exists"
+        )
+
+    @pytest.mark.parametrize(
+        "name", ["require_auth", "CODEFRAME_AUTH_REQUIRED", "require_method_scope"]
+    )
+    def test_the_real_model_is_documented(self, name: str):
+        assert name in self._contributing()
+
+    @pytest.mark.parametrize(
+        "name", ["require_auth", "require_method_scope", "require_scope"]
+    )
+    def test_each_documented_symbol_actually_exists(self, name: str):
+        """Naming the right thing is only half of it — the names have to be real."""
+        from codeframe.auth import dependencies
+
+        assert hasattr(dependencies, name)
+
+    def test_the_env_switch_it_names_is_the_one_the_code_reads(self):
+        source = (REPO_ROOT / "codeframe/auth/dependencies.py").read_text()
+
+        assert "CODEFRAME_AUTH_REQUIRED" in source
+
+
+class TestTestingMdDescribesTheCurrentSuite:
+    def _testing(self) -> str:
+        return (REPO_ROOT / "TESTING.md").read_text()
+
+    def test_the_sprint_1_checklist_is_gone(self):
+        assert "Sprint 1 Manual Test Checklist" not in self._testing()
+
+    def test_it_names_the_command_ci_actually_runs(self):
+        text = self._testing()
+
+        assert "uv run pytest" in text
+        assert "uv run ruff check ." in text
+        assert "npm run build" in text
+
+    def test_every_test_directory_it_lists_exists(self):
+        listed = re.findall(r"`(tests/[\w/]+)/`", self._testing())
+
+        assert listed, "the layout table stopped parsing"
+        missing = [d for d in listed if not (REPO_ROOT / d).is_dir()]
+        assert not missing, f"TESTING.md lists directories that do not exist: {missing}"
+
+    def test_every_marker_it_lists_is_registered_in_pytest_ini(self):
+        ini = (REPO_ROOT / "pytest.ini").read_text()
+        listed = re.findall(r"^\| `(\w+)`", self._testing(), re.MULTILINE)
+
+        assert listed, "the marker table stopped parsing"
+        for marker in listed:
+            assert f"\n    {marker}:" in ini, f"{marker} is not a registered marker"
+
+    def test_the_coverage_floor_it_quotes_matches_coveragerc(self):
+        import configparser
+
+        parser = configparser.ConfigParser()
+        parser.read(REPO_ROOT / ".coveragerc")
+        threshold = parser.getint("report", "fail_under")
+
+        assert f"fail_under = {threshold}" in self._testing()


### PR DESCRIPTION
Closes #950.

The files a first-time user or contributor opens described something that does not exist.

## CONTRIBUTING.md taught a dead auth model (AC1)

It documented `get_current_user`, `db.user_has_project_access()` and `/api/projects/{id}` — **none of which are in the codebase** — and linked four paths that are not either: `docs/architecture/`, `docs/authentication.md`, `codeframe/providers/base.py`, `codeframe/tasks/test_runner.py`.

Rewritten around what actually enforces auth today:

- router-level `dependencies=_AUTH` in `server.py` — **a new v2 router is protected by how it is mounted, and by nothing else**, which is the one thing a contributor needs to know
- `require_auth` accepting a JWT *or* an `X-API-Key`, gated by `CODEFRAME_AUTH_REQUIRED` read **at request time**
- real scopes derived from the user row (#898), with `require_scope(SCOPE_ADMIN)` shown on the actual merge handler
- `get_v2_workspace` as the tenancy boundary rather than hand-rolled ownership checks
- single-use stream tickets instead of a JWT in a URL (#745)
- how to test a protected endpoint, given the suite runs auth-off by default

The provider and adapter sections now point at `codeframe/adapters/llm/base.py` and `codeframe/core/adapters/agent_adapter.py`, which exist.

## The README contradicted itself (AC2)

PROVE and SHIP listed as *pending* exactly what the Web UI section listed as *shipped*. A reader cannot tell which half is true.

Checked each against the code before flipping it:

| Roadmap line | Proof it shipped |
|---|---|
| Run gates from the web UI | `components/proof/GateRunPanel.tsx`, `RunHistoryPanel.tsx`, `GateEvidencePanel.tsx` |
| Glitch capture web UI | `components/proof/CaptureGlitchModal.tsx` |
| Glitch capture form and REQ detail view | `app/proof/[req_id]/` |
| PR status tracking + CI check display | `components/review/PRStatusPanel.tsx` (renders `data.ci_checks`) |

Also `0.9.0` → `0.9.1` to match `pyproject.toml`, and the `DATABASE_PATH` default from *"in-memory SQLite"* to `./.codeframe/state.db`, which is what `get_db_for_cli` actually does.

## CHANGELOG listed 1 of 212 commits since v0.9.1 (AC3)

`SECURITY.md` supports only the latest release, so that omission mattered most for the security work. The new Unreleased section leads with it and flags the ones that **change defaults and need configuration on an existing deploy**:

- `WORKSPACE_ROOT` fails closed — the server refuses to start when auth is enforced and no allowlist is set (#896)
- bootstrap `/auth/register` requires an out-of-band secret; **required for any networked deploy** (#897)
- scopes are real, so `admin` genuinely refuses a non-superuser session (#898)
- untrusted-repo boundaries: hooks, `llm.base_url`, `.env` (#905, #903, #904, #895)
- subprocess containment and a sandboxed agent `$HOME` (#906, #907, #899, #721, #996)
- stream tickets (#745), dispatch-time webhook SSRF vetting (#746), credential handling (#772, #790, #718)

Phases 5.1–5.5, the PROOF9 merge gate, worktree isolation and the Playwright rewrite are summarized alongside, with the Changed section covering #946 and #948.

## TESTING.md (AC4)

~400 lines of Sprint-1 checklist that imported `codeframe.agents.providers.anthropic_provider` and told you to start the server with a long-renamed command. Replaced with the current suite: the one gate command, the directory layout, which markers change what runs and why `-m` **replaces** rather than combines, the enforced coverage floor (and that it bites on subset runs), and how to run the lifecycle and Playwright suites.

## The link/import check (AC5)

`tests/test_root_docs_950.py`, in the default gate — 43 tests:

- every relative link in a root doc resolves
- every `codeframe.*` module named in a fenced ```python block is importable
- the README version equals `pyproject.toml`'s
- the coverage floor TESTING.md quotes equals `.coveragerc`'s
- every test directory and every marker TESTING.md lists actually exists
- the roadmap checks **pair each claim with the component that proves it**, so a box cannot be flipped back to pending without deleting the file
- CLAUDE.md's doc table is checked separately, since it uses backticked paths the link regex cannot see

It carries its own guards: a non-empty-links assertion per doc (*all of zero links resolve*), a checkbox-syntax check (a typo'd `- [X]` renders as plain text, which is how stale entries survive review), and `test_the_check_would_catch_a_deleted_module`, which asserts the import check still rejects the exact module the old TESTING.md named.

**19 of the 43 fail against the pre-fix tree.**

## Known limitations

- The link check only sees markdown links. Backticked paths are checked in CLAUDE.md's doc table and TESTING.md's layout/marker tables, but not exhaustively everywhere.
- `SECURITY.md` and `CHANGELOG.md` are skipped by the non-empty-links guard: they legitimately link almost entirely externally. Broken *relative* links in them are still caught.
- Only root docs are covered. `docs/**` is untouched here.
- The Unreleased section summarizes 212 commits by theme rather than enumerating them; the dependency bumps in particular are left to the commit log.
