### PR TITLE
fix(ci): give claude-review the OIDC permission it dies without (#1011)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,8 +17,32 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      # Required (#1011). The action exchanges a GitHub OIDC token for the
+      # installation token it posts the review with; without this the job dies
+      # ~15s in with "Could not fetch an OIDC token", on every PR, regardless of
+      # content. It is not a required check, so it sat red indefinitely and the
+      # repo quietly lost one of its two bot reviewers.
+      id-token: write
 
     steps:
+      - name: Verify the review credential is present
+        # Distinguishes "no credential" from "the review ran and found nothing"
+        # (#1011 AC3). Without this, both look like a red X on the PR.
+        env:
+          OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$OAUTH_TOKEN" ]; then
+            echo "::error title=claude-review is not configured::CLAUDE_CODE_OAUTH_TOKEN is unset or empty. This is a repository configuration problem, not a finding about this PR."
+            {
+              echo "## claude-review could not run"
+              echo
+              echo "\`CLAUDE_CODE_OAUTH_TOKEN\` is unset or empty, so no review was attempted."
+              echo "**This says nothing about this PR.** Rotate the secret in repository settings."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "✅ Review credential present"
+
       - name: Calculate total changes
         id: calc
         run: |
@@ -86,4 +110,26 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+      - name: Explain a failed review
+        # A red X that everyone learns to ignore is worse than no check (#1011).
+        # Name the two causes so the next reader does not have to open the log.
+        if: failure() && steps.claude-review.outcome == 'failure'
+        run: |
+          {
+            echo "## claude-review failed"
+            echo
+            echo "This is a **job failure**, not a review finding — no feedback was posted."
+            echo
+            echo "Most likely causes, in order:"
+            echo "1. **OIDC unavailable.** The job needs \`id-token: write\`; if that"
+            echo "   permission was removed, the action dies ~15s in (#1011)."
+            echo "2. **Credential rejected.** \`CLAUDE_CODE_OAUTH_TOKEN\` is set but"
+            echo "   expired or revoked — the preflight step only checks it is non-empty."
+            echo
+            echo "Neither is a reason to hold this PR. It is not a required check;"
+            echo "fix the repository configuration instead of re-running."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=claude-review job failure::The review did not run. See the job summary — this is a configuration problem, not a finding about this PR."
+
 

--- a/tests/test_claude_review_workflow_1011.py
+++ b/tests/test_claude_review_workflow_1011.py
@@ -1,0 +1,143 @@
+"""The claude-review job failed on every PR for want of one permission (#1011).
+
+It died ~15 seconds in with
+
+    Could not fetch an OIDC token. Did you remember to add `id-token: write`
+    to your workflow permissions?
+
+on every PR regardless of content — reproduced identically on two unrelated PRs
+opened minutes apart. The action exchanges a GitHub OIDC token for the
+installation token it posts with, and the job's `permissions:` block granted
+only reads.
+
+Because it is not a required status check it never blocked a merge, which is the
+actual damage: the repo silently lost one of its two bot reviewers behind a red X
+everyone learned to ignore.
+
+These tests pin the permission and the two diagnostics that make a
+configuration failure distinguishable from a review that found nothing.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude-code-review.yml"
+
+
+@pytest.fixture(scope="module")
+def job() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]["claude-review"]
+
+
+def _step(job: dict, name: str) -> dict:
+    for step in job["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r}")
+
+
+class TestOidcIsAvailableToTheJob:
+    """AC2. The error message names the fix; the log confirms the credential
+    itself was present (`CLAUDE_CODE_OAUTH_TOKEN: ***`), which rules out the
+    other candidate cause."""
+
+    def test_the_job_can_mint_an_oidc_token(self, job):
+        assert job["permissions"].get("id-token") == "write", (
+            "without id-token: write the action cannot fetch an OIDC token and "
+            "the job fails ~15s in on every PR"
+        )
+
+    def test_nothing_else_was_widened_to_get_there(self, job):
+        """A review bot needs no write access to the repository. Granting
+        `contents: write` to fix an auth error would be a much worse trade."""
+        perms = job["permissions"]
+
+        assert perms["contents"] == "read"
+        assert perms["pull-requests"] == "read"
+        assert perms["issues"] == "read"
+
+    def test_the_action_is_still_sha_pinned(self, job):
+        """The version is immutable, which is how the issue ruled out an action
+        change and left the permissions block as the cause."""
+        uses = _step(job, "Run Claude Code Review")["uses"]
+
+        ref = uses.split("@", 1)[1]
+        assert len(ref) == 40 and all(c in "0123456789abcdef" for c in ref), (
+            f"the action is pinned to {ref!r}, not an immutable SHA"
+        )
+
+
+class TestAConfigurationFailureIsDistinguishable:
+    """AC3. A red X that means "the secret expired" and a red X that means
+    "the reviewer disliked your code" must not look the same."""
+
+    def test_a_missing_credential_is_caught_before_the_action_runs(self, job):
+        step = _step(job, "Verify the review credential is present")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in yaml.safe_dump(step["env"])
+        assert "exit 1" in step["run"]
+
+    def test_it_says_the_failure_is_not_about_the_pr(self, job):
+        step = _step(job, "Verify the review credential is present")
+
+        assert "not a finding about this PR" in step["run"]
+
+    def test_the_preflight_runs_before_the_review(self, job):
+        names = [s.get("name") for s in job["steps"]]
+
+        assert names.index("Verify the review credential is present") < names.index(
+            "Run Claude Code Review"
+        )
+
+    def test_the_preflight_is_unconditional(self, job):
+        """The review steps are gated on PR size. The credential check must not
+        be, or a small PR would report success having checked nothing."""
+        step = _step(job, "Verify the review credential is present")
+
+        assert "if" not in step
+
+    def test_a_failed_review_explains_itself(self, job):
+        step = _step(job, "Explain a failed review")
+
+        assert "GITHUB_STEP_SUMMARY" in step["run"]
+        assert "not a review finding" in step["run"]
+
+    def test_the_explainer_only_fires_on_a_real_review_failure(self, job):
+        """`if: failure()` alone would also fire when the preflight failed,
+        printing the wrong diagnosis for the case it already explained."""
+        condition = _step(job, "Explain a failed review")["if"]
+
+        assert "failure()" in condition
+        assert "steps.claude-review.outcome == 'failure'" in condition
+
+    def test_the_review_step_has_the_id_that_condition_references(self, job):
+        assert _step(job, "Run Claude Code Review")["id"] == "claude-review"
+
+
+class TestTheJobStillTriggersOnCodeChanges:
+    """Guard on the premise: none of the above matters if the job stops running.
+    `paths-ignore` covers `.github/**`, so a workflow-only PR does not trigger
+    it — this PR carries this test file precisely so the fix is exercised."""
+
+    @pytest.fixture(scope="class")
+    def workflow(self) -> dict:
+        # `on:` parses as the boolean True under YAML 1.1.
+        parsed = yaml.safe_load(WORKFLOW.read_text())
+        return parsed.get("on", parsed.get(True))
+
+    def test_it_runs_on_pull_requests(self, workflow):
+        assert set(workflow["pull_request"]["types"]) == {"opened", "synchronize"}
+
+    def test_python_and_typescript_changes_are_not_ignored(self, workflow):
+        ignored = workflow["pull_request"]["paths-ignore"]
+
+        assert not any(pattern.endswith((".py", ".ts", ".tsx")) for pattern in ignored)
+
+    def test_workflow_only_changes_are_ignored(self, workflow):
+        """Which is why this file exists — so the fix gets a real run."""
+        assert ".github/**" in workflow["pull_request"]["paths-ignore"]


### PR DESCRIPTION
Closes #1011.

## Root cause: candidate 2, and the action says so itself

```
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to add
`id-token: write` to your workflow permissions?
Operation failed after 3 attempts
##[error]Action failed with error: Could not fetch an OIDC token.
```

**Not candidate 1.** The same log shows `CLAUDE_CODE_OAUTH_TOKEN: ***` — the credential is present and is not the problem. The action exchanges a GitHub OIDC token for the installation token it posts the review with, and the job's `permissions:` block granted only reads.

Added `id-token: write`, **and nothing else**. A review bot needs no write access to the repository; widening `contents` or `pull-requests` to make an auth error go away would be a far worse trade, so there's a test pinning that they stayed `read`.

## The red X that everyone learned to ignore

It is not a required status check, so it never blocked a merge — which is the actual damage. The repo silently lost one of its two bot reviewers, and a failing check nobody reads is worse than no check.

AC3 asks for a credential problem to be distinguishable from a review that found nothing. Two diagnostics:

**A preflight step**, deliberately **unconditional** — the review steps are gated on PR size (5+ files or 20+ lines), so a small PR would otherwise report success having checked nothing:

```
::error title=claude-review is not configured::CLAUDE_CODE_OAUTH_TOKEN is unset
or empty. This is a repository configuration problem, not a finding about this PR.
```

**An on-failure step** that writes both candidate causes to the job summary and states plainly that no feedback was posted and the PR should not be held. Scoped to `steps.claude-review.outcome == 'failure'` rather than a bare `failure()`, so it cannot print the wrong diagnosis on top of the preflight's own.

## Tests

13, in the default gate. They pin the permission, that nothing else was widened, that the action is **still SHA-pinned** (immutability is how the issue ruled out an action-side change and left the permissions block as the cause), the preflight's ordering and unconditionality, and the explainer's guard condition.

**7 of the 13 fail against the pre-fix tree.**

## AC1 is verified by this PR, not asserted in code

`paths-ignore` covers `.github/**`, so a workflow-only PR does not trigger the job at all. The test file is what makes this PR exercise the fix — **check this PR's own `claude-review` run**: it either posts a review comment (AC1 met) or fails with one of the two now-explicit messages.

If it still fails after this, that is positive evidence for candidate 1 after all — an expired or revoked token, or the GitHub App not installed — and the new job summary will say which. I will report that outcome here rather than closing on the assumption.

## Known limitations

- The preflight only checks the secret is **non-empty**. An expired-but-present token still reaches the action and fails there; that is what the on-failure explainer is for.
- Making the job a required check is deliberately not done here. That is a branch-protection change, and it should only happen once the job is observed green.
