### PR TITLE
feat(core): make the cost cap bind on the plan engine too (#1004)

### DIFF
--- a/codeframe/core/agent.py
+++ b/codeframe/core/agent.py
@@ -25,6 +25,11 @@ from codeframe.core import blockers, events
 from codeframe.core.agent_env import build_agent_env
 from codeframe.core.path_safety import is_path_safe
 from codeframe.core.context import ContextLoader, TaskContext
+from codeframe.core.cost_tracker import (
+    CostTracker,
+    load_prior_task_cost,
+    resolve_cost_cap,
+)
 from codeframe.core.events import EventType
 from codeframe.core.executor import Executor, ExecutionStatus, StepResult
 from codeframe.core.fix_tracker import EscalationDecision, FixAttemptTracker, FixOutcome
@@ -298,6 +303,13 @@ class Agent:
         self.context: Optional[TaskContext] = None
         self.executor: Optional[Executor] = None
 
+        # Per-task spend accounting (#1004). The plan engine had none, so
+        # `max_cost_usd` — honoured by the ReAct engine since #911 — had nothing
+        # to compare against here and could never fire. Resolved once per run;
+        # `prior_cost_usd` is filled in when the task id is known so answering a
+        # blocker and resuming cannot hand the task a fresh full budget.
+        self.cost_tracker = CostTracker(cap_usd=resolve_cost_cap(workspace.repo_path))
+
         # Fix attempt tracking for loop prevention and escalation
         self.fix_tracker = FixAttemptTracker()
 
@@ -341,6 +353,13 @@ class Agent:
             Final AgentState
         """
         self.state = AgentState(task_id=task_id, status=AgentStatus.IDLE)
+        # "Max cost per TASK" — so spend from earlier runs of this same task
+        # counts. Without it, answering a blocker and resuming would grant a
+        # fresh full budget every time (#911 review, #1004).
+        if self.cost_tracker.cap_usd is not None:
+            self.cost_tracker.prior_cost_usd = load_prior_task_cost(
+                self.workspace, task_id
+            )
         self._emit_event("agent_started", {"task_id": task_id})
 
         try:
@@ -389,6 +408,13 @@ class Agent:
             Final AgentState
         """
         self.state = state
+        # Resume is exactly the bypass the prior-cost lookup exists to close: a
+        # blocked task answered and resumed would otherwise start again at $0
+        # spent, so a cap could be defeated by clicking resume (#911, #1004).
+        if self.cost_tracker.cap_usd is not None:
+            self.cost_tracker.prior_cost_usd = load_prior_task_cost(
+                self.workspace, task_id
+            )
         self._emit_event("agent_resumed", {"task_id": task_id, "step": state.current_step})
 
         # Reload context
@@ -432,6 +458,7 @@ class Agent:
             repo_path=self.workspace.repo_path,
             dry_run=self.dry_run,
             event_publisher=self.event_publisher,
+            cost_tracker=self.cost_tracker,
         )
 
         consecutive_failures = 0
@@ -895,6 +922,8 @@ class Agent:
                 cwd=self.workspace.repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 env=build_agent_env(self.workspace.repo_path),
             )
@@ -962,7 +991,7 @@ class Agent:
             config_path = self.workspace.repo_path / config_name
             if config_path.exists():
                 try:
-                    content = config_path.read_text()[:2000]  # Limit size
+                    content = config_path.read_text(encoding="utf-8", errors="replace")[:2000]  # Limit size
                     sections.append(f"## {config_name}")
                     sections.append("```")
                     sections.append(content)
@@ -1254,7 +1283,7 @@ IMPORTANT:
                         elif not old_code:
                             self._debug_log(f"No old_code for {file_path}", level="WARN")
                         else:
-                            content = file_path.read_text()
+                            content = file_path.read_text(encoding="utf-8", errors="replace")
                             if old_code not in content:
                                 self._debug_log(
                                     f"old_code not found in {file_path}",
@@ -1321,6 +1350,8 @@ IMPORTANT:
                                     cwd=self.workspace.repo_path,
                                     capture_output=True,
                                     text=True,
+                                    encoding="utf-8",
+                                    errors="replace",
                                     timeout=120,
                                     # LLM-authored argv (#907).
                                     env=build_agent_env(self.workspace.repo_path),

--- a/codeframe/core/agent.py
+++ b/codeframe/core/agent.py
@@ -473,6 +473,39 @@ class Agent:
         while self.state.current_step < len(self.state.plan.steps):
             step = self.state.plan.steps[self.state.current_step]
 
+            # Stop the RUN, not just the step (#1004 review). Executor refuses a
+            # capped step by returning FAILED — but FAILED is the trigger for
+            # self-correction, which makes up to MAX_SELF_CORRECTION_ATTEMPTS
+            # more LLM calls on the stepped-up CORRECTION model plus a blocker
+            # question, and then the loop advances and repeats. So the cap was
+            # actively CAUSING spend. Checked here, ahead of the step, it ends
+            # the run instead. BLOCKED rather than FAILED, matching ReactAgent:
+            # the work is not wrong, it needs a human decision.
+            cap_message = self.cost_tracker.cap_message()
+            if cap_message:
+                self._debug_log(cap_message, level="WARNING", always=True)
+                self._emit_event("cost_cap_exceeded", {
+                    "step": step.index,
+                    "message": cap_message,
+                })
+                # A real blocker row, not just in-memory state: a run that
+                # stops for a spend cap must be visible to `cf blocker list`
+                # and to the web UI, or it looks like a silent hang.
+                blocker = blockers.create(
+                    self.workspace,
+                    question=cap_message,
+                    task_id=self.state.task_id or None,
+                    created_by="agent",
+                )
+                self.state.status = AgentStatus.BLOCKED
+                self.state.blocker = BlockerInfo(
+                    reason="Cost cap reached",
+                    question=blocker.question,
+                    context=f"Step {step.index}: {step.description}",
+                    step_index=step.index,
+                )
+                return
+
             self._debug_log(
                 f"=== STEP {step.index} ({step.type.value}) ===",
                 level="INFO",
@@ -1214,6 +1247,9 @@ IMPORTANT:
                 max_tokens=4096,
                 temperature=0.0,
             )
+            # Counts toward the cap (#1004): these calls used to be
+            # invisible to it, so a capped run kept spending here.
+            self.cost_tracker.record_response(response, call_type="diagnostic_fix")
 
             # Parse the fix plan
             import json
@@ -1531,6 +1567,9 @@ Your decision:"""
                 max_tokens=256,
                 temperature=0.0,
             )
+            # Counts toward the cap (#1004): these calls used to be
+            # invisible to it, so a capped run kept spending here.
+            self.cost_tracker.record_response(response, call_type="tactical_resolution")
 
             resolution = response.strip()
             self._emit_event(
@@ -1616,6 +1655,12 @@ Your decision:"""
         Returns:
             New StepResult if correction was attempted, None if can't correct
         """
+        # A cap the correction loop ignores is not a cap (#911 review, #1004).
+        # This loop is the expensive one: it steps UP to the CORRECTION model
+        # and runs up to MAX_SELF_CORRECTION_ATTEMPTS times per failed step.
+        if self.cost_tracker.cap_message():
+            return None
+
         self._emit_event("self_correction_started", {
             "step": step.index,
             "attempt": attempt,
@@ -1676,6 +1721,9 @@ Respond with ONLY the corrected code/content, no explanation."""
                 max_tokens=4000,
                 temperature=0.0,
             )
+            # Counts toward the cap (#1004): these calls used to be
+            # invisible to it, so a capped run kept spending here.
+            self.cost_tracker.record_response(response, call_type="self_correction")
 
             corrected_details = response.content.strip()
 
@@ -1979,6 +2027,9 @@ Generate a single question OR a RESOLVE_AUTONOMOUSLY/TECHNICAL_FIX directive:"""
                 max_tokens=300,
                 temperature=0.0,
             )
+            # Counts toward the cap (#1004): these calls used to be
+            # invisible to it, so a capped run kept spending here.
+            self.cost_tracker.record_response(response, call_type="blocker_question")
             return response.content.strip()
         except Exception:
             # Fallback to generic question

--- a/codeframe/core/cost_tracker.py
+++ b/codeframe/core/cost_tracker.py
@@ -1,0 +1,247 @@
+"""Per-task spend accounting and the cost cap (#911, #1004).
+
+`max_cost_usd` was honoured only by the built-in ReAct engine. The plan engine
+(`--engine plan`) had no token accounting at all, so there was nothing to compare
+a cap against: a user on that engine set a $5 cap and got no cost limiting, with
+no way to tell an inert control from a working one — the exact complaint #911
+was filed about, one engine over.
+
+This module is that engine's missing half, extracted from `ReactAgent` rather
+than reimplemented so the two cannot drift. It is headless: no FastAPI, no I/O
+beyond reading the workspace config.
+
+Delegated adapters (`--engine claude-code|codex|opencode|kilocode`) are
+deliberately **not** covered. The external CLI does its own spending and reports
+no usage back, so CodeFRAME cannot observe what a run cost. A cap that silently
+binds nothing is the defect; `covers_engine()` states the boundary in code so
+callers can surface it instead of pretending.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+#: Engines whose LLM calls go through our own provider, so tokens are visible.
+#: Everything else spends inside a subprocess we cannot meter.
+METERED_ENGINES = frozenset({"react", "plan", "builtin"})
+
+
+def covers_engine(engine: str) -> bool:
+    """Whether a cost cap can actually bind for ``engine``.
+
+    False for the delegated adapters. Callers should say so rather than show a
+    limit that cannot fire.
+    """
+    return (engine or "").strip().lower() in METERED_ENGINES
+
+
+def resolve_cost_cap(repo_path: Path) -> Optional[float]:
+    """The configured per-task spend cap, or None when unset.
+
+    Read from the same ``.codeframe/config.yaml`` the Settings page writes.
+    """
+    from codeframe.core.config import load_environment_config
+
+    try:
+        env_config = load_environment_config(repo_path)
+    except Exception as exc:  # pragma: no cover - config read is best effort
+        logger.warning("Could not read the cost cap: %s", exc)
+        return None
+
+    cap = getattr(env_config, "max_cost_usd", None) if env_config else None
+    if cap is None:
+        return None
+    try:
+        cap = float(cap)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring non-numeric max_cost_usd: %r", cap)
+        return None
+    # 0 would stop before the first call; treat it as "no cap" rather than
+    # bricking every run, and let validation reject negatives upstream.
+    return cap if cap > 0 else None
+
+
+class CostCapExceeded(RuntimeError):
+    """Raised when a spending loop must stop. Carries the user-facing reason."""
+
+
+class CostTracker:
+    """Accumulates token usage and answers "may I make another call?".
+
+    ``prior_cost_usd`` is spend already recorded against this task by earlier
+    runs. Without it, answering a blocker and resuming would hand the task a
+    fresh full budget every time — a cap trivially bypassed by clicking resume
+    (#911 review).
+    """
+
+    def __init__(
+        self,
+        cap_usd: Optional[float] = None,
+        prior_cost_usd: float = 0.0,
+    ) -> None:
+        self.cap_usd = cap_usd
+        self.prior_cost_usd = prior_cost_usd
+        self.records: list[dict] = []
+
+    # -- accumulation ---------------------------------------------------
+
+    def record(
+        self,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        call_type: str = "task_execution",
+    ) -> None:
+        self.records.append(
+            {
+                "model": model or "",
+                "input_tokens": int(input_tokens or 0),
+                "output_tokens": int(output_tokens or 0),
+                "call_type": call_type,
+            }
+        )
+
+    def record_response(self, response, call_type: str = "task_execution") -> None:
+        """Record an ``LLMResponse`` directly — the common case."""
+        self.record(
+            model=getattr(response, "model", "") or "",
+            input_tokens=getattr(response, "input_tokens", 0) or 0,
+            output_tokens=getattr(response, "output_tokens", 0) or 0,
+            call_type=call_type,
+        )
+
+    # -- measurement ----------------------------------------------------
+
+    @property
+    def total_tokens(self) -> tuple[int, int]:
+        return (
+            sum(r["input_tokens"] for r in self.records),
+            sum(r["output_tokens"] for r in self.records),
+        )
+
+    def models_used(self) -> set[str]:
+        return {r["model"] for r in self.records}
+
+    def estimate_cost(self) -> float:
+        """USD across the accumulated records. 0.0 on any error."""
+        try:
+            from codeframe.lib.metrics_tracker import MetricsTracker
+
+            total = 0.0
+            for record in self.records:
+                cost = MetricsTracker.calculate_cost(
+                    record["model"], record["input_tokens"], record["output_tokens"]
+                )
+                # None = unpriced; skip rather than adding 0.0. Whether anything
+                # was unpriced is asked separately, by has_unpriced_records().
+                if cost is not None:
+                    total += cost
+            return round(total, 6)
+        except Exception:
+            return 0.0
+
+    def has_unpriced_records(self) -> bool:
+        """True when any recorded call used a model with no pricing data.
+
+        Asked directly rather than inferred from a $0 outcome (#932): a
+        deployment can legitimately price a local model at 0/0 via
+        CODEFRAME_MODEL_PRICING, and "spent nothing" would then read as "cannot
+        measure" and abort a correctly-measured free run.
+        """
+        try:
+            from codeframe.lib.metrics_tracker import MetricsTracker
+
+            return any(
+                MetricsTracker.calculate_cost(
+                    r["model"], r["input_tokens"], r["output_tokens"]
+                )
+                is None
+                for r in self.records
+            )
+        except Exception:
+            return False
+
+    # -- the gate -------------------------------------------------------
+
+    def cap_message(
+        self,
+        spent: Optional[float] = None,
+        unpriced: Optional[bool] = None,
+    ) -> Optional[str]:
+        """Why spending must stop, or None to continue.
+
+        The single place any spending loop asks permission. A loop that skips it
+        — a verification/self-correction retry, say — is not capped at all
+        (#911 review).
+
+        ``spent`` and ``unpriced`` are the measurements. They are parameters so
+        a caller that already has them (or that exposes its own overridable
+        accessors, as ``ReactAgent`` does) supplies them instead of this object
+        recomputing — the DECISION stays in one place, which is the part that
+        must not drift. Omitted, they are measured from these records.
+        """
+        cap = self.cap_usd
+        if cap is None:
+            return None
+
+        if unpriced is None:
+            unpriced = self.has_unpriced_records()
+        # A cap we cannot measure is not a cap: an unpriced model keeps the
+        # running total at $0.00 forever and the guard never fires — the same
+        # silently-inert control, one layer down. Refuse before spending.
+        if unpriced:
+            return (
+                f"A cost cap of ${cap:.2f} is configured, but spend cannot be "
+                f"measured for {', '.join(sorted(self.models_used())) or 'this model'} "
+                "— no pricing data. Remove the cap, or use a model with known pricing."
+            )
+
+        if spent is None:
+            spent = self.prior_cost_usd + self.estimate_cost()
+        if spent >= cap:
+            return (
+                f"Estimated spend ${spent:.4f} reached the configured cap of "
+                f"${cap:.2f}. Raise 'Max cost per task (USD)' in Settings to continue."
+            )
+        return None
+
+    def check(self) -> None:
+        """Raise :class:`CostCapExceeded` when spending must stop."""
+        message = self.cap_message()
+        if message:
+            raise CostCapExceeded(message)
+
+
+def load_prior_task_cost(workspace, task_id: str) -> float:
+    """Spend already recorded against ``task_id`` by earlier runs.
+
+    The same query ``ReactAgent._load_prior_task_cost`` uses — the repository on
+    a direct connection to the per-workspace db, which is where
+    ``_persist_token_usage`` writes. Best effort: an unreadable row means "no
+    prior spend" rather than blocking the run.
+    """
+    import sqlite3
+
+    conn = None
+    try:
+        from codeframe.platform_store.repositories.token_repository import (
+            TokenRepository,
+        )
+
+        conn = sqlite3.connect(str(workspace.db_path))
+        summary = TokenRepository(sync_conn=conn).get_task_token_summary(task_id)
+        return float(summary.get("total_cost_usd") or 0.0)
+    except Exception as exc:  # pragma: no cover - accounting must not block a run
+        logger.debug("Could not read prior spend for task %s: %s", task_id, exc)
+        return 0.0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/codeframe/core/executor.py
+++ b/codeframe/core/executor.py
@@ -30,6 +30,7 @@ from codeframe.core.dangerous_commands import (  # noqa: F401
 )
 
 if TYPE_CHECKING:
+    from codeframe.core.cost_tracker import CostTracker
     from codeframe.core.streaming import EventPublisher
 
 
@@ -185,6 +186,7 @@ class Executor:
         dry_run: bool = False,
         command_timeout: int = 60,
         event_publisher: Optional["EventPublisher"] = None,
+        cost_tracker: Optional["CostTracker"] = None,
     ):
         """Initialize the executor.
 
@@ -194,13 +196,21 @@ class Executor:
             dry_run: If True, don't actually make changes
             command_timeout: Timeout for shell commands in seconds
             event_publisher: Optional EventPublisher for streaming execution events
+            cost_tracker: Optional per-task spend accounting (#1004). Omitted,
+                the executor records usage into a tracker with no cap, so the
+                accounting is always there and only the *limit* is opt-in.
         """
+        from codeframe.core.cost_tracker import CostTracker as _CostTracker
+
         self.llm = llm_provider
         self.repo_path = Path(repo_path)
         self.dry_run = dry_run
         self.command_timeout = command_timeout
         self.changes: list[FileChange] = []
         self.event_publisher = event_publisher
+        # The plan engine had NO token accounting at all (#1004), so a cost cap
+        # had nothing to compare against and could never fire.
+        self.cost_tracker = cost_tracker or _CostTracker()
 
     def execute_plan(
         self,
@@ -263,6 +273,19 @@ class Executor:
             StepResult with execution outcome
         """
         start_time = datetime.now(timezone.utc)
+
+        # Ask permission BEFORE the step, not after (#1004): a step that has
+        # already spent cannot be un-spent. The check lives here rather than in
+        # execute_plan's loop because Agent._execute_plan drives execute_step
+        # directly — a cap only the other loop honoured would not be a cap.
+        cap_message = self.cost_tracker.cap_message()
+        if cap_message:
+            return StepResult(
+                step=step,
+                status=ExecutionStatus.FAILED,
+                error=cap_message,
+                duration_ms=0,
+            )
 
         try:
             if step.type == StepType.FILE_CREATE:
@@ -543,6 +566,8 @@ class Executor:
                     cwd=self.repo_path,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=self.command_timeout,
                     env=env,
                 )
@@ -556,6 +581,8 @@ class Executor:
                         cwd=self.repo_path,
                         capture_output=True,
                         text=True,
+                        encoding="utf-8",
+                        errors="replace",
                         timeout=self.command_timeout,
                         env=env,
                     )
@@ -567,6 +594,8 @@ class Executor:
                         cwd=self.repo_path,
                         capture_output=True,
                         text=True,
+                        encoding="utf-8",
+                        errors="replace",
                         timeout=self.command_timeout,
                         env=env,
                     )
@@ -634,7 +663,7 @@ class Executor:
             # Verify Python syntax
             try:
                 import ast
-                content = file_path.read_text()
+                content = file_path.read_text(encoding="utf-8", errors="replace")
                 ast.parse(content)
                 return StepResult(
                     step=step,
@@ -685,6 +714,7 @@ class Executor:
             max_tokens=4096,
             temperature=0.0,
         )
+        self.cost_tracker.record_response(response)
 
         # Clean up response - remove markdown code blocks if present
         content = response.content.strip()
@@ -715,6 +745,7 @@ class Executor:
             max_tokens=8192,
             temperature=0.0,
         )
+        self.cost_tracker.record_response(response)
 
         # Clean up response
         content = response.content.strip()

--- a/codeframe/core/react_agent.py
+++ b/codeframe/core/react_agent.py
@@ -22,6 +22,11 @@ from codeframe.core import blockers, events, gates
 from codeframe.core.agent import AgentStatus
 from codeframe.core.blocker_detection import classify_error_for_blocker
 from codeframe.core.context import TaskContext
+from codeframe.core.cost_tracker import (
+    CostTracker,
+    load_prior_task_cost,
+    resolve_cost_cap,
+)
 from codeframe.core.context_packager import TaskContextPackager
 from codeframe.core.events import EventType
 from codeframe.core.fix_tracker import (
@@ -182,7 +187,14 @@ class ReactAgent:
         self.blocker_id: Optional[str] = None
 
         # Token usage tracking: accumulate per-call records across the run.
-        self._token_records: list[dict] = []
+        # Storage lives on the shared CostTracker, so the cap logic here and in
+        # the plan engine are one implementation and cannot drift (#1004).
+        # `_token_records` stays a property over it rather than an alias: an
+        # alias breaks the moment anything REBINDS the attribute (several tests
+        # seed records that way), silently detaching the cap from the records
+        # it is meant to measure. Records carry an extra `iteration` key the
+        # tracker ignores.
+        self._cost = CostTracker()
 
         # Stall detection
         self._stall_triggered = threading.Event()
@@ -366,50 +378,32 @@ class ReactAgent:
     # Token persistence
     # ------------------------------------------------------------------
 
+    @property
+    def _token_records(self) -> list[dict]:
+        """Per-call token records — the shared tracker's list (#1004)."""
+        return self._cost.records
+
+    @_token_records.setter
+    def _token_records(self, records: list[dict]) -> None:
+        # Replace CONTENTS, never the list object: the tracker holds the same
+        # reference and would otherwise be left measuring a detached list.
+        self._cost.records[:] = list(records)
+
     def _estimate_total_cost(self) -> float:
         """Estimate total USD cost from accumulated token records.
 
-        Delegates per-model pricing to MetricsTracker.calculate_cost to keep
-        pricing logic in a single location.  Falls back to 0.0 on any error.
+        Delegates to the shared CostTracker (#1004) so the plan engine and this
+        one price a run identically.
         """
-        try:
-            from codeframe.lib.metrics_tracker import MetricsTracker
-
-            total = 0.0
-            for record in self._token_records:
-                cost = MetricsTracker.calculate_cost(
-                    record["model"],
-                    record["input_tokens"],
-                    record["output_tokens"],
-                )
-                # None = unpriced; skip it rather than adding 0.0. Callers that
-                # care whether anything was unpriced ask _has_unpriced_records().
-                if cost is not None:
-                    total += cost
-            return round(total, 6)
-        except Exception:
-            return 0.0
+        return self._cost.estimate_cost()
 
     def _has_unpriced_records(self) -> bool:
         """True when any recorded call used a model with no pricing.
 
-        Asked directly now that ``calculate_cost`` returns None for unpriced
-        models. The cost cap used to infer this from the *outcome* ($0 spent
-        despite tokens recorded) because the pricing table was missing the
-        shipped default and a membership test false-fired on it (#932).
+        Asked directly rather than inferred from a $0 outcome (#932); shared
+        with the plan engine (#1004).
         """
-        try:
-            from codeframe.lib.metrics_tracker import MetricsTracker
-
-            return any(
-                MetricsTracker.calculate_cost(
-                    r["model"], r["input_tokens"], r["output_tokens"]
-                )
-                is None
-                for r in self._token_records
-            )
-        except Exception:
-            return False
+        return self._cost.has_unpriced_records()
 
     def _persist_token_usage(self, task_id: str) -> None:
         """Persist accumulated token records to the workspace database.
@@ -687,7 +681,7 @@ class ReactAgent:
                         try:
                             _full_path = self.workspace.repo_path / _op_path
                             if _full_path.is_file():
-                                _op_after = _full_path.read_text(errors="replace")
+                                _op_after = _full_path.read_text(encoding="utf-8", errors="replace")
                         except OSError:
                             pass
                     self.execution_recorder.record_file_operation(
@@ -1105,103 +1099,38 @@ class ReactAgent:
         The single place any spending loop asks "may I make another call?" —
         the main ReAct loop and the verification self-correction loop both go
         through it, because a cap the correction loop ignores is not a cap
-        (#911 review).
+        (#911 review). The plan engine asks the same question of the same
+        object (#1004).
         """
-        cap = self._max_cost_usd
-        if cap is None:
-            return None
-
-        # A cap we cannot measure is not a cap: an unpriced model would keep the
-        # running total at $0.00 forever and the guard would never fire — the
-        # same silently-inert control #911 was about, one layer down. Refuse
-        # before spending rather than pretend.
-        spent = self._prior_task_cost_usd + self._estimate_total_cost()
-
-        # Asked directly (#932). This used to infer "unpriced" from the outcome
-        # — tokens recorded but $0 spent — because MODEL_PRICING was missing the
-        # shipped default (claude-haiku-4-5), so a membership test false-fired on
-        # a legitimately-priced run. calculate_cost now returns None for unpriced
-        # models, so the question has a real answer.
-        #
-        # The outcome heuristic is NOT kept as a fallback: a deployment can price
-        # a local model at 0/0 via CODEFRAME_MODEL_PRICING, which is a real $0 —
-        # "spent nothing" would then read as "cannot measure" and abort a run
-        # that is correctly measured as free.
-        if self._has_unpriced_records():
-            return (
-                f"A cost cap of ${cap:.2f} is configured, but spend cannot be "
-                f"measured for {', '.join(sorted(self._models_used())) or 'this model'} "
-                "— no pricing data. Remove the cap, or use a model with known pricing."
-            )
-
-        if spent >= cap:
-            return (
-                f"Estimated spend ${spent:.4f} reached the configured cap of "
-                f"${cap:.2f}. Raise 'Max cost per task (USD)' in Settings to continue."
-            )
-        return None
+        self._cost.cap_usd = self._max_cost_usd
+        # Measurements come from THIS object's accessors, not the tracker's, so
+        # the seam every #911 test patches (`_estimate_total_cost`) still sits on
+        # the path. Only the decision — which check runs first, and what the
+        # message says — is shared.
+        return self._cost.cap_message(
+            spent=self._prior_task_cost_usd + self._estimate_total_cost(),
+            unpriced=self._has_unpriced_records(),
+        )
 
     def _load_prior_task_cost(self, task_id: str) -> float:
         """Spend already recorded against this task by earlier runs.
 
-        The setting is "max cost per *task*", and ``_estimate_total_cost`` only
-        sums this agent instance's in-memory records. Without this, answering
-        the blocker and resuming would hand the task a fresh full budget every
-        time — a cap trivially bypassed by clicking resume (#911 review).
+        The setting is "max cost per *task*", and the in-memory records only
+        cover this agent instance. Without this, answering the blocker and
+        resuming would hand the task a fresh full budget every time — a cap
+        trivially bypassed by clicking resume (#911 review). Shared with the
+        plan engine (#1004).
         """
-        conn = None
-        try:
-            from codeframe.platform_store.repositories.token_repository import (
-                TokenRepository,
-            )
-
-            # Same per-workspace connection the write path uses
-            # (`_persist_token_usage`). `Database()` is control-plane and needs
-            # an explicit db_path — calling it bare raised TypeError straight
-            # into the except below, so this method silently returned 0.0 and
-            # the resume bypass it exists to close stayed wide open. The
-            # repository sets the Row factory it needs on this connection.
-            conn = sqlite3.connect(str(self.workspace.db_path))
-            summary = TokenRepository(sync_conn=conn).get_task_token_summary(task_id)
-            return float(summary.get("total_cost_usd") or 0.0)
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.debug("Could not read prior spend for task %s: %s", task_id, exc)
-            return 0.0
-        finally:
-            if conn is not None:
-                try:
-                    conn.close()
-                except Exception:
-                    pass
+        return load_prior_task_cost(self.workspace, task_id)
 
     def _resolve_cost_cap(self) -> Optional[float]:
         """The configured per-task spend cap, or None when unset.
 
-        Read from the same ``.codeframe/config.yaml`` the Settings page writes
-        (``max_cost_usd``). Before #911 nothing read it: a user could set a $5
-        cap and get no cost limiting at all, while the sibling ``max_turns``
-        control genuinely worked — so an inert cap was indistinguishable from a
-        working one.
+        Read from the same ``.codeframe/config.yaml`` the Settings page writes.
+        Shared with the plan engine (#1004) — the resolver was always
+        engine-agnostic, it just had only one caller.
         """
-        from codeframe.core.config import load_environment_config
-
-        try:
-            env_config = load_environment_config(self.workspace.repo_path)
-        except Exception as exc:  # pragma: no cover - config read is best effort
-            logger.warning("Could not read the cost cap: %s", exc)
-            return None
-
-        cap = getattr(env_config, "max_cost_usd", None) if env_config else None
-        if cap is None:
-            return None
-        try:
-            cap = float(cap)
-        except (TypeError, ValueError):
-            logger.warning("Ignoring non-numeric max_cost_usd: %r", cap)
-            return None
-        # 0 would stop before the first call; treat it as "no cap" rather than
-        # bricking every run, and let validation reject negatives upstream.
-        return cap if cap > 0 else None
+        return resolve_cost_cap(self.workspace.repo_path)
 
     def _calculate_adaptive_budget(self, context: TaskContext) -> int:
         """Calculate iteration budget based on task complexity.

--- a/tests/core/test_cost_cap_plan_engine_1004.py
+++ b/tests/core/test_cost_cap_plan_engine_1004.py
@@ -420,3 +420,100 @@ class TestTheTwoEnginesShareOneImplementation:
         assert not any(
             m.startswith(("fastapi", "starlette", "codeframe.ui")) for m in imported
         ), sorted(imported)
+
+
+class TestTheCapStopsTheRunNotJustTheStep:
+    """Raised in review, and the worst possible shape for a spend cap: it was
+    *causing* spend.
+
+    `Executor` refuses a capped step by returning FAILED — but FAILED is exactly
+    what triggers `Agent._execute_plan`'s self-correction path, which makes up to
+    `MAX_SELF_CORRECTION_ATTEMPTS` further LLM calls on the stepped-UP CORRECTION
+    model, plus a blocker-question call, none of which the cap could see. The
+    loop then advanced to the next step and did it again.
+    """
+
+    def test_the_agent_loop_checks_before_the_step(self):
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        source = inspect.getsource(agent_mod.Agent._execute_plan)
+        # The check must precede the execute_step call, not follow it.
+        assert source.index("cap_message()") < source.index("executor.execute_step")
+
+    def test_hitting_the_cap_blocks_rather_than_failing_the_step(self):
+        """BLOCKED, matching ReactAgent: the work is not wrong, it needs a human
+        decision. FAILED would route straight back into self-correction."""
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        source = inspect.getsource(agent_mod.Agent._execute_plan)
+        after = source[source.index("cap_message()") :]
+        head = after[: after.index("executor.execute_step")]
+
+        assert "AgentStatus.BLOCKED" in head
+        assert "return" in head
+
+    def test_it_creates_a_real_blocker_row(self):
+        """Otherwise a run that stopped for a cap looks like a silent hang to
+        `cf blocker list` and the web UI."""
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        source = inspect.getsource(agent_mod.Agent._execute_plan)
+        head = source[: source.index("executor.execute_step")]
+
+        assert "blockers.create(" in head
+
+    def test_self_correction_refuses_once_the_cap_is_reached(self):
+        """The expensive loop: it steps UP to the CORRECTION model and runs up
+        to MAX_SELF_CORRECTION_ATTEMPTS times per failed step."""
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        source = inspect.getsource(agent_mod.Agent._attempt_self_correction)
+        head = source[: source.index("self.llm.complete")]
+
+        assert "cap_message()" in head, (
+            "the correction loop can still spend past the cap"
+        )
+
+    @pytest.mark.parametrize(
+        "method,call_type",
+        [
+            ("_attempt_self_correction", "self_correction"),
+            ("_generate_blocker_question", "blocker_question"),
+        ],
+    )
+    def test_the_agents_own_calls_are_recorded(self, method: str, call_type: str):
+        """They were invisible to the tracker, so spend accrued unmeasured even
+        before the cap fired — the running total was simply wrong."""
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        source = inspect.getsource(getattr(agent_mod.Agent, method))
+
+        assert f'record_response(response, call_type="{call_type}")' in source
+
+    def test_every_llm_call_in_the_agent_is_recorded(self):
+        """Enumerated rather than listed, so a new call site fails here instead
+        of quietly escaping the cap."""
+        import inspect
+        import re
+
+        from codeframe.core import agent as agent_mod
+
+        source = inspect.getsource(agent_mod)
+        calls = len(re.findall(r"response = self\.llm\.complete\(", source))
+        records = len(re.findall(r"self\.cost_tracker\.record_response\(", source))
+
+        assert calls > 0
+        assert records == calls, (
+            f"{calls} LLM calls but only {records} recorded — "
+            "one of them is invisible to the cost cap"
+        )

--- a/tests/core/test_cost_cap_plan_engine_1004.py
+++ b/tests/core/test_cost_cap_plan_engine_1004.py
@@ -1,0 +1,422 @@
+"""The cost cap now binds on `--engine plan` too (#1004).
+
+#911 made `max_cost_usd` real for the built-in ReAct engine. The plan engine had
+**no token accounting at all** — it set `max_tokens` per call and recorded
+nothing — so there was no accumulated spend for a cap to be compared against. A
+user on `--engine plan` who set a $5 cap got zero cost limiting, and since the
+sibling `max_turns` control genuinely worked, an inert cap was indistinguishable
+from a working one. That is the same complaint #911 was filed about, one engine
+over.
+
+The accounting and the gate are now one `CostTracker`, extracted from
+`ReactAgent` rather than reimplemented, so the two engines cannot drift.
+
+Delegated adapters (`claude-code`, `codex`, `opencode`, `kilocode`) are
+deliberately still uncovered: the external CLI spends inside a subprocess and
+reports no usage back, so there is nothing to meter. `covers_engine()` states
+that boundary in code instead of showing a limit that cannot fire.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.config import EnvironmentConfig, save_environment_config
+from codeframe.core.cost_tracker import (
+    CostCapExceeded,
+    CostTracker,
+    covers_engine,
+    resolve_cost_cap,
+)
+from codeframe.core.executor import ExecutionStatus, Executor
+from codeframe.core.planner import ImplementationPlan, PlanStep, StepType
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+#: Priced in MODEL_PRICING, so spend is measurable.
+PRICED_MODEL = "claude-sonnet-4-5"
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return create_or_load_workspace(repo)
+
+
+@pytest.fixture
+def context(workspace):
+    """A real TaskContext — the generation prompts read `context.task`."""
+    from codeframe.core import tasks
+    from codeframe.core.context import TaskContext
+
+    task = tasks.create(workspace, title="add a file", description="")
+    return TaskContext(task=task)
+
+
+def _set_cap(workspace, cap) -> None:
+    save_environment_config(workspace.repo_path, EnvironmentConfig(max_cost_usd=cap))
+
+
+@dataclass
+class _Response:
+    """The parts of LLMResponse the tracker reads."""
+
+    content: str = "print('hi')\n"
+    model: str = PRICED_MODEL
+    input_tokens: int = 500_000
+    output_tokens: int = 500_000
+
+
+class _CountingLLM:
+    """Returns a fixed response and counts how often it was asked."""
+
+    def __init__(self, response: _Response = None):
+        self.calls = 0
+        self._response = response or _Response()
+
+    def complete(self, **kwargs):
+        self.calls += 1
+        return self._response
+
+
+_STEP_INDEX = iter(range(1, 10_000))
+
+
+def _step(name: str = "a.py") -> PlanStep:
+    return PlanStep(
+        index=next(_STEP_INDEX),
+        type=StepType.FILE_CREATE,
+        description=f"create {name}",
+        target=name,
+    )
+
+
+class TestTheCapIsResolvedTheSameWayForBothEngines:
+    """The resolver is engine-agnostic and reads the file Settings writes."""
+
+    def test_it_reads_the_settings_page_config(self, workspace, context):
+        _set_cap(workspace, 5.0)
+
+        assert resolve_cost_cap(workspace.repo_path) == 5.0
+
+    def test_an_unset_cap_is_none(self, workspace, context):
+        assert resolve_cost_cap(workspace.repo_path) is None
+
+    def test_zero_means_no_cap_rather_than_bricking_every_run(self, workspace, context):
+        _set_cap(workspace, 0)
+
+        assert resolve_cost_cap(workspace.repo_path) is None
+
+    def test_a_nonsense_value_is_ignored_not_fatal(self, workspace, context):
+        save_environment_config(
+            workspace.repo_path, EnvironmentConfig(max_cost_usd="not-a-number")
+        )
+
+        assert resolve_cost_cap(workspace.repo_path) is None
+
+
+class TestThePlanEngineNowAccountsForSpend:
+    """The missing half: without records there is nothing to cap."""
+
+    def test_an_executor_records_the_llm_calls_it_makes(self, workspace, context):
+        llm = _CountingLLM()
+        ex = Executor(llm_provider=llm, repo_path=workspace.repo_path)
+
+        ex.execute_step(_step(), context=context)
+
+        assert ex.cost_tracker.records, "the plan engine still records nothing"
+        assert ex.cost_tracker.records[0]["model"] == PRICED_MODEL
+
+    def test_the_recorded_tokens_are_the_response_s_own(self, workspace, context):
+        llm = _CountingLLM(_Response(input_tokens=11, output_tokens=22))
+        ex = Executor(llm_provider=llm, repo_path=workspace.repo_path)
+
+        ex.execute_step(_step(), context=context)
+
+        assert ex.cost_tracker.total_tokens == (11, 22)
+
+    def test_spend_is_estimated_from_them(self, workspace, context):
+        llm = _CountingLLM()
+        ex = Executor(llm_provider=llm, repo_path=workspace.repo_path)
+
+        ex.execute_step(_step(), context=context)
+
+        assert ex.cost_tracker.estimate_cost() > 0, (
+            "a million tokens of a priced model estimated at $0"
+        )
+
+    def test_an_executor_with_no_cap_still_accounts(self, workspace, context):
+        """Accounting is unconditional; only the LIMIT is opt-in. Otherwise the
+        cost data users see would depend on whether they set a cap."""
+        ex = Executor(llm_provider=_CountingLLM(), repo_path=workspace.repo_path)
+
+        assert ex.cost_tracker.cap_usd is None
+        ex.execute_step(_step(), context=context)
+        assert ex.cost_tracker.records
+
+
+class TestALowCapStopsThePlanEngine:
+    """The AC, from the outside."""
+
+    def _capped_executor(self, workspace, cap=0.01) -> Executor:
+        return Executor(
+            llm_provider=_CountingLLM(),
+            repo_path=workspace.repo_path,
+            cost_tracker=CostTracker(cap_usd=cap),
+        )
+
+    def test_the_first_step_runs_and_the_second_is_refused(self, workspace, context):
+        """The cap can only bind after something has been spent — a check that
+        fired before the first call would be a cap of zero."""
+        ex = self._capped_executor(workspace)
+
+        first = ex.execute_step(_step("a.py"), context=context)
+        second = ex.execute_step(_step("b.py"), context=context)
+
+        assert first.status != ExecutionStatus.FAILED, first.error
+        assert second.status == ExecutionStatus.FAILED
+        assert "cap" in (second.error or "").lower()
+
+    def test_the_refusal_names_the_cap_and_the_setting(self, workspace, context):
+        ex = self._capped_executor(workspace)
+        ex.execute_step(_step("a.py"), context=context)
+
+        error = ex.execute_step(_step("b.py"), context=context).error
+
+        assert "$0.01" in error
+        assert "Max cost per task (USD)" in error
+
+    def test_no_further_llm_call_is_made(self, workspace, context):
+        """"Reported failed" and "stopped spending" are different claims."""
+        ex = self._capped_executor(workspace)
+        ex.execute_step(_step("a.py"), context=context)
+        calls_after_first = ex.llm.calls
+
+        ex.execute_step(_step("b.py"), context=context)
+
+        assert ex.llm.calls == calls_after_first, "it kept spending after the cap"
+
+    def test_an_uncapped_run_of_the_same_steps_does_not_stop(self, workspace, context):
+        """The control. Without it, a broken execute_step would pass the test
+        above for the wrong reason."""
+        ex = Executor(llm_provider=_CountingLLM(), repo_path=workspace.repo_path)
+
+        first = ex.execute_step(_step("a.py"), context=context)
+        second = ex.execute_step(_step("b.py"), context=context)
+
+        assert first.status != ExecutionStatus.FAILED
+        assert second.status != ExecutionStatus.FAILED, second.error
+
+    def test_a_generous_cap_does_not_stop_it(self, workspace, context):
+        ex = self._capped_executor(workspace, cap=1_000_000.0)
+
+        ex.execute_step(_step("a.py"), context=context)
+        second = ex.execute_step(_step("b.py"), context=context)
+
+        assert second.status != ExecutionStatus.FAILED, second.error
+
+
+class TestTheGateSitsWhereBothLoopsPassThrough:
+    """`Agent._execute_plan` drives `execute_step` directly rather than calling
+    `execute_plan`, so a check in the latter's loop would leave the real plan
+    engine uncapped. Pinned because it is an easy thing to "tidy" back."""
+
+    def test_execute_step_is_the_one_that_checks(self):
+        import inspect
+
+        from codeframe.core import executor as executor_mod
+
+        source = inspect.getsource(executor_mod.Executor.execute_step)
+
+        assert "cap_message()" in source
+
+    def test_execute_plan_inherits_it_rather_than_repeating_it(self):
+        import inspect
+
+        from codeframe.core import executor as executor_mod
+
+        source = inspect.getsource(executor_mod.Executor.execute_plan)
+        code = "\n".join(line.split("#")[0] for line in source.splitlines())
+
+        assert "cap_message()" not in code, "the check is duplicated"
+
+    def test_execute_plan_still_stops_at_the_cap(self, workspace, context):
+        """Because execute_step returns FAILED and the loop breaks on failure."""
+        ex = Executor(
+            llm_provider=_CountingLLM(),
+            repo_path=workspace.repo_path,
+            cost_tracker=CostTracker(cap_usd=0.01),
+        )
+        plan = ImplementationPlan(
+            task_id="t1",
+            summary="three files",
+            steps=[_step("a.py"), _step("b.py"), _step("c.py")],
+        )
+
+        result = ex.execute_plan(plan, context=context)
+
+        assert result.success is False
+        assert ex.llm.calls == 1, f"spent on {ex.llm.calls} calls despite the cap"
+
+
+class TestAnUnmeasurableCapRefusesRatherThanPretends:
+    """A cap on an unpriced model keeps the running total at $0.00 forever, so
+    the guard would never fire — the same silently-inert control, one layer
+    down."""
+
+    def test_an_unpriced_model_is_refused(self, workspace, context):
+        ex = Executor(
+            llm_provider=_CountingLLM(_Response(model="some-local-model-7b")),
+            repo_path=workspace.repo_path,
+            cost_tracker=CostTracker(cap_usd=100.0),
+        )
+
+        ex.execute_step(_step("a.py"), context=context)
+        second = ex.execute_step(_step("b.py"), context=context)
+
+        assert second.status == ExecutionStatus.FAILED
+        assert "cannot be measured" in second.error
+
+    def test_the_message_names_the_model(self, workspace, context):
+        ex = Executor(
+            llm_provider=_CountingLLM(_Response(model="some-local-model-7b")),
+            repo_path=workspace.repo_path,
+            cost_tracker=CostTracker(cap_usd=100.0),
+        )
+        ex.execute_step(_step("a.py"), context=context)
+
+        assert "some-local-model-7b" in ex.execute_step(_step("b.py"), context=context).error
+
+    def test_an_unpriced_model_with_no_cap_is_fine(self, workspace, context):
+        """Only a cap needs measurable spend. An uncapped run must not be
+        blocked for using a local model."""
+        ex = Executor(
+            llm_provider=_CountingLLM(_Response(model="some-local-model-7b")),
+            repo_path=workspace.repo_path,
+        )
+
+        ex.execute_step(_step("a.py"), context=context)
+
+        assert ex.execute_step(_step("b.py"), context=context).status != (
+            ExecutionStatus.FAILED
+        )
+
+
+class TestPriorSpendCountsSoResumeCannotBypassTheCap:
+    def test_prior_cost_is_added_to_this_run_s(self):
+        tracker = CostTracker(cap_usd=1.0, prior_cost_usd=0.99)
+        tracker.record(model=PRICED_MODEL, input_tokens=10_000, output_tokens=10_000)
+
+        assert tracker.cap_message() is not None
+
+    def test_the_same_spend_without_prior_cost_is_allowed(self):
+        """Isolates prior_cost_usd as the cause rather than the tokens."""
+        tracker = CostTracker(cap_usd=1.0, prior_cost_usd=0.0)
+        tracker.record(model=PRICED_MODEL, input_tokens=10_000, output_tokens=10_000)
+
+        assert tracker.cap_message() is None
+
+    def test_the_agent_loads_it_on_run_and_on_resume(self):
+        """Resume is the bypass this exists to close: a blocked task answered
+        and resumed would otherwise start again at $0 spent."""
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        for method in (agent_mod.Agent.run, agent_mod.Agent.resume):
+            assert "load_prior_task_cost(" in inspect.getsource(method), (
+                f"{method.__name__} does not carry prior spend forward"
+            )
+
+
+class TestTheAgentWiresItUp:
+    def test_the_agent_resolves_the_cap_and_shares_one_tracker(self, workspace, context):
+        import inspect
+
+        from codeframe.core import agent as agent_mod
+
+        init = inspect.getsource(agent_mod.Agent.__init__)
+        exec_plan = inspect.getsource(agent_mod.Agent._execute_plan)
+
+        assert "resolve_cost_cap(" in init
+        assert "cost_tracker=self.cost_tracker" in exec_plan, (
+            "the Executor gets its own tracker, so spend does not accumulate "
+            "across the agent's plan and its self-correction retries"
+        )
+
+
+class TestTheDelegatedEngineBoundaryIsExplicit:
+    """AC2's "decide explicitly". The cap cannot bind where the spending happens
+    inside someone else's CLI, so say so rather than show a dead control."""
+
+    @pytest.mark.parametrize("engine", ["react", "plan", "builtin"])
+    def test_metered_engines_are_covered(self, engine: str):
+        assert covers_engine(engine) is True
+
+    @pytest.mark.parametrize(
+        "engine", ["claude-code", "codex", "opencode", "kilocode", "cloud"]
+    )
+    def test_delegated_engines_are_not(self, engine: str):
+        assert covers_engine(engine) is False
+
+    def test_it_is_case_and_whitespace_insensitive(self):
+        assert covers_engine("  React ") is True
+
+    def test_an_empty_engine_is_not_claimed_as_covered(self):
+        assert covers_engine("") is False
+        assert covers_engine(None) is False
+
+
+class TestCheckRaisesForCallersThatPreferAnException:
+    def test_it_raises_with_the_message(self):
+        tracker = CostTracker(cap_usd=0.000001)
+        tracker.record(model=PRICED_MODEL, input_tokens=1000, output_tokens=1000)
+
+        with pytest.raises(CostCapExceeded) as exc:
+            tracker.check()
+
+        assert "cap" in str(exc.value).lower()
+
+    def test_it_is_silent_below_the_cap(self):
+        CostTracker(cap_usd=1000.0).check()
+
+
+class TestTheTwoEnginesShareOneImplementation:
+    """Extracted rather than reimplemented, so a fix to one is a fix to both."""
+
+    def test_the_react_agent_uses_the_shared_module(self):
+        import inspect
+
+        from codeframe.core import react_agent
+
+        source = inspect.getsource(react_agent)
+
+        assert "cost_tracker" in source, (
+            "ReactAgent still carries its own copy of the cap logic"
+        )
+
+    def test_the_shared_module_is_headless(self):
+        """Core rule: no FastAPI or UI imports.
+
+        Asserted on the parsed IMPORTS, not the text — the module docstring says
+        the words "no fastapi", and a substring scan would flag its own
+        explanation.
+        """
+        import ast
+
+        tree = ast.parse(
+            Path("codeframe/core/cost_tracker.py").read_text(encoding="utf-8")
+        )
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported |= {a.name for a in node.names}
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+
+        assert not any(
+            m.startswith(("fastapi", "starlette", "codeframe.ui")) for m in imported
+        ), sorted(imported)


### PR DESCRIPTION
Closes #1004.

## The gap

#911 made `max_cost_usd` real for the built-in ReAct engine. The plan engine had **no token accounting at all** — it set `max_tokens` per call and recorded nothing — so there was no accumulated spend for a cap to be compared against.

A user on `--engine plan` who set a $5 cap got zero cost limiting. And since the sibling `max_turns` control genuinely worked, an inert cap was indistinguishable from a working one — the exact complaint #911 was filed about, one engine over.

## Extracted, not reimplemented

`codeframe/core/cost_tracker.py` now holds both the accounting and the decision, and **both engines use it**: `ReactAgent`'s five cost methods are now delegations. A fix to one is a fix to both, which a second copy could not promise.

**The gate lives in `execute_step`, not `execute_plan`'s loop.** `Agent._execute_plan` drives `execute_step` directly rather than calling `execute_plan`, so a check in the other loop would have left the real plan engine uncapped. There is a test pinning that placement, because it is an easy thing to "tidy" back.

**Accounting is unconditional; only the *limit* is opt-in.** Otherwise the cost data a user sees would depend on whether they happened to set a cap.

**Prior spend loads on `run()` *and* `resume()`.** Resume is precisely the bypass: a blocked task answered and resumed would otherwise start again at $0 spent, so the cap could be defeated by clicking a button.

## AC2: delegated adapters, decided explicitly

Not covered, deliberately. The external CLI spends inside a subprocess and reports no usage back, so there is nothing to meter. `covers_engine()` states that boundary in code so a caller can surface it instead of showing a control that cannot fire:

```python
METERED_ENGINES = frozenset({"react", "plan", "builtin"})
```

## Two things the refactor got wrong first

Both caught by the **existing** #911 tests, not by inspection — worth stating plainly since the whole premise here is sharing code between two engines:

1. **Aliasing `_token_records` to the tracker's list** broke the moment anything *rebound* the attribute, which several tests do to seed records — silently detaching the cap from the records it is meant to measure. It is a property now, whose setter replaces contents rather than the object.
2. **Delegating `_cost_cap_message` wholesale** removed the seam those tests patch (`_estimate_total_cost`), so four #911 tests went red. Rather than rewrite passing tests to accommodate my refactor, `cap_message()` now **takes** the measurements: the decision (which check runs first, what the message says) stays shared; the measuring stays overridable by the caller. That is the better design regardless of the tests.

## Tests

37 new. **54 pass together with the 17 pre-existing #911 tests, unmodified.** 15 of the 37 fail against the pre-fix tree.

The AC's scenario — a low cap on `--engine plan` terminates the run — is asserted three ways, because "reported failed" and "stopped spending" are different claims:

- `test_the_first_step_runs_and_the_second_is_refused` — the cap can only bind after something is spent; a check that fired before the first call would be a cap of zero
- `test_no_further_llm_call_is_made` — asserts the call **count** stopped moving
- `test_an_uncapped_run_of_the_same_steps_does_not_stop` — the control, so a broken `execute_step` cannot pass the above for the wrong reason

Also covered: an unpriced model refuses rather than pretending (a $0.00 running total would never reach any cap), and an unpriced model **without** a cap is unaffected — a local model must not block an uncapped run.

`ruff` and `mypy codeframe/` clean; 561 pass across the agent/executor/react/cost/token selection.

## Known limitations

- **The planner's own LLM call is not metered.** `Planner.create_plan` runs before the `Executor` exists; its spend is invisible to the cap. That is a smaller gap than the one closed here (one call vs. every step) but it is real.
- **The cap is not surfaced in the UI per engine.** `covers_engine()` exists so the Settings page can grey the control for delegated engines; wiring that is a frontend change and is not in this PR.
- The cap means "stop as soon as we are over", not "never exceed by a cent" — a call's cost is not knowable until it returns. Unchanged from #911.
