### PR TITLE
test: remove two load-sensitive flakes without weakening either proof (#976, #1038)

### DIFF
--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -1523,36 +1523,81 @@ class TestParallelExecution:
         detection is avoided on purpose: per-task bookkeeping is serialized, so a
         short sleep makes overlap timing-dependent and flaky.
         """
+        import os
         import threading
 
         workspace, task_list = workspace_with_tasks
         task_ids = [t.id for t in task_list]  # 3 independent tasks
         n = len(task_ids)
 
-        barrier = threading.Barrier(n, timeout=15)
+        # The budget is spent on the MACHINE's ability to schedule n worker
+        # threads simultaneously, not on the code under test (#976). At 15s it
+        # tripped under the CPU contention of a 4-hour full-suite run and read
+        # as "parallel execution is broken", which is alarming enough to stop
+        # work. Raising it does not weaken the proof by any amount: a serial
+        # executor never gets n bodies here CONCURRENTLY, so it times out at
+        # any budget. Only a busy scheduler benefits.
+        timeout_s = float(os.getenv("CODEFRAME_TEST_BARRIER_TIMEOUT_S", "90"))
+
+        barrier = threading.Barrier(n, timeout=timeout_s)
         threads_seen: set[str] = set()
         seen_lock = threading.Lock()
+        broke = threading.Event()
 
         def mock_execute(ws, tid, batch_id=None, **kwargs):
             with seen_lock:
                 threads_seen.add(threading.current_thread().name)
-            # Blocks until all N task bodies reach here at the same time. Serial
-            # execution never reaches N concurrently → BrokenBarrierError on timeout.
-            barrier.wait()
+            # Blocks until all n task bodies reach here at the same time. Serial
+            # execution never reaches n concurrently → BrokenBarrierError on timeout.
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                broke.set()
+                raise
             return "COMPLETED"
 
+        batch = None
         with patch('codeframe.core.conductor._execute_task_subprocess', side_effect=mock_execute):
-            batch = start_batch(
-                workspace,
-                task_ids,
-                strategy="parallel",
-                max_parallel=n,
+            try:
+                batch = start_batch(
+                    workspace,
+                    task_ids,
+                    strategy="parallel",
+                    max_parallel=n,
+                )
+            except threading.BrokenBarrierError:
+                # A broken barrier propagates out of the worker and up through
+                # start_batch, so without this the diagnostic below is
+                # unreachable and the reader gets a bare BrokenBarrierError —
+                # exactly the uninformative red that cost a diagnosis cycle
+                # during #895. Swallowed only when `broke` is set, i.e. only
+                # when it came from our own mock.
+                if not broke.is_set():
+                    raise
+
+        # Report the two failures differently (#976). Both are "the barrier
+        # broke", but one means the executor serialised and the other means the
+        # box never scheduled n threads together, and a reader cannot tell
+        # those apart from the exception alone.
+        if broke.is_set():
+            distinct = len(threads_seen)
+            pytest.fail(
+                f"Only {distinct} of {n} task bodies were in-flight together "
+                f"within {timeout_s}s.\n"
+                + (
+                    "Distinct worker threads were seen, so the executor IS "
+                    "parallel — the machine simply never scheduled them "
+                    "simultaneously. Raise CODEFRAME_TEST_BARRIER_TIMEOUT_S."
+                    if distinct == n
+                    else "Task bodies ran on fewer threads than tasks: "
+                    "execution was SERIALISED. This is a real defect (#773)."
+                )
             )
 
         assert batch.status == BatchStatus.COMPLETED
         for tid in task_ids:
             assert batch.results[tid] == "COMPLETED"
-        # All N task bodies were in-flight simultaneously on distinct workers.
+        # All n task bodies were in-flight simultaneously on distinct workers.
         assert len(threads_seen) == n
 
     def test_parallel_respects_max_parallel(self, workspace_with_tasks):

--- a/tests/core/test_streaming.py
+++ b/tests/core/test_streaming.py
@@ -165,44 +165,75 @@ class TestTailRunOutput:
     def test_tail_yields_new_lines_from_concurrent_writer(
         self, temp_workspace: Workspace, run_id: str
     ):
-        """Tail should yield new lines as they're written by another process."""
+        """Tail yields new lines as a concurrent writer appends them (#1038).
+
+        Synchronised on events, not sleeps. The previous version wrote three
+        lines with ``time.sleep(0.2)`` between them against a tailer given
+        ``max_wait=2.0``: under the CPU contention of a ~4900-test run the
+        writer's 0.6s of sleeps plus thread-start latency could drift past that
+        budget, the tailer would exit before "Final line" was written, and the
+        test failed for the box being busy rather than for anything being wrong.
+        ``tail_run_output`` itself is fine — it re-reads the file each poll and
+        tracks its position, so no line is ever missed.
+
+        Now the writer waits until the tailer has actually *observed* the
+        previous line before writing the next. That removes every fixed sleep,
+        and asserts something strictly stronger than the original: each line is
+        provably delivered to a live tailer before the next is written, so this
+        is incremental delivery rather than merely eventual.
+        """
         from codeframe.core.streaming import RunOutputLogger, tail_run_output
 
-        # Start with empty log
         logger = RunOutputLogger(temp_workspace, run_id)
 
-        collected_lines = []
-        stop_event = threading.Event()
+        collected_lines: list[str] = []
+        observed = threading.Event()
+        finished = threading.Event()
 
         def tail_collector():
-            for line in tail_run_output(
-                temp_workspace, run_id, poll_interval=0.1, max_wait=2.0
-            ):
-                collected_lines.append(line)
-                if "Final" in line:
-                    stop_event.set()
-                    break
+            try:
+                # A generous max_wait is not a timing assumption: the handshake
+                # below ends the loop as soon as "Final" arrives. It is only a
+                # backstop so a genuine hang fails rather than blocking forever.
+                for line in tail_run_output(
+                    temp_workspace, run_id, poll_interval=0.01, max_wait=30.0
+                ):
+                    collected_lines.append(line)
+                    observed.set()
+                    if "Final" in line:
+                        break
+            finally:
+                finished.set()
 
-        # Start tailing in background
-        tail_thread = threading.Thread(target=tail_collector)
+        tail_thread = threading.Thread(target=tail_collector, daemon=True)
         tail_thread.start()
 
-        # Write lines with small delays
-        time.sleep(0.2)
-        logger.write("First line\n")
-        time.sleep(0.2)
-        logger.write("Second line\n")
-        time.sleep(0.2)
-        logger.write("Final line\n")
+        def write_and_wait(text: str) -> None:
+            observed.clear()
+            logger.write(text)
+            assert observed.wait(timeout=30.0), (
+                f"the tailer never observed {text!r}; collected={collected_lines}"
+            )
+
+        write_and_wait("First line\n")
+        write_and_wait("Second line\n")
+        write_and_wait("Final line\n")
         logger.close()
 
-        # Wait for tail to finish
-        stop_event.wait(timeout=3.0)
-        tail_thread.join(timeout=1.0)
+        assert finished.wait(timeout=30.0), "the tail generator never terminated"
+        tail_thread.join(timeout=30.0)
+        assert not tail_thread.is_alive()
 
         assert len(collected_lines) >= 3
         assert any("First" in line for line in collected_lines)
         assert any("Final" in line for line in collected_lines)
+        # Order matters for a tail: a reader that re-yielded from the top would
+        # still satisfy the membership assertions above.
+        assert [line.strip() for line in collected_lines[:3]] == [
+            "First line",
+            "Second line",
+            "Final line",
+        ]
 
     def test_tail_handles_missing_file_gracefully(
         self, temp_workspace: Workspace


### PR DESCRIPTION
Closes #976. Closes #1038.

Both fail only under the CPU contention of a full-suite run and pass in isolation. **Neither is a product defect** — verified before changing anything, which #1038's AC1 asks for explicitly.

## #976 — the parallel-execution barrier

The proof is a `threading.Barrier(n)`: every task body blocks until all `n` are simultaneously in-flight, so a serial executor can never satisfy it. Good design, deliberately hardened in #773.

But the budget was a fixed **15s spent on the machine's ability to schedule `n` threads together**, not on the code under test — and it tripped during a 4-hour run.

Raised to **90s**, overridable via `CODEFRAME_TEST_BARRIER_TIMEOUT_S`.

**This weakens the proof by exactly nothing.** A serial executor never gets `n` bodies to the barrier *concurrently*, so it times out at **any** budget — only a busy scheduler benefits. The barrier and `assert len(threads_seen) == n` are untouched (AC3).

### The more useful half: telling the two failures apart (AC4)

A bare `BrokenBarrierError` cannot distinguish "the executor serialised" from "the box was busy", and that ambiguity cost a diagnosis cycle during #895. Now:

```
Only 1 of 3 task bodies were in-flight together within 3.0s.
Task bodies ran on fewer threads than tasks: execution was SERIALISED.
This is a real defect (#773).
```

versus, when the executor is fine:

```
Distinct worker threads were seen, so the executor IS parallel — the machine
simply never scheduled them simultaneously. Raise CODEFRAME_TEST_BARRIER_TIMEOUT_S.
```

That message was **unreachable** in my first attempt: `BrokenBarrierError` propagates out of the worker and up through `start_batch`, so the test died before reaching the diagnostic. It has to be caught — and only when our own mock set the flag, never blindly.

## #1038 — the tail test

**AC1 answered: the flake is in the test, not the product.** `tail_run_output` re-reads the file each poll and tracks its position, so no line is ever missed.

The test wrote three lines with `time.sleep(0.2)` between them against a tailer given `max_wait=2.0`. Under load, 0.6s of sleeps plus thread-start latency drifted past that budget and the tailer exited before the last line was written.

**AC2: synchronised deterministically, not lengthened.** Every sleep is gone. The writer proceeds only once the tailer has actually *observed* the previous line:

```python
def write_and_wait(text):
    observed.clear()
    logger.write(text)
    assert observed.wait(timeout=30.0), f"the tailer never observed {text!r}"
```

That is **strictly stronger** than what it replaced — it proves incremental delivery to a live reader rather than eventual arrival — and it cannot drift, because nothing is timed. The remaining 30s waits are backstops so a genuine hang fails rather than blocking forever, not timing assumptions.

Also added an order assertion: a reader that re-yielded from the top would have satisfied the old membership-only checks.

## Verified, not asserted

- **Mutation** — `max_parallel=1` still fails #976's test, with the SERIALISED message quoted above. The concurrency proof is intact (AC2 of #976).
- **20 consecutive runs of both tests under 24 CPU burners on 8 cores** (3× oversubscription): **PASS=20 FAIL=0**. That is #1038's AC4.
- 97 pass across both files; `ruff` clean.

## Known limitations

- The load harness is 3× CPU oversubscription for ~7 minutes, not a 4-hour full-suite run. It reproduces the *contention* that caused both flakes, but a 4-hour run has other pressures (memory, page cache, SQLite fsync — see #2.18) this does not simulate.
- 90s is a judgement call, not a measurement. It is ~6× the old budget and the barrier still fails closed, so the cost of being wrong is a slower failure rather than a missed defect.
- #976's issue asks to verify on a contended machine via the full gate. I ran the two tests under synthetic contention instead; the full 4-hour gate was not run locally for this change.
