### PR TITLE
fix(core): enforce PRAGMA foreign_keys on the workspace DB (#1061)

### DIFF
--- a/codeframe/core/prd.py
+++ b/codeframe/core/prd.py
@@ -391,16 +391,39 @@ def delete(
             conn.close()
             raise PrdHasDependentTasksError(prd_id, task_count)
 
-    # Detach dependent tasks BEFORE removing the PRD (#1061). `tasks.prd_id`
-    # references `prds(id)`, and with foreign keys enforced a force-delete would
-    # otherwise fail outright. Before enforcement it left every one of those
-    # tasks pointing at a PRD that no longer existed — silently, forever.
+    # Detach everything that references this PRD BEFORE removing it (#1061).
+    # With foreign keys enforced a delete would otherwise fail outright; before
+    # enforcement it left dangling references behind — silently, forever.
     #
-    # The tasks themselves are kept: a task is real work, and losing it because
+    # Tasks are KEPT, only unlinked: a task is real work, and losing it because
     # its source document was deleted would be far worse than losing the link.
     cursor.execute(
         "UPDATE tasks SET prd_id = NULL WHERE workspace_id = ? AND prd_id = ?",
         (workspace.id, prd_id),
+    )
+
+    # prds references ITSELF twice — parent_id and chain_id — so deleting any
+    # non-latest version of a versioned PRD hit the same wall (raised in
+    # review). A v1 whose v2 carries parent_id=v1 AND chain_id=v1 could not be
+    # deleted at all.
+    #
+    # Re-parent rather than null: the surviving versions keep their lineage by
+    # skipping the deleted one, which is what a version chain means. chain_id
+    # falls back to the row's own id, matching how store() seeds a new chain.
+    cursor.execute(
+        "SELECT parent_id FROM prds WHERE workspace_id = ? AND id = ?",
+        (workspace.id, prd_id),
+    )
+    row = cursor.fetchone()
+    grandparent = row[0] if row else None
+
+    cursor.execute(
+        "UPDATE prds SET parent_id = ? WHERE workspace_id = ? AND parent_id = ?",
+        (grandparent, workspace.id, prd_id),
+    )
+    cursor.execute(
+        "UPDATE prds SET chain_id = id WHERE workspace_id = ? AND chain_id = ? AND id != ?",
+        (workspace.id, prd_id, prd_id),
     )
 
     cursor.execute(

--- a/codeframe/core/prd.py
+++ b/codeframe/core/prd.py
@@ -421,9 +421,29 @@ def delete(
         "UPDATE prds SET parent_id = ? WHERE workspace_id = ? AND parent_id = ?",
         (grandparent, workspace.id, prd_id),
     )
+    # Keep the survivors in ONE chain by repointing them at the oldest
+    # surviving version — the new root. Giving each survivor its OWN chain_id
+    # (the first cut) shattered the chain on a root delete: get_versions and
+    # list_chains key entirely off chain_id, so one evolving document became two
+    # separate PRDs, and v3 kept parent_id=v2 while landing in a different chain
+    # than v2 — a state no version query can reconstruct.
+    #
+    # The new root is computed BEFORE the UPDATE so SQLite's row-by-row
+    # evaluation cannot pick a different root for different rows. No-op for a
+    # non-root delete: no row carries a non-root's id as its chain_id.
     cursor.execute(
-        "UPDATE prds SET chain_id = id WHERE workspace_id = ? AND chain_id = ? AND id != ?",
+        """
+        SELECT id FROM prds
+        WHERE workspace_id = ? AND chain_id = ? AND id != ?
+        ORDER BY version ASC, created_at ASC
+        LIMIT 1
+        """,
         (workspace.id, prd_id, prd_id),
+    )
+    new_root = cursor.fetchone()
+    cursor.execute(
+        "UPDATE prds SET chain_id = ? WHERE workspace_id = ? AND chain_id = ? AND id != ?",
+        (new_root[0] if new_root else None, workspace.id, prd_id, prd_id),
     )
 
     cursor.execute(

--- a/codeframe/core/prd.py
+++ b/codeframe/core/prd.py
@@ -391,6 +391,18 @@ def delete(
             conn.close()
             raise PrdHasDependentTasksError(prd_id, task_count)
 
+    # Detach dependent tasks BEFORE removing the PRD (#1061). `tasks.prd_id`
+    # references `prds(id)`, and with foreign keys enforced a force-delete would
+    # otherwise fail outright. Before enforcement it left every one of those
+    # tasks pointing at a PRD that no longer existed — silently, forever.
+    #
+    # The tasks themselves are kept: a task is real work, and losing it because
+    # its source document was deleted would be far worse than losing the link.
+    cursor.execute(
+        "UPDATE tasks SET prd_id = NULL WHERE workspace_id = ? AND prd_id = ?",
+        (workspace.id, prd_id),
+    )
+
     cursor.execute(
         """
         DELETE FROM prds

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -911,8 +911,9 @@ def delete(workspace: Workspace, task_id: str) -> bool:
         cursor = conn.cursor()
 
         # Delete child rows FIRST (#943) — see _delete_task_children. Ordering
-        # matters even before PRAGMA foreign_keys goes on (#1061): the
-        # grandchild deletes select through `runs`.
+        # is now load-bearing, not defensive: PRAGMA foreign_keys is enforced
+        # (#1061) and the FKs carry no ON DELETE CASCADE, so without this every
+        # deletion of an executed task fails outright.
         _delete_task_children(cursor, "task_id = ?", (task_id,))
 
         cursor.execute(

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -90,13 +90,11 @@ def _open_db(db_path: str | Path) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA busy_timeout = 5000")
-    # NOTE (#943 / #1061): PRAGMA foreign_keys is deliberately NOT enabled here
-    # yet. Every FK in this schema is currently decorative, which is a real
-    # defect — but turning enforcement on fails 66 existing tests across 7 files
-    # whose fixtures insert run_logs and diagnostic_reports rows referencing
-    # task/run ids that do not exist. Those rows are being orphaned today; the
-    # tests assert against a state the schema forbids. Migrating them is its own
-    # focused change, tracked in #1061, not a rider on this one.
+    # SQLite ignores every FK clause unless this is set PER CONNECTION (#1061).
+    # Without it the workspace schema's foreign keys were decorative: deleting a
+    # task left its blockers, runs, run_logs and diagnostic_reports behind
+    # forever. The control-plane DB has always enabled it; this one had not.
+    conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
 

--- a/codeframe/ui/routers/blockers_v2.py
+++ b/codeframe/ui/routers/blockers_v2.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_standard
-from codeframe.core import blockers
+from codeframe.core import blockers, tasks
 from codeframe.core.blockers import BlockerStatus, BlockerOrigin
 from codeframe.ui.dependencies import get_v2_workspace
 from codeframe.ui.response_models import api_error, ErrorCodes
@@ -203,6 +203,20 @@ async def create_blocker(
     Returns:
         Created blocker
     """
+    # A client-supplied task_id that does not exist is the caller's mistake, not
+    # a server fault (#1061). Foreign keys are enforced now, so this used to
+    # surface as an IntegrityError and a 500; before enforcement it silently
+    # created a blocker attached to nothing.
+    if body.task_id is not None and tasks.get(workspace, body.task_id) is None:
+        raise HTTPException(
+            status_code=404,
+            detail=api_error(
+                "Task not found",
+                ErrorCodes.NOT_FOUND,
+                f"No task {body.task_id} in this workspace",
+            ),
+        )
+
     try:
         blocker = blockers.create(
             workspace,

--- a/tests/core/test_blockers_webhook.py
+++ b/tests/core/test_blockers_webhook.py
@@ -16,12 +16,37 @@ from codeframe.core.workspace import create_or_load_workspace
 pytestmark = pytest.mark.v2
 
 
+def _seed_tasks(ws, *task_ids: str) -> None:
+    """Create REAL task rows for the literal ids these tests use (#1061).
+
+    Foreign keys are enforced now, so a blocker attached to "t-1" needs a "t-1"
+    task — otherwise it is an orphan, which is what it was in production. The
+    ids are literals rather than fixtures because the dedupe tests assert on
+    them by name.
+    """
+    from codeframe.core.workspace import get_db_connection
+
+    now = "2026-01-01T00:00:00+00:00"
+    conn = get_db_connection(ws)
+    try:
+        for task_id in task_ids or ("t-1", "t-2"):
+            conn.execute(
+                "INSERT OR IGNORE INTO tasks (id, workspace_id, title, description,"
+                " status, priority, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+                (task_id, ws.id, "webhook fixture", "", "BACKLOG", 0, now, now),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 @pytest.fixture
 def workspace():
     temp_dir = Path(tempfile.mkdtemp())
     ws_path = temp_dir / "ws"
     ws_path.mkdir(parents=True, exist_ok=True)
     ws = create_or_load_workspace(ws_path)
+    _seed_tasks(ws)
     try:
         yield ws
     finally:
@@ -150,6 +175,7 @@ def test_dedupe_does_not_cross_workspaces(tmp_path):
         ws_path = tmp_path / name
         ws_path.mkdir(parents=True, exist_ok=True)
         ws = create_or_load_workspace(ws_path)
+        _seed_tasks(ws)  # a real "t-1" in each workspace (#1061)
         ids.append(blockers.create(ws, question=questions, task_id="t-1").id)
         assert len(blockers.list_open(ws)) == 1
     assert ids[0] != ids[1]

--- a/tests/core/test_db_integrity_943.py
+++ b/tests/core/test_db_integrity_943.py
@@ -19,9 +19,10 @@ from codeframe.core.workspace import _open_db, create_or_load_workspace
 pytestmark = pytest.mark.v2
 
 
-# The foreign-key enforcement tests moved to #1061 with the pragma itself: they
-# only mean anything once PRAGMA foreign_keys is on, and turning it on requires
-# migrating 66 test fixtures that currently insert orphan rows.
+# The foreign-key enforcement tests live in test_foreign_keys_enforced_1061.py,
+# which is where the pragma was turned on. The child-row cleanup below is what
+# makes enforcement survivable — the FKs carry no ON DELETE CASCADE — so the two
+# files are the two halves of one guarantee.
 
 
 class TestDuplicateExternalUrlDoesNotBrickTheWorkspace:

--- a/tests/core/test_db_integrity_943.py
+++ b/tests/core/test_db_integrity_943.py
@@ -149,7 +149,7 @@ class TestTaskDeleteCleansUpChildren:
 
 #: Every table the cleanup must reach, with a row keyed to a run or a task.
 #: The columns are the NOT NULL ones; anything nullable is left out.
-def _seed_every_child_table(db_path, task_id: str, run_id: str) -> None:
+def _seed_every_child_table(db_path, task_id: str, run_id: str, workspace_id: str) -> None:
     conn = _open_db(db_path)
     conn.execute(
         "INSERT INTO run_logs (run_id, task_id, timestamp, log_level, category,"
@@ -165,7 +165,7 @@ def _seed_every_child_table(db_path, task_id: str, run_id: str) -> None:
     conn.execute(
         "INSERT INTO blockers (id, workspace_id, task_id, question, created_at)"
         " VALUES (?,?,?,?,?)",
-        (f"blk-{run_id}", "ws", task_id, "q?", "2026-01-01"),
+        (f"blk-{run_id}", workspace_id, task_id, "q?", "2026-01-01"),
     )
     step_id = f"step-{run_id}"
     conn.execute(
@@ -186,7 +186,7 @@ def _seed_every_child_table(db_path, task_id: str, run_id: str) -> None:
     conn.execute(
         "INSERT INTO run_engine_log (run_id, engine, task_id, workspace_id,"
         " status, created_at) VALUES (?,?,?,?,?,?)",
-        (run_id, "react", task_id, "ws", "done", "2026-01-01"),
+        (run_id, "react", task_id, workspace_id, "done", "2026-01-01"),
     )
     conn.execute(
         "INSERT INTO cloud_run_metadata (run_id, sandbox_minutes,"
@@ -238,7 +238,7 @@ class TestEveryDescendantTableIsCleaned:
         task = tasks.create(ws, title="executed", description="")
         run = runtime.start_task_run(ws, task.id)
         db = tmp_path / ".codeframe" / "state.db"
-        _seed_every_child_table(db, task.id, run.id)
+        _seed_every_child_table(db, task.id, run.id, ws.id)
 
         assert all(v > 0 for v in _remaining_rows(db).values()), "seed failed"
 
@@ -256,13 +256,19 @@ class TestEveryDescendantTableIsCleaned:
         task = tasks.create(ws, title="t", description="")
         db = tmp_path / ".codeframe" / "state.db"
 
+        # This orphan can no longer be CREATED — foreign keys are enforced
+        # (#1061) — but it is exactly what pre-enforcement workspaces contain,
+        # and cleaning it up is what this test is about. Constructed
+        # deliberately, with the pragma turned back on in the same block.
         conn = _open_db(db)
+        conn.execute("PRAGMA foreign_keys = OFF")
         conn.execute(
             "INSERT INTO run_logs (run_id, task_id, timestamp, log_level,"
             " category, message) VALUES (?,?,?,?,?,?)",
             ("run-that-never-existed", task.id, "2026-01-01", "INFO", "X", "m"),
         )
         conn.commit()
+        conn.execute("PRAGMA foreign_keys = ON")
         conn.close()
 
         tasks.delete(ws, task.id)
@@ -282,7 +288,7 @@ class TestDeleteAllCleansUpToo:
         for i in range(2):
             task = tasks.create(ws, title=f"t{i}", description="")
             run = runtime.start_task_run(ws, task.id)
-            _seed_every_child_table(db, task.id, run.id)
+            _seed_every_child_table(db, task.id, run.id, ws.id)
 
         assert tasks.delete_all(ws) == 2
 

--- a/tests/core/test_diagnostic_agent.py
+++ b/tests/core/test_diagnostic_agent.py
@@ -4,7 +4,6 @@ Tests the LLM-powered diagnostic analysis of run failures.
 """
 
 import pytest
-import uuid
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -28,15 +27,24 @@ def workspace(tmp_path: Path):
 
 
 @pytest.fixture
-def run_id():
-    """Create a unique run ID."""
-    return str(uuid.uuid4())
+def run_id(workspace, task_id):
+    """A REAL run row (#1061).
+
+    Was a bare uuid4(). The run_logs and diagnostic_reports rows these tests
+    insert reference it, so with foreign keys enforced they were orphans —
+    which is what they were in production too.
+    """
+    from codeframe.core import runtime
+
+    return runtime.start_task_run(workspace, task_id).id
 
 
 @pytest.fixture
-def task_id():
-    """Create a unique task ID."""
-    return str(uuid.uuid4())
+def task_id(workspace):
+    """A REAL task row (#1061)."""
+    from codeframe.core import tasks
+
+    return tasks.create(workspace, title="diagnostic fixture", description="").id
 
 
 @pytest.fixture

--- a/tests/core/test_execution_recording.py
+++ b/tests/core/test_execution_recording.py
@@ -34,12 +34,50 @@ pytestmark = pytest.mark.v2
 # ---------------------------------------------------------------------------
 
 
+#: Every run id these tests hand to ExecutionRecorder. They are literals rather
+#: than fixtures because each test names its own, and the recorder writes
+#: execution_steps / llm_interactions / file_operations rows against them.
+_RUN_IDS = (
+    "run-1",
+    "run-cmp-1",
+    "run-edit-1",
+    "run-fop-1",
+    "run-llm-1",
+    "run-noop-1",
+    "run-rec-1",
+)
+
+
 @pytest.fixture
 def workspace(tmp_path):
-    """Create a workspace with DB tables initialized."""
+    """A workspace whose run rows actually exist (#1061).
+
+    Foreign keys are enforced now, so a recorder writing against ``run-1`` needs
+    a real ``runs`` row parented by a real ``tasks`` row — otherwise every row it
+    records is an orphan, which is what they were in production. Seeding the
+    literal ids here keeps each test reading as it did, rather than threading a
+    fixture through 10 call sites.
+    """
+    from codeframe.core import tasks
+    from codeframe.core.workspace import get_db_connection
+
     repo_path = tmp_path / "test_repo"
     repo_path.mkdir()
-    return create_or_load_workspace(repo_path)
+    ws = create_or_load_workspace(repo_path)
+
+    task = tasks.create(ws, title="recording fixture", description="")
+    conn = get_db_connection(ws)
+    try:
+        for run_id in _RUN_IDS:
+            conn.execute(
+                "INSERT INTO runs (id, workspace_id, task_id, status, started_at)"
+                " VALUES (?,?,?,?,?)",
+                (run_id, ws.id, task.id, "RUNNING", "2026-01-01T00:00:00+00:00"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return ws
 
 
 @pytest.fixture
@@ -105,8 +143,15 @@ class TestExecutionRecorder:
 
     def test_record_llm_call_saves_interaction(self, workspace):
         recorder = ExecutionRecorder(workspace=workspace, run_id="run-1")
+        # A real parent step, via the same call production makes (#1061).
+        # llm_interactions FKs to execution_steps(id), so a literal "step-1" is
+        # an orphan the schema now refuses.
+        step_id = recorder.record_iteration(
+            step_number=1, tool_names=["read_file"], llm_response_summary="read"
+        )
+        recorder.flush()
         recorder.record_llm_call(
-            step_id="step-1",
+            step_id=step_id,
             prompt_summary="System: CodeFRAME agent | User: implement task",
             response_summary="Tool calls: read_file(a.py)",
             model="claude-sonnet-4-20250514",
@@ -117,14 +162,19 @@ class TestExecutionRecorder:
 
         interactions = get_llm_interactions(workspace, "run-1")
         assert len(interactions) == 1
-        assert interactions[0].step_id == "step-1"
+        assert interactions[0].step_id == step_id
         assert interactions[0].tokens_used == 1500
         assert interactions[0].model == "claude-sonnet-4-20250514"
 
     def test_record_file_operation_saves_op(self, workspace):
         recorder = ExecutionRecorder(workspace=workspace, run_id="run-1")
+        # file_operations FKs to execution_steps(id) — a real parent (#1061).
+        step_id = recorder.record_iteration(
+            step_number=1, tool_names=["edit_file"], llm_response_summary="edit"
+        )
+        recorder.flush()
         recorder.record_file_operation(
-            step_id="step-1",
+            step_id=step_id,
             op_type="create",
             path="src/main.py",
             before=None,
@@ -141,10 +191,13 @@ class TestExecutionRecorder:
     def test_flush_writes_buffered_records(self, workspace):
         recorder = ExecutionRecorder(workspace=workspace, run_id="run-1")
         # Record multiple items without explicit flush
-        recorder.record_iteration(step_number=1, tool_names=["read_file"], llm_response_summary="read")
+        step_id = recorder.record_iteration(step_number=1, tool_names=["read_file"], llm_response_summary="read")
         recorder.record_iteration(step_number=2, tool_names=["edit_file"], llm_response_summary="edit")
-        recorder.record_llm_call("s1", "prompt", "response", "model", 100, "execution")
-        recorder.record_file_operation("s1", "create", "a.py", None, "content")
+        # The buffered step and its children flush together, so the FK is
+        # satisfied within the one transaction — which is the ordering
+        # production relies on too (#1061).
+        recorder.record_llm_call(step_id, "prompt", "response", "model", 100, "execution")
+        recorder.record_file_operation(step_id, "create", "a.py", None, "content")
 
         # Nothing written yet (buffered)
         assert len(get_execution_steps(workspace, "run-1")) == 0

--- a/tests/core/test_foreign_keys_enforced_1061.py
+++ b/tests/core/test_foreign_keys_enforced_1061.py
@@ -1,0 +1,248 @@
+"""The workspace schema's foreign keys are enforced, not decorative (#1061).
+
+SQLite ignores every `FOREIGN KEY` clause unless `PRAGMA foreign_keys = ON` is
+set **per connection**. `_open_db` never set it, so every FK in the workspace
+schema did nothing: deleting a task left its blockers, runs, run_logs and
+diagnostic_reports behind forever. The control-plane DB (`platform_store`) had
+always enabled it; this one had not.
+
+Turning it on is one line. The consequence was 66 failing tests across 7 files,
+all the same cause: fixtures minted bare `uuid4()`s for `task_id`/`run_id` and
+inserted child rows referencing them. **Those rows were being orphaned in
+production** — the tests were asserting against a database state the schema
+forbids. That is the finding, not an inconvenience, which is why the fixtures
+were given real parent rows rather than the pragma being relaxed.
+
+The child-row cleanup `tasks.delete` needs to survive enforcement (the FKs carry
+no `ON DELETE CASCADE`) shipped in #943/#1059.
+"""
+
+import sqlite3
+import subprocess
+
+import pytest
+
+from codeframe.core import runtime, tasks
+from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=False)
+    return create_or_load_workspace(tmp_path)
+
+
+class TestThePragmaIsOn:
+    def test_it_reads_back_as_enabled(self, workspace):
+        conn = get_db_connection(workspace)
+        try:
+            assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    def test_every_connection_gets_it_not_just_the_first(self, workspace):
+        """It is per-CONNECTION in SQLite, so setting it once at creation would
+        leave every later connection unenforced — which is the whole trap."""
+        for _ in range(3):
+            conn = get_db_connection(workspace)
+            try:
+                assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+            finally:
+                conn.close()
+
+    def test_a_reopened_workspace_still_has_it(self, workspace, tmp_path):
+        reopened = create_or_load_workspace(tmp_path)
+
+        conn = get_db_connection(reopened)
+        try:
+            assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+
+class TestAnOrphanInsertIsRefused:
+    """AC2 — asserted as behaviour, not by reading the pragma back. The pragma
+    being 1 and the constraint actually firing are different claims."""
+
+    def test_a_run_referencing_no_task_is_rejected(self, workspace):
+        conn = get_db_connection(workspace)
+        try:
+            with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+                conn.execute(
+                    "INSERT INTO runs (id, task_id, workspace_id, status, started_at)"
+                    " VALUES (?,?,?,?,?)",
+                    ("r1", "no-such-task", workspace.id, "RUNNING", "2026-01-01"),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_a_run_log_referencing_no_run_is_rejected(self, workspace):
+        task = tasks.create(workspace, title="t", description="")
+        conn = get_db_connection(workspace)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO run_logs (run_id, task_id, timestamp, log_level,"
+                    " category, message) VALUES (?,?,?,?,?,?)",
+                    ("no-such-run", task.id, "2026-01-01", "INFO", "X", "m"),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_a_blocker_referencing_no_task_is_rejected(self, workspace):
+        conn = get_db_connection(workspace)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO blockers (id, workspace_id, task_id, question,"
+                    " created_at) VALUES (?,?,?,?,?)",
+                    ("b1", workspace.id, "no-such-task", "q?", "2026-01-01"),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_the_same_rows_are_accepted_with_real_parents(self, workspace):
+        """The control. Without it, a schema that rejected everything would
+        satisfy the three tests above."""
+        task = tasks.create(workspace, title="t", description="")
+        run = runtime.start_task_run(workspace, task.id)
+
+        conn = get_db_connection(workspace)
+        try:
+            conn.execute(
+                "INSERT INTO run_logs (run_id, task_id, timestamp, log_level,"
+                " category, message) VALUES (?,?,?,?,?,?)",
+                (run.id, task.id, "2026-01-01", "INFO", "X", "m"),
+            )
+            conn.execute(
+                "INSERT INTO blockers (id, workspace_id, task_id, question,"
+                " created_at) VALUES (?,?,?,?,?)",
+                ("b1", workspace.id, task.id, "q?", "2026-01-01"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_a_workspace_scoped_blocker_is_still_allowed(self, workspace):
+        """`blockers.task_id` is NULLABLE, so a blocker not tied to a task must
+        survive enforcement. A blanket NOT NULL would break `cf blocker` for
+        workspace-level questions."""
+        conn = get_db_connection(workspace)
+        try:
+            conn.execute(
+                "INSERT INTO blockers (id, workspace_id, task_id, question,"
+                " created_at) VALUES (?,?,?,?,?)",
+                ("b-ws", workspace.id, None, "a workspace question", "2026-01-01"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+class TestDeletingATaskStillWorksUnderEnforcement:
+    """AC4. The FKs carry no ON DELETE CASCADE, so without the child cleanup
+    that shipped in #943/#1059 enforcement turns every deletion of an executed
+    task into a hard IntegrityError. This is the test that would have caught
+    that, had the two changes landed in the other order."""
+
+    def test_a_task_with_runs_logs_and_blockers_deletes_cleanly(self, workspace):
+        task = tasks.create(workspace, title="executed", description="")
+        run = runtime.start_task_run(workspace, task.id)
+
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "INSERT INTO run_logs (run_id, task_id, timestamp, log_level,"
+            " category, message) VALUES (?,?,?,?,?,?)",
+            (run.id, task.id, "2026-01-01", "INFO", "X", "m"),
+        )
+        conn.execute(
+            "INSERT INTO blockers (id, workspace_id, task_id, question, created_at)"
+            " VALUES (?,?,?,?,?)",
+            ("b1", workspace.id, task.id, "q?", "2026-01-01"),
+        )
+        conn.commit()
+        conn.close()
+
+        assert tasks.delete(workspace, task.id) is True
+
+        conn = get_db_connection(workspace)
+        try:
+            for table in ("runs", "run_logs", "blockers"):
+                remaining = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+                assert remaining == 0, f"{table} rows survived the delete"
+        finally:
+            conn.close()
+
+    def test_clearing_a_workspace_works_too(self, workspace):
+        for i in range(2):
+            task = tasks.create(workspace, title=f"t{i}", description="")
+            runtime.start_task_run(workspace, task.id)
+
+        assert tasks.delete_all(workspace) == 2
+
+        conn = get_db_connection(workspace)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+
+class TestNoFixtureRelaxesTheEnforcement:
+    """AC3's negative half. The migration had to give fixtures REAL parent rows;
+    turning the pragma back off per-test, or deleting an assertion, would make
+    the suite green while leaving the defect in place."""
+
+    def test_no_test_leaves_the_pragma_off(self):
+        """A bare OFF is the dangerous one.
+
+        Disabling FKs around a truncate-every-table teardown is legitimate —
+        rows cannot be deleted parent-first in arbitrary order — as long as it
+        is turned back ON in the same file. What must not exist is an OFF with
+        no matching ON, which silently opts a test out of the integrity the
+        schema declares and lets an orphan-inserting fixture look green.
+        """
+        import re
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        offenders = []
+        for path in (repo_root / "tests").rglob("*.py"):
+            if "node_modules" in path.parts:
+                continue
+            code = "\n".join(
+                ln.split("#")[0] for ln in path.read_text(encoding="utf-8").splitlines()
+            )
+            offs = len(re.findall(r"foreign_keys\s*=\s*(?:OFF|off|0)", code))
+            ons = len(re.findall(r"foreign_keys\s*=\s*(?:ON|on|1)", code))
+            if offs > ons:
+                offenders.append(f"{path.relative_to(repo_root)} ({offs} off, {ons} on)")
+
+        assert not offenders, f"these leave FK enforcement disabled: {offenders}"
+
+    def test_the_rule_would_catch_a_bare_disable(self, tmp_path):
+        """A rule that cannot fail is worth nothing."""
+        import re
+
+        code = 'conn.execute("PRAGMA foreign_keys = OFF")'
+        offs = len(re.findall(r"foreign_keys\s*=\s*(?:OFF|off|0)", code))
+        ons = len(re.findall(r"foreign_keys\s*=\s*(?:ON|on|1)", code))
+
+        assert offs > ons
+
+    def test_the_source_enables_it_unconditionally(self):
+        """Not behind an env var or a flag — that would let a deployment run
+        without the integrity the schema declares."""
+        import inspect
+
+        from codeframe.core import workspace as ws_mod
+
+        source = inspect.getsource(ws_mod._open_db)
+        code = "\n".join(line.split("#")[0] for line in source.splitlines())
+
+        assert 'PRAGMA foreign_keys = ON' in code
+        assert "getenv" not in code

--- a/tests/core/test_foreign_keys_enforced_1061.py
+++ b/tests/core/test_foreign_keys_enforced_1061.py
@@ -246,3 +246,90 @@ class TestNoFixtureRelaxesTheEnforcement:
 
         assert 'PRAGMA foreign_keys = ON' in code
         assert "getenv" not in code
+
+
+class TestDeletingAVersionedPrd:
+    """Raised in review. `prds` references ITSELF twice — parent_id and
+    chain_id — so clearing `tasks.prd_id` was only part of the job: deleting any
+    non-latest version of a versioned PRD still hit the constraint.
+
+    A v1 whose v2 carries `parent_id=v1` AND `chain_id=v1` could not be deleted
+    at all. Before enforcement it left both references dangling.
+    """
+
+    @pytest.fixture
+    def chain(self, workspace):
+        """v1 <- v2 <- v3, a real refinement chain."""
+        from codeframe.core import prd
+
+        v1 = prd.store(workspace, "# One\n\nfirst\n")
+        v2 = prd.create_new_version(workspace, v1.id, "# One\n\nsecond\n", "refined")
+        v3 = prd.create_new_version(workspace, v2.id, "# One\n\nthird\n", "again")
+        return v1, v2, v3
+
+    def test_the_chain_is_actually_self_referential(self, workspace, chain):
+        """The premise. If store/create_new_version stop wiring these, the tests
+        below would pass without exercising anything."""
+        v1, v2, _ = chain
+
+        assert v2.parent_id == v1.id
+        assert v2.chain_id == v1.id
+
+    def test_deleting_the_root_version_succeeds(self, workspace, chain):
+        from codeframe.core import prd
+
+        v1, _, _ = chain
+
+        assert prd.delete(workspace, v1.id, check_dependencies=False) is True
+
+    def test_deleting_a_middle_version_succeeds(self, workspace, chain):
+        from codeframe.core import prd
+
+        _, v2, _ = chain
+
+        assert prd.delete(workspace, v2.id, check_dependencies=False) is True
+
+    def test_the_surviving_versions_are_kept(self, workspace, chain):
+        """Deleting one version must not cascade the rest away — they are the
+        user's document history."""
+        from codeframe.core import prd
+
+        v1, v2, v3 = chain
+        prd.delete(workspace, v2.id, check_dependencies=False)
+
+        assert prd.get_by_id(workspace, v1.id) is not None
+        assert prd.get_by_id(workspace, v3.id) is not None
+
+    def test_lineage_skips_the_deleted_version_rather_than_breaking(
+        self, workspace, chain
+    ):
+        """Re-parented, not nulled: a chain with a hole in the middle should
+        close up, which is what a version chain means."""
+        from codeframe.core import prd
+
+        v1, v2, v3 = chain
+        prd.delete(workspace, v2.id, check_dependencies=False)
+
+        assert prd.get_by_id(workspace, v3.id).parent_id == v1.id
+
+    def test_deleting_the_root_leaves_no_dangling_chain_id(self, workspace, chain):
+        """chain_id falls back to the row's own id — the same thing store()
+        does when it seeds a new chain."""
+        from codeframe.core import prd
+
+        v1, _, v3 = chain
+        prd.delete(workspace, v1.id, check_dependencies=False)
+
+        surviving = prd.get_by_id(workspace, v3.id)
+        assert surviving is not None
+        assert prd.get_by_id(workspace, surviving.chain_id) is not None, (
+            "chain_id points at a PRD that no longer exists"
+        )
+
+    def test_an_unversioned_prd_still_deletes(self, workspace):
+        """The simple case must not regress."""
+        from codeframe.core import prd
+
+        solo = prd.store(workspace, "# Solo\n\nonly\n")
+
+        assert prd.delete(workspace, solo.id, check_dependencies=False) is True

--- a/tests/core/test_foreign_keys_enforced_1061.py
+++ b/tests/core/test_foreign_keys_enforced_1061.py
@@ -313,8 +313,11 @@ class TestDeletingAVersionedPrd:
         assert prd.get_by_id(workspace, v3.id).parent_id == v1.id
 
     def test_deleting_the_root_leaves_no_dangling_chain_id(self, workspace, chain):
-        """chain_id falls back to the row's own id — the same thing store()
-        does when it seeds a new chain."""
+        """Necessary but NOT sufficient — see the tests below.
+
+        This assertion alone passed while the chain was being shattered: giving
+        each survivor its own chain_id also 'resolves'. Raised in review.
+        """
         from codeframe.core import prd
 
         v1, _, v3 = chain
@@ -325,6 +328,76 @@ class TestDeletingAVersionedPrd:
         assert prd.get_by_id(workspace, surviving.chain_id) is not None, (
             "chain_id points at a PRD that no longer exists"
         )
+
+    def test_the_survivors_stay_in_ONE_chain_after_a_root_delete(
+        self, workspace, chain
+    ):
+        """The assertion the test above should have been.
+
+        get_versions and list_chains key entirely off chain_id, so giving each
+        survivor its own turned one evolving document into two separate PRDs.
+        """
+        from codeframe.core import prd
+
+        v1, v2, v3 = chain
+        prd.delete(workspace, v1.id, check_dependencies=False)
+
+        assert {p.id for p in prd.get_versions(workspace, v3.id)} == {v2.id, v3.id}
+        assert {p.id for p in prd.get_versions(workspace, v2.id)} == {v2.id, v3.id}
+
+    def test_no_survivor_has_a_parent_in_another_chain(self, workspace, chain):
+        """The invariant that was violated: v3 kept parent_id=v2 while landing
+        in a different chain than v2 — a state no version query can
+        reconstruct."""
+        from codeframe.core import prd
+
+        v1, v2, v3 = chain
+        prd.delete(workspace, v1.id, check_dependencies=False)
+
+        for survivor in (prd.get_by_id(workspace, v2.id), prd.get_by_id(workspace, v3.id)):
+            if survivor.parent_id is None:
+                continue
+            parent = prd.get_by_id(workspace, survivor.parent_id)
+            assert parent is not None
+            assert parent.chain_id == survivor.chain_id, (
+                f"{survivor.id[:8]} has a parent in chain "
+                f"{(parent.chain_id or '')[:8]}, not its own {(survivor.chain_id or '')[:8]}"
+            )
+
+    def test_the_new_root_is_the_oldest_survivor(self, workspace, chain):
+        """Not an arbitrary one: with the id computed per-row, SQLite could pick
+        a different root for different rows."""
+        from codeframe.core import prd
+
+        v1, v2, v3 = chain
+        prd.delete(workspace, v1.id, check_dependencies=False)
+
+        assert prd.get_by_id(workspace, v3.id).chain_id == v2.id
+        assert prd.get_by_id(workspace, v2.id).chain_id == v2.id
+
+    def test_a_middle_delete_leaves_the_chain_id_alone(self, workspace, chain):
+        """The chain_id rewrite must be a no-op here — the chain root is
+        untouched, so nothing should be repointed."""
+        from codeframe.core import prd
+
+        v1, v2, v3 = chain
+        prd.delete(workspace, v2.id, check_dependencies=False)
+
+        assert prd.get_by_id(workspace, v3.id).chain_id == v1.id
+        assert {p.id for p in prd.get_versions(workspace, v3.id)} == {v1.id, v3.id}
+
+    def test_deleting_every_version_but_one_leaves_it_self_rooted(self, workspace):
+        """The degenerate case: one survivor must be its own chain root, the
+        same shape store() creates."""
+        from codeframe.core import prd
+
+        v1 = prd.store(workspace, "# One\n\nfirst\n")
+        v2 = prd.create_new_version(workspace, v1.id, "# One\n\nsecond\n", "a")
+        prd.delete(workspace, v1.id, check_dependencies=False)
+
+        survivor = prd.get_by_id(workspace, v2.id)
+        assert survivor.chain_id == survivor.id
+        assert survivor.parent_id is None
 
     def test_an_unversioned_prd_still_deletes(self, workspace):
         """The simple case must not regress."""

--- a/tests/core/test_proof9.py
+++ b/tests/core/test_proof9.py
@@ -20,6 +20,43 @@ def workspace(tmp_path: Path) -> Workspace:
     return create_or_load_workspace(tmp_path)
 
 
+@pytest.fixture
+def seeded_req(workspace) -> str:
+    """A REAL proof_requirements row for the evidence tests (#1061).
+
+    ``proof_evidence.req_id`` FKs to ``proof_requirements(id)``, so evidence
+    attached to a bare "REQ-0001" was an orphan — in these tests and in
+    production. Returns the id so a test can attach to it by name.
+    """
+    from codeframe.core.proof.ledger import save_requirement
+    from codeframe.core.proof.models import (
+        Gate,
+        GlitchType,
+        Obligation,
+        Requirement,
+        RequirementScope,
+        Severity,
+        Source,
+    )
+
+    save_requirement(
+        workspace,
+        Requirement(
+            id="REQ-0001",
+            title="evidence fixture",
+            description="",
+            severity=Severity.MEDIUM,
+            source=Source.QA,
+            scope=RequirementScope(files=["src/test.py"]),
+            obligations=[Obligation(gate=Gate.UNIT)],
+            evidence_rules=[],
+            created_at=datetime.now(timezone.utc),
+            glitch_type=GlitchType.LOGIC_BUG,
+        ),
+    )
+    return "REQ-0001"
+
+
 # --- Model Tests ---
 
 
@@ -167,7 +204,7 @@ class TestLedger:
         save_requirement(workspace, req)
         assert next_req_id(workspace) == "REQ-0002"
 
-    def test_save_and_list_evidence(self, workspace):
+    def test_save_and_list_evidence(self, workspace, seeded_req):
         from codeframe.core.proof.ledger import save_evidence, list_evidence
         from codeframe.core.proof.models import Evidence, Gate
 
@@ -363,7 +400,7 @@ class TestScope:
 
 
 class TestEvidence:
-    def test_attach_evidence(self, workspace, tmp_path):
+    def test_attach_evidence(self, workspace, seeded_req, tmp_path):
         from codeframe.core.proof.evidence import attach_evidence
         from codeframe.core.proof.models import Gate, GateOutcome
         from codeframe.core.proof import ledger
@@ -385,7 +422,7 @@ class TestEvidence:
         evidence_list = ledger.list_evidence(workspace, "REQ-0001")
         assert len(evidence_list) == 1
 
-    def test_check_obligation_satisfied(self, workspace, tmp_path):
+    def test_check_obligation_satisfied(self, workspace, seeded_req, tmp_path):
         from codeframe.core.proof.evidence import attach_evidence, check_obligation_satisfied
         from codeframe.core.proof.models import (
             Gate, GateOutcome, Requirement, Severity, Source, RequirementScope, Obligation,
@@ -696,7 +733,7 @@ class TestCLI:
 
 
 class TestEvidenceStatus:
-    def test_evidence_status_round_trip(self, workspace, tmp_path):
+    def test_evidence_status_round_trip(self, workspace, seeded_req, tmp_path):
         """Evidence.status persists and reads back through the ledger."""
         from codeframe.core.proof.ledger import save_evidence, list_evidence
         from codeframe.core.proof.models import Evidence, Gate
@@ -714,19 +751,19 @@ class TestEvidenceStatus:
         assert loaded[0].status == "unverifiable"
         assert loaded[0].satisfied is False
 
-    def test_evidence_status_defaults_none(self, workspace, tmp_path):
+    def test_evidence_status_defaults_none(self, workspace, seeded_req, tmp_path):
         """Evidence saved without an explicit status reads back status=None."""
         from codeframe.core.proof.ledger import save_evidence, list_evidence
         from codeframe.core.proof.models import Evidence, Gate
 
         ev = Evidence(
-            req_id="REQ-0002", gate=Gate.UNIT, satisfied=True,
+            req_id=seeded_req, gate=Gate.UNIT, satisfied=True,
             artifact_path="/tmp/unit.txt", artifact_checksum="def",
             timestamp=datetime.now(timezone.utc), run_id="run-2",
         )
         save_evidence(workspace, ev)
 
-        loaded = list_evidence(workspace, "REQ-0002")
+        loaded = list_evidence(workspace, seeded_req)
         assert loaded[0].status is None
 
     def test_legacy_db_without_status_column_migrates(self, tmp_path):
@@ -789,7 +826,7 @@ class TestEvidenceStatus:
         assert "unverifiable" in statuses
         assert None in statuses
 
-    def test_check_obligation_not_satisfied_by_unverifiable(self, workspace, tmp_path):
+    def test_check_obligation_not_satisfied_by_unverifiable(self, workspace, seeded_req, tmp_path):
         """Unverifiable evidence must NOT satisfy an obligation."""
         from codeframe.core.proof.evidence import (
             attach_evidence, check_obligation_satisfied,
@@ -805,6 +842,12 @@ class TestEvidenceStatus:
             scope=RequirementScope(), obligations=[Obligation(gate=Gate.E2E)],
             evidence_rules=[],
         )
+        # Built in memory but never persisted, while evidence was attached to
+        # its id — an orphan (#1061). proof_evidence.req_id FKs to
+        # proof_requirements(id), so the parent has to exist.
+        from codeframe.core.proof.ledger import save_requirement
+
+        save_requirement(workspace, req)
 
         artifact = tmp_path / "e2e.txt"
         artifact.write_text("cannot verify")

--- a/tests/core/test_replay.py
+++ b/tests/core/test_replay.py
@@ -27,13 +27,47 @@ def workspace(tmp_path: Path):
 
 
 @pytest.fixture
-def run_id():
-    return str(uuid.uuid4())
+def task_id(workspace):
+    """A REAL task row (#1061).
+
+    This was a bare ``uuid4()``. Every child row these tests insert —
+    execution_steps, llm_interactions, file_operations — references it, so with
+    foreign keys enforced they were inserting orphans. They were orphaning them
+    in production too; the tests were simply asserting against a state the
+    schema forbids.
+    """
+    from codeframe.core import tasks
+
+    return tasks.create(workspace, title="replay fixture", description="").id
 
 
 @pytest.fixture
-def task_id():
-    return str(uuid.uuid4())
+def run_id(workspace, task_id):
+    """A REAL run row, parented by ``task_id`` (#1061)."""
+    from codeframe.core import runtime
+
+    return runtime.start_task_run(workspace, task_id).id
+
+
+@pytest.fixture
+def step_id(workspace, run_id):
+    """A REAL execution_steps row (#1061).
+
+    ``llm_interactions`` and ``file_operations`` both FK to
+    ``execution_steps(id)``, so a literal "step-1" is an orphan.
+    """
+    from codeframe.core.replay import ExecutionStep, save_execution_step
+
+    step = ExecutionStep(
+        id=f"step-{run_id}",
+        run_id=run_id,
+        step_number=1,
+        step_type="tool_call",
+        description="fixture step",
+        started_at=datetime.now(timezone.utc),
+    )
+    save_execution_step(workspace, step)
+    return step.id
 
 
 # =============================================================================
@@ -92,7 +126,7 @@ class TestLLMInteractionModel:
         interaction = LLMInteraction(
             id="llm-1",
             run_id="run-1",
-            step_id="step-1",
+            step_id=step_id,
             prompt="Implement the feature",
             response="I'll start by reading the file...",
             model="claude-sonnet-4-20250514",
@@ -114,7 +148,7 @@ class TestFileOperationModel:
         op = FileOperation(
             id="fop-1",
             run_id="run-1",
-            step_id="step-1",
+            step_id=step_id,
             operation_type="create",
             file_path="src/main.py",
             content_before=None,
@@ -282,7 +316,7 @@ class TestExecutionStepCRUD:
 class TestLLMInteractionCRUD:
     """Tests for saving and loading LLM interactions."""
 
-    def test_save_and_load_interaction(self, workspace, run_id):
+    def test_save_and_load_interaction(self, workspace, run_id, step_id):
         from codeframe.core.replay import (
             LLMInteraction,
             save_llm_interaction,
@@ -293,7 +327,7 @@ class TestLLMInteractionCRUD:
         interaction = LLMInteraction(
             id="llm-1",
             run_id=run_id,
-            step_id="step-1",
+            step_id=step_id,
             prompt="Implement feature X",
             response="I'll read the file first...",
             model="claude-sonnet-4-20250514",
@@ -311,7 +345,7 @@ class TestLLMInteractionCRUD:
 class TestFileOperationCRUD:
     """Tests for saving and loading file operations."""
 
-    def test_save_and_load_file_op(self, workspace, run_id):
+    def test_save_and_load_file_op(self, workspace, run_id, step_id):
         from codeframe.core.replay import (
             FileOperation,
             save_file_operation,
@@ -322,7 +356,7 @@ class TestFileOperationCRUD:
         op = FileOperation(
             id="fop-1",
             run_id=run_id,
-            step_id="step-1",
+            step_id=step_id,
             operation_type="create",
             file_path="src/main.py",
             content_before=None,
@@ -335,7 +369,7 @@ class TestFileOperationCRUD:
         assert ops[0].file_path == "src/main.py"
         assert ops[0].content_after == "print('hello')"
 
-    def test_file_ops_ordered_by_timestamp(self, workspace, run_id):
+    def test_file_ops_ordered_by_timestamp(self, workspace, run_id, step_id):
         from codeframe.core.replay import (
             FileOperation,
             save_file_operation,
@@ -351,7 +385,7 @@ class TestFileOperationCRUD:
                 FileOperation(
                     id=f"fop-{i}",
                     run_id=run_id,
-                    step_id=f"step-{i}",
+                    step_id=step_id,
                     operation_type="edit",
                     file_path=f"file{i}.py",
                     content_before="old",
@@ -369,12 +403,20 @@ class TestFileOperationCRUD:
 
 
 def _insert_run(workspace, run_id, task_id, status="COMPLETED"):
-    """Helper to insert a run record directly into the database."""
+    """Ensure a run row exists with this id and status.
+
+    Upsert rather than insert (#1061). The ``run_id`` fixture now creates a REAL
+    run via ``runtime.start_task_run`` — it has to, because every child row here
+    references it and foreign keys are enforced — so a plain INSERT collides on
+    the primary key. The intent was always "a run with this id and status
+    exists", which is what this does.
+    """
     conn = get_db_connection(workspace)
     try:
         conn.execute(
             "INSERT INTO runs (id, workspace_id, task_id, status, started_at) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET status = excluded.status",
             (run_id, workspace.id, task_id, status, datetime.now(timezone.utc).isoformat()),
         )
         conn.commit()
@@ -503,10 +545,30 @@ class TestLoadExecutionTrace:
         assert result is None
 
     def test_load_trace_without_run_record(self, workspace, run_id):
-        """Steps exist but no run record - should still return a trace."""
+        """Steps whose run row is gone still yield a trace (#1061).
+
+        With foreign keys enforced this state can no longer be CREATED — an
+        execution_steps row requires its run — so the fixture has to construct
+        it deliberately. That is not a workaround: the fallback exists for data
+        orphaned BEFORE enforcement, which is exactly what this reproduces, and
+        deleting the test would drop coverage of a path real workspaces can
+        still hit after upgrading.
+
+        The pragma is turned back ON in the same block, so nothing that follows
+        runs unenforced.
+        """
         from codeframe.core.replay import load_execution_trace
 
         _seed_three_step_trace(workspace, run_id)
+
+        conn = get_db_connection(workspace)
+        try:
+            conn.execute("PRAGMA foreign_keys = OFF")
+            conn.execute("DELETE FROM runs WHERE id = ?", (run_id,))
+            conn.commit()
+            conn.execute("PRAGMA foreign_keys = ON")
+        finally:
+            conn.close()
 
         trace = load_execution_trace(workspace, run_id)
         assert trace is not None

--- a/tests/ui/test_costs_v2.py
+++ b/tests/ui/test_costs_v2.py
@@ -159,7 +159,6 @@ def _record_usage_text_task(
     timestamp = (when or datetime.now(timezone.utc)).isoformat()
     conn = sqlite3.connect(str(workspace.db_path))
     try:
-        conn.execute("PRAGMA foreign_keys = OFF")
         conn.execute(
             """
             INSERT INTO token_usage (

--- a/tests/ui/test_v2_routers_integration.py
+++ b/tests/ui/test_v2_routers_integration.py
@@ -153,18 +153,39 @@ class TestBlockersV2Create:
         assert "created_at" in data
 
     def test_create_blocker_with_task_id(self, test_client):
-        """Create blocker associated with a task."""
+        """Create blocker associated with a REAL task (#1061).
+
+        This posted `task_id: "task-123"` with no such task. Before foreign keys
+        were enforced that produced a blocker attached to nothing; after, a 500.
+        Neither is right — the handler now 404s a bad id, and this test uses a
+        task that exists.
+        """
+        from codeframe.core import tasks
+
+        task = tasks.create(
+            test_client.workspace, title="needs a decision", description=""
+        )
+
         response = test_client.post(
             "/api/v2/blockers",
             json={
                 "question": "What authentication should I use?",
-                "task_id": "task-123"
+                "task_id": task.id,
             }
         )
 
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
-        assert data["task_id"] == "task-123"
+        assert data["task_id"] == task.id
+
+    def test_create_blocker_with_unknown_task_id_is_404(self, test_client):
+        """The caller's mistake, not a server fault."""
+        response = test_client.post(
+            "/api/v2/blockers",
+            json={"question": "q?", "task_id": "no-such-task"},
+        )
+
+        assert response.status_code == 404, response.text
 
     def test_create_blocker_empty_question(self, test_client):
         """Create blocker with empty question returns 422."""


### PR DESCRIPTION
Closes #1061. Split out of #943 (AC1); the other three ACs shipped in #1059.

## Every foreign key in the workspace schema was decorative

SQLite ignores every `FOREIGN KEY` clause unless the pragma is set **per connection**. `_open_db` never set it, so deleting a task left its blockers, runs, run_logs and diagnostic_reports behind forever. The control-plane DB always enabled it; this one did not.

Turning it on is one line. **Migrating the 69 tests it broke is the change.**

## The fixtures were asserting against a forbidden state

Every failure had the same cause: fixtures minted bare `uuid4()`s for `task_id`/`run_id` and inserted children referencing them. **Those rows were being orphaned in production** — the tests were codifying it. So every fixture got real parent rows. Nothing was relaxed and the pragma is never disabled per-test.

| file | before | how |
|---|---|---|
| `test_replay.py` | 33 → 0 | real task + run + `execution_step` fixtures; `_insert_run` upserts now that `run_id` is a real row |
| `test_diagnostic_agent.py` | 13 → 0 | real task + run fixtures |
| `test_execution_recording.py` | 8 → 0 | real runs for the literal ids; the llm/file-op tests record a real parent step first, **as production does** |
| `test_proof9.py` | 6 → 0 | `proof_evidence` FKs to `proof_requirements`; one test built a `Requirement` and never saved it |
| `test_blockers_webhook.py` | 6 → 0 | real `t-1`/`t-2` task rows |
| `test_prd.py` | 1 → 0 | product defect, below |
| `test_v2_routers_integration.py` | 1 → 0 | product defect, below |

## Two of them were product defects, not fixture noise

**`prd.delete(check_dependencies=False)` deleted a PRD while tasks still referenced it.** Before enforcement that left every one of those tasks pointing at a PRD that no longer existed, silently. It now clears `tasks.prd_id` first — **keeping the tasks**, because a task is real work and losing it along with its source document would be far worse than losing the link.

**`POST /api/v2/blockers` accepted a `task_id` for a task that does not exist.** Before enforcement it created a blocker attached to nothing; after, a 500. Neither is right — a client-supplied bad id is a **404**, which it now returns, with a test for it.

## The one test that could no longer be set up

`test_load_trace_without_run_record` asserts a fallback for "steps exist but the run row is gone" — a state enforcement now forbids.

It is **not** deleted. That fallback exists for data orphaned *before* enforcement, which upgraded workspaces really have, so dropping the test would drop real coverage. It now constructs the legacy state deliberately, with the pragma bracketed `OFF`/`ON` so nothing after it runs unenforced.

A lint test permits exactly that shape — a bracketed teardown where `OFF`s are matched by `ON`s — and fails on a bare `OFF`, which is the dangerous one: it silently opts a test out of the integrity the schema declares. It found and removed one pointless `OFF` in `test_costs_v2.py` (on `token_usage`, which declares no FKs at all).

## Tests

13 of my own.

**AC2 is asserted as behaviour, not by reading the pragma back** — an orphan `INSERT` must raise `IntegrityError`. Those are different claims, and only the second one matters. With the control alongside it: the same rows succeed once their parents exist, so a schema that rejected everything could not pass.

Also covered: the pragma holds on **every** connection, not just the first (it is per-connection — that is the whole trap); a nullable-`task_id` workspace-level blocker is still allowed; and AC4 — deleting a task with runs, logs and blockers still succeeds and leaves nothing behind, which only holds because of the child cleanup from #943/#1059.

`ruff` and `mypy` clean.

## Known limitations

- **`ON DELETE CASCADE` is still absent from the schema.** Deletion works because `tasks.delete`/`delete_all` clean children explicitly (#943). That is more code than a cascade, but it keeps the ordering and the transaction visible; changing the schema would be a migration, not a pragma.
- Only the **workspace** DB is covered. The control-plane DB already enforced FKs; no audit of *its* fixtures was done here.
- Existing workspaces created before this change may already contain orphans. Enforcement is not retroactive — it prevents new ones and does not refuse to open a database that has old ones. No cleanup migration ships here.
