### PR TITLE
docs(api): make the published API docs describe the server that exists (#951)

### DIFF
--- a/codeframe/ui/routers/checkpoints_v2.py
+++ b/codeframe/ui/routers/checkpoints_v2.py
@@ -2,8 +2,6 @@
 
 This module provides v2-style API endpoints for checkpoint management that
 delegate to core/checkpoints.py. It uses the v2 Workspace model.
-
-The v1 router (checkpoints.py) remains for backwards compatibility.
 """
 
 import logging

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -1,17 +1,12 @@
 """V2 Discovery workflow router - delegates to core modules.
 
 This module provides v2-style API endpoints for PRD discovery that delegate
-to core/prd_discovery.py. It uses the v2 Workspace model and is designed
-to work alongside the v1 discovery router during migration.
+to core/prd_discovery.py.
 
-Key differences from v1:
 - Uses Workspace (path-based) instead of project_id
 - Delegates to core/prd_discovery functions
 - Stateless session management via session_id
 - No LeadAgent dependency
-
-The v1 router (discovery.py) remains for backwards compatibility with
-existing web UI until Phase 3 (Web UI Rebuild).
 """
 
 import logging

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -1,7 +1,7 @@
 """V2 Discovery workflow router - delegates to core modules.
 
 This module provides v2-style API endpoints for PRD discovery that delegate
-to core/prd_discovery.py.
+to core/prd_discovery.py. It:
 
 - Uses Workspace (path-based) instead of project_id
 - Delegates to core/prd_discovery functions

--- a/codeframe/ui/routers/git_v2.py
+++ b/codeframe/ui/routers/git_v2.py
@@ -2,8 +2,6 @@
 
 This module provides v2-style API endpoints for git operations
 that delegate to core modules. It uses the v2 Workspace model.
-
-The v1 router (git.py) remains for backwards compatibility.
 """
 
 import logging

--- a/codeframe/ui/routers/prd_v2.py
+++ b/codeframe/ui/routers/prd_v2.py
@@ -420,8 +420,9 @@ async def stress_test_prd_stream_endpoint(
     the web equivalent of ``cf prd stress-test``.
 
     Declared as GET (not POST) so it is reachable from a browser
-    ``EventSource``, matching ``GET /api/v2/tasks/{task_id}/stream``. No custom
-    auth headers are required (cookie-based auth via ``withCredentials``).
+    ``EventSource``, matching ``GET /api/v2/tasks/{task_id}/stream``. Since
+    ``EventSource`` cannot send an ``Authorization`` header, this route accepts
+    a single-use ``?ticket=`` from ``POST /auth/stream-ticket`` (#745).
 
     Event payloads (JSON in the SSE ``data:`` field, ``type`` field):
         - ``goals_extracted``: high-level goals parsed from the PRD

--- a/codeframe/ui/routers/review_v2.py
+++ b/codeframe/ui/routers/review_v2.py
@@ -2,8 +2,6 @@
 
 This module provides v2-style API endpoints for code review operations
 that delegate to core modules. It uses the v2 Workspace model.
-
-The v1 router (review.py) remains for backwards compatibility.
 """
 
 import logging

--- a/codeframe/ui/routers/schedule_v2.py
+++ b/codeframe/ui/routers/schedule_v2.py
@@ -2,8 +2,6 @@
 
 This module provides v2-style API endpoints for schedule management that
 delegate to core/schedule.py. It uses the v2 Workspace model.
-
-The v1 router (schedule.py) remains for backwards compatibility.
 """
 
 import logging

--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -1,7 +1,10 @@
 """WebSocket router for per-session streaming agent chat.
 
 Endpoint:
-    WS /ws/sessions/{session_id}/chat?token=<JWT>
+    WS /ws/sessions/{session_id}/chat?ticket=<ticket>
+
+Auth: a single-use, 60s ticket from ``POST /auth/stream-ticket`` (#745). A JWT
+in the query string is not accepted.
 
 Client → Server message types:
     {"type": "message", "content": "..."}

--- a/codeframe/ui/routers/session_chat_ws.py
+++ b/codeframe/ui/routers/session_chat_ws.py
@@ -28,8 +28,8 @@ core.session_chat_service) would make this a thin transport adapter. See
 GitHub issue #502 for context.
 
 Workspace scoping: This endpoint is intentionally exempt from workspace_path
-query param validation. Auth is already scoped to a user via JWT and the
-session_id identifies the resource — workspace scoping on a per-session WS
+query param validation. The redeemed ticket already scopes auth to a user and
+the session_id identifies the resource — workspace scoping on a per-session WS
 would be redundant. Revisit if multi-tenant workspace isolation is required.
 """
 
@@ -49,7 +49,9 @@ from codeframe.ui.shared import session_chat_manager
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["websocket"])
+# No tags: add_api_websocket_route ignores the router-level ``tags`` kwarg,
+# because WebSockets are not part of the OpenAPI schema at all (#951).
+router = APIRouter()
 
 # Maps a session ``agent_type`` (agent vocabulary: "claude", "codex", ...) to an
 # LLM ``provider_type`` understood by ``get_provider`` ("anthropic", ...). Only

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -1,7 +1,7 @@
 """V2 Task execution router - delegates to core modules.
 
 This module provides v2-style API endpoints for task management that delegate
-to core/runtime.py and core/conductor.py.
+to core/runtime.py and core/conductor.py. It:
 
 - Uses Workspace (path-based) instead of project_id
 - Delegates to core/runtime and core/conductor functions

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -1,18 +1,13 @@
 """V2 Task execution router - delegates to core modules.
 
 This module provides v2-style API endpoints for task management that delegate
-to core/runtime.py and core/conductor.py. It uses the v2 Workspace model and
-is designed to work alongside the v1 tasks router during migration.
+to core/runtime.py and core/conductor.py.
 
-Key differences from v1:
 - Uses Workspace (path-based) instead of project_id
 - Delegates to core/runtime and core/conductor functions
 - No LeadAgent dependency for execution
 - Uses conductor.create_batch() + a worker thread, so batch execution never
   blocks the event loop (#901)
-
-The v1 router (tasks.py) remains for backwards compatibility with
-existing web UI until Phase 3 (Web UI Rebuild).
 """
 
 import functools

--- a/codeframe/ui/routers/templates_v2.py
+++ b/codeframe/ui/routers/templates_v2.py
@@ -2,8 +2,6 @@
 
 This module provides v2-style API endpoints for template management that
 delegate to core/templates.py. It uses the v2 Workspace model.
-
-The v1 router (templates.py) remains for backwards compatibility.
 """
 
 import logging

--- a/codeframe/ui/routers/terminal_ws.py
+++ b/codeframe/ui/routers/terminal_ws.py
@@ -1,7 +1,10 @@
 """WebSocket router for interactive terminal in a session workspace.
 
 Endpoint:
-    WS /ws/sessions/{session_id}/terminal?token=<JWT>
+    WS /ws/sessions/{session_id}/terminal?ticket=<ticket>
+
+Auth: a single-use, 60s ticket from ``POST /auth/stream-ticket`` (#745). A JWT
+in the query string is not accepted.
 
 Client → Server message types:
     Raw bytes / text: forwarded verbatim to subprocess stdin.

--- a/codeframe/ui/routers/terminal_ws.py
+++ b/codeframe/ui/routers/terminal_ws.py
@@ -32,7 +32,9 @@ from codeframe.ui.dependencies import revalidate_workspace_path
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["websocket"])
+# No tags: add_api_websocket_route ignores the router-level ``tags`` kwarg,
+# because WebSockets are not part of the OpenAPI schema at all (#951).
+router = APIRouter()
 
 # Per-user concurrent terminal connection counter (in-process; resets on restart).
 # Key is the user_id, or None in no-auth mode (all local terminals share a bucket).

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -564,7 +564,7 @@ OPENAPI_TAGS = [
     },
     {
         "name": "review-v2",
-        "description": "Code review - inspect the working diff and export it as a patch.",
+        "description": "Code review - inspect the working diff, export it as a patch, run an AI review over changed files or a task, and draft a commit message.",
     },
     {
         "name": "git-v2",

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -497,137 +497,174 @@ async def lifespan(app: FastAPI):
 # OpenAPI Tags and Metadata
 # ============================================================================
 
+# Tags must stay in sync with the tags of the routers actually mounted below —
+# tests/ui/test_openapi_docs_accuracy.py asserts the two sets are equal (#951).
+# The two WebSocket routes carry no OpenAPI tag (WebSockets are not part of the
+# OpenAPI schema); they are documented in OPENAPI_DESCRIPTION instead.
 OPENAPI_TAGS = [
     {
         "name": "health",
         "description": "Health check endpoints - verify API availability and get deployment information.",
     },
     {
-        "name": "projects",
-        "description": "Project lifecycle and management - create, read, update, delete projects and access project status, tasks, activity, PRD, and session state.",
-    },
-    {
-        "name": "tasks",
-        "description": "Task creation, management, and approval workflow - create tasks, approve generated tasks to start development, and manually trigger task assignment.",
-    },
-    {
-        "name": "agents",
-        "description": "Agent lifecycle and assignment - start/pause/resume agents, assign agents to projects with roles, and manage multi-agent workflows.",
-    },
-    {
-        "name": "blockers",
-        "description": "Human-in-the-loop blocker management - list, view, and resolve blockers that require human guidance for agents to continue.",
-    },
-    {
-        "name": "checkpoints",
-        "description": "Project checkpoint and restore functionality - create snapshots of project state and restore to previous checkpoints.",
-    },
-    {
-        "name": "chat",
-        "description": "Chat and communication endpoints for real-time interaction with agents.",
-    },
-    {
-        "name": "context",
-        "description": "Context management for agent execution - manage codebase context, file references, and relevant information.",
-    },
-    {
-        "name": "discovery",
-        "description": "Discovery phase operations - codebase analysis, structure detection, and initial project understanding.",
-    },
-    {
-        "name": "git",
-        "description": "Git operations - commit, branch, diff, and repository management.",
-    },
-    {
-        "name": "lint",
-        "description": "Code linting operations - run and manage linting checks.",
-    },
-    {
-        "name": "metrics",
-        "description": "Metrics and analytics - project progress, agent performance, and quality metrics.",
-    },
-    {
-        "name": "quality_gates",
-        "description": "Quality gates and checks - run tests, type checking, coverage, and code review gates.",
-    },
-    {
-        "name": "review",
-        "description": "Code review functionality - trigger and manage AI-powered code reviews.",
-    },
-    {
-        "name": "schedule",
-        "description": "Task scheduling - view schedule predictions, bottlenecks, and critical path analysis.",
-    },
-    {
-        "name": "session",
-        "description": "Session management - track session state, progress, and continuity across work sessions.",
-    },
-    {
-        "name": "templates",
-        "description": "Project and task templates - list, view, and apply reusable templates.",
-    },
-    {
-        "name": "websocket",
-        "description": "WebSocket connections for real-time updates and event streaming.",
-    },
-    {
         "name": "auth",
-        "description": "Authentication and authorization - login, logout, API keys, and session management.",
+        "description": "Authentication - bootstrap registration, login, and short-lived stream tickets for SSE/WebSocket connections.",
+    },
+    {
+        "name": "users",
+        "description": "The authenticated user's own account - read and update the current user record.",
+    },
+    {
+        "name": "api-keys",
+        "description": "API key management - create, list, and revoke long-lived `X-API-Key` credentials.",
+    },
+    {
+        "name": "workspaces-v2",
+        "description": "Workspace lifecycle - initialize a workspace on a repository path, read its status, and manage its configuration.",
+    },
+    {
+        "name": "prd-v2",
+        "description": "PRD management - read and version the product requirements document, and run the streaming stress-test that surfaces and resolves ambiguities.",
+    },
+    {
+        "name": "discovery-v2",
+        "description": "Discovery phase - interactive PRD discovery sessions that turn a codebase and a conversation into a PRD.",
+    },
+    {
+        "name": "tasks-v2",
+        "description": "Task management and execution - list, create, and update tasks, start work on one, and stream its execution events (SSE).",
+    },
+    {
+        "name": "batches-v2",
+        "description": "Batch orchestration - run many tasks serially or in parallel, and monitor, cancel, or resume a batch.",
+    },
+    {
+        "name": "diagnose-v2",
+        "description": "Task diagnostics - explain why a task stalled, failed, or is blocked.",
+    },
+    {
+        "name": "blockers-v2",
+        "description": "Human-in-the-loop blockers - list, view, and answer the questions an agent raised before it can continue.",
+    },
+    {
+        "name": "sessions-v2",
+        "description": "Interactive agent sessions - create a session, replay its message history, and manage its lifecycle. Live chat and terminal I/O run over the WebSocket routes described above.",
+    },
+    {
+        "name": "events",
+        "description": "Append-only event log - query the durable record of what the orchestrator and its agents did.",
     },
     {
         "name": "proof-v2",
-        "description": "PROOF9 quality system — capture requirements from glitches, run proof obligations, manage waivers, and query evidence.",
+        "description": "PROOF9 quality system - capture requirements from glitches, run proof obligations, manage waivers, and query evidence.",
+    },
+    {
+        "name": "gates-v2",
+        "description": "Verification gates - run the test, lint, type-check and coverage gates and read their results.",
+    },
+    {
+        "name": "review-v2",
+        "description": "Code review - inspect the working diff and export it as a patch.",
+    },
+    {
+        "name": "git-v2",
+        "description": "Git operations - status, diff, branch, and commit against the workspace repository.",
+    },
+    {
+        "name": "pr-v2",
+        "description": "GitHub pull requests - create a PR, read its status and checks, and merge it through the PROOF9 merge gate.",
+    },
+    {
+        "name": "checkpoints-v2",
+        "description": "Workspace checkpoints - snapshot workspace state and restore a previous snapshot.",
+    },
+    {
+        "name": "schedule-v2",
+        "description": "Task scheduling - schedule predictions, bottlenecks, and critical-path analysis over the task graph.",
+    },
+    {
+        "name": "templates-v2",
+        "description": "Project and task templates - list, view, and apply reusable templates.",
+    },
+    {
+        "name": "environment-v2",
+        "description": "Environment management - check the toolchain a workspace needs, install what is missing, and run diagnostics.",
+    },
+    {
+        "name": "metrics",
+        "description": "Cost and token metrics - spend summaries and per-task / per-agent token breakdowns.",
+    },
+    {
+        "name": "settings",
+        "description": "Server and workspace settings - agent defaults, provider API keys, PROOF9 defaults, and outbound notification webhooks.",
     },
     {
         "name": "integrations",
-        "description": "External service integrations — connect a GitHub repository via Personal Access Token for issue import.",
+        "description": "External service integrations - connect a GitHub repository via Personal Access Token, then browse and import its issues as tasks.",
     },
 ]
 
 OPENAPI_DESCRIPTION = """
 # CodeFRAME API
 
-**CodeFRAME** is an AI-powered software development framework that orchestrates multiple agents
-to complete programming tasks. This API provides real-time monitoring and control for CodeFRAME projects.
+**CodeFRAME** is a project delivery system for AI-assisted software work: Think → Build →
+Prove → Ship. It owns the edges of the pipeline — requirements, task decomposition,
+verification gates, and shipping — and delegates the code writing to frontier coding
+agents. This API is the HTTP surface over that system; the `cf` CLI drives the same core
+without a server.
 
 ## Overview
 
 The CodeFRAME API enables you to:
 
-- **Create and manage projects** - Initialize projects from git repos, local paths, or start empty
-- **Generate and approve tasks** - AI generates implementation tasks from PRDs; approve to start development
-- **Monitor agent execution** - Track agents as they work through tasks with real-time WebSocket updates
-- **Handle blockers** - Provide human guidance when agents encounter decisions requiring input
-- **Review and ship** - Run quality gates, review code changes, and manage the deployment process
+- **Set up a workspace** - Initialize CodeFRAME on a repository path and manage its configuration
+- **Think** - Author and version a PRD, stress-test it for ambiguities, and generate tasks from it
+- **Build** - Start work on a task or a batch of tasks, follow execution events in real time, and answer blockers
+- **Prove** - Run verification gates and the PROOF9 evidence system over the result
+- **Ship** - Review the diff, open a pull request, and merge it through the PROOF9 merge gate
 
 ## Authentication
 
 All `/api/v2/*` endpoints require authentication by default (disable for local
-development with `CODEFRAME_AUTH_REQUIRED=false`). Public: `/`, `/health`, docs,
-and the `/auth/*` login/register endpoints. Two authentication methods:
+development with `CODEFRAME_AUTH_REQUIRED=false`). Public: `/`, `/health`, the docs, and
+the `/auth/*` login and bootstrap-registration endpoints. Two authentication methods:
 
-1. **API Key** - Include `X-API-Key` header with your API key
-2. **Session Token** - Use JWT token from login endpoint in `Authorization: Bearer <token>` header
+1. **API Key** - Include an `X-API-Key` header with your API key
+2. **Session Token** - Use the JWT from the login endpoint in an `Authorization: Bearer <token>` header
 
-SSE streaming endpoints additionally accept the JWT as a `?token=` query
-parameter (browser EventSource cannot send headers); this applies to the
-streaming routes only.
+Scopes are derived from the account: every principal has `read` and `write`; `admin` is
+granted only to a superuser. Safe methods require `read`, mutating methods require
+`write`, and a few routes (credential storage, PR merge) require `admin`.
+
+### Streaming connections
+
+Browser `EventSource` and `WebSocket` clients cannot send an `Authorization` header, so
+streams authenticate with a **single-use ticket** instead — never with a JWT in the URL.
+Call `POST /auth/stream-ticket` (write scope) to mint a ticket, then append it as
+`?ticket=<value>` when opening the connection. A ticket is valid for 60 seconds and is
+consumed on first use, so fetch a fresh one for every connection and every reconnect.
+
+Tickets are accepted **only** on these routes:
+
+| Route | Kind |
+|---|---|
+| `GET /api/v2/tasks/{task_id}/stream` | SSE |
+| `GET /api/v2/tasks/{task_id}/output` | SSE |
+| `GET /api/v2/prd/stress-test` | SSE |
+| `WS /ws/sessions/{session_id}/chat` | WebSocket |
+| `WS /ws/sessions/{session_id}/terminal` | WebSocket |
+
+The two WebSocket routes do not appear in this schema — OpenAPI does not describe
+WebSockets. `chat` streams agent output as `text_delta`, `tool_use_start`, `tool_result`,
+`thinking`, `cost_update`, `done` and `error` messages; `terminal` forwards raw bytes to
+and from a shell in the session workspace.
 
 ## Rate Limiting
 
-The API implements rate limiting to ensure fair usage:
-- **Standard endpoints**: Higher request limits for read operations
-- **AI endpoints** (agent start, LLM calls): Lower limits due to computational cost
-
-Rate limit headers are included in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
-
-## WebSocket Events
-
-For real-time updates, connect to the WebSocket endpoint. Events include:
-- `task_assigned`, `task_completed`, `task_failed`
-- `agent_created`, `agent_status`
-- `blocker_created`, `blocker_resolved`
-- `discovery_starting`, `discovery_completed`
+The API rate-limits by client, with a lower limit on AI endpoints (agent start, LLM
+calls) than on ordinary reads. Exceeding a limit returns `429` with a `Retry-After`
+header (seconds) and an `X-RateLimit-Limit` header describing the limit that was hit.
+Successful responses do not carry rate-limit headers.
 
 ## Error Responses
 
@@ -860,7 +897,7 @@ app.include_router(auth_router.router)
 # methods need ``write``. Admin-only routes (credential storage, PR merge) add
 # their own ``Depends(require_scope("admin"))``. The two WebSocket routers
 # (session_chat_ws, terminal_ws) are intentionally excluded — they perform
-# their own ?token= JWT auth. The auth_router (login/register) stays public.
+# their own single-use ?ticket= auth (#745). The auth_router stays public.
 _AUTH = [Depends(require_method_scope)]
 app.include_router(batches_v2.router, dependencies=_AUTH)       # /api/v2/batches
 app.include_router(blockers_v2.router, dependencies=_AUTH)      # /api/v2/blockers

--- a/tests/ui/test_openapi_docs_accuracy.py
+++ b/tests/ui/test_openapi_docs_accuracy.py
@@ -1,0 +1,75 @@
+"""The published API docs must describe the server that actually exists (#951).
+
+/docs is the integrator's first contact with the product. When it advertises
+endpoints that were deleted, an auth mechanism that was removed (#745's
+``?token=``), or response headers the limiter never emits, every integrator
+following it gets 401s on day one. These are cheap assertions that break the
+build the next time prose and code diverge.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from codeframe.ui import server
+
+pytestmark = pytest.mark.v2
+
+ROUTERS = Path(server.__file__).parent / "routers"
+
+
+def _tags_used_by_mounted_routers() -> set:
+    return {t for route in server.app.routes for t in (getattr(route, "tags", None) or [])}
+
+
+def test_openapi_tags_match_the_mounted_routers():
+    """OPENAPI_TAGS listed 16 tags no router uses ('projects', 'agents', ...)
+    while 20 real tags went undocumented."""
+    declared = {t["name"] for t in server.OPENAPI_TAGS}
+    assert declared == _tags_used_by_mounted_routers()
+
+
+def test_openapi_tag_names_are_unique_and_described():
+    names = [t["name"] for t in server.OPENAPI_TAGS]
+    assert len(names) == len(set(names))
+    assert all(t.get("description") for t in server.OPENAPI_TAGS)
+
+
+def test_description_does_not_advertise_query_string_jwt_auth():
+    """``?token=<JWT>`` was removed in #745 — only single-use ``?ticket=`` works."""
+    assert "?token=" not in server.OPENAPI_DESCRIPTION
+
+
+def test_description_does_not_promise_headers_the_limiter_never_emits():
+    """The 429 handler sends Retry-After and X-RateLimit-Limit. Nothing sends
+    X-RateLimit-Remaining or X-RateLimit-Reset, on any response."""
+    assert "X-RateLimit-Remaining" not in server.OPENAPI_DESCRIPTION
+    assert "X-RateLimit-Reset" not in server.OPENAPI_DESCRIPTION
+
+
+def test_description_documents_only_websocket_events_that_are_sent():
+    """The only WS routes are the two session sockets; there is no general
+    event stream emitting task_assigned / agent_created."""
+    for phantom in ("task_assigned", "agent_created", "discovery_starting"):
+        assert phantom not in server.OPENAPI_DESCRIPTION
+
+
+@pytest.mark.parametrize("module", ["terminal_ws.py", "session_chat_ws.py", "prd_v2.py", "server.py"])
+def test_modules_do_not_document_removed_auth_mechanisms(module):
+    """#745 removed query-string JWTs; cookie auth never existed at all."""
+    path = ROUTERS / module if module != "server.py" else Path(server.__file__)
+    source = path.read_text(encoding="utf-8")
+    assert "?token=" not in source, f"{module} still documents ?token= auth"
+    assert not re.search(r"cookie[- ]based auth", source, re.I), f"{module} documents nonexistent cookie auth"
+
+
+def test_no_router_claims_a_deleted_v1_router_still_exists():
+    """The v1 routers were deleted; seven v2 modules still told readers they
+    'remain for backwards compatibility'."""
+    offenders = [
+        p.name
+        for p in ROUTERS.glob("*.py")
+        if re.search(r"The v1 router \(", p.read_text(encoding="utf-8"))
+    ]
+    assert offenders == []


### PR DESCRIPTION
Closes #951.

The `/docs` page of a public-beta product described a server that no longer exists. An integrator following it got 401s on day one.

## What was wrong

| Claim in the docs | Reality |
|---|---|
| `OPENAPI_TAGS` listed `projects`, `agents`, `chat`, `lint`, `websocket`, `quality_gates`, … | 16 of the 26 declared tags matched **no mounted router**; 20 real tags (`tasks-v2`, `proof-v2`, `pr-v2`, `settings`, …) were undocumented |
| "Create and manage projects", agent CRUD | Neither exists — the surface is workspace-based |
| A general WebSocket event stream emitting `task_assigned`, `agent_created`, `discovery_starting` | The only WS routes are the two session sockets, which emit a completely different message set |
| "SSE streaming endpoints additionally accept the JWT as a `?token=` query parameter" | Removed in #745 — only a single-use `?ticket=` is accepted, on exactly 5 routes |
| "Rate limit headers are included in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`" | The 429 handler sends `Retry-After` + `X-RateLimit-Limit`; nothing ever sends the other two, on any response |
| `prd_v2` stress-test: "cookie-based auth via `withCredentials`" | Cookie auth has never existed |
| Seven v2 routers: "The v1 router (x.py) remains for backwards compatibility" | Those v1 modules were deleted |

## Changes

- **`OPENAPI_TAGS` rebuilt from the mounted routers** — 25 tags, each describing endpoints that exist.
- **`OPENAPI_DESCRIPTION` rewritten**: the real Think → Build → Prove → Ship surface; the scope model (`read`/`write` always, `admin` for superusers); a dedicated *Streaming connections* section documenting the `POST /auth/stream-ticket` → `?ticket=` flow, its 60s single-use lifetime, and a table of the exact 5 routes that accept it (the 2 WS routes are documented in prose since OpenAPI cannot describe WebSockets); accurate rate-limit headers.
- **Docstrings corrected** in `terminal_ws.py`, `session_chat_ws.py`, `prd_v2.py`, and the router-mount comment in `server.py`.
- **Stale v1 claims deleted** from `checkpoints_v2`, `schedule_v2`, `git_v2`, `review_v2`, `templates_v2`, `discovery_v2`, `tasks_v2`.

Docs-only: no runtime behavior changes.

## Test

`tests/ui/test_openapi_docs_accuracy.py` (10 tests) fails the build the next time prose and code diverge:

- declared tags **==** tags used by mounted routers (set equality, so both a phantom tag and an undocumented one break it)
- `?token=` and cookie-auth claims stay out of `server.py`, both WS routers and `prd_v2.py`
- the description never promises `X-RateLimit-Remaining` / `X-RateLimit-Reset`
- no router claims a deleted v1 router still exists
- no phantom WebSocket events in the description

Written RED first — 9 of 10 failed against `main`.

## Verification

Against the **served** `/openapi.json`, not just the source constants:

```
AC1 declared=25 used=25 equal=True
    phantom tags gone: True
AC2 '?token=' in served description: False   cookie: False
    terminal_ws.py / session_chat_ws.py / prd_v2.py — both claims gone
AC3 X-RateLimit-Remaining claimed: False   X-RateLimit-Reset claimed: False
    documents real 429 headers (Retry-After + X-RateLimit-Limit): True
    each documented ticket route accepted by _query_ticket_allowed: True (3/3)
    /api/v2/tasks (not documented as ticketed): False
/docs renders: 200   tag groups in spec: 25
```

Every new factual claim was checked against the code: `TICKET_TTL_SECONDS = 60`, `create_stream_ticket` enforces `SCOPE_WRITE`, `_QUERY_TICKET_PATHS` holds exactly the 3 SSE routes, `authenticate_websocket` requires a ticket, `rate_limit_exceeded_handler` sets exactly `Retry-After` + `X-RateLimit-Limit`.

`uv run pytest tests/ui tests/api tests/lib` → **982 passed, 30 skipped**. `ruff check .` clean.

## Review

`codex review --base main`: no actionable correctness issues. One self-caught inaccuracy in the first pass (the `review-v2` tag description omitted the AI-review and commit-message endpoints) is fixed in the second commit.

## Known limitations

- Rate-limit headers are documented as-is rather than turning on `headers_enabled` and emitting `X-RateLimit-Remaining`/`Reset` on every response. The issue explicitly allows either; emitting them is a behavior change (needs `SlowAPIMiddleware`) and belongs in its own PR.
- The tag-equality test pins tag *names*, not descriptions — a tag can still drift semantically without failing. Worth a follow-up only if it actually happens.
