### PR TITLE
feat(core): reconcile batch tasks against linked GitHub issue state (#1032)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1214,6 +1214,16 @@ def resume_batch(
     if on_event:
         on_event("batch_resumed", {"batch_id": batch_id, "task_count": len(tasks_to_run)})
 
+    # Void the prior result of every task about to be re-run. Deciding to
+    # re-run a task is deciding its last verdict no longer stands, and
+    # ``_record_task_result`` refuses to overwrite a recorded COMPLETED — so
+    # without this, ``resume --force`` would re-run a completed task, see it
+    # fail, and keep the stale COMPLETED (#1032). Clearing here rather than
+    # weakening the guard keeps a *new* external completion during the rerun
+    # protected, which is what the guard is for.
+    for tid in tasks_to_run:
+        batch.results.pop(tid, None)
+
     # Update status to running. This is the one intentional CANCELLED->RUNNING
     # transition, so bypass the terminal-cancel guard (#726).
     batch.status = BatchStatus.RUNNING

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1224,6 +1224,23 @@ def resume_batch(
     for tid in tasks_to_run:
         batch.results.pop(tid, None)
 
+    # ...and put a DONE task row back in a runnable state. The subprocess starts
+    # with runtime.start_task_run, which needs IN_PROGRESS, and the state machine
+    # allows only {READY, MERGED} out of DONE — so `resume --force` on a completed
+    # task raised InvalidTransitionError before the agent ever started. Predates
+    # this change; found reviewing the result-clearing above (#1032). Best-effort:
+    # a task that cannot be reset is left to fail on its own terms rather than
+    # taking the whole resume down.
+    from codeframe.core.state_machine import TaskStatus
+
+    for tid in tasks_to_run:
+        try:
+            task = tasks.get(workspace, tid)
+            if task is not None and task.status == TaskStatus.DONE:
+                tasks.update_status(workspace, tid, TaskStatus.READY)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not reset task %s for rerun: %s", tid, exc)
+
     # Update status to running. This is the one intentional CANCELLED->RUNNING
     # transition, so bypass the terminal-cancel guard (#726).
     batch.status = BatchStatus.RUNNING

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1330,7 +1330,7 @@ def _run_serial_resume(
             exec_ctx.cleanup()
 
         # Record result (overwrites previous result)
-        _record_task_result(batch, task_id, result_status)
+        result_status = _record_task_result(batch, task_id, result_status)
         _save_batch(workspace, batch)
 
         # Emit appropriate event based on result
@@ -1528,7 +1528,7 @@ def _run_retries(
                 exec_ctx.cleanup()
 
             # Update result
-            _record_task_result(batch, task_id, result_status)
+            result_status = _record_task_result(batch, task_id, result_status)
             _save_batch(workspace, batch)
 
             if result_status == RunStatus.COMPLETED.value:
@@ -1784,7 +1784,7 @@ def _execute_serial(
                 exec_ctx.cleanup()
 
             # Record result
-            _record_task_result(batch, task_id, result_status)
+            result_status = _record_task_result(batch, task_id, result_status)
             _save_batch(workspace, batch)
 
             # Emit appropriate event based on result
@@ -2135,12 +2135,19 @@ def _completed_outside_the_batch(batch: "BatchRun", task_id: str) -> bool:
     return batch.results.get(task_id) in _TERMINAL_BATCH_RESULTS
 
 
-def _record_task_result(batch: "BatchRun", task_id: str, status: str) -> None:
+def _record_task_result(batch: "BatchRun", task_id: str, status: str) -> str:
     """Record a worker's result unless a terminal one is already recorded.
 
     Only COMPLETED is protected. A recorded FAILED or BLOCKED is the worker's
     own earlier verdict and may legitimately be replaced, and RUNNING is a
     placeholder that must still resolve.
+
+    Returns the **effective** result — which is not the worker's when an
+    external completion won. Callers must tally and emit events off the return
+    value, not off what they passed in: otherwise the reconciler's COMPLETED
+    sits in ``batch.results`` while ``failed_count`` counts the discarded
+    FAILED, and a batch whose every task recorded COMPLETED finalizes as
+    PARTIAL (#1032).
     """
     if batch.results.get(task_id) in _TERMINAL_BATCH_RESULTS:
         logger.info(
@@ -2148,8 +2155,9 @@ def _record_task_result(batch: "BatchRun", task_id: str, status: str) -> None:
             "not overwriting with %s",
             task_id, batch.results[task_id], status,
         )
-        return
+        return batch.results[task_id]
     batch.results[task_id] = status
+    return status
 
 
 def _start_reconciliation_thread(
@@ -2231,6 +2239,15 @@ def _execute_single_task(
     Returns:
         RunStatus value string
     """
+    # _execute_parallel routes dependency groups of size 1 here rather than
+    # through the pool worker, so this needs the same skip (#1032) — otherwise
+    # a single-task group whose issue closed earlier still runs.
+    if _completed_outside_the_batch(batch, task_id):
+        logger.info(
+            "Task %s already completed outside the batch — skipping", task_id
+        )
+        return batch.results[task_id]
+
     # Emit task queued event
     events.emit_for_workspace(
         workspace,
@@ -2291,7 +2308,7 @@ def _execute_single_task(
         exec_ctx.cleanup()
 
     # Record result
-    _record_task_result(batch, task_id, result_status)
+    result_status = _record_task_result(batch, task_id, result_status)
     _save_batch(workspace, batch)
 
     # Emit appropriate event based on result
@@ -2406,7 +2423,7 @@ def _execute_group_parallel(
             exec_ctx.cleanup()
 
         # Record result (thread-safe due to GIL for simple dict operations)
-        _record_task_result(batch, task_id, result_status)
+        result_status = _record_task_result(batch, task_id, result_status)
         _save_batch(workspace, batch)
 
         return task_id, batch.results[task_id]

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -2209,10 +2209,16 @@ def _start_reconciliation_thread(
         """One reconciliation sweep. Raises nothing the caller must handle."""
         try:
             # Get currently active task IDs from the batch
+            # BLOCKED belongs here, not just None/RUNNING (#1032). A blocked
+            # task is precisely the one whose state can change from outside —
+            # a human answering the blocker, or closing the linked GitHub
+            # issue. Excluding it meant both the blocker-resolved requeue and
+            # the GitHub check were unreachable the moment a task's first
+            # attempt reported BLOCKED, since nothing clears that entry
+            # mid-batch. COMPLETED and FAILED stay excluded: finished work.
             active_ids = [
                 tid for tid in batch.task_ids
-                if batch.results.get(tid) is None
-                or batch.results.get(tid) == "RUNNING"
+                if batch.results.get(tid) in (None, "RUNNING", "BLOCKED")
             ]
             if not active_ids:
                 return

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -2205,46 +2205,59 @@ def _start_reconciliation_thread(
     stop_event = threading.Event()
     engine = ReconciliationEngine(workspace)
 
+    def _pass() -> None:
+        """One reconciliation sweep. Raises nothing the caller must handle."""
+        try:
+            # Get currently active task IDs from the batch
+            active_ids = [
+                tid for tid in batch.task_ids
+                if batch.results.get(tid) is None
+                or batch.results.get(tid) == "RUNNING"
+            ]
+            if not active_ids:
+                return
+
+            result = engine.check_all_active(active_ids)
+            if result.changes_detected:
+                with _active_processes_lock:
+                    procs = _active_processes.get(batch.id, {})
+                    engine.apply_changes(result, batch, procs)
+
+                # Emit events for changes
+                for tid in result.tasks_skipped:
+                    events.emit_for_workspace(
+                        workspace,
+                        events.EventType.RECONCILIATION_TASK_SKIPPED,
+                        {"batch_id": batch.id, "task_id": tid},
+                    )
+                for tid in result.tasks_requeued:
+                    events.emit_for_workspace(
+                        workspace,
+                        events.EventType.RECONCILIATION_TASK_REQUEUED,
+                        {"batch_id": batch.id, "task_id": tid},
+                    )
+            if result.errors:
+                for err in result.errors:
+                    events.emit_for_workspace(
+                        workspace,
+                        events.EventType.RECONCILIATION_ERROR,
+                        {"batch_id": batch.id, "error": err},
+                    )
+        except Exception as exc:
+            logger.warning("Reconciliation loop error: %s", exc)
+
     def _loop() -> None:
         while not stop_event.wait(timeout=interval_seconds):
-            try:
-                # Get currently active task IDs from the batch
-                active_ids = [
-                    tid for tid in batch.task_ids
-                    if batch.results.get(tid) is None
-                    or batch.results.get(tid) == "RUNNING"
-                ]
-                if not active_ids:
-                    continue
+            _pass()
 
-                result = engine.check_all_active(active_ids)
-                if result.changes_detected:
-                    with _active_processes_lock:
-                        procs = _active_processes.get(batch.id, {})
-                        engine.apply_changes(result, batch, procs)
-
-                    # Emit events for changes
-                    for tid in result.tasks_skipped:
-                        events.emit_for_workspace(
-                            workspace,
-                            events.EventType.RECONCILIATION_TASK_SKIPPED,
-                            {"batch_id": batch.id, "task_id": tid},
-                        )
-                    for tid in result.tasks_requeued:
-                        events.emit_for_workspace(
-                            workspace,
-                            events.EventType.RECONCILIATION_TASK_REQUEUED,
-                            {"batch_id": batch.id, "task_id": tid},
-                        )
-                if result.errors:
-                    for err in result.errors:
-                        events.emit_for_workspace(
-                            workspace,
-                            events.EventType.RECONCILIATION_ERROR,
-                            {"batch_id": batch.id, "error": err},
-                        )
-            except Exception as exc:
-                logger.warning("Reconciliation loop error: %s", exc)
+    # One sweep before the executor launches anything (#1032). The loop waits a
+    # full interval before its first pass, so without this the likeliest case
+    # of all — the linked issue was ALREADY closed when the batch started —
+    # was missed for every task reached inside the first 30 seconds, which in a
+    # serial batch means the first one. Synchronous rather than an early tick
+    # on the thread, so the executor's skip check cannot race it. Costs one
+    # call per linked task, and nothing at all when no task carries an issue.
+    _pass()
 
     thread = threading.Thread(target=_loop, daemon=True, name=f"reconcile-{batch.id[:8]}")
     thread.start()

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1330,7 +1330,7 @@ def _run_serial_resume(
             exec_ctx.cleanup()
 
         # Record result (overwrites previous result)
-        batch.results[task_id] = result_status
+        _record_task_result(batch, task_id, result_status)
         _save_batch(workspace, batch)
 
         # Emit appropriate event based on result
@@ -1528,7 +1528,7 @@ def _run_retries(
                 exec_ctx.cleanup()
 
             # Update result
-            batch.results[task_id] = result_status
+            _record_task_result(batch, task_id, result_status)
             _save_batch(workspace, batch)
 
             if result_status == RunStatus.COMPLETED.value:
@@ -1715,6 +1715,17 @@ def _execute_serial(
             if current_batch and current_batch.status == BatchStatus.CANCELLED:
                 break
 
+            # Completed outside the batch (manually, or its linked GitHub issue
+            # was closed — #1032). Running it would spend an agent run redoing
+            # finished work, and its FAILED verdict would then be discarded by
+            # _record_task_result anyway.
+            if _completed_outside_the_batch(batch, task_id):
+                completed_count += 1
+                logger.info(
+                    "Task %s already completed outside the batch — skipping", task_id
+                )
+                continue
+
             # Check for config reloads between tasks
             if reload_state is not None:
                 _last_seen_reload = _apply_pending_config_reload(
@@ -1773,7 +1784,7 @@ def _execute_serial(
                 exec_ctx.cleanup()
 
             # Record result
-            batch.results[task_id] = result_status
+            _record_task_result(batch, task_id, result_status)
             _save_batch(workspace, batch)
 
             # Emit appropriate event based on result
@@ -2112,6 +2123,18 @@ def _execute_parallel(
 _TERMINAL_BATCH_RESULTS = frozenset({"COMPLETED"})
 
 
+def _completed_outside_the_batch(batch: "BatchRun", task_id: str) -> bool:
+    """Whether the reconciler already recorded this task as done elsewhere.
+
+    Executors call this before launching work. Without it the guard below is
+    only half a fix: it stops a worker's verdict from *overwriting* an external
+    completion, but the worker still burns an agent run on a task that is
+    already finished — e.g. one whose linked GitHub issue was closed before the
+    batch reached it (#1032).
+    """
+    return batch.results.get(task_id) in _TERMINAL_BATCH_RESULTS
+
+
 def _record_task_result(batch: "BatchRun", task_id: str, status: str) -> None:
     """Record a worker's result unless a terminal one is already recorded.
 
@@ -2268,7 +2291,7 @@ def _execute_single_task(
         exec_ctx.cleanup()
 
     # Record result
-    batch.results[task_id] = result_status
+    _record_task_result(batch, task_id, result_status)
     _save_batch(workspace, batch)
 
     # Emit appropriate event based on result
@@ -2344,6 +2367,14 @@ def _execute_group_parallel(
 
     def execute_task(task_id: str) -> tuple[str, str]:
         """Execute a single task and return (task_id, status)."""
+        # Same skip as the serial path: don't spend an agent run on a task the
+        # reconciler already completed from outside the batch (#1032).
+        if _completed_outside_the_batch(batch, task_id):
+            logger.info(
+                "Task %s already completed outside the batch — skipping", task_id
+            )
+            return task_id, batch.results[task_id]
+
         # Emit task started event
         events.emit_for_workspace(
             workspace,

--- a/codeframe/core/github_issues_service.py
+++ b/codeframe/core/github_issues_service.py
@@ -224,6 +224,9 @@ class GitHubIssueDetail(TypedDict):
     body: str
     labels: list[str]
     html_url: str
+    #: ``"open"`` or ``"closed"``. The import path (#565) ignores it — batch
+    #: reconciliation (#1032) uses it to spot an issue closed mid-run.
+    state: str
 
 
 async def get_issue(
@@ -331,6 +334,9 @@ async def get_issue(
             "body": str(raw.get("body") or ""),
             "labels": labels,
             "html_url": str(raw.get("html_url") or ""),
+            # Default to "open": treating an unreadable state as closed would
+            # let reconciliation (#1032) skip a task that is still in flight.
+            "state": str(raw.get("state") or "open"),
         }
     finally:
         if own_client:

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -226,6 +226,9 @@ class ReconciliationEngine:
     ) -> None:
         self._workspace = workspace
         self._issue_state = issue_state if issue_state is not None else GitHubIssueState()
+        #: Tasks already reported as blocker-resolved. The engine lives for the
+        #: batch, so this makes that report one-shot per run — see check_task.
+        self._requeued: set[str] = set()
 
     def check_task(self, task_id: str) -> list[ExternalStateChange]:
         """Check a single task for external state changes.
@@ -250,9 +253,21 @@ class ReconciliationEngine:
         # Task is blocked but all blockers have been answered
         elif task.status == TaskStatus.BLOCKED:
             task_blockers = blockers.list_for_task(self._workspace, task_id)
-            if task_blockers and all(
-                b.status.value in ("ANSWERED", "RESOLVED") for b in task_blockers
+            if (
+                task_id not in self._requeued
+                and task_blockers
+                and all(
+                    b.status.value in ("ANSWERED", "RESOLVED")
+                    for b in task_blockers
+                )
             ):
+                # One-shot per run. This branch reads only the current row,
+                # which stays BLOCKED with answered blockers until the batch
+                # ends — so once BLOCKED tasks became sweepable (#1032) it
+                # matched on every tick and re-emitted the requeue every ~30s.
+                # apply_changes' pop is idempotent, so the repeat corrupted
+                # nothing; it just made a one-shot signal into a heartbeat.
+                self._requeued.add(task_id)
                 changes.append(ExternalStateChange(
                     task_id=task_id,
                     change_type="blocker_resolved",

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -256,6 +256,39 @@ class ReconciliationEngine:
 
         return changes
 
+    def _mark_task_done(self, task_id: str) -> None:
+        """Bring the local task row in line with the closed issue (#1032).
+
+        The ``source="manual"`` path needs nothing here: the row is *already*
+        DONE, which is how the change was detected. A GitHub closure sets
+        nothing, so without this the batch records COMPLETED while the board
+        still shows the task READY — and the next batch picks it up again.
+
+        ``READY -> DONE`` is not a permitted transition, so a task the batch
+        had not started yet passes through IN_PROGRESS, the same path a real
+        run takes. Best-effort throughout: the batch-level record stands on its
+        own, so a refused or failing transition is logged, not raised.
+
+        ponytail: only handles states from which IN_PROGRESS is reachable
+        (READY, BLOCKED, FAILED). BACKLOG would need BACKLOG -> READY first —
+        add that step if a batch ever runs BACKLOG tasks.
+        """
+        try:
+            task = tasks.get(self._workspace, task_id)
+            if task is None or task.status == TaskStatus.DONE:
+                return
+            if task.status != TaskStatus.IN_PROGRESS:
+                tasks.update_status(self._workspace, task_id, TaskStatus.IN_PROGRESS)
+            # Fires the auto-close dispatch (#565) when the task opted in. The
+            # issue is already closed, so that PATCH is a no-op — not worth a
+            # special path to avoid.
+            tasks.update_status(self._workspace, task_id, TaskStatus.DONE)
+        except Exception as exc:  # noqa: BLE001 - accounting must not break
+            logger.warning(
+                "Could not mark task %s DONE after its GitHub issue closed: %s",
+                task_id, exc,
+            )
+
     def check_all_active(
         self, active_task_ids: list[str]
     ) -> ReconciliationResult:
@@ -292,6 +325,9 @@ class ReconciliationEngine:
         """
         for change in result.changes_detected:
             try:
+                if change.source == "github" and change.change_type == "completed":
+                    self._mark_task_done(change.task_id)
+
                 if change.change_type in ("completed", "closed"):
                     # Terminate subprocess if running
                     proc = active_processes.get(change.task_id)

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -24,10 +24,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: How long a fetched issue state is trusted. An order of magnitude above the
-#: 30s reconciliation interval, so a long batch costs a handful of calls per
-#: linked issue rather than one per tick.
-_ISSUE_STATE_TTL_SECONDS = 300.0
+#: How long an **open** answer is trusted. Two reconciliation ticks: long
+#: enough to halve the call rate, short enough that a closure is noticed before
+#: a serial batch works through much of its queue. A longer window (300s was
+#: the first cut) makes the feature mostly decorative — the issue closes, the
+#: cached "open" hides it, and the executor launches the agent anyway.
+#:
+#: Cost, worst case: one call per linked task per 60s. A batch with 20 imported
+#: tasks running an hour is ~1200 calls against GitHub's 5000/hour authenticated
+#: limit, and the first failure disables the checker entirely.
+_ISSUE_STATE_OPEN_TTL_SECONDS = 60.0
 
 #: Bound on distinct issues cached per batch. Reconciliation only ever asks
 #: about the batch's own tasks, so this is a runaway guard, not a tuning knob.
@@ -95,7 +101,12 @@ class GitHubIssueState:
 
     * A task with no ``github_issue_number`` (or no source URL to name a repo)
       never reaches the network. Most tasks are not imported from GitHub.
-    * Answers are cached per ``(repo, number)`` for ``ttl_seconds``.
+    * Answers are cached per ``(repo, number)``. **Closed** is cached for the
+      life of the checker — it is terminal for a batch's purposes. **Open** is
+      cached only briefly (``open_ttl_seconds``), because an open answer is
+      exactly the one that goes stale in a way that matters: cache it for
+      minutes and the issue closes, the batch reaches the task, and the agent
+      runs anyway.
     * The first missing PAT or GitHub failure **disables the checker for the
       rest of the batch** and logs once. A GitHub outage must never fail a
       batch, and retrying every 30s through one is how you get rate-limited —
@@ -111,15 +122,18 @@ class GitHubIssueState:
         *,
         fetch: Optional[Callable[[str, str, int], str]] = None,
         pat: Optional[str] = None,
-        ttl_seconds: float = _ISSUE_STATE_TTL_SECONDS,
+        open_ttl_seconds: float = _ISSUE_STATE_OPEN_TTL_SECONDS,
         now: Callable[[], float] = time.monotonic,
     ) -> None:
         self._fetch = fetch if fetch is not None else _default_fetch_issue_state
         self._pat = pat
         self._pat_resolved = pat is not None
-        self._ttl = ttl_seconds
+        self._open_ttl = open_ttl_seconds
         self._now = now
-        self._cache: dict[tuple[str, int], tuple[bool, float]] = {}
+        #: Issues known closed. Never re-fetched — closed is terminal here.
+        self._closed: set[tuple[str, int]] = set()
+        #: Issues seen open, with the time the answer stops being trusted.
+        self._open_until: dict[tuple[str, int], float] = {}
         self._disabled = False
 
     def is_closed(self, task) -> bool:
@@ -146,9 +160,10 @@ class GitHubIssueState:
             return False
 
         key = (repo, number)
-        cached = self._cache.get(key)
-        if cached is not None and cached[1] > self._now():
-            return cached[0]
+        if key in self._closed:
+            return True
+        if self._open_until.get(key, 0.0) > self._now():
+            return False
 
         pat = self._resolve_pat()
         if pat is None:
@@ -161,11 +176,14 @@ class GitHubIssueState:
             self._disable(f"GitHub issue lookup failed ({exc})")
             return False
 
-        closed = str(state).lower() == "closed"
-        if len(self._cache) >= _ISSUE_STATE_CACHE_MAX:
-            self._cache.clear()
-        self._cache[key] = (closed, self._now() + self._ttl)
-        return closed
+        if len(self._closed) + len(self._open_until) >= _ISSUE_STATE_CACHE_MAX:
+            self._open_until.clear()  # the cheap half to rebuild
+
+        if str(state).lower() == "closed":
+            self._closed.add(key)
+            return True
+        self._open_until[key] = self._now() + self._open_ttl
+        return False
 
     def _resolve_pat(self) -> Optional[str]:
         if not self._pat_resolved:
@@ -264,25 +282,35 @@ class ReconciliationEngine:
         nothing, so without this the batch records COMPLETED while the board
         still shows the task READY — and the next batch picks it up again.
 
-        ``READY -> DONE`` is not a permitted transition, so a task the batch
-        had not started yet passes through IN_PROGRESS, the same path a real
-        run takes. Best-effort throughout: the batch-level record stands on its
-        own, so a refused or failing transition is logged, not raised.
+        Nothing goes straight to DONE: the state machine only allows it from
+        IN_PROGRESS, and only READY from BACKLOG. So this walks the same path a
+        real run takes — and it must start from BACKLOG, because that is what
+        ``tasks.create`` defaults to and therefore what the GitHub importer
+        (#565) produces. Imported tasks sitting in BACKLOG are the *primary*
+        case for this feature, not an edge one.
 
-        ponytail: only handles states from which IN_PROGRESS is reachable
-        (READY, BLOCKED, FAILED). BACKLOG would need BACKLOG -> READY first —
-        add that step if a batch ever runs BACKLOG tasks.
+        Best-effort throughout: the batch-level record stands on its own, so a
+        refused or failing transition is logged, not raised.
         """
+        walk = {
+            TaskStatus.BACKLOG: (TaskStatus.READY, TaskStatus.IN_PROGRESS, TaskStatus.DONE),
+            TaskStatus.READY: (TaskStatus.IN_PROGRESS, TaskStatus.DONE),
+            TaskStatus.BLOCKED: (TaskStatus.IN_PROGRESS, TaskStatus.DONE),
+            TaskStatus.FAILED: (TaskStatus.IN_PROGRESS, TaskStatus.DONE),
+            TaskStatus.IN_PROGRESS: (TaskStatus.DONE,),
+        }
         try:
             task = tasks.get(self._workspace, task_id)
-            if task is None or task.status == TaskStatus.DONE:
+            if task is None:
                 return
-            if task.status != TaskStatus.IN_PROGRESS:
-                tasks.update_status(self._workspace, task_id, TaskStatus.IN_PROGRESS)
-            # Fires the auto-close dispatch (#565) when the task opted in. The
-            # issue is already closed, so that PATCH is a no-op — not worth a
-            # special path to avoid.
-            tasks.update_status(self._workspace, task_id, TaskStatus.DONE)
+            steps = walk.get(task.status)
+            if steps is None:  # already DONE, or MERGED (terminal)
+                return
+            for step in steps:
+                # The final DONE fires the auto-close dispatch (#565) when the
+                # task opted in. The issue is already closed, so that PATCH is
+                # a no-op — not worth a special path to avoid.
+                tasks.update_status(self._workspace, task_id, step)
         except Exception as exc:  # noqa: BLE001 - accounting must not break
             logger.warning(
                 "Could not mark task %s DONE after its GitHub issue closed: %s",

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -12,8 +12,9 @@ conductor.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional
 
 from codeframe.core import blockers, tasks
 from codeframe.core.state_machine import TaskStatus
@@ -22,6 +23,15 @@ if TYPE_CHECKING:
     from codeframe.core.workspace import Workspace
 
 logger = logging.getLogger(__name__)
+
+#: How long a fetched issue state is trusted. An order of magnitude above the
+#: 30s reconciliation interval, so a long batch costs a handful of calls per
+#: linked issue rather than one per tick.
+_ISSUE_STATE_TTL_SECONDS = 300.0
+
+#: Bound on distinct issues cached per batch. Reconciliation only ever asks
+#: about the batch's own tasks, so this is a runaway guard, not a tuning knob.
+_ISSUE_STATE_CACHE_MAX = 512
 
 
 @dataclass
@@ -44,6 +54,133 @@ class ReconciliationResult:
     errors: list[str] = field(default_factory=list)
 
 
+def _default_fetch_issue_state(pat: str, repo: str, number: int) -> str:
+    """Fetch one issue's ``"open"``/``"closed"`` state from GitHub.
+
+    Runs the async service call to completion on this thread — reconciliation
+    is a plain daemon thread with no event loop of its own.
+    """
+    import asyncio
+
+    from codeframe.core.github_issues_service import get_issue
+
+    issue = asyncio.run(get_issue(pat, repo, number))
+    return issue["state"]
+
+
+def _default_pat() -> Optional[str]:
+    """Resolve the machine-wide GitHub PAT, or ``None`` if there is none.
+
+    Same source and same limitation as the auto-close path (``tasks.
+    _dispatch_github_autoclose``): reconciliation runs on a background thread
+    with no request-scoped user, so per-user stored PATs are not reachable here.
+    """
+    try:
+        from codeframe.core.credentials import CredentialManager, CredentialProvider
+
+        return CredentialManager().get_credential(CredentialProvider.GIT_GITHUB)
+    except Exception:  # noqa: BLE001 - never break a batch over credential lookup
+        logger.debug("GitHub PAT lookup failed for reconciliation", exc_info=True)
+        return None
+
+
+class GitHubIssueState:
+    """Answers "has this task's linked GitHub issue been closed?" (#1032).
+
+    #921 removed an injectable issue-check parameter because it was wired at no
+    call site. The hard part it skipped is cost: reconciliation ticks every 30s
+    over every active task, so the naive version is one API call per task per
+    tick against a single machine-wide PAT. Three things bound that, and each
+    one is a test in ``test_github_issue_reconciliation_1032.py``:
+
+    * A task with no ``github_issue_number`` (or no source URL to name a repo)
+      never reaches the network. Most tasks are not imported from GitHub.
+    * Answers are cached per ``(repo, number)`` for ``ttl_seconds``.
+    * The first missing PAT or GitHub failure **disables the checker for the
+      rest of the batch** and logs once. A GitHub outage must never fail a
+      batch, and retrying every 30s through one is how you get rate-limited —
+      so this doubles as the back-off.
+
+    The repo comes from the task's own ``external_url``, not the workspace's
+    current connection, matching auto-close (#565): a workspace may have been
+    reconnected to a different repository since the task was imported.
+    """
+
+    def __init__(
+        self,
+        *,
+        fetch: Optional[Callable[[str, str, int], str]] = None,
+        pat: Optional[str] = None,
+        ttl_seconds: float = _ISSUE_STATE_TTL_SECONDS,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._fetch = fetch if fetch is not None else _default_fetch_issue_state
+        self._pat = pat
+        self._pat_resolved = pat is not None
+        self._ttl = ttl_seconds
+        self._now = now
+        self._cache: dict[tuple[str, int], tuple[bool, float]] = {}
+        self._disabled = False
+
+    def is_closed(self, task) -> bool:
+        """Whether the task's linked issue is closed on GitHub.
+
+        Returns ``False`` — never raises — for every "don't know" case: no
+        linked issue, no PAT, GitHub unreachable, checker already disabled.
+        Reconciliation acts on a ``True`` only, so an unknown state leaves the
+        task running, which is the safe direction.
+        """
+        if self._disabled:
+            return False
+
+        # Type-check rather than trust: this runs on a background thread, and
+        # anything raising here would surface as a reconciliation *error* on an
+        # otherwise healthy tick. ``_repo_from_issue_url`` only guards against
+        # ValueError/AttributeError, so a non-str URL would escape it.
+        number = getattr(task, "github_issue_number", None)
+        url = getattr(task, "external_url", None)
+        if not isinstance(number, int) or not isinstance(url, str):
+            return False
+        repo = tasks._repo_from_issue_url(url)
+        if repo is None:
+            return False
+
+        key = (repo, number)
+        cached = self._cache.get(key)
+        if cached is not None and cached[1] > self._now():
+            return cached[0]
+
+        pat = self._resolve_pat()
+        if pat is None:
+            self._disable("no GitHub PAT is configured")
+            return False
+
+        try:
+            state = self._fetch(pat, repo, int(number))
+        except Exception as exc:  # noqa: BLE001 - an outage must not fail a batch
+            self._disable(f"GitHub issue lookup failed ({exc})")
+            return False
+
+        closed = str(state).lower() == "closed"
+        if len(self._cache) >= _ISSUE_STATE_CACHE_MAX:
+            self._cache.clear()
+        self._cache[key] = (closed, self._now() + self._ttl)
+        return closed
+
+    def _resolve_pat(self) -> Optional[str]:
+        if not self._pat_resolved:
+            self._pat = _default_pat()
+            self._pat_resolved = True
+        return self._pat
+
+    def _disable(self, reason: str) -> None:
+        """Stop checking for the rest of this batch, saying why exactly once."""
+        self._disabled = True
+        logger.warning(
+            "GitHub issue reconciliation disabled for this batch: %s", reason
+        )
+
+
 class ReconciliationEngine:
     """Checks tasks for external state changes and applies adjustments.
 
@@ -52,10 +189,19 @@ class ReconciliationEngine:
 
     Args:
         workspace: The workspace to check tasks in.
+        issue_state: GitHub issue-state checker. Constructed by default, so
+            both conductor call sites get it without passing anything — unlike
+            the parameter #921 removed, which was passed at neither. Injected
+            by tests.
     """
 
-    def __init__(self, workspace: Workspace) -> None:
+    def __init__(
+        self,
+        workspace: Workspace,
+        issue_state: Optional[GitHubIssueState] = None,
+    ) -> None:
         self._workspace = workspace
+        self._issue_state = issue_state if issue_state is not None else GitHubIssueState()
 
     def check_task(self, task_id: str) -> list[ExternalStateChange]:
         """Check a single task for external state changes.
@@ -90,12 +236,23 @@ class ReconciliationEngine:
                     details={"blockers_resolved": len(task_blockers)},
                 ))
 
-        # An injectable GitHub issue-state check used to hang off this point.
-        # It was passed at neither conductor call site, so it advertised a
-        # capability that did not exist. Removed rather than half-built: a real
-        # check means a network call per task per tick, against a PAT, with its
-        # own rate-limit and caching design — that is a feature with its own
-        # issue, not a parameter. (#921)
+        # The task's linked GitHub issue was closed by someone outside this
+        # batch — an external completion, exactly like a task marked DONE in
+        # the UI (#1032). Only asked for tasks that are not already finished
+        # locally: the DONE branch above has already fired for those, so a
+        # lookup would be a wasted call on every tick for the rest of the run.
+        # GitHubIssueState never raises and answers False when it does not
+        # know, so a GitHub outage leaves the batch exactly as it was.
+        elif self._issue_state.is_closed(task):
+            changes.append(ExternalStateChange(
+                task_id=task_id,
+                change_type="completed",
+                source="github",
+                details={
+                    "issue_number": task.github_issue_number,
+                    "issue_url": task.external_url,
+                },
+            ))
 
         return changes
 

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -176,8 +176,14 @@ class GitHubIssueState:
             self._disable(f"GitHub issue lookup failed ({exc})")
             return False
 
+        # Runaway guard. Drop the open half first — it is the cheap one to
+        # rebuild — and only clear the closed set if that alone is at the cap,
+        # otherwise the guard would keep firing as a no-op once _closed filled
+        # it (CI review).
         if len(self._closed) + len(self._open_until) >= _ISSUE_STATE_CACHE_MAX:
-            self._open_until.clear()  # the cheap half to rebuild
+            self._open_until.clear()
+            if len(self._closed) >= _ISSUE_STATE_CACHE_MAX:
+                self._closed.clear()
 
         if str(state).lower() == "closed":
             self._closed.add(key)

--- a/codeframe/core/reconciliation.py
+++ b/codeframe/core/reconciliation.py
@@ -256,12 +256,19 @@ class ReconciliationEngine:
 
         # The task's linked GitHub issue was closed by someone outside this
         # batch — an external completion, exactly like a task marked DONE in
-        # the UI (#1032). Only asked for tasks that are not already finished
-        # locally: the DONE branch above has already fired for those, so a
-        # lookup would be a wasted call on every tick for the rest of the run.
-        # GitHubIssueState never raises and answers False when it does not
-        # know, so a GitHub outage leaves the batch exactly as it was.
-        elif self._issue_state.is_closed(task):
+        # the UI (#1032).
+        #
+        # Deliberately NOT an `elif` off the blocker branch: a BLOCKED task
+        # whose blockers are still unanswered falls through both branches
+        # above, and that task is exactly the one worth asking about — the
+        # human may have resolved the work on GitHub instead of answering.
+        #
+        # Guarded on `not changes` so it costs nothing when a local signal
+        # already fired, and on `not DONE` because the first branch has already
+        # handled those — otherwise it would be a wasted call every tick for
+        # the rest of the run. GitHubIssueState never raises and answers False
+        # when it does not know, so an outage leaves the batch as it was.
+        if not changes and task.status != TaskStatus.DONE and self._issue_state.is_closed(task):
             changes.append(ExternalStateChange(
                 task_id=task_id,
                 change_type="completed",

--- a/tests/core/test_external_completion_honored_1032.py
+++ b/tests/core/test_external_completion_honored_1032.py
@@ -245,6 +245,51 @@ class TestForcedResumeStillOverwritesCompletedResults:
         assert resumed.results[target] == "COMPLETED"
 
 
+class TestForcedResumeCanActuallyRerunADoneTask:
+    """`resume --force` never really re-ran a completed task.
+
+    Pre-existing, not caused by this branch: the row is DONE, and
+    ``runtime.start_task_run`` needs DONE -> IN_PROGRESS, which the state
+    machine forbids (DONE allows only READY, MERGED). So a forced rerun failed
+    before the agent started. Found while reviewing the results-clearing above,
+    which sits on the same path.
+    """
+
+    def test_a_done_task_is_runnable_again_after_a_forced_resume(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        from codeframe.core import runtime, tasks as tasks_mod
+        from codeframe.core.conductor import BatchStatus
+        from codeframe.core.state_machine import TaskStatus
+
+        for tid in three_tasks:
+            tasks_mod.update_status(workspace, tid, TaskStatus.IN_PROGRESS)
+            tasks_mod.update_status(workspace, tid, TaskStatus.DONE)
+
+        started = []
+
+        def fake_subprocess(ws, task_id, batch_id, **kwargs):
+            # What the real subprocess does first: claim the task.
+            runtime.start_task_run(ws, task_id)
+            started.append(task_id)
+            return "COMPLETED"
+
+        monkeypatch.setattr(conductor, "_execute_task_subprocess", fake_subprocess)
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        batch = _make_batch(workspace, three_tasks, {t: "COMPLETED" for t in three_tasks})
+        batch.status = BatchStatus.PARTIAL
+        conductor._save_batch(workspace, batch)
+
+        conductor.resume_batch(workspace, batch.id, force=True)
+
+        assert started == three_tasks, (
+            "forced resume could not re-run completed tasks — DONE -> IN_PROGRESS "
+            "is refused by the state machine"
+        )
+
+
 class TestEveryWriteSiteUsesTheGuard:
     def test_no_executor_writes_batch_results_directly(self):
         """A guard that four of five call sites bypass guards nothing.

--- a/tests/core/test_external_completion_honored_1032.py
+++ b/tests/core/test_external_completion_honored_1032.py
@@ -290,6 +290,62 @@ class TestForcedResumeCanActuallyRerunADoneTask:
         )
 
 
+class TestTheFirstTaskIsCheckedBeforeItStarts:
+    """The reconciliation thread waits a full interval before its first pass.
+
+    So "the issue was already closed when the batch started" — the likeliest
+    case of all — was missed for every task the serial loop reached inside the
+    first 30 seconds, which in practice means the first one.
+    """
+
+    def test_a_pass_runs_before_the_loop_launches_anything(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        executed = []
+        monkeypatch.setattr(
+            conductor, "_execute_task_subprocess",
+            lambda ws, tid, bid, **kw: executed.append(tid) or "COMPLETED",
+        )
+
+        # A reconciler that would find the first task's issue closed. Real
+        # thread start is left intact except for the interval, so this pins the
+        # *synchronous* pass, not a lucky race with the daemon.
+        from codeframe.core.reconciliation import ExternalStateChange
+
+        target = three_tasks[0]
+
+        class StubEngine:
+            def __init__(self, workspace):
+                pass
+
+            def check_all_active(self, ids):
+                from codeframe.core.reconciliation import ReconciliationResult
+
+                r = ReconciliationResult()
+                if target in ids:
+                    r.changes_detected.append(
+                        ExternalStateChange(target, "completed", "github", {})
+                    )
+                return r
+
+            def apply_changes(self, result, batch, procs):
+                for c in result.changes_detected:
+                    batch.results[c.task_id] = "COMPLETED"
+                    result.tasks_skipped.append(c.task_id)
+
+        monkeypatch.setattr(
+            "codeframe.core.reconciliation.ReconciliationEngine", StubEngine
+        )
+
+        batch = _make_batch(workspace, three_tasks)
+        conductor._execute_serial(workspace, batch)
+
+        assert target not in executed, (
+            "the first task ran before reconciliation ever looked at it"
+        )
+        assert batch.results[target] == "COMPLETED"
+
+
 class TestEveryWriteSiteUsesTheGuard:
     def test_no_executor_writes_batch_results_directly(self):
         """A guard that four of five call sites bypass guards nothing.

--- a/tests/core/test_external_completion_honored_1032.py
+++ b/tests/core/test_external_completion_honored_1032.py
@@ -178,6 +178,73 @@ class TestSingleTaskGroupsAreSkippedToo:
         assert result == "COMPLETED"
 
 
+class TestForcedResumeStillOverwritesCompletedResults:
+    """The guard must not swallow `cf work batch resume --force`.
+
+    Force re-runs every task, including completed ones. Their stale COMPLETED
+    is the batch's own earlier verdict, not an external completion — if the
+    rerun fails, the batch must say so rather than keep the old success.
+    """
+
+    def test_a_forced_rerun_that_fails_replaces_the_old_COMPLETED(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        from codeframe.core.conductor import BatchStatus
+
+        monkeypatch.setattr(
+            conductor, "_execute_task_subprocess",
+            lambda ws, tid, bid, **kw: "FAILED",
+        )
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        batch = _make_batch(workspace, three_tasks, {t: "COMPLETED" for t in three_tasks})
+        batch.status = BatchStatus.PARTIAL
+        conductor._save_batch(workspace, batch)
+
+        resumed = conductor.resume_batch(workspace, batch.id, force=True)
+
+        assert set(resumed.results.values()) == {"FAILED"}, (
+            "a forced rerun kept its stale COMPLETED results"
+        )
+
+    def test_an_external_completion_during_a_forced_rerun_is_still_protected(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        """Clearing stale results must not reopen the hole the guard closed."""
+        from codeframe.core.conductor import BatchStatus
+
+        target = three_tasks[0]
+
+        # resume_batch reloads the batch, so the reconciler stand-in has to
+        # mutate *that* object, not the fixture's. Capture it on the way in.
+        live = []
+        real_resume_exec = conductor._execute_serial_resume
+
+        def capture(ws, b, task_ids, on_event=None):
+            live.append(b)
+            return real_resume_exec(ws, b, task_ids, on_event)
+
+        def fake_subprocess(ws, task_id, batch_id, **kwargs):
+            if task_id == target:
+                live[0].results[task_id] = "COMPLETED"  # reconciler, mid-rerun
+                return "FAILED"
+            return "FAILED"
+
+        monkeypatch.setattr(conductor, "_execute_serial_resume", capture)
+        monkeypatch.setattr(conductor, "_execute_task_subprocess", fake_subprocess)
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        batch = _make_batch(workspace, three_tasks, {t: "COMPLETED" for t in three_tasks})
+        batch.status = BatchStatus.PARTIAL
+        conductor._save_batch(workspace, batch)
+
+        resumed = conductor.resume_batch(workspace, batch.id, force=True)
+
+        assert resumed.results[target] == "COMPLETED"
+
+
 class TestEveryWriteSiteUsesTheGuard:
     def test_no_executor_writes_batch_results_directly(self):
         """A guard that four of five call sites bypass guards nothing.

--- a/tests/core/test_external_completion_honored_1032.py
+++ b/tests/core/test_external_completion_honored_1032.py
@@ -1,0 +1,152 @@
+"""Workers must honor an externally-recorded completion (#1032).
+
+#921 added ``_record_task_result`` so a reconciler-recorded COMPLETED survives
+the worker's own verdict — but tested the helper in isolation and never checked
+that the executors call it. They mostly did not: of the five sites that wrote
+``batch.results[task_id]``, exactly one used the guard, and the one that did was
+the *parallel* path. On the default ``--strategy serial`` the guard was dead
+code, so the GitHub reconciliation added by #1032 would:
+
+* run a task whose linked issue was already closed before it started, and
+* overwrite the COMPLETED with FAILED when the reconciler killed the subprocess
+  mid-run and the worker saw the non-zero exit.
+
+These tests drive the real executors with a stubbed subprocess.
+"""
+
+import pytest
+
+from codeframe.core import conductor
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return create_or_load_workspace(ws_dir)
+
+
+def _make_batch(workspace, task_ids, results=None):
+    batch = conductor.create_batch(workspace, task_ids, strategy="serial")
+    batch.results.update(results or {})
+    return batch
+
+
+@pytest.fixture
+def three_tasks(workspace):
+    from codeframe.core import tasks
+    from codeframe.core.state_machine import TaskStatus
+
+    return [
+        tasks.create(
+            workspace, title=f"task {i}", description="", status=TaskStatus.READY
+        ).id
+        for i in range(3)
+    ]
+
+
+class TestSerialSkipsAnExternallyCompletedTask:
+    def test_a_task_already_recorded_COMPLETED_is_not_executed(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        """Its linked GitHub issue closed before the batch reached it."""
+        executed = []
+
+        def fake_subprocess(ws, task_id, batch_id, **kwargs):
+            executed.append(task_id)
+            return "COMPLETED"
+
+        monkeypatch.setattr(
+            conductor, "_execute_task_subprocess", fake_subprocess
+        )
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        batch = _make_batch(workspace, three_tasks, {three_tasks[1]: "COMPLETED"})
+        conductor._execute_serial(workspace, batch)
+
+        assert three_tasks[1] not in executed, (
+            "ran a task that was already completed outside the batch"
+        )
+        assert executed == [three_tasks[0], three_tasks[2]]
+
+    def test_the_skipped_task_stays_COMPLETED(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        monkeypatch.setattr(
+            conductor, "_execute_task_subprocess",
+            lambda ws, tid, bid, **kw: "COMPLETED",
+        )
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        batch = _make_batch(workspace, three_tasks, {three_tasks[1]: "COMPLETED"})
+        conductor._execute_serial(workspace, batch)
+
+        assert batch.results[three_tasks[1]] == "COMPLETED"
+
+
+class TestSerialDoesNotOverwriteAnExternalCompletion:
+    def test_a_completion_recorded_mid_run_survives_the_workers_failure(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        """The reconciler kills the subprocess, so the worker reports FAILED.
+        The external COMPLETED must win — this is exactly what #921's helper
+        was for, and the serial path was not calling it."""
+        target = three_tasks[0]
+
+        def fake_subprocess(ws, task_id, batch_id, **kwargs):
+            if task_id == target:
+                # Reconciliation recorded the external completion while the
+                # subprocess was running, then terminated it.
+                ws_batch.results[task_id] = "COMPLETED"
+                return "FAILED"
+            return "COMPLETED"
+
+        monkeypatch.setattr(conductor, "_execute_task_subprocess", fake_subprocess)
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        ws_batch = _make_batch(workspace, three_tasks)
+        conductor._execute_serial(workspace, ws_batch)
+
+        assert ws_batch.results[target] == "COMPLETED", (
+            "the external completion was reverted and counted as a failure"
+        )
+
+
+class TestEveryWriteSiteUsesTheGuard:
+    def test_no_executor_writes_batch_results_directly(self):
+        """A guard that four of five call sites bypass guards nothing.
+
+        Pinned at source level because each bypass is a distinct code path with
+        its own expensive end-to-end setup; the behavioral tests above cover
+        the default serial path specifically.
+        """
+        import re
+        from pathlib import Path
+
+        lines = Path(conductor.__file__).read_text(encoding="utf-8").splitlines()
+        # The one legitimate direct write is inside _record_task_result itself.
+        guard_start = next(
+            i for i, ln in enumerate(lines)
+            if ln.startswith("def _record_task_result(")
+        )
+        guard_end = next(
+            i for i, ln in enumerate(lines[guard_start + 1:], guard_start + 1)
+            if ln.startswith("def ")
+        )
+        direct = [
+            f"line {i + 1}: {ln.strip()}"
+            for i, ln in enumerate(lines)
+            if re.match(r"^\s*batch\.results\[[^\]]+\]\s*=", ln)
+            and not (guard_start <= i < guard_end)
+        ]
+        assert direct == [], (
+            "these bypass _record_task_result and can revert an external "
+            f"completion: {direct}"
+        )

--- a/tests/core/test_external_completion_honored_1032.py
+++ b/tests/core/test_external_completion_honored_1032.py
@@ -346,6 +346,74 @@ class TestTheFirstTaskIsCheckedBeforeItStarts:
         assert batch.results[target] == "COMPLETED"
 
 
+class TestBlockedTasksStayUnderReconciliation:
+    """A task recorded BLOCKED must keep being re-checked.
+
+    ``_pass`` selected tasks whose result is None or RUNNING. Once a task's
+    first attempt returned BLOCKED, that entry is neither — so the task was
+    excluded from every later sweep for the rest of the batch. That silently
+    disabled both the pre-existing blocker-resolved requeue and this branch's
+    GitHub check for blocked tasks: the code ran, but nothing ever reached it.
+    """
+
+    def test_a_blocked_task_is_still_swept(self, workspace, three_tasks, monkeypatch):
+        swept = []
+
+        class StubEngine:
+            def __init__(self, workspace):
+                pass
+
+            def check_all_active(self, ids):
+                from codeframe.core.reconciliation import ReconciliationResult
+
+                swept.append(list(ids))
+                return ReconciliationResult()
+
+            def apply_changes(self, result, batch, procs):
+                pass
+
+        monkeypatch.setattr(
+            "codeframe.core.reconciliation.ReconciliationEngine", StubEngine
+        )
+
+        blocked = three_tasks[0]
+        batch = _make_batch(workspace, three_tasks, {blocked: "BLOCKED"})
+        conductor._start_reconciliation_thread(workspace, batch, interval_seconds=3600)
+
+        assert swept, "no sweep ran"
+        assert blocked in swept[0], (
+            "a BLOCKED task is excluded from reconciliation for the rest of "
+            "the batch, so it can never be unblocked or completed externally"
+        )
+
+    def test_a_completed_task_is_not_swept(self, workspace, three_tasks, monkeypatch):
+        """The exclusion is still right for genuinely finished work."""
+        swept = []
+
+        class StubEngine:
+            def __init__(self, workspace):
+                pass
+
+            def check_all_active(self, ids):
+                from codeframe.core.reconciliation import ReconciliationResult
+
+                swept.append(list(ids))
+                return ReconciliationResult()
+
+            def apply_changes(self, result, batch, procs):
+                pass
+
+        monkeypatch.setattr(
+            "codeframe.core.reconciliation.ReconciliationEngine", StubEngine
+        )
+
+        done = three_tasks[0]
+        batch = _make_batch(workspace, three_tasks, {done: "COMPLETED"})
+        conductor._start_reconciliation_thread(workspace, batch, interval_seconds=3600)
+
+        assert done not in swept[0]
+
+
 class TestEveryWriteSiteUsesTheGuard:
     def test_no_executor_writes_batch_results_directly(self):
         """A guard that four of five call sites bypass guards nothing.

--- a/tests/core/test_external_completion_honored_1032.py
+++ b/tests/core/test_external_completion_honored_1032.py
@@ -119,6 +119,65 @@ class TestSerialDoesNotOverwriteAnExternalCompletion:
         )
 
 
+class TestAccountingFollowsTheGuardedResult:
+    """Preserving the result is only half of it — the tally must agree.
+
+    Otherwise the reconciler's COMPLETED sits in ``batch.results`` while
+    ``failed_count`` counts the worker's discarded FAILED, and the batch
+    finalizes as FAILED/PARTIAL with a full set of COMPLETED results.
+    """
+
+    def test_serial_batch_does_not_finish_FAILED_with_a_completed_result(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        target = three_tasks[0]
+
+        def fake_subprocess(ws, task_id, batch_id, **kwargs):
+            if task_id == target:
+                batch.results[task_id] = "COMPLETED"  # reconciler, mid-run
+                return "FAILED"
+            return "COMPLETED"
+
+        monkeypatch.setattr(conductor, "_execute_task_subprocess", fake_subprocess)
+        monkeypatch.setattr(conductor, "_start_reconciliation_thread",
+                            lambda *a, **k: __import__("threading").Event())
+
+        batch = _make_batch(workspace, three_tasks)
+        conductor._execute_serial(workspace, batch)
+
+        assert set(batch.results.values()) == {"COMPLETED"}
+        final = conductor.get_batch(workspace, batch.id)
+        assert final.status.value == "COMPLETED", (
+            f"every task recorded COMPLETED but the batch finalized as "
+            f"{final.status.value}"
+        )
+
+
+class TestSingleTaskGroupsAreSkippedToo:
+    def test_execute_single_task_skips_an_external_completion(
+        self, workspace, three_tasks, monkeypatch
+    ):
+        """_execute_parallel routes dependency groups of size 1 through
+        _execute_single_task, which bypassed the parallel worker's guard."""
+        executed = []
+
+        def fake_subprocess(ws, task_id, batch_id, **kwargs):
+            executed.append(task_id)
+            return "COMPLETED"
+
+        monkeypatch.setattr(conductor, "_execute_task_subprocess", fake_subprocess)
+
+        target = three_tasks[0]
+        batch = _make_batch(workspace, three_tasks, {target: "COMPLETED"})
+
+        result = conductor._execute_single_task(
+            workspace, batch, target, 1, len(three_tasks)
+        )
+
+        assert executed == [], "launched an agent run for finished work"
+        assert result == "COMPLETED"
+
+
 class TestEveryWriteSiteUsesTheGuard:
     def test_no_executor_writes_batch_results_directly(self):
         """A guard that four of five call sites bypass guards nothing.

--- a/tests/core/test_github_issue_reconciliation_1032.py
+++ b/tests/core/test_github_issue_reconciliation_1032.py
@@ -189,29 +189,50 @@ class TestClosedIssueDetected:
 
 
 class TestCallCountsStayBounded:
-    def test_repeated_ticks_within_the_ttl_make_one_call(self):
+    def test_repeated_ticks_within_the_open_ttl_make_one_call(self):
         gh = FakeGitHub(state="open")
         clock = FakeClock()
-        checker = GitHubIssueState(fetch=gh, pat="tok", ttl_seconds=300, now=clock)
+        checker = GitHubIssueState(fetch=gh, pat="tok", open_ttl_seconds=60, now=clock)
         task = make_task()
 
-        for _ in range(10):  # 10 ticks x 30s = 300s of batch time
-            checker.is_closed(task)
-            clock.advance(30)
+        checker.is_closed(task)
+        clock.advance(30)  # one tick later, still inside the TTL
+        checker.is_closed(task)
 
         assert len(gh.calls) == 1
 
-    def test_the_cache_expires_after_its_ttl(self):
+    def test_an_open_issue_is_rechecked_soon_enough_to_catch_a_closure(self):
+        """An "open" answer must go stale fast. Caching it for minutes on a 30s
+        loop means a closure lands, the task is reached, and the agent runs
+        anyway — the very case this feature exists to prevent."""
         gh = FakeGitHub(state="open")
         clock = FakeClock()
-        checker = GitHubIssueState(fetch=gh, pat="tok", ttl_seconds=300, now=clock)
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=clock)
         task = make_task()
 
         checker.is_closed(task)
-        clock.advance(301)
-        checker.is_closed(task)
+        clock.advance(90)  # three ticks
+        gh.state = "closed"
 
-        assert len(gh.calls) == 2
+        assert checker.is_closed(task) is True, (
+            "a closure was invisible for longer than a batch takes to reach "
+            "the next task"
+        )
+
+    def test_ten_ticks_over_an_open_issue_stay_bounded(self):
+        """Rechecking sooner must not mean rechecking every tick."""
+        gh = FakeGitHub(state="open")
+        clock = FakeClock()
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=clock)
+        task = make_task()
+
+        for _ in range(10):  # 300s of batch time at the 30s interval
+            checker.is_closed(task)
+            clock.advance(30)
+
+        assert len(gh.calls) <= 5, (
+            f"{len(gh.calls)} calls for one issue over 10 ticks is not bounded"
+        )
 
     def test_distinct_issues_are_cached_separately(self):
         gh = FakeGitHub(state="open")
@@ -225,13 +246,18 @@ class TestCallCountsStayBounded:
 
         assert len(gh.calls) == 2
 
-    def test_a_closed_answer_is_cached_too(self):
+    def test_a_closed_answer_is_never_refetched(self):
+        """Closed is effectively terminal for a batch's lifetime — unlike
+        "open", it cannot go stale in a way that matters here."""
         gh = FakeGitHub(state="closed")
-        checker = GitHubIssueState(fetch=gh, pat="tok", now=FakeClock())
+        clock = FakeClock()
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=clock)
         task = make_task()
 
-        assert checker.is_closed(task) is True
-        assert checker.is_closed(task) is True
+        for _ in range(10):
+            assert checker.is_closed(task) is True
+            clock.advance(600)
+
         assert len(gh.calls) == 1
 
 
@@ -368,16 +394,22 @@ class TestLocalTaskRowFollowsTheClosedIssue:
     def _task_with_closed_issue(self, workspace, status):
         from codeframe.core import tasks as tasks_mod
 
+        # BACKLOG is what tasks.create defaults to, and what the GitHub
+        # importer uses; walk forward from there to whatever the test wants.
         task = tasks_mod.create(
             workspace,
             title="imported",
             description="",
-            status=TaskStatus.READY,
             github_issue_number=42,
             external_url=ISSUE_URL,
         )
-        if status != TaskStatus.READY:
-            tasks_mod.update_status(workspace, task.id, status)
+        path = {
+            TaskStatus.BACKLOG: [],
+            TaskStatus.READY: [TaskStatus.READY],
+            TaskStatus.IN_PROGRESS: [TaskStatus.READY, TaskStatus.IN_PROGRESS],
+        }[status]
+        for step in path:
+            tasks_mod.update_status(workspace, task.id, step)
         return task
 
     def _reconcile(self, workspace, task_id):
@@ -407,6 +439,19 @@ class TestLocalTaskRowFollowsTheClosedIssue:
             "batch says COMPLETED but the board still shows the task undone, "
             "so the next batch will run it again"
         )
+
+    def test_a_backlog_task_is_marked_DONE(self, workspace):
+        """BACKLOG is what the GitHub importer creates, so this is the primary
+        case, not an edge one — and BACKLOG only permits READY."""
+        from codeframe.core import tasks as tasks_mod
+
+        task = self._task_with_closed_issue(workspace, TaskStatus.BACKLOG)
+        assert tasks_mod.get(workspace, task.id).status == TaskStatus.BACKLOG
+
+        _, batch = self._reconcile(workspace, task.id)
+
+        assert batch.results[task.id] == "COMPLETED"
+        assert tasks_mod.get(workspace, task.id).status == TaskStatus.DONE
 
     def test_an_in_progress_task_is_marked_DONE(self, workspace):
         from codeframe.core import tasks as tasks_mod
@@ -445,7 +490,7 @@ class TestWholePathWithStubbedIssuesService:
     added to ``GitHubIssueDetail`` are all exercised for real.
     """
 
-    def test_ten_ticks_over_three_tasks_make_three_service_calls(self, monkeypatch):
+    def test_ten_ticks_over_three_tasks_stay_bounded(self, monkeypatch):
         calls = []
 
         async def fake_get_issue(pat, repo, number, *, client=None):
@@ -486,9 +531,14 @@ class TestWholePathWithStubbedIssuesService:
             detected.extend(engine.check_all_active(list(by_id)).changes_detected)
             clock.advance(30)
 
-        # Two linked issues, each fetched once and then served from cache for
-        # the remaining ticks; the unlinked task never reaches the service.
-        assert sorted(calls) == [("acme/app", 42), ("acme/app", 43)]
+        # The unlinked task never reaches the service at all.
+        assert [c for c in calls if c[1] not in (42, 43)] == []
+        # The closed issue is fetched once and never again.
+        assert [c for c in calls if c[1] == 42] == [("acme/app", 42)]
+        # The open one is re-checked so a later closure is not missed, but at
+        # the open-TTL, not once per tick: 10 ticks x 30s / 60s TTL = 5, not 10.
+        assert 1 < len([c for c in calls if c[1] == 43]) <= 5
+
         assert {c.task_id for c in detected} == {"linked-closed"}
         assert detected[0].change_type == "completed"
         assert detected[0].source == "github"

--- a/tests/core/test_github_issue_reconciliation_1032.py
+++ b/tests/core/test_github_issue_reconciliation_1032.py
@@ -1,0 +1,403 @@
+"""Batch reconciliation against linked GitHub issue state (#1032).
+
+#921 deleted the ``github_checker`` parameter because it was passed at neither
+call site — an advertised capability that did not exist. This is the feature it
+was standing in for, built with the auth, caching and failure behavior the
+parameter never had.
+
+The expensive part is the loop, not the call: reconciliation ticks every 30s
+over every active task, so the tests below pin the three things that keep it
+from exhausting a single machine-wide PAT — no linked issue means no call, a
+cached answer means no call, and a failure disables the checker instead of
+retrying forever.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from codeframe.core.reconciliation import GitHubIssueState, ReconciliationEngine
+from codeframe.core.state_machine import TaskStatus
+from codeframe.core.tasks import Task
+
+pytestmark = pytest.mark.v2
+
+ISSUE_URL = "https://github.com/acme/app/issues/42"
+
+
+def make_task(
+    *,
+    task_id="t1",
+    status=TaskStatus.IN_PROGRESS,
+    issue_number=42,
+    external_url=ISSUE_URL,
+):
+    return Task(
+        id=task_id,
+        workspace_id="w1",
+        prd_id=None,
+        title="Imported task",
+        description="",
+        status=status,
+        priority=0,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        github_issue_number=issue_number,
+        external_url=external_url,
+    )
+
+
+class FakeGitHub:
+    """Stubbed issue fetch that records every call it receives."""
+
+    def __init__(self, state="closed", raises=None):
+        self.state = state
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, pat, repo, number):
+        self.calls.append((pat, repo, number))
+        if self.raises is not None:
+            raise self.raises
+        return self.state
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+# ---------------------------------------------------------------------------
+# AC2: tasks without a linked issue cost zero API calls
+# ---------------------------------------------------------------------------
+
+
+class TestNoLinkedIssueCostsNothing:
+    def test_task_without_issue_number_never_calls_github(self):
+        gh = FakeGitHub()
+        checker = GitHubIssueState(fetch=gh, pat="tok")
+
+        assert checker.is_closed(make_task(issue_number=None)) is False
+        assert gh.calls == []
+
+    def test_task_without_external_url_never_calls_github(self):
+        """A linked number with no source URL has no repo to ask about."""
+        gh = FakeGitHub()
+        checker = GitHubIssueState(fetch=gh, pat="tok")
+
+        assert checker.is_closed(make_task(external_url=None)) is False
+        assert gh.calls == []
+
+    def test_a_batch_of_unlinked_tasks_makes_no_calls_across_many_ticks(self):
+        gh = GitHubIssueState(fetch=(fake := FakeGitHub()), pat="tok")
+        tasks_ = [make_task(task_id=f"t{i}", issue_number=None) for i in range(20)]
+
+        for _ in range(10):  # ten reconciliation ticks
+            for t in tasks_:
+                gh.is_closed(t)
+
+        assert fake.calls == []
+
+
+# ---------------------------------------------------------------------------
+# AC1: a closed issue is detected and recorded as an external completion
+# ---------------------------------------------------------------------------
+
+
+class TestClosedIssueDetected:
+    def test_closed_issue_reports_closed(self):
+        checker = GitHubIssueState(fetch=FakeGitHub(state="closed"), pat="tok")
+        assert checker.is_closed(make_task()) is True
+
+    def test_open_issue_reports_not_closed(self):
+        checker = GitHubIssueState(fetch=FakeGitHub(state="open"), pat="tok")
+        assert checker.is_closed(make_task()) is False
+
+    def test_repo_comes_from_the_tasks_own_source_url(self):
+        """Matches auto-close (#565): the task's source repo, not the
+        workspace's current connection — a workspace may have been reconnected
+        to a different repository since the import."""
+        gh = FakeGitHub()
+        checker = GitHubIssueState(fetch=gh, pat="tok")
+        checker.is_closed(
+            make_task(external_url="https://github.com/other/repo/issues/7", issue_number=7)
+        )
+        assert gh.calls == [("tok", "other/repo", 7)]
+
+    def test_engine_emits_a_completed_change_sourced_to_github(self, monkeypatch):
+        task = make_task()
+        monkeypatch.setattr(
+            "codeframe.core.tasks.get", lambda ws, tid: task
+        )
+        engine = ReconciliationEngine(
+            workspace=object(),
+            issue_state=GitHubIssueState(fetch=FakeGitHub(state="closed"), pat="tok"),
+        )
+
+        changes = engine.check_task("t1")
+
+        assert len(changes) == 1
+        assert changes[0].change_type == "completed"
+        assert changes[0].source == "github"
+        assert changes[0].details["issue_number"] == 42
+
+    def test_completed_change_lands_in_batch_results_as_COMPLETED(self, monkeypatch):
+        """apply_changes maps 'completed' -> COMPLETED and 'closed' -> FAILED.
+        An issue closed on GitHub is a completion, not a failure."""
+        task = make_task()
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: task)
+        engine = ReconciliationEngine(
+            workspace=object(),
+            issue_state=GitHubIssueState(fetch=FakeGitHub(state="closed"), pat="tok"),
+        )
+
+        class Batch:
+            results = {}
+
+        result = engine.check_all_active(["t1"])
+        batch = Batch()
+        engine.apply_changes(result, batch, {})
+
+        assert batch.results["t1"] == "COMPLETED"
+        assert result.tasks_skipped == ["t1"]
+
+    def test_already_done_task_is_not_charged_a_github_call(self, monkeypatch):
+        """The local DONE check already fires; asking GitHub would be a wasted
+        call on every tick for every finished task."""
+        task = make_task(status=TaskStatus.DONE)
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: task)
+        gh = FakeGitHub()
+        engine = ReconciliationEngine(
+            workspace=object(), issue_state=GitHubIssueState(fetch=gh, pat="tok")
+        )
+
+        changes = engine.check_task("t1")
+
+        assert [c.source for c in changes] == ["manual"]
+        assert gh.calls == []
+
+
+# ---------------------------------------------------------------------------
+# AC4: call counts stay bounded across several ticks
+# ---------------------------------------------------------------------------
+
+
+class TestCallCountsStayBounded:
+    def test_repeated_ticks_within_the_ttl_make_one_call(self):
+        gh = FakeGitHub(state="open")
+        clock = FakeClock()
+        checker = GitHubIssueState(fetch=gh, pat="tok", ttl_seconds=300, now=clock)
+        task = make_task()
+
+        for _ in range(10):  # 10 ticks x 30s = 300s of batch time
+            checker.is_closed(task)
+            clock.advance(30)
+
+        assert len(gh.calls) == 1
+
+    def test_the_cache_expires_after_its_ttl(self):
+        gh = FakeGitHub(state="open")
+        clock = FakeClock()
+        checker = GitHubIssueState(fetch=gh, pat="tok", ttl_seconds=300, now=clock)
+        task = make_task()
+
+        checker.is_closed(task)
+        clock.advance(301)
+        checker.is_closed(task)
+
+        assert len(gh.calls) == 2
+
+    def test_distinct_issues_are_cached_separately(self):
+        gh = FakeGitHub(state="open")
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=FakeClock())
+        a = make_task(task_id="a", issue_number=1, external_url="https://github.com/acme/app/issues/1")
+        b = make_task(task_id="b", issue_number=2, external_url="https://github.com/acme/app/issues/2")
+
+        for _ in range(5):
+            checker.is_closed(a)
+            checker.is_closed(b)
+
+        assert len(gh.calls) == 2
+
+    def test_a_closed_answer_is_cached_too(self):
+        gh = FakeGitHub(state="closed")
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=FakeClock())
+        task = make_task()
+
+        assert checker.is_closed(task) is True
+        assert checker.is_closed(task) is True
+        assert len(gh.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC3: an outage or missing PAT logs once and leaves the batch unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestDegradesQuietly:
+    def test_missing_pat_makes_no_calls_and_never_raises(self, monkeypatch):
+        # Stub the resolver rather than passing pat=None: pat=None means
+        # "resolve it lazily", which on a developer machine with a stored PAT
+        # would find one and make the call this test says never happens.
+        monkeypatch.setattr(
+            "codeframe.core.reconciliation._default_pat", lambda: None
+        )
+        gh = FakeGitHub()
+        checker = GitHubIssueState(fetch=gh)
+
+        assert checker.is_closed(make_task()) is False
+        assert gh.calls == []
+
+    def test_missing_pat_stops_further_lookups(self, monkeypatch):
+        """One PAT lookup for the batch, not one per task per tick."""
+        lookups = []
+        monkeypatch.setattr(
+            "codeframe.core.reconciliation._default_pat",
+            lambda: lookups.append(1) or None,
+        )
+        checker = GitHubIssueState(fetch=FakeGitHub(), now=FakeClock())
+
+        for _ in range(10):
+            checker.is_closed(make_task())
+
+        assert len(lookups) == 1
+
+    def test_github_failure_does_not_propagate(self):
+        checker = GitHubIssueState(
+            fetch=FakeGitHub(raises=RuntimeError("GitHub is down")), pat="tok"
+        )
+        assert checker.is_closed(make_task()) is False
+
+    def test_after_a_failure_the_checker_stops_calling_github(self):
+        """Retrying every 30s through an outage is how you get rate-limited."""
+        gh = FakeGitHub(raises=RuntimeError("GitHub is down"))
+        clock = FakeClock()
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=clock)
+        task = make_task()
+
+        for _ in range(10):
+            checker.is_closed(task)
+            clock.advance(30)
+
+        assert len(gh.calls) == 1
+
+    def test_a_failure_is_logged_once_not_every_tick(self, caplog):
+        gh = FakeGitHub(raises=RuntimeError("GitHub is down"))
+        checker = GitHubIssueState(fetch=gh, pat="tok", now=FakeClock())
+        task = make_task()
+
+        with caplog.at_level("WARNING"):
+            for _ in range(10):
+                checker.is_closed(task)
+
+        warnings = [r for r in caplog.records if "GitHub is down" in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_engine_survives_a_github_outage_and_reports_no_changes(self, monkeypatch):
+        task = make_task()
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: task)
+        monkeypatch.setattr(
+            "codeframe.core.blockers.list_for_task", lambda ws, tid: []
+        )
+        engine = ReconciliationEngine(
+            workspace=object(),
+            issue_state=GitHubIssueState(
+                fetch=FakeGitHub(raises=RuntimeError("boom")), pat="tok"
+            ),
+        )
+
+        result = engine.check_all_active(["t1"])
+
+        assert result.changes_detected == []
+        assert result.errors == []  # an outage is not a reconciliation error
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the engine builds a real checker when none is injected
+# ---------------------------------------------------------------------------
+
+
+class TestWiredByDefault:
+    def test_engine_has_an_issue_state_checker_without_injection(self):
+        engine = ReconciliationEngine(workspace=object())
+        assert isinstance(engine._issue_state, GitHubIssueState)
+
+    def test_conductor_thread_does_not_need_a_checker_argument(self):
+        """#921's invariant holds: no advertised-but-unwired parameter. The
+        checker is constructed by the engine, so both call sites get it."""
+        import inspect
+
+        from codeframe.core import conductor
+
+        params = inspect.signature(conductor._start_reconciliation_thread).parameters
+        assert "github_checker" not in params
+
+    def test_default_fetch_reads_state_from_the_issues_service(self):
+        """The default fetch must ask for something get_issue actually returns."""
+        from codeframe.core.github_issues_service import GitHubIssueDetail
+
+        assert "state" in GitHubIssueDetail.__annotations__
+
+
+class TestWholePathWithStubbedIssuesService:
+    """AC4 end-to-end: engine → default fetch → issues service, several ticks.
+
+    Unlike the tests above this does not stub the ``fetch`` callable — it stubs
+    ``github_issues_service.get_issue`` itself, so the default fetch, the
+    ``asyncio.run`` bridge off the reconciliation thread, and the ``state`` key
+    added to ``GitHubIssueDetail`` are all exercised for real.
+    """
+
+    def test_ten_ticks_over_three_tasks_make_three_service_calls(self, monkeypatch):
+        calls = []
+
+        async def fake_get_issue(pat, repo, number, *, client=None):
+            calls.append((repo, number))
+            return {
+                "number": number,
+                "title": "t",
+                "body": "",
+                "labels": [],
+                "html_url": f"https://github.com/{repo}/issues/{number}",
+                "state": "closed" if number == 42 else "open",
+            }
+
+        monkeypatch.setattr(
+            "codeframe.core.github_issues_service.get_issue", fake_get_issue
+        )
+
+        by_id = {
+            "linked-closed": make_task(task_id="linked-closed", issue_number=42),
+            "linked-open": make_task(
+                task_id="linked-open",
+                issue_number=43,
+                external_url="https://github.com/acme/app/issues/43",
+            ),
+            "unlinked": make_task(task_id="unlinked", issue_number=None),
+        }
+        monkeypatch.setattr(
+            "codeframe.core.tasks.get", lambda ws, tid: by_id[tid]
+        )
+
+        clock = FakeClock()
+        engine = ReconciliationEngine(
+            workspace=object(), issue_state=GitHubIssueState(pat="tok", now=clock)
+        )
+
+        detected = []
+        for _ in range(10):
+            detected.extend(engine.check_all_active(list(by_id)).changes_detected)
+            clock.advance(30)
+
+        # Two linked issues, each fetched once and then served from cache for
+        # the remaining ticks; the unlinked task never reaches the service.
+        assert sorted(calls) == [("acme/app", 42), ("acme/app", 43)]
+        assert {c.task_id for c in detected} == {"linked-closed"}
+        assert detected[0].change_type == "completed"
+        assert detected[0].source == "github"

--- a/tests/core/test_github_issue_reconciliation_1032.py
+++ b/tests/core/test_github_issue_reconciliation_1032.py
@@ -204,6 +204,56 @@ class TestClosedIssueDetected:
         assert [c.change_type for c in changes] == ["blocker_resolved"]
         assert gh.calls == [], "spent a call on a task that already had a change"
 
+    def test_a_resolved_blocker_is_reported_once_not_on_every_sweep(
+        self, monkeypatch
+    ):
+        """Once BLOCKED tasks were swept again, this branch started firing on
+        every tick: it reads only the current row, which stays BLOCKED with its
+        blockers answered until the batch ends. The pop in apply_changes is
+        idempotent so nothing corrupts, but 're-queued' is a one-shot signal,
+        not a heartbeat every 30 seconds for the rest of the run.
+        """
+        task = make_task(status=TaskStatus.BLOCKED)
+        answered = type("B", (), {"status": type("S", (), {"value": "ANSWERED"})()})()
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: task)
+        monkeypatch.setattr(
+            "codeframe.core.blockers.list_for_task", lambda ws, tid: [answered]
+        )
+        engine = ReconciliationEngine(
+            workspace=object(),
+            issue_state=GitHubIssueState(fetch=FakeGitHub(state="open"), pat="tok"),
+        )
+
+        emitted = [
+            c.change_type for _ in range(3) for c in engine.check_task("t1")
+        ]
+
+        assert emitted == ["blocker_resolved"], (
+            f"requeue reported {len(emitted)} times across three sweeps"
+        )
+
+    def test_the_one_shot_requeue_is_per_task(self, monkeypatch):
+        """Suppressing a repeat must not suppress a different task's first."""
+        answered = type("B", (), {"status": type("S", (), {"value": "ANSWERED"})()})()
+        rows = {
+            "a": make_task(task_id="a", status=TaskStatus.BLOCKED),
+            "b": make_task(task_id="b", status=TaskStatus.BLOCKED),
+        }
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: rows[tid])
+        monkeypatch.setattr(
+            "codeframe.core.blockers.list_for_task", lambda ws, tid: [answered]
+        )
+        engine = ReconciliationEngine(
+            workspace=object(),
+            issue_state=GitHubIssueState(fetch=FakeGitHub(state="open"), pat="tok"),
+        )
+
+        first = engine.check_all_active(["a", "b"])
+        second = engine.check_all_active(["a", "b"])
+
+        assert len(first.changes_detected) == 2
+        assert second.changes_detected == []
+
     def test_already_done_task_is_not_charged_a_github_call(self, monkeypatch):
         """The local DONE check already fires; asking GitHub would be a wasted
         call on every tick for every finished task."""

--- a/tests/core/test_github_issue_reconciliation_1032.py
+++ b/tests/core/test_github_issue_reconciliation_1032.py
@@ -345,6 +345,97 @@ class TestWiredByDefault:
         assert "state" in GitHubIssueDetail.__annotations__
 
 
+class TestLocalTaskRowFollowsTheClosedIssue:
+    """Recording the batch result alone leaves the system inconsistent.
+
+    The ``source="manual"`` path is consistent for free: the task row is
+    *already* DONE, which is how the change was detected. Nothing sets the row
+    for a GitHub closure, so without this the batch finishes COMPLETED while
+    the board still shows the task READY — and the next batch runs it again.
+
+    ``READY -> DONE`` is not a permitted transition, so a task the batch had not
+    started yet must pass through IN_PROGRESS, the same path a real run takes.
+    """
+
+    @pytest.fixture
+    def workspace(self, tmp_path):
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws_dir = tmp_path / "ws"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        return create_or_load_workspace(ws_dir)
+
+    def _task_with_closed_issue(self, workspace, status):
+        from codeframe.core import tasks as tasks_mod
+
+        task = tasks_mod.create(
+            workspace,
+            title="imported",
+            description="",
+            status=TaskStatus.READY,
+            github_issue_number=42,
+            external_url=ISSUE_URL,
+        )
+        if status != TaskStatus.READY:
+            tasks_mod.update_status(workspace, task.id, status)
+        return task
+
+    def _reconcile(self, workspace, task_id):
+        engine = ReconciliationEngine(
+            workspace=workspace,
+            issue_state=GitHubIssueState(fetch=FakeGitHub(state="closed"), pat="tok"),
+        )
+        result = engine.check_all_active([task_id])
+
+        class Batch:
+            id = "b1"
+            results = {}
+
+        batch = Batch()
+        engine.apply_changes(result, batch, {})
+        return result, batch
+
+    def test_a_not_yet_started_task_is_marked_DONE(self, workspace):
+        from codeframe.core import tasks as tasks_mod
+
+        task = self._task_with_closed_issue(workspace, TaskStatus.READY)
+
+        _, batch = self._reconcile(workspace, task.id)
+
+        assert batch.results[task.id] == "COMPLETED"
+        assert tasks_mod.get(workspace, task.id).status == TaskStatus.DONE, (
+            "batch says COMPLETED but the board still shows the task undone, "
+            "so the next batch will run it again"
+        )
+
+    def test_an_in_progress_task_is_marked_DONE(self, workspace):
+        from codeframe.core import tasks as tasks_mod
+
+        task = self._task_with_closed_issue(workspace, TaskStatus.IN_PROGRESS)
+
+        self._reconcile(workspace, task.id)
+
+        assert tasks_mod.get(workspace, task.id).status == TaskStatus.DONE
+
+    def test_a_refused_transition_does_not_break_reconciliation(
+        self, workspace, monkeypatch
+    ):
+        """The batch-level record still stands if the row cannot be moved."""
+        from codeframe.core import tasks as tasks_mod
+
+        task = self._task_with_closed_issue(workspace, TaskStatus.READY)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("state machine said no")
+
+        monkeypatch.setattr(tasks_mod, "update_status", boom)
+
+        result, batch = self._reconcile(workspace, task.id)
+
+        assert batch.results[task.id] == "COMPLETED"
+        assert result.errors == []
+
+
 class TestWholePathWithStubbedIssuesService:
     """AC4 end-to-end: engine → default fetch → issues service, several ticks.
 

--- a/tests/core/test_github_issue_reconciliation_1032.py
+++ b/tests/core/test_github_issue_reconciliation_1032.py
@@ -167,6 +167,43 @@ class TestClosedIssueDetected:
         assert batch.results["t1"] == "COMPLETED"
         assert result.tasks_skipped == ["t1"]
 
+    def test_a_blocked_task_with_open_blockers_still_checks_github(self, monkeypatch):
+        """The blocker branch used to swallow this case: a BLOCKED task whose
+        blockers are unanswered never reached the GitHub check, so closing the
+        issue left the task stuck and re-runnable forever."""
+        task = make_task(status=TaskStatus.BLOCKED)
+        unanswered = type("B", (), {"status": type("S", (), {"value": "OPEN"})()})()
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: task)
+        monkeypatch.setattr(
+            "codeframe.core.blockers.list_for_task", lambda ws, tid: [unanswered]
+        )
+        engine = ReconciliationEngine(
+            workspace=object(),
+            issue_state=GitHubIssueState(fetch=FakeGitHub(state="closed"), pat="tok"),
+        )
+
+        changes = engine.check_task("t1")
+
+        assert [(c.change_type, c.source) for c in changes] == [("completed", "github")]
+
+    def test_a_resolved_blocker_still_wins_over_the_github_check(self, monkeypatch):
+        """Don't let the new check displace the existing signal."""
+        task = make_task(status=TaskStatus.BLOCKED)
+        answered = type("B", (), {"status": type("S", (), {"value": "ANSWERED"})()})()
+        monkeypatch.setattr("codeframe.core.tasks.get", lambda ws, tid: task)
+        monkeypatch.setattr(
+            "codeframe.core.blockers.list_for_task", lambda ws, tid: [answered]
+        )
+        gh = FakeGitHub(state="closed")
+        engine = ReconciliationEngine(
+            workspace=object(), issue_state=GitHubIssueState(fetch=gh, pat="tok")
+        )
+
+        changes = engine.check_task("t1")
+
+        assert [c.change_type for c in changes] == ["blocker_resolved"]
+        assert gh.calls == [], "spent a call on a task that already had a change"
+
     def test_already_done_task_is_not_charged_a_github_call(self, monkeypatch):
         """The local DONE check already fires; asking GitHub would be a wasted
         call on every tick for every finished task."""


### PR DESCRIPTION
Closes #1032.

#921 deleted the `github_checker` parameter because it was passed at neither call site — an advertised capability that did not exist. This is the feature it stood in for, with the auth, caching and failure behavior the parameter never had.

An issue closed on GitHub mid-batch is now an external completion, exactly like a task marked DONE in the UI.

## The decisions the issue asked for

| Question | Answer |
|---|---|
| Closed issue → COMPLETED or skip? | **COMPLETED.** `apply_changes` already maps `change_type="completed"` → `COMPLETED`; `"closed"` maps to FAILED, which would be wrong. |
| Reuse "the existing 60s TTL cache in `github_issues_service`"? | **It does not exist** — nothing in that module caches. Built a small one in the checker. |
| Reintroduce `github_checker`? | **No.** `test_batch_reconciliation_921.py` guards against an advertised-but-unwired parameter, and that invariant still holds: the checker is constructed by the engine, so both call sites get it. **That test is untouched.** |

## Keeping it cheap

Reconciliation ticks every 30s over every active task against a single machine-wide PAT, so the naive version is one API call per task per tick. Three things bound it:

- A task with no `github_issue_number`, or no `external_url` to name a repo, **never reaches the network**. Most tasks are not imported from GitHub.
- **Closed** is cached for the checker's life (terminal for a batch). **Open** is cached only 60s — an open answer is precisely the one that goes stale in a way that matters.
- The first missing PAT or GitHub failure **disables the checker for the rest of the batch** and logs once. An outage must never fail a batch, and retrying every 30s through one is how you get rate-limited, so this doubles as the back-off.

The repo comes from the task's own `external_url`, not the live connection — matching auto-close (#565), since a workspace may have been reconnected elsewhere since the import.

Also: `get_issue` fetched the issue's `state` and dropped it. Added to `GitHubIssueDetail`, defaulting to `"open"` — treating an unreadable state as closed would skip a task still in flight.

## What review turned up

The feature is commit 1 of 9. `codex review` ran nine times and the CI reviewer once; seven found something. Four were **pre-existing or latent defects in the batch executor** that this feature made reachable, and I fixed them rather than filing them:

1. **#921's guard was dead code on the default strategy.** `_record_task_result` was used at **1 of 5** write sites, and the one was the *parallel* path. On `--strategy serial` an external completion was overwritten by the worker's FAILED — the exact bug #921 set out to fix. The old test only exercised the helper in isolation, never the executors.
2. **Accounting ignored the guard.** Callers kept tallying off the worker's stale status, so a batch whose every task recorded COMPLETED finalized as **PARTIAL**. The helper now returns the *effective* result.
3. **Already-completed tasks still ran.** Added a skip before launching work — serial loop, parallel pool worker, and single-task dependency groups (which bypass the pool).
4. **`resume --force` could not re-run a completed task at all.** A DONE row cannot go to IN_PROGRESS (the state machine allows only `{READY, MERGED}`), so it raised `InvalidTransitionError` before the agent started. Pre-existing — verified against the pre-branch code. Resume now voids prior results *and* resets DONE rows to READY.
5. **The task row was left behind.** Recording only `batch.results` meant the batch finished COMPLETED while the board still showed the task undone, so the next batch would run it again. Now walked to DONE — and it must start from **BACKLOG**, because that is what `tasks.create` defaults to and therefore what the GitHub importer produces. My first cut called BACKLOG an edge case; it is the primary one.
6. **The first task was never checked.** The reconciliation loop waits a full interval before its first pass, so "the issue was already closed when the batch started" was missed for everything reached in the first 30s. One sweep now runs synchronously before the thread starts.
7. **Blocked tasks were skipped.** The check hung off an `elif` after the blocker branch, so a BLOCKED task with *unanswered* blockers was never asked about — despite being the one most worth asking about, since the human may have resolved the work on GitHub instead of answering.

8. **A BLOCKED task dropped out of reconciliation entirely.** Found by the CI reviewer. The sweep selected results that are `None`/`RUNNING`, so the moment a task's first attempt reported BLOCKED it was excluded from every later sweep — silently disabling both the pre-existing blocker-resolved requeue *and* fix 7 above. The code ran; nothing reached it.

The final codex and CI passes were clean.

## Verification

Demo drives a **real serial batch** through the real executor, with only the GitHub fetch and the agent subprocess stubbed:

```
AC1  linked issue #42 closed on GitHub -> batch result: COMPLETED
     its task row is now:                DONE (was BACKLOG->READY)
     it was NOT executed:                True
AC2  GitHub API calls made:              [('acme/app', 42), ('acme/app', 43)]
     the unlinked task cost 0 calls:     True
AC1b open issue #43 ran normally:        True -> COMPLETED
     plain task ran normally:            True -> COMPLETED
     batch finalized as:                 COMPLETED
```
`RECONCILIATION_TASK_SKIPPED` fires at t=0 — the pre-start sweep, not a lucky race.

AC3, with GitHub unreachable:
```
AC3  GitHub down. Lookup attempts before giving up: 1 (not 1 per task per tick)
     every task still ran:                         True
     batch results:                                {'COMPLETED'}
     batch finalized as:                           COMPLETED
```

## Tests

Two new modules, 49 tests, every one written RED first.

- `test_github_issue_reconciliation_1032.py` — one class per AC. Call-count assertions across ten simulated ticks (AC4) with a stubbed **fetch**, plus an end-to-end class that stubs `github_issues_service.get_issue` itself so the default fetch, the `asyncio.run` bridge, and the new `state` key are all exercised.
- `test_external_completion_honored_1032.py` — drives the real serial executor and `resume --force` with a stubbed subprocess, plus a source-level check that no executor writes `batch.results` directly again.

`tests/core -k "reconcil or conductor or batch or github or task or resume or runtime"`: **544 passed, 4 skipped**. `ruff check .` clean.

One test's assertion changed deliberately, and it is worth flagging: the end-to-end call count was pinned to the old single 300s TTL. Splitting the TTL changed the right answer, so it now asserts the *property* (unlinked never fetched, closed fetched exactly once, open re-checked but bounded at TTL rate) rather than a number.

## Known limitations

- Uses the single machine-wide PAT, the same limitation as auto-close (#565) — reconciliation runs on a background thread with no request-scoped user.
- Detection latency for a closure is up to the 60s open-TTL plus the 30s tick. That is inherent to polling; the pre-start sweep covers the case that actually matters.
- The pre-start sweep fetches each linked task's issue state sequentially, so batch startup pays one network round-trip per GitHub-linked task before the first task launches. Bounded by linked tasks only, and nothing at all when none are linked; worth parallelising if large imported batches become common.
- Marking the task DONE fires the auto-close dispatch when the task opted in. The issue is already closed, so that PATCH is a no-op — not worth a special path to avoid.