### PR TITLE
fix(proof): close four PROOF9 evidence-integrity holes (#952)

### DIFF
--- a/codeframe/cli/pr_commands.py
+++ b/codeframe/cli/pr_commands.py
@@ -457,27 +457,31 @@ def _check_merge_gate(
         # evidence no longer verifies must stop the merge too (#952).
         from codeframe.core.proof.evidence import list_blocking_requirements
 
-        open_reqs = list_blocking_requirements(workspace)
+        blocking_reqs = list_blocking_requirements(workspace)
     except Exception as e:
         # Fail closed, like the API path: a broken ledger blocks the merge.
         console.print(f"[red]PROOF9 gate check failed:[/red] {e} — merge blocked")
         raise typer.Exit(1)
-    if not open_reqs:
+    if not blocking_reqs:
         return None
 
     if not override:
         console.print(
-            f"[red]PROOF9 merge gate:[/red] {len(open_reqs)} open requirement(s) block this merge:"
+            f"[red]PROOF9 merge gate:[/red] {len(blocking_reqs)} requirement(s) block this merge:"
         )
-        for r in open_reqs[:10]:
+        for r in blocking_reqs[:10]:
             console.print(f"  - {r.id}: {r.title}")
-        console.print('Satisfy or waive them, or pass --override --reason "...".')
+        console.print(
+            "Each is either unproven, or recorded satisfied with evidence that "
+            "no longer matches its checksum."
+        )
+        console.print('Satisfy, waive or re-prove them, or pass --override --reason "...".')
         raise typer.Exit(1)
 
     console.print(
-        f"[yellow]PROOF9 merge gate overridden[/yellow] ({len(open_reqs)} open requirement(s) bypassed — audited)"
+        f"[yellow]PROOF9 merge gate overridden[/yellow] ({len(blocking_reqs)} requirement(s) bypassed — audited)"
     )
-    return workspace, [{"id": r.id, "title": r.title} for r in open_reqs]
+    return workspace, [{"id": r.id, "title": r.title} for r in blocking_reqs]
 
 
 @pr_app.command("merge")

--- a/codeframe/cli/pr_commands.py
+++ b/codeframe/cli/pr_commands.py
@@ -432,8 +432,6 @@ def _check_merge_gate(
     override is pending so the caller can persist the audit record after the
     merge actually succeeds, or None when nothing was bypassed.
     """
-    from codeframe.core.proof import ledger as proof_ledger
-    from codeframe.core.proof.models import ReqStatus
     from codeframe.core.workspace import find_workspace_root, get_workspace
 
     reason = (override_reason or "").strip()
@@ -455,7 +453,11 @@ def _check_merge_gate(
         return None
 
     try:
-        open_reqs = proof_ledger.list_requirements(workspace, status=ReqStatus.OPEN)
+        # Blocking, not merely open: a requirement recorded SATISFIED whose
+        # evidence no longer verifies must stop the merge too (#952).
+        from codeframe.core.proof.evidence import list_blocking_requirements
+
+        open_reqs = list_blocking_requirements(workspace)
     except Exception as e:
         # Fail closed, like the API path: a broken ledger blocks the merge.
         console.print(f"[red]PROOF9 gate check failed:[/red] {e} — merge blocked")

--- a/codeframe/core/proof/evidence.py
+++ b/codeframe/core/proof/evidence.py
@@ -160,6 +160,13 @@ def list_blocking_requirements(workspace: Workspace) -> list[Requirement]:
       so editing its artifact afterwards left the merge gate waving the change
       through (codex review on #952).
 
+    Only the **latest** passing evidence per gate is checked, not every row
+    ever recorded. Runs accumulate evidence, and deleting last month's
+    artifacts is routine housekeeping — blocking on any historical row would
+    make that cleanup wedge the gate permanently, which is a worse failure than
+    the hole this closes (codex review). Each gate is judged separately, so a
+    stale-but-intact UNIT artifact cannot mask a tampered SEC one.
+
     A SATISFIED requirement with *no* evidence rows does not block. That is a
     pre-existing state in older ledgers, not a tamper signal, and treating it
     as one would wedge every workspace that has it. Only evidence that is
@@ -170,9 +177,14 @@ def list_blocking_requirements(workspace: Workspace) -> list[Requirement]:
     blocking = list(ledger.list_requirements(workspace, status=ReqStatus.OPEN))
 
     for req in ledger.list_requirements(workspace, status=ReqStatus.SATISFIED):
+        # list_evidence returns newest first, so the first passing row for a
+        # gate is that gate's current proof.
+        latest: dict[Gate, Evidence] = {}
         for ev in ledger.list_evidence(workspace, req.id):
-            if not ev.satisfied:
-                continue
+            if ev.satisfied:
+                latest.setdefault(ev.gate, ev)
+
+        for ev in latest.values():
             try:
                 verify_evidence(ev)
             except EvidenceTamperError as exc:

--- a/codeframe/core/proof/evidence.py
+++ b/codeframe/core/proof/evidence.py
@@ -5,6 +5,7 @@ to requirements with SHA-256 checksums for integrity.
 """
 
 import hashlib
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -12,15 +13,88 @@ from codeframe.core.proof import ledger
 from codeframe.core.proof.models import Evidence, Gate, GateOutcome, Requirement
 from codeframe.core.workspace import Workspace
 
+logger = logging.getLogger(__name__)
+
+
+class EvidenceTamperError(Exception):
+    """A stored artifact no longer matches the checksum recorded with it.
+
+    A hard state, never a warning: the whole point of the ledger is that a
+    recorded pass is attributable. Raised on a mutated artifact, a missing one,
+    and on one transplanted from a different run or gate.
+    """
+
 
 def _sha256(file_path: str) -> str:
-    """Compute SHA-256 checksum of a file. Raises if file missing."""
+    """Compute SHA-256 checksum of a file's bytes. Raises if file missing.
+
+    The pre-#952 digest. Kept because evidence written before that change is
+    stored in this form — see ``verify_evidence``.
+    """
     path = Path(file_path)
     if not path.exists():
         raise FileNotFoundError(f"Artifact not found: {file_path}")
     h = hashlib.sha256()
     h.update(path.read_bytes())
     return h.hexdigest()
+
+
+def _bound_digest(run_id: str, gate: Gate, artifact_path: str) -> str:
+    """Checksum binding the artifact's bytes to *where it came from* (#952).
+
+    Hashing bytes alone proves only that a file is unmodified — it says nothing
+    about which run produced it, so a genuinely passing artifact could be
+    transplanted into another run's evidence and still verify. The digest
+    therefore covers a canonical header (run id, gate, resolved path) as well
+    as the content.
+
+    The header is length-prefixed so no two different tuples can produce the
+    same byte stream (``run="a|b", gate="c"`` vs ``run="a", gate="b|c"``).
+    """
+    path = Path(artifact_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Artifact not found: {artifact_path}")
+    h = hashlib.sha256()
+    for part in ("codeframe-proof-evidence-v1", run_id, gate.value, str(path.resolve())):
+        raw = part.encode("utf-8")
+        h.update(len(raw).to_bytes(4, "big"))
+        h.update(raw)
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def verify_evidence(evidence: Evidence) -> None:
+    """Re-derive an artifact's checksum and raise if it does not match.
+
+    Checksums were computed and stored but never checked on read, so the
+    integrity claim was unenforced (#952). This is the check.
+
+    Accepts the legacy bytes-only digest as well as the bound one, so evidence
+    recorded before #952 does not all become 'tampered' at once. Legacy rows
+    still detect modification of the artifact; they just cannot detect a
+    transplant. New evidence is always written in the bound form, so the
+    legacy path drains as runs happen.
+    """
+    try:
+        if _bound_digest(evidence.run_id, evidence.gate, evidence.artifact_path) == evidence.artifact_checksum:
+            return
+        if _sha256(evidence.artifact_path) == evidence.artifact_checksum:
+            logger.debug(
+                "Evidence for %s/%s verified via the pre-#952 bytes-only digest",
+                evidence.req_id, evidence.gate.value,
+            )
+            return
+    except FileNotFoundError as exc:
+        raise EvidenceTamperError(
+            f"Evidence artifact for {evidence.req_id}/{evidence.gate.value} "
+            f"is missing: {evidence.artifact_path}"
+        ) from exc
+
+    raise EvidenceTamperError(
+        f"Evidence artifact for {evidence.req_id}/{evidence.gate.value} does not "
+        f"match its recorded checksum: {evidence.artifact_path} "
+        f"(run {evidence.run_id})"
+    )
 
 
 def attach_evidence(
@@ -41,7 +115,7 @@ def attach_evidence(
         gate=gate,
         satisfied=(outcome == GateOutcome.PASSED),
         artifact_path=artifact_path,
-        artifact_checksum=_sha256(artifact_path),
+        artifact_checksum=_bound_digest(run_id, gate, artifact_path),
         timestamp=datetime.now(timezone.utc),
         run_id=run_id,
         status=outcome.value,
@@ -53,9 +127,22 @@ def attach_evidence(
 def check_obligation_satisfied(
     workspace: Workspace, req: Requirement, gate: Gate
 ) -> bool:
-    """Check if a gate obligation has passing evidence."""
+    """Check if a gate obligation has passing evidence.
+
+    Evidence whose artifact no longer matches its checksum does not count. The
+    verification has to happen here, before a gate accepts the artifact, or the
+    stored checksum buys nothing (#952). A tampered record is skipped and
+    logged rather than raised: one corrupted artifact must not take down the
+    whole proof run, and the obligation correctly reports unsatisfied.
+    """
     evidence_list = ledger.list_evidence(workspace, req.id)
     for ev in evidence_list:
-        if ev.gate == gate and ev.satisfied:
-            return True
+        if ev.gate != gate or not ev.satisfied:
+            continue
+        try:
+            verify_evidence(ev)
+        except EvidenceTamperError as exc:
+            logger.warning("Rejecting evidence for %s: %s", req.id, exc)
+            continue
+        return True
     return False

--- a/codeframe/core/proof/evidence.py
+++ b/codeframe/core/proof/evidence.py
@@ -84,10 +84,16 @@ def verify_evidence(evidence: Evidence) -> None:
                 evidence.req_id, evidence.gate.value,
             )
             return
-    except FileNotFoundError as exc:
+    # OSError, not just FileNotFoundError: an artifact replaced by a directory
+    # or made unreadable still exists, so read_bytes raises IsADirectoryError /
+    # PermissionError instead. Those escaped, 500ing the evidence endpoints and
+    # taking down the merge gate before it could block the specific requirement
+    # or honor an override (codex review on #1080). An artifact we cannot read
+    # is an artifact we cannot verify, which is the tamper state.
+    except OSError as exc:
         raise EvidenceTamperError(
             f"Evidence artifact for {evidence.req_id}/{evidence.gate.value} "
-            f"is missing: {evidence.artifact_path}"
+            f"cannot be read: {evidence.artifact_path} ({exc.__class__.__name__})"
         ) from exc
 
     raise EvidenceTamperError(

--- a/codeframe/core/proof/evidence.py
+++ b/codeframe/core/proof/evidence.py
@@ -146,3 +146,40 @@ def check_obligation_satisfied(
             continue
         return True
     return False
+
+
+def list_blocking_requirements(workspace: Workspace) -> list[Requirement]:
+    """Requirements that must stop a merge (#731 gate, #952 verification).
+
+    Two reasons a requirement blocks:
+
+    * It is still OPEN — never proven.
+    * It is recorded SATISFIED but its evidence no longer verifies. Checksum
+      verification is worthless if the only path that runs it is a fresh proof
+      run: a requirement marked satisfied yesterday keeps that status forever,
+      so editing its artifact afterwards left the merge gate waving the change
+      through (codex review on #952).
+
+    A SATISFIED requirement with *no* evidence rows does not block. That is a
+    pre-existing state in older ledgers, not a tamper signal, and treating it
+    as one would wedge every workspace that has it. Only evidence that is
+    present and fails to verify counts.
+    """
+    from codeframe.core.proof.models import ReqStatus
+
+    blocking = list(ledger.list_requirements(workspace, status=ReqStatus.OPEN))
+
+    for req in ledger.list_requirements(workspace, status=ReqStatus.SATISFIED):
+        for ev in ledger.list_evidence(workspace, req.id):
+            if not ev.satisfied:
+                continue
+            try:
+                verify_evidence(ev)
+            except EvidenceTamperError as exc:
+                logger.warning(
+                    "Requirement %s blocks the merge gate: %s", req.id, exc
+                )
+                blocking.append(req)
+                break
+
+    return blocking

--- a/codeframe/core/proof/ledger.py
+++ b/codeframe/core/proof/ledger.py
@@ -703,7 +703,9 @@ def get_run_evidence(workspace: Workspace, run_id: str) -> list[Evidence]:
 def check_expired_waivers(workspace: Workspace) -> list[Requirement]:
     """Find and revert expired waivers to open status."""
     _ensure_tables(workspace)
-    today = date.today().isoformat()
+    # UTC, not the machine's local date: the ledger's timestamps are UTC, so a
+    # local date makes expiry depend on the operator's timezone (#952).
+    today = datetime.now(timezone.utc).date()
     conn = get_db_connection(workspace)
     cursor = conn.cursor()
 
@@ -720,7 +722,12 @@ def check_expired_waivers(workspace: Workspace) -> list[Requirement]:
 
     for row in rows:
         req = _row_to_requirement(row)
-        if req.waiver and req.waiver.expires and req.waiver.expires.isoformat() <= today:
+        # `<` not `<=`: the expiry date is the waiver's LAST VALID day, so a
+        # waiver expiring today must survive today. `<=` expired it a day early
+        # and spuriously blocked the #731 merge gate (#952). Compared as dates,
+        # not isoformat strings, so the comparison cannot silently go
+        # lexicographic on a malformed value.
+        if req.waiver and req.waiver.expires and req.waiver.expires < today:
             cursor.execute(
                 "UPDATE proof_requirements SET status = 'open', waiver = NULL WHERE id = ?",
                 (req.id,),

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -27,6 +27,19 @@ from codeframe.core.workspace import Workspace
 logger = logging.getLogger(__name__)
 
 
+def _new_run_id() -> str:
+    """A fresh proof-run identifier.
+
+    A full UUID, never a truncated one. ``str(uuid4())[:8]`` gives 32 bits, so
+    two runs in a workspace collide around 600 runs by the birthday bound — and
+    a collision merges evidence across runs, letting a passing run absorb a
+    failing run's artifacts (#952). Callers that need the id before the run
+    starts (the v2 router, so its response matches the evidence rows) use this
+    too, so there is one definition.
+    """
+    return str(uuid.uuid4())
+
+
 def _load_proof_config(workspace: Workspace) -> tuple[Optional[set[Gate]], str]:
     """Load (enabled_gates, strictness) from .codeframe/proof_config.json.
 
@@ -270,7 +283,7 @@ def run_proof(
         Dict mapping req_id → list of (Gate, GateOutcome) tuples
     """
     if not run_id:
-        run_id = str(uuid.uuid4())[:8]
+        run_id = _new_run_id()
 
     started_at = datetime.now(timezone.utc)
 

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -184,10 +184,20 @@ def _inline(text: str) -> str:
     captured glitch or an imported issue — and every place a template puts them
     is line-scoped: a Python docstring, a ``//`` comment, a markdown heading. A
     raw newline escapes that context, so the second line lands as code. Collapse
-    whitespace runs to single spaces and neutralize the only sequence that can
-    close a docstring from inside one.
+    whitespace runs to single spaces and neutralize the sequence that can close
+    a docstring from inside one.
+
+    The trailing character matters separately. Six templates butt the text
+    straight against their own closing delimiter — ``\"\"\"Proves: {description}\"\"\"``
+    — so text ending in a single quote yields four in a row: Python closes the
+    docstring on the first three and the fourth opens an unterminated literal.
+    A trailing backslash escapes the delimiter's first quote for the same
+    result. Neither is a ``\"\"\"`` run, so the replacement above does not see
+    them (CI review on #952). One space is enough to separate them, and reads
+    identically.
     """
-    return " ".join(str(text).split()).replace('"""', "'''")
+    collapsed = " ".join(str(text).split()).replace('"""', "'''")
+    return collapsed + " " if collapsed.endswith(('"', "\\")) else collapsed
 
 
 def _js_string(text: str) -> str:

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -177,6 +177,22 @@ def _slugify(text: str) -> str:
     return slugify(text)
 
 
+#: Gates whose template is markdown, where none of the Python/JS escaping
+#: applies — the text is rendered as prose.
+_MARKDOWN_GATES = frozenset({Gate.DEMO, Gate.MANUAL})
+
+
+def _collapse(text: str) -> str:
+    """One line, with no sequence that can close a Python docstring.
+
+    The context-neutral half of the escaping: safe to render anywhere, and the
+    input every context-specific escaper starts from. Keeping it separate is
+    the point — escaping is per context and must be applied exactly once, never
+    stacked (CI review on #952).
+    """
+    return " ".join(str(text).split()).replace('"""', "'''")
+
+
 def _inline(text: str) -> str:
     """Collapse user text to a single harmless line (#952).
 
@@ -201,7 +217,7 @@ def _inline(text: str) -> str:
     ``\"\"\"`` run, so the replacement above does not see it. One space separates
     them and reads the same.
     """
-    collapsed = " ".join(str(text).split()).replace("\\", "\\\\").replace('"""', "'''")
+    collapsed = _collapse(text).replace("\\", "\\\\")
     return collapsed + " " if collapsed.endswith('"') else collapsed
 
 
@@ -212,8 +228,14 @@ def _js_string(text: str) -> str:
     the literal and append statements. JSON string syntax is a subset of
     JavaScript's, so ``json.dumps`` produces a correct literal — quotes
     included, which is why the template no longer supplies its own.
+
+    Takes the *collapsed* text, never ``_inline``'s output: that is already
+    backslash-doubled for a Python docstring, and ``json.dumps`` would escape
+    those doubles again — so a title of ``\\d+`` reached the .ts source as four
+    backslashes and read back as ``\\\\d+`` (CI review on #952). Escaping is per
+    context, applied once, never stacked.
     """
-    return json.dumps(str(text))
+    return json.dumps(_collapse(text))
 
 
 def generate_stubs(req: Requirement) -> dict[Gate, str]:
@@ -226,20 +248,24 @@ def generate_stubs(req: Requirement) -> dict[Gate, str]:
     """
     result: dict[Gate, str] = {}
     slug = _slugify(req.title)
-    title = _inline(req.title)
-    description = _inline(req.description)
 
     for obligation in req.obligations:
-        template = _TEMPLATES.get(obligation.gate, _TEMPLATES[Gate.UNIT])
+        gate = obligation.gate
+        template = _TEMPLATES.get(gate, _TEMPLATES[Gate.UNIT])
+        # Escaping is chosen by the template's language and applied exactly
+        # once. Markdown renders the text as prose, so it wants neither the
+        # Python backslash-doubling nor JSON escaping; ``title_js`` always
+        # starts from the raw title for the same reason.
+        escape = _collapse if gate in _MARKDOWN_GATES else _inline
         content = template.format(
             req_id=req.id,
-            title=title,
-            title_js=_js_string(title),
-            description=description,
+            title=escape(req.title),
+            title_js=_js_string(req.title),
+            description=escape(req.description),
             slug=slug,
-            filename=f"test_{slug}_{obligation.gate.value}",
+            filename=f"test_{slug}_{gate.value}",
         )
-        result[obligation.gate] = content
+        result[gate] = content
 
     return result
 

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -4,6 +4,7 @@ Generates skeleton test files for each proof gate obligation.
 Uses inline templates (no Jinja2 dependency for simplicity).
 """
 
+import json
 import logging
 from pathlib import Path
 from typing import Optional
@@ -66,7 +67,7 @@ def test_contract_{slug}():
 // collects it, then run: npx playwright test tests/proof/{req_id}/{filename}.spec.ts
 import {{ test, expect }} from '@playwright/test';
 
-test('{title}', async ({{ page }}) => {{
+test({title_js}, async ({{ page }}) => {{
   // {description}
   // TODO: Navigate to the relevant page
   // TODO: Interact with the UI
@@ -176,20 +177,50 @@ def _slugify(text: str) -> str:
     return slugify(text)
 
 
+def _inline(text: str) -> str:
+    """Collapse user text to a single harmless line (#952).
+
+    Requirement titles and descriptions are free text — they reach here from a
+    captured glitch or an imported issue — and every place a template puts them
+    is line-scoped: a Python docstring, a ``//`` comment, a markdown heading. A
+    raw newline escapes that context, so the second line lands as code. Collapse
+    whitespace runs to single spaces and neutralize the only sequence that can
+    close a docstring from inside one.
+    """
+    return " ".join(str(text).split()).replace('"""', "'''")
+
+
+def _js_string(text: str) -> str:
+    """Render text as a complete, escaped JavaScript string literal.
+
+    ``test('{title}')`` broke on any apostrophe and let a crafted title close
+    the literal and append statements. JSON string syntax is a subset of
+    JavaScript's, so ``json.dumps`` produces a correct literal — quotes
+    included, which is why the template no longer supplies its own.
+    """
+    return json.dumps(str(text))
+
+
 def generate_stubs(req: Requirement) -> dict[Gate, str]:
     """Generate test stub content for each obligation in a requirement.
 
     Returns a mapping of Gate → file content string.
+
+    Title and description are untrusted free text and are escaped per the
+    context each template drops them into (#952).
     """
     result: dict[Gate, str] = {}
     slug = _slugify(req.title)
+    title = _inline(req.title)
+    description = _inline(req.description)
 
     for obligation in req.obligations:
         template = _TEMPLATES.get(obligation.gate, _TEMPLATES[Gate.UNIT])
         content = template.format(
             req_id=req.id,
-            title=req.title,
-            description=req.description,
+            title=title,
+            title_js=_js_string(title),
+            description=description,
             slug=slug,
             filename=f"test_{slug}_{obligation.gate.value}",
         )

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -177,9 +177,12 @@ def _slugify(text: str) -> str:
     return slugify(text)
 
 
-#: Gates whose template is markdown, where none of the Python/JS escaping
-#: applies — the text is rendered as prose.
-_MARKDOWN_GATES = frozenset({Gate.DEMO, Gate.MANUAL})
+#: Gates whose template is not Python, so ``{title}``/``{description}`` need
+#: only line-collapsing: DEMO/MANUAL render the text as markdown prose, and
+#: E2E puts it in ``//`` comments. Backslash-doubling would show up verbatim in
+#: all three. (E2E's ``{title_js}`` is separate — that one is a real string
+#: literal and gets ``_js_string``.)
+_NON_PYTHON_GATES = frozenset({Gate.DEMO, Gate.MANUAL, Gate.E2E})
 
 
 def _collapse(text: str) -> str:
@@ -253,10 +256,10 @@ def generate_stubs(req: Requirement) -> dict[Gate, str]:
         gate = obligation.gate
         template = _TEMPLATES.get(gate, _TEMPLATES[Gate.UNIT])
         # Escaping is chosen by the template's language and applied exactly
-        # once. Markdown renders the text as prose, so it wants neither the
-        # Python backslash-doubling nor JSON escaping; ``title_js`` always
+        # once. Only the Python templates need backslash-doubling; markdown
+        # prose and JS comments would show it verbatim. ``title_js`` always
         # starts from the raw title for the same reason.
-        escape = _collapse if gate in _MARKDOWN_GATES else _inline
+        escape = _collapse if gate in _NON_PYTHON_GATES else _inline
         content = template.format(
             req_id=req.id,
             title=escape(req.title),

--- a/codeframe/core/proof/stubs.py
+++ b/codeframe/core/proof/stubs.py
@@ -187,17 +187,22 @@ def _inline(text: str) -> str:
     whitespace runs to single spaces and neutralize the sequence that can close
     a docstring from inside one.
 
-    The trailing character matters separately. Six templates butt the text
-    straight against their own closing delimiter — ``\"\"\"Proves: {description}\"\"\"``
-    — so text ending in a single quote yields four in a row: Python closes the
-    docstring on the first three and the fourth opens an unterminated literal.
-    A trailing backslash escapes the delimiter's first quote for the same
-    result. Neither is a ``\"\"\"`` run, so the replacement above does not see
-    them (CI review on #952). One space is enough to separate them, and reads
-    identically.
+    Backslashes are escaped rather than left alone. Inside a non-raw docstring
+    every ``\\x`` is an escape sequence, so a Windows path or a regex in the
+    text emits ``SyntaxWarning: invalid escape sequence`` — an error under this
+    repo's pytest config — and a *trailing* backslash escapes the template's
+    own closing delimiter outright. Doubling renders identically when the
+    docstring is read.
+
+    The trailing quote matters separately. Six templates butt the text straight
+    against their closing delimiter — ``\"\"\"Proves: {description}\"\"\"`` — so text
+    ending in one quote yields four in a row: Python closes the docstring on
+    the first three and the fourth opens an unterminated literal. That is not a
+    ``\"\"\"`` run, so the replacement above does not see it. One space separates
+    them and reads the same.
     """
-    collapsed = " ".join(str(text).split()).replace('"""', "'''")
-    return collapsed + " " if collapsed.endswith(('"', "\\")) else collapsed
+    collapsed = " ".join(str(text).split()).replace("\\", "\\\\").replace('"""', "'''")
+    return collapsed + " " if collapsed.endswith('"') else collapsed
 
 
 def _js_string(text: str) -> str:

--- a/codeframe/ui/routers/pr_v2.py
+++ b/codeframe/ui/routers/pr_v2.py
@@ -24,7 +24,6 @@ from pydantic import BaseModel, Field
 
 from codeframe.auth.api_keys import SCOPE_ADMIN
 from codeframe.auth.dependencies import require_auth, require_scope
-from codeframe.core.proof.models import ReqStatus
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_standard
 from codeframe.git.github_integration import GitHubIntegration, GitHubAPIError, PRDetails
@@ -752,10 +751,13 @@ async def merge_pull_request(
 
     # PROOF9 merge gate: a ledger failure blocks the merge (explicit 500)
     # rather than silently allowing an ungated merge.
+    # Blocking, not merely open: a requirement recorded SATISFIED whose
+    # evidence no longer verifies must stop the merge too (#952).
     from codeframe.core.proof import ledger as proof_ledger
+    from codeframe.core.proof.evidence import list_blocking_requirements
 
     try:
-        open_reqs = proof_ledger.list_requirements(workspace, status=ReqStatus.OPEN)
+        open_reqs = list_blocking_requirements(workspace)
     except Exception as e:
         logger.error(f"PROOF9 gate check failed for PR #{pr_number}: {e}", exc_info=True)
         raise HTTPException(

--- a/codeframe/ui/routers/pr_v2.py
+++ b/codeframe/ui/routers/pr_v2.py
@@ -757,7 +757,7 @@ async def merge_pull_request(
     from codeframe.core.proof.evidence import list_blocking_requirements
 
     try:
-        open_reqs = list_blocking_requirements(workspace)
+        blocking_reqs = list_blocking_requirements(workspace)
     except Exception as e:
         logger.error(f"PROOF9 gate check failed for PR #{pr_number}: {e}", exc_info=True)
         raise HTTPException(
@@ -770,16 +770,16 @@ async def merge_pull_request(
         )
 
     bypassed: list[dict] = []
-    if open_reqs:
-        bypassed = [{"id": r.id, "title": r.title} for r in open_reqs]
+    if blocking_reqs:
+        bypassed = [{"id": r.id, "title": r.title} for r in blocking_reqs]
         if not override:
             summary = ", ".join(f"{b['id']}: {b['title']}" for b in bypassed[:10])
             raise HTTPException(
                 status_code=409,
                 detail=api_error(
-                    f"PROOF9 merge gate: {len(open_reqs)} open requirement(s) block this merge",
+                    f"PROOF9 merge gate: {len(blocking_reqs)} requirement(s) block this merge",
                     ErrorCodes.INVALID_STATE,
-                    f"{summary}. Satisfy or waive them, or pass override=true with a reason.",
+                    f"{summary}. Each is either unproven, or recorded satisfied with evidence that no longer matches its checksum. Satisfy, waive or re-prove them, or pass override=true with a reason.",
                 ),
             )
 

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -243,6 +243,12 @@ class EvidenceResponse(BaseModel):
     timestamp: str
     run_id: str
     status: Optional[str] = None
+    #: False when the stored artifact no longer matches its recorded checksum,
+    #: or has been deleted (#952). A consumer must not treat a `satisfied`
+    #: record as proof while this is False — the artifact backing it is not the
+    #: one the gate saw.
+    verified: bool = True
+    tamper_detail: Optional[str] = None
 
 
 class EvidenceWithContentResponse(EvidenceResponse):
@@ -621,6 +627,24 @@ async def list_runs_endpoint(
 _ARTIFACT_LINE_LIMIT = 200
 
 
+def _verification(evidence) -> tuple[bool, Optional[str]]:
+    """Re-derive an evidence artifact's checksum for the read paths (#952).
+
+    AC3 is about *reads*: serving `satisfied: true` next to the contents of a
+    file that no longer matches its checksum presents forged text as proof.
+    Reported as a field rather than raised, so one bad artifact does not 404 a
+    whole run's evidence list — the caller sees exactly which record is
+    untrustworthy.
+    """
+    from codeframe.core.proof.evidence import EvidenceTamperError, verify_evidence
+
+    try:
+        verify_evidence(evidence)
+    except EvidenceTamperError as exc:
+        return False, str(exc)
+    return True, None
+
+
 def _read_artifact_text(artifact_path: str, max_lines: int = _ARTIFACT_LINE_LIMIT) -> Optional[str]:
     """Read artifact file content up to max_lines, returning None if the file is missing."""
     from pathlib import Path
@@ -687,20 +711,27 @@ async def get_run_evidence_endpoint(
         )
 
     evidence_records = get_run_evidence(workspace, run_id)
-    evidence_out = [
-        EvidenceWithContentResponse(
-            req_id=e.req_id,
-            gate=e.gate.value,
-            satisfied=e.satisfied,
-            status=e.status,
-            artifact_path=e.artifact_path,
-            artifact_checksum=e.artifact_checksum,
-            timestamp=e.timestamp.isoformat(),
-            run_id=e.run_id,
-            artifact_text=_read_artifact_text(e.artifact_path),
+    evidence_out = []
+    for e in evidence_records:
+        verified, detail = _verification(e)
+        evidence_out.append(
+            EvidenceWithContentResponse(
+                req_id=e.req_id,
+                gate=e.gate.value,
+                satisfied=e.satisfied,
+                status=e.status,
+                artifact_path=e.artifact_path,
+                artifact_checksum=e.artifact_checksum,
+                timestamp=e.timestamp.isoformat(),
+                run_id=e.run_id,
+                verified=verified,
+                tamper_detail=detail,
+                # Withheld when the checksum does not match: the bytes on disk
+                # are not the ones this record attests to, so rendering them
+                # would show forged output as evidence.
+                artifact_text=_read_artifact_text(e.artifact_path) if verified else None,
+            )
         )
-        for e in evidence_records
-    ]
     return ProofRunDetailResponse(
         run_id=run.run_id,
         started_at=run.started_at.isoformat(),
@@ -806,16 +837,21 @@ async def list_evidence_endpoint(
         )
 
     evidence = list_evidence(workspace, req_id)
-    return [
-        EvidenceResponse(
-            req_id=e.req_id,
-            gate=e.gate.value,
-            satisfied=e.satisfied,
-            status=e.status,
-            artifact_path=e.artifact_path,
-            artifact_checksum=e.artifact_checksum,
-            timestamp=e.timestamp.isoformat(),
-            run_id=e.run_id,
+    out = []
+    for e in evidence:
+        verified, detail = _verification(e)
+        out.append(
+            EvidenceResponse(
+                req_id=e.req_id,
+                gate=e.gate.value,
+                satisfied=e.satisfied,
+                status=e.status,
+                artifact_path=e.artifact_path,
+                artifact_checksum=e.artifact_checksum,
+                timestamp=e.timestamp.isoformat(),
+                run_id=e.run_id,
+                verified=verified,
+                tamper_detail=detail,
+            )
         )
-        for e in evidence
-    ]
+    return out

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -645,6 +645,26 @@ def _verification(evidence) -> tuple[bool, Optional[str]]:
     return True, None
 
 
+def _serialized_outcome(evidence, verified: bool) -> tuple[bool, Optional[str]]:
+    """The (satisfied, status) an unverified record must be served with.
+
+    Adding ``verified: false`` beside an unchanged ``satisfied: true`` is not
+    enough: every existing client — the web UI's GateEvidencePanel and the
+    requirement detail table included — renders green from ``satisfied`` and
+    ``status`` and knows nothing about the new fields, so a tampered artifact
+    still displayed as passing proof (codex review on #1080).
+
+    A record whose artifact no longer matches its checksum is not a pass. It is
+    serialized as UNVERIFIABLE — the existing vocabulary for 'this obligation
+    could not be checked', which every client already renders as not-green —
+    while ``verified``/``tamper_detail`` carry the precise reason for clients
+    that do look.
+    """
+    if verified:
+        return evidence.satisfied, evidence.status
+    return False, GateOutcome.UNVERIFIABLE.value
+
+
 def _read_artifact_text(artifact_path: str, max_lines: int = _ARTIFACT_LINE_LIMIT) -> Optional[str]:
     """Read artifact file content up to max_lines, returning None if the file is missing."""
     from pathlib import Path
@@ -714,12 +734,13 @@ async def get_run_evidence_endpoint(
     evidence_out = []
     for e in evidence_records:
         verified, detail = _verification(e)
+        satisfied, status = _serialized_outcome(e, verified)
         evidence_out.append(
             EvidenceWithContentResponse(
                 req_id=e.req_id,
                 gate=e.gate.value,
-                satisfied=e.satisfied,
-                status=e.status,
+                satisfied=satisfied,
+                status=status,
                 artifact_path=e.artifact_path,
                 artifact_checksum=e.artifact_checksum,
                 timestamp=e.timestamp.isoformat(),
@@ -840,12 +861,13 @@ async def list_evidence_endpoint(
     out = []
     for e in evidence:
         verified, detail = _verification(e)
+        satisfied, status = _serialized_outcome(e, verified)
         out.append(
             EvidenceResponse(
                 req_id=e.req_id,
                 gate=e.gate.value,
-                satisfied=e.satisfied,
-                status=e.status,
+                satisfied=satisfied,
+                status=status,
                 artifact_path=e.artifact_path,
                 artifact_checksum=e.artifact_checksum,
                 timestamp=e.timestamp.isoformat(),

--- a/codeframe/ui/routers/proof_v2.py
+++ b/codeframe/ui/routers/proof_v2.py
@@ -16,7 +16,6 @@ Routes:
 import json
 import logging
 import time
-import uuid
 from datetime import date
 from typing import Any, Literal, Optional
 
@@ -45,7 +44,7 @@ from codeframe.core.proof.models import (
     Source,
     Waiver,
 )
-from codeframe.core.proof.runner import run_proof
+from codeframe.core.proof.runner import _new_run_id, run_proof
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
 from codeframe.auth.dependencies import require_auth
@@ -434,7 +433,7 @@ async def run_proof_endpoint(
     """
     try:
         # Generate run_id before calling run_proof so the response ID matches evidence records
-        run_id = str(uuid.uuid4())[:8]
+        run_id = _new_run_id()
         # Offload: runs pytest/ruff etc. — blocks for minutes (#732).
         results = await run_in_threadpool(
             run_proof,

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -526,3 +526,75 @@ class TestTextEndingAtTheDocstringBoundary:
 
         req = _requirement("REQ-952-10", "t", 'he said "hi"', [Gate.UNIT])
         assert 'he said "hi"' in generate_stubs(req)[Gate.UNIT]
+
+
+class TestUnreadableArtifactsAreTamper:
+    """An artifact we cannot read is one we cannot verify.
+
+    `FileNotFoundError` is only one kind of `OSError`. An artifact replaced by
+    a directory, or made unreadable, still exists — `read_bytes` then raises
+    `IsADirectoryError`/`PermissionError`, which escaped `verify_evidence`,
+    500ing the read endpoints and taking down the merge gate before it could
+    block the specific requirement or honor an override (CI review).
+    """
+
+    def _evidence(self, workspace, req, artifact):
+        from codeframe.core.proof.evidence import attach_evidence
+
+        return attach_evidence(
+            workspace, req.id, Gate.UNIT, str(artifact), GateOutcome.PASSED, "run-1"
+        )
+
+    def test_an_artifact_replaced_by_a_directory_is_tamper(
+        self, workspace, req, tmp_path
+    ):
+        from codeframe.core.proof.evidence import EvidenceTamperError, verify_evidence
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("output")
+        ev = self._evidence(workspace, req, artifact)
+
+        artifact.unlink()
+        artifact.mkdir()
+
+        with pytest.raises(EvidenceTamperError):
+            verify_evidence(ev)
+
+    def test_an_unreadable_artifact_is_tamper(self, workspace, req, tmp_path):
+        import os
+
+        from codeframe.core.proof.evidence import EvidenceTamperError, verify_evidence
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("output")
+        ev = self._evidence(workspace, req, artifact)
+
+        artifact.chmod(0o000)
+        if os.access(artifact, os.R_OK):  # root, or a filesystem ignoring mode
+            pytest.skip("cannot make a file unreadable in this environment")
+        try:
+            with pytest.raises(EvidenceTamperError):
+                verify_evidence(ev)
+        finally:
+            artifact.chmod(0o644)
+
+    def test_the_merge_gate_blocks_rather_than_raising(
+        self, workspace, tmp_path
+    ):
+        """The gate must still name the requirement, not die on the read."""
+        from codeframe.core.proof.evidence import attach_evidence, list_blocking_requirements
+        from codeframe.core.proof.ledger import save_requirement
+
+        r = _requirement("REQ-952-11", "proven", "d", [Gate.UNIT])
+        r.status = ReqStatus.SATISFIED
+        save_requirement(workspace, r)
+        artifact = tmp_path / "b.txt"
+        artifact.write_text("output")
+        attach_evidence(
+            workspace, r.id, Gate.UNIT, str(artifact), GateOutcome.PASSED, "run-1"
+        )
+
+        artifact.unlink()
+        artifact.mkdir()
+
+        assert [x.id for x in list_blocking_requirements(workspace)] == [r.id]

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -610,3 +610,54 @@ class TestUnreadableArtifactsAreTamper:
         artifact.mkdir()
 
         assert [x.id for x in list_blocking_requirements(workspace)] == [r.id]
+
+
+class TestEscapingIsPerContextNotStacked:
+    """Each template context needs its own escaping, applied once.
+
+    Backslash-doubling is correct for a Python docstring — the parser collapses
+    it back on read. Feeding that already-doubled text to `json.dumps` for the
+    E2E literal escapes it a second time, so a title of `\\d+` reaches the .ts
+    source as four backslashes and reads back as `\\\\d+` (CI review).
+    """
+
+    RAW_TITLE = "Regex check: \\d+ matches"
+    RAW_DESC = "Path C:\\temp\\out must exist"
+
+    def _stubs(self, gates):
+        from codeframe.core.proof.stubs import generate_stubs
+
+        return generate_stubs(
+            _requirement("REQ-952-12", self.RAW_TITLE, self.RAW_DESC, gates)
+        )
+
+    def test_the_e2e_title_round_trips_to_exactly_the_original(self):
+        import json
+
+        content = self._stubs([Gate.E2E])[Gate.E2E]
+        line = next(ln for ln in content.splitlines() if ln.startswith("test("))
+        literal = line[len("test("):line.rindex(", async")]
+
+        assert json.loads(literal) == self.RAW_TITLE, (
+            "the E2E title was escaped twice"
+        )
+
+    def test_the_python_docstring_reads_back_as_the_original(self):
+        """Doubling is right here — but only once."""
+        import ast
+
+        content = self._stubs([Gate.UNIT])[Gate.UNIT]
+        tree = ast.parse(content)
+        func = next(n for n in tree.body if isinstance(n, ast.FunctionDef))
+
+        assert ast.get_docstring(func) == f"Proves: {self.RAW_DESC}"
+        assert self.RAW_TITLE in ast.get_docstring(tree)
+
+    @pytest.mark.parametrize("gate", [Gate.DEMO, Gate.MANUAL])
+    def test_markdown_stubs_show_the_original_text(self, gate):
+        """Markdown is not Python — a doubled backslash is just wrong there."""
+        content = self._stubs([gate])[gate]
+
+        assert self.RAW_TITLE in content
+        if gate is Gate.MANUAL:
+            assert self.RAW_DESC in content

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -414,3 +414,77 @@ class TestTamperedEvidenceBlocksTheMergeGate:
             assert "list_requirements(workspace, status=ReqStatus.OPEN)" not in source, (
                 f"{mod} still trusts stored status without verifying evidence"
             )
+
+
+class TestOnlyTheLatestEvidencePerGateIsChecked:
+    """Blocking on *any* historical row would be worse than the hole it closes.
+
+    Proof runs accumulate evidence rows. Deleting last month's artifacts is
+    routine housekeeping, not tampering — if every row ever recorded had to
+    verify, that cleanup would wedge the merge gate permanently.
+    """
+
+    def _satisfied_with_two_runs(self, workspace, tmp_path):
+        from codeframe.core.proof.evidence import attach_evidence
+        from codeframe.core.proof.ledger import save_requirement
+
+        req = _requirement("REQ-952-06", "proven twice", "held", [Gate.UNIT])
+        req.status = ReqStatus.SATISFIED
+        save_requirement(workspace, req)
+
+        old = tmp_path / "old.txt"
+        old.write_text("first run")
+        attach_evidence(workspace, req.id, Gate.UNIT, str(old),
+                        GateOutcome.PASSED, "run-old")
+
+        new = tmp_path / "new.txt"
+        new.write_text("second run")
+        attach_evidence(workspace, req.id, Gate.UNIT, str(new),
+                        GateOutcome.PASSED, "run-new")
+        return req, old, new
+
+    def test_a_deleted_old_artifact_does_not_block_when_the_latest_verifies(
+        self, workspace, tmp_path
+    ):
+        from codeframe.core.proof.evidence import list_blocking_requirements
+
+        req, old, new = self._satisfied_with_two_runs(workspace, tmp_path)
+        old.unlink()  # routine cleanup of a superseded artifact
+
+        assert list_blocking_requirements(workspace) == [], (
+            "cleaning up a superseded artifact permanently blocked the merge gate"
+        )
+
+    def test_tampering_with_the_latest_artifact_still_blocks(
+        self, workspace, tmp_path
+    ):
+        from codeframe.core.proof.evidence import list_blocking_requirements
+
+        req, old, new = self._satisfied_with_two_runs(workspace, tmp_path)
+        new.write_text("second run (edited)")
+
+        assert [r.id for r in list_blocking_requirements(workspace)] == [req.id]
+
+    def test_each_gate_is_judged_on_its_own_latest_evidence(
+        self, workspace, tmp_path
+    ):
+        """A stale UNIT artifact must not mask a tampered SEC one."""
+        from codeframe.core.proof.evidence import attach_evidence, list_blocking_requirements
+        from codeframe.core.proof.ledger import save_requirement
+
+        req = _requirement("REQ-952-07", "two gates", "held", [Gate.UNIT, Gate.SEC])
+        req.status = ReqStatus.SATISFIED
+        save_requirement(workspace, req)
+
+        unit = tmp_path / "unit.txt"
+        unit.write_text("unit ok")
+        attach_evidence(workspace, req.id, Gate.UNIT, str(unit),
+                        GateOutcome.PASSED, "run-1")
+        sec = tmp_path / "sec.txt"
+        sec.write_text("sec ok")
+        attach_evidence(workspace, req.id, Gate.SEC, str(sec),
+                        GateOutcome.PASSED, "run-1")
+
+        sec.write_text("sec ok (edited)")
+
+        assert [r.id for r in list_blocking_requirements(workspace)] == [req.id]

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -502,24 +502,36 @@ class TestTextEndingAtTheDocstringBoundary:
 
     _PY_GATES = [Gate.UNIT, Gate.CONTRACT, Gate.VISUAL, Gate.A11Y, Gate.PERF, Gate.SEC]
 
-    @pytest.mark.parametrize("tail", ['"', '""', "\\", '\\"'])
+    @pytest.mark.parametrize(
+        "tail", ['"', '""', "\\", '\\"', "C:\\path", "re: \\d+", "\\n"]
+    )
     @pytest.mark.parametrize("gate", _PY_GATES)
     def test_a_description_ending_at_the_delimiter_still_parses(self, gate, tail):
+        """Also asserts no SyntaxWarning: a stray backslash makes an invalid
+        escape sequence inside a non-raw docstring, which this repo's pytest
+        config escalates to an error — so a stub that merely *parses* is not
+        enough."""
         import ast
+        import warnings
 
         from codeframe.core.proof.stubs import generate_stubs
 
         req = _requirement("REQ-952-08", "t", f"ends with {tail}", [gate])
-        ast.parse(generate_stubs(req)[gate])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ast.parse(generate_stubs(req)[gate])
 
-    @pytest.mark.parametrize("tail", ['"', '""', "\\"])
+    @pytest.mark.parametrize("tail", ['"', '""', "\\", "C:\\path"])
     def test_a_title_ending_at_a_delimiter_still_parses(self, tail):
         import ast
+        import warnings
 
         from codeframe.core.proof.stubs import generate_stubs
 
         req = _requirement("REQ-952-09", f"ends with {tail}", "d", [Gate.UNIT])
-        ast.parse(generate_stubs(req)[Gate.UNIT])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ast.parse(generate_stubs(req)[Gate.UNIT])
 
     def test_the_description_is_still_present_and_readable(self):
         from codeframe.core.proof.stubs import generate_stubs

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -340,3 +340,77 @@ class TestStubsSurviveHostileText:
 
         assert "Login rejects a bad password" in content
         assert "A wrong password returns 401." in content
+
+
+class TestTamperedEvidenceBlocksTheMergeGate:
+    """Verification must reach the path that actually gates a merge.
+
+    A first cut wired `verify_evidence` into `check_obligation_satisfied` —
+    which has no production callers. The #731 merge gate asks for OPEN
+    requirements only, so a requirement already marked SATISFIED kept its
+    status after its artifact was edited, and the merge sailed through until
+    someone happened to re-run the full proof.
+    """
+
+    def _satisfied_req_with_evidence(self, workspace, tmp_path):
+        from codeframe.core.proof.evidence import attach_evidence
+        from codeframe.core.proof.ledger import save_requirement
+
+        artifact = tmp_path / "proof.txt"
+        artifact.write_text("the gate passed")
+
+        req = _requirement("REQ-952-04", "already proven", "it held", [Gate.UNIT])
+        req.status = ReqStatus.SATISFIED
+        save_requirement(workspace, req)
+        attach_evidence(
+            workspace, req.id, Gate.UNIT, str(artifact), GateOutcome.PASSED, "run-x"
+        )
+        return req, artifact
+
+    def test_an_intact_satisfied_requirement_does_not_block(self, workspace, tmp_path):
+        from codeframe.core.proof.evidence import list_blocking_requirements
+
+        self._satisfied_req_with_evidence(workspace, tmp_path)
+
+        assert list_blocking_requirements(workspace) == []
+
+    def test_a_tampered_satisfied_requirement_blocks(self, workspace, tmp_path):
+        from codeframe.core.proof.evidence import list_blocking_requirements
+
+        req, artifact = self._satisfied_req_with_evidence(workspace, tmp_path)
+        artifact.write_text("the gate passed (edited)")
+
+        blocking = list_blocking_requirements(workspace)
+
+        assert [r.id for r in blocking] == [req.id], (
+            "tampered evidence left the requirement satisfied, so the merge "
+            "gate would not have stopped the merge"
+        )
+
+    def test_open_requirements_still_block(self, workspace, req):
+        from codeframe.core.proof.evidence import list_blocking_requirements
+
+        assert [r.id for r in list_blocking_requirements(workspace)] == [req.id]
+
+    def test_a_satisfied_requirement_with_no_evidence_does_not_block(self, workspace):
+        """Absent evidence is a pre-existing state (e.g. an older ledger); only
+        evidence that is present and no longer verifies is a tamper signal."""
+        from codeframe.core.proof.evidence import list_blocking_requirements
+        from codeframe.core.proof.ledger import save_requirement
+
+        r = _requirement("REQ-952-05", "legacy", "no artifacts", [Gate.UNIT])
+        r.status = ReqStatus.SATISFIED
+        save_requirement(workspace, r)
+
+        assert list_blocking_requirements(workspace) == []
+
+    def test_both_merge_gates_use_the_verifying_query(self):
+        """API and CLI must agree, and neither may go back to the raw query."""
+        from pathlib import Path as _P
+
+        for mod in ("codeframe/ui/routers/pr_v2.py", "codeframe/cli/pr_commands.py"):
+            source = _P(mod).read_text(encoding="utf-8")
+            assert "list_blocking_requirements(" in source, f"{mod} skips verification"
+            assert "list_requirements(workspace, status=ReqStatus.OPEN)" not in source, (
+                f"{mod} still trusts stored status without verifying evidence"
+            )

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -488,3 +488,41 @@ class TestOnlyTheLatestEvidencePerGateIsChecked:
         sec.write_text("sec ok (edited)")
 
         assert [r.id for r in list_blocking_requirements(workspace)] == [req.id]
+
+
+class TestTextEndingAtTheDocstringBoundary:
+    """A lone trailing quote is not a `\"\"\"` run, so collapsing runs missed it.
+
+    Six templates butt `{description}` straight against their own closing
+    delimiter — `\"\"\"Proves: {description}\"\"\"`. A description ending in one
+    quote makes four in a row; Python closes the docstring on the first three
+    and the fourth starts an unterminated literal. That is a SyntaxError in the
+    generated stub, the exact failure AC4 exists to prevent (CI review).
+    """
+
+    _PY_GATES = [Gate.UNIT, Gate.CONTRACT, Gate.VISUAL, Gate.A11Y, Gate.PERF, Gate.SEC]
+
+    @pytest.mark.parametrize("tail", ['"', '""', "\\", '\\"'])
+    @pytest.mark.parametrize("gate", _PY_GATES)
+    def test_a_description_ending_at_the_delimiter_still_parses(self, gate, tail):
+        import ast
+
+        from codeframe.core.proof.stubs import generate_stubs
+
+        req = _requirement("REQ-952-08", "t", f"ends with {tail}", [gate])
+        ast.parse(generate_stubs(req)[gate])
+
+    @pytest.mark.parametrize("tail", ['"', '""', "\\"])
+    def test_a_title_ending_at_a_delimiter_still_parses(self, tail):
+        import ast
+
+        from codeframe.core.proof.stubs import generate_stubs
+
+        req = _requirement("REQ-952-09", f"ends with {tail}", "d", [Gate.UNIT])
+        ast.parse(generate_stubs(req)[Gate.UNIT])
+
+    def test_the_description_is_still_present_and_readable(self):
+        from codeframe.core.proof.stubs import generate_stubs
+
+        req = _requirement("REQ-952-10", "t", 'he said "hi"', [Gate.UNIT])
+        assert 'he said "hi"' in generate_stubs(req)[Gate.UNIT]

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -1,0 +1,342 @@
+"""PROOF9 evidence integrity (#952).
+
+Four defects in one invariant: stored proof must stay uniquely attributable,
+verifiable on read, and safe to render.
+
+1. A waiver expiring today was already expired, so it spuriously blocked the
+   #731 merge gate on its last valid day — and the comparison used local date,
+   not UTC.
+2. ``run_id`` was ``str(uuid4())[:8]``, so two runs collide at around 600 runs
+   (birthday bound) and a passing run can absorb a failing run's artifacts.
+3. Artifact checksums were computed and stored but never checked on read, so
+   the integrity claim was unenforced.
+4. Requirement title/description were interpolated unescaped into generated
+   test stubs.
+"""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.proof.models import Gate, GateOutcome, ReqStatus, Waiver
+
+pytestmark = pytest.mark.v2
+
+
+def _requirement(req_id, title, description, gates):
+    from codeframe.core.proof.models import (
+        Obligation,
+        RequirementScope,
+        Requirement,
+        Severity,
+        Source,
+    )
+
+    return Requirement(
+        id=req_id,
+        title=title,
+        description=description,
+        severity=Severity.MEDIUM,
+        source=Source.QA,
+        scope=RequirementScope(),
+        obligations=[Obligation(gate=g) for g in gates],
+        evidence_rules=[],
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return create_or_load_workspace(ws_dir)
+
+
+@pytest.fixture
+def req(workspace):
+    from codeframe.core.proof.ledger import save_requirement
+
+    r = _requirement("REQ-952-01", "a requirement", "it must hold", [Gate.UNIT])
+    save_requirement(workspace, r)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# AC1: waiver expiry is UTC and the expiry date is inclusive
+# ---------------------------------------------------------------------------
+
+
+class TestWaiverExpiryIsInclusive:
+    def _waive(self, workspace, req_id, expires):
+        from codeframe.core.proof.ledger import waive_requirement
+
+        return waive_requirement(
+            workspace, req_id, Waiver(reason="because", expires=expires)
+        )
+
+    def test_a_waiver_expiring_today_is_still_valid(self, workspace, req):
+        """Its last valid day. `<= today` made it expire a day early, which
+        spuriously blocks the #731 merge gate."""
+        from codeframe.core.proof.ledger import check_expired_waivers, get_requirement
+
+        today = datetime.now(timezone.utc).date()
+        self._waive(workspace, req.id, today)
+
+        expired = check_expired_waivers(workspace)
+
+        assert expired == []
+        assert get_requirement(workspace, req.id).status == ReqStatus.WAIVED
+
+    def test_a_waiver_that_expired_yesterday_is_reverted(self, workspace, req):
+        from codeframe.core.proof.ledger import check_expired_waivers, get_requirement
+
+        yesterday = datetime.now(timezone.utc).date() - timedelta(days=1)
+        self._waive(workspace, req.id, yesterday)
+
+        expired = check_expired_waivers(workspace)
+
+        assert [r.id for r in expired] == [req.id]
+        assert get_requirement(workspace, req.id).status == ReqStatus.OPEN
+
+    def test_a_future_waiver_survives(self, workspace, req):
+        from codeframe.core.proof.ledger import check_expired_waivers
+
+        tomorrow = datetime.now(timezone.utc).date() + timedelta(days=1)
+        self._waive(workspace, req.id, tomorrow)
+
+        assert check_expired_waivers(workspace) == []
+
+    def test_expiry_is_evaluated_against_utc_not_local_time(self, workspace, req):
+        """A machine hours behind UTC would otherwise disagree with the server
+        about which day it is, and expire waivers early or late."""
+        import codeframe.core.proof.ledger as ledger_mod
+
+        source = Path(ledger_mod.__file__).read_text(encoding="utf-8")
+        assert "date.today()" not in source, (
+            "local date makes expiry depend on the machine's timezone"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC2: run_id is a full UUID
+# ---------------------------------------------------------------------------
+
+
+class TestRunIdIsAFullUUID:
+    def test_the_runner_generates_a_full_uuid(self, workspace, monkeypatch):
+        import uuid as uuid_mod
+
+        from codeframe.core.proof import runner
+
+        captured = {}
+
+        def fake_save(ws, run):
+            captured["run_id"] = run.run_id
+
+        monkeypatch.setattr(runner.ledger, "save_run", fake_save)
+        runner.run_proof(workspace)
+
+        run_id = captured["run_id"]
+        assert len(run_id) == 36, f"{run_id!r} is truncated ({len(run_id)} chars)"
+        uuid_mod.UUID(run_id)  # raises if not a well-formed UUID
+
+    def test_no_source_truncates_a_uuid_for_a_run_id(self):
+        """`str(uuid4())[:8]` collides at ~600 runs, letting a passing run
+        absorb a failing run's evidence."""
+        import codeframe.core.proof.runner as runner_mod
+        import codeframe.ui.routers.proof_v2 as router_mod
+
+        for mod in (runner_mod, router_mod):
+            source = Path(mod.__file__).read_text(encoding="utf-8")
+            assert "uuid.uuid4())[:8]" not in source, (
+                f"{Path(mod.__file__).name} still truncates the run id"
+            )
+
+    def test_evidence_from_two_runs_stays_separable(self, workspace, req, tmp_path):
+        from codeframe.core.proof.evidence import attach_evidence
+        from codeframe.core.proof.ledger import get_run_evidence
+        from codeframe.core.proof.runner import _new_run_id
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("evidence")
+
+        run_a, run_b = _new_run_id(), _new_run_id()
+        assert run_a != run_b
+        attach_evidence(workspace, req.id, Gate.UNIT, str(artifact),
+                        GateOutcome.PASSED, run_a)
+        attach_evidence(workspace, req.id, Gate.UNIT, str(artifact),
+                        GateOutcome.FAILED, run_b)
+
+        assert len(get_run_evidence(workspace, run_a)) == 1
+        assert len(get_run_evidence(workspace, run_b)) == 1
+        assert get_run_evidence(workspace, run_a)[0].satisfied is True
+        assert get_run_evidence(workspace, run_b)[0].satisfied is False
+
+
+# ---------------------------------------------------------------------------
+# AC3: reads verify the checksum and surface a tamper error
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactChecksumsAreVerifiedOnRead:
+    def _attach(self, workspace, req, artifact, run_id="run-1"):
+        from codeframe.core.proof.evidence import attach_evidence
+
+        return attach_evidence(
+            workspace, req.id, Gate.UNIT, str(artifact), GateOutcome.PASSED, run_id
+        )
+
+    def test_an_untouched_artifact_verifies(self, workspace, req, tmp_path):
+        from codeframe.core.proof.evidence import verify_evidence
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("passing output")
+        ev = self._attach(workspace, req, artifact)
+
+        verify_evidence(ev)  # must not raise
+
+    def test_a_mutated_artifact_raises_tamper(self, workspace, req, tmp_path):
+        from codeframe.core.proof.evidence import EvidenceTamperError, verify_evidence
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("passing output")
+        ev = self._attach(workspace, req, artifact)
+
+        artifact.write_text("passing output (edited)")
+
+        with pytest.raises(EvidenceTamperError):
+            verify_evidence(ev)
+
+    def test_a_deleted_artifact_raises_tamper(self, workspace, req, tmp_path):
+        from codeframe.core.proof.evidence import EvidenceTamperError, verify_evidence
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("passing output")
+        ev = self._attach(workspace, req, artifact)
+        artifact.unlink()
+
+        with pytest.raises(EvidenceTamperError):
+            verify_evidence(ev)
+
+    def test_an_artifact_cannot_be_transplanted_into_another_run(
+        self, workspace, req, tmp_path
+    ):
+        """The checksum binds run id, gate and canonical path — not bytes
+        alone — so a valid artifact from one run cannot be presented as
+        another run's proof."""
+        from codeframe.core.proof.evidence import EvidenceTamperError, verify_evidence
+        from dataclasses import replace
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("passing output")
+        ev = self._attach(workspace, req, artifact, run_id="run-1")
+
+        with pytest.raises(EvidenceTamperError):
+            verify_evidence(replace(ev, run_id="run-2"))
+
+    def test_a_tampered_artifact_does_not_satisfy_an_obligation(
+        self, workspace, req, tmp_path
+    ):
+        """Verification has to happen before a gate accepts the artifact,
+        otherwise the integrity claim buys nothing."""
+        from codeframe.core.proof.evidence import check_obligation_satisfied
+
+        artifact = tmp_path / "a.txt"
+        artifact.write_text("passing output")
+        self._attach(workspace, req, artifact)
+        assert check_obligation_satisfied(workspace, req, Gate.UNIT) is True
+
+        artifact.write_text("forged pass")
+
+        assert check_obligation_satisfied(workspace, req, Gate.UNIT) is False, (
+            "a mutated artifact still satisfied its gate"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4: generated stubs are safe against a hostile title/description
+# ---------------------------------------------------------------------------
+
+
+HOSTILE_TITLE = 'He said "stop"\nimport os; os.system("rm -rf /")'
+HOSTILE_DESC = 'ends a docstring """ then\nassert True  # injected'
+
+
+class TestStubsSurviveHostileText:
+    def _req(self):
+
+        return _requirement("REQ-952-02", HOSTILE_TITLE, HOSTILE_DESC, list(Gate))
+
+    @pytest.mark.parametrize("gate", [g for g in Gate])
+    def test_every_generated_stub_is_single_expression_safe(self, gate):
+        """No raw newline from user text may reach the output, or it escapes
+        whatever line context it was placed in — docstring, comment or string
+        literal alike."""
+        from codeframe.core.proof.stubs import generate_stubs
+
+        content = generate_stubs(self._req())[gate]
+
+        # The payload may appear as inert prose inside a docstring or comment —
+        # that is harmless. What must never happen is a line of its own, which
+        # is what the injected newline was for.
+        for line in content.splitlines():
+            stripped = line.strip()
+            for marker in ('import os; os.system("rm -rf /")', "assert True  # injected"):
+                assert stripped != marker, f"{gate} stub: {marker!r} became code"
+
+    @pytest.mark.parametrize(
+        "gate", [g for g in Gate if g not in (Gate.E2E, Gate.DEMO, Gate.MANUAL)]
+    )
+    def test_python_stubs_still_parse(self, gate):
+        import ast
+
+        from codeframe.core.proof.stubs import generate_stubs
+
+        content = generate_stubs(self._req())[gate]
+        ast.parse(content)  # raises SyntaxError if the text broke out
+
+    def test_python_stub_docstrings_are_not_terminated_early(self):
+        from codeframe.core.proof.stubs import generate_stubs
+
+        content = generate_stubs(self._req())[Gate.UNIT]
+        # Exactly the delimiters the template itself opens and closes.
+        assert content.count('"""') == 4, (
+            f'unbalanced docstring delimiters ({content.count(chr(34)*3)})'
+        )
+
+    def test_the_e2e_stub_string_literal_is_escaped(self):
+        """`test('{title}')` with a quote or newline in the title produced
+        invalid — and injectable — TypeScript."""
+        from codeframe.core.proof.stubs import generate_stubs
+
+        content = generate_stubs(self._req())[Gate.E2E]
+        test_line = next(ln for ln in content.splitlines() if ln.startswith("test("))
+
+        # The title's embedded double quotes must be escaped inside the literal,
+        # and the statement must still be the well-formed call it was.
+        assert '\\"stop\\"' in test_line, (
+            f"quotes in the title were not escaped: {test_line}"
+        )
+        assert test_line.rstrip().endswith("=> {")
+        # And the literal itself round-trips back to exactly the title.
+        import json
+
+        literal = test_line[len("test("):test_line.rindex(", async")]
+        assert json.loads(literal) == " ".join(HOSTILE_TITLE.split())
+
+    def test_ordinary_titles_are_still_readable(self):
+        """Escaping must not mangle the normal case."""
+        from codeframe.core.proof.stubs import generate_stubs
+
+        req = _requirement(
+            "REQ-952-03",
+            "Login rejects a bad password",
+            "A wrong password returns 401.",
+            [Gate.UNIT],
+        )
+        content = generate_stubs(req)[Gate.UNIT]
+
+        assert "Login rejects a bad password" in content
+        assert "A wrong password returns 401." in content

--- a/tests/core/test_proof9_evidence_integrity_952.py
+++ b/tests/core/test_proof9_evidence_integrity_952.py
@@ -661,3 +661,13 @@ class TestEscapingIsPerContextNotStacked:
         assert self.RAW_TITLE in content
         if gate is Gate.MANUAL:
             assert self.RAW_DESC in content
+
+    def test_the_e2e_comments_show_the_original_text(self):
+        """E2E's title/description live in `//` comments, not Python
+        docstrings, so they want no backslash-doubling either — only the
+        `title_js` string literal needs JSON escaping."""
+        content = self._stubs([Gate.E2E])[Gate.E2E]
+        comments = [ln for ln in content.splitlines() if ln.lstrip().startswith("//")]
+
+        assert any(self.RAW_TITLE in ln for ln in comments), comments
+        assert any(self.RAW_DESC in ln for ln in comments), comments

--- a/tests/ui/test_proof_evidence_read_verification_952.py
+++ b/tests/ui/test_proof_evidence_read_verification_952.py
@@ -149,3 +149,50 @@ class TestRunEvidenceRead:
         assert r.status_code == 200
         by_gate = {e["gate"]: e["verified"] for e in r.json()["evidence"]}
         assert by_gate == {"unit": False, "sec": True}
+
+
+class TestUnverifiedEvidenceIsNotServedAsAPass:
+    """`verified: false` beside an unchanged `satisfied: true` is not enough.
+
+    Every existing client renders green from `satisfied`/`status` and knows
+    nothing about the new fields, so a tampered artifact still showed as
+    passing proof — just without its text (codex review on #1080).
+    """
+
+    def test_a_tampered_record_is_not_satisfied(self, client, workspace, seeded):
+        req, artifact, _ = seeded
+        artifact.write_text("forged: everything passed")
+
+        item = client.get(
+            f"/api/v2/proof/requirements/{req.id}/evidence", params=_params(workspace)
+        ).json()[0]
+
+        assert item["satisfied"] is False, (
+            "a client rendering green from `satisfied` still shows tampered "
+            "evidence as proof"
+        )
+        assert item["status"] == "unverifiable"
+        assert item["verified"] is False
+
+    def test_a_tampered_run_record_is_not_satisfied(self, client, workspace, seeded):
+        _, artifact, run_id = seeded
+        artifact.write_text("forged")
+
+        ev = client.get(
+            f"/api/v2/proof/runs/{run_id}/evidence", params=_params(workspace)
+        ).json()["evidence"][0]
+
+        assert ev["satisfied"] is False
+        assert ev["status"] == "unverifiable"
+
+    def test_an_intact_record_keeps_its_real_outcome(self, client, workspace, seeded):
+        """The downgrade must apply only to records that fail verification."""
+        req, _, _ = seeded
+
+        item = client.get(
+            f"/api/v2/proof/requirements/{req.id}/evidence", params=_params(workspace)
+        ).json()[0]
+
+        assert item["satisfied"] is True
+        assert item["status"] == "passed"
+        assert item["verified"] is True

--- a/tests/ui/test_proof_evidence_read_verification_952.py
+++ b/tests/ui/test_proof_evidence_read_verification_952.py
@@ -1,0 +1,151 @@
+"""Evidence read endpoints must not present tampered artifacts as proof (#952).
+
+AC3 is about *reads*. Verification reached the merge gate, but the two public
+evidence endpoints still serialized `satisfied` straight from the ledger and
+served the artifact's current bytes alongside it — so after editing a file, the
+UI showed a pass next to forged text (codex review on #1080).
+"""
+
+
+import pytest
+from fastapi.testclient import TestClient
+
+from codeframe.core.proof.evidence import attach_evidence
+from codeframe.core.proof.ledger import save_requirement, save_run
+from codeframe.core.proof.models import (
+    Gate,
+    GateOutcome,
+    Obligation,
+    ProofRun,
+    Requirement,
+    RequirementScope,
+    Severity,
+    Source,
+)
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    from codeframe.core.workspace import create_or_load_workspace
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return create_or_load_workspace(ws_dir)
+
+
+@pytest.fixture
+def client():
+    from codeframe.ui.server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def seeded(workspace, tmp_path):
+    from datetime import datetime, timezone
+
+    req = Requirement(
+        id="REQ-READ-01",
+        title="proven",
+        description="d",
+        severity=Severity.MEDIUM,
+        source=Source.QA,
+        scope=RequirementScope(),
+        obligations=[Obligation(gate=Gate.UNIT)],
+        evidence_rules=[],
+    )
+    save_requirement(workspace, req)
+
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("gate output the run actually saw")
+    run_id = "11111111-2222-3333-4444-555555555555"
+    save_run(
+        workspace,
+        ProofRun(
+            run_id=run_id,
+            workspace_id=workspace.id,
+            duration_ms=1,
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            triggered_by="test",
+            overall_passed=True,
+        ),
+    )
+    attach_evidence(
+        workspace, req.id, Gate.UNIT, str(artifact), GateOutcome.PASSED, run_id
+    )
+    return req, artifact, run_id
+
+
+def _params(workspace):
+    return {"workspace_path": str(workspace.repo_path)}
+
+
+class TestRequirementEvidenceRead:
+    def test_intact_evidence_reports_verified(self, client, workspace, seeded):
+        req, _, _ = seeded
+        r = client.get(f"/api/v2/proof/requirements/{req.id}/evidence", params=_params(workspace))
+        assert r.status_code == 200
+        assert [e["verified"] for e in r.json()] == [True]
+
+    def test_a_tampered_artifact_reports_unverified(self, client, workspace, seeded):
+        req, artifact, _ = seeded
+        artifact.write_text("forged: everything passed")
+
+        r = client.get(f"/api/v2/proof/requirements/{req.id}/evidence", params=_params(workspace))
+
+        assert r.status_code == 200
+        item = r.json()[0]
+        assert item["verified"] is False, (
+            "the API presented a tampered artifact as verified evidence"
+        )
+        assert item["tamper_detail"]
+
+
+class TestRunEvidenceRead:
+    def test_intact_run_evidence_serves_its_text(self, client, workspace, seeded):
+        _, _, run_id = seeded
+        r = client.get(f"/api/v2/proof/runs/{run_id}/evidence", params=_params(workspace))
+        assert r.status_code == 200
+        ev = r.json()["evidence"][0]
+        assert ev["verified"] is True
+        assert "gate output the run actually saw" in ev["artifact_text"]
+
+    def test_a_tampered_artifacts_text_is_withheld(self, client, workspace, seeded):
+        _, artifact, run_id = seeded
+        artifact.write_text("forged: everything passed")
+
+        r = client.get(f"/api/v2/proof/runs/{run_id}/evidence", params=_params(workspace))
+
+        ev = r.json()["evidence"][0]
+        assert ev["verified"] is False
+        assert ev["artifact_text"] is None, (
+            "forged artifact contents were served as evidence text"
+        )
+
+    def test_a_deleted_artifact_reports_unverified(self, client, workspace, seeded):
+        _, artifact, run_id = seeded
+        artifact.unlink()
+
+        ev = client.get(f"/api/v2/proof/runs/{run_id}/evidence", params=_params(workspace)).json()["evidence"][0]
+
+        assert ev["verified"] is False
+        assert ev["artifact_text"] is None
+
+    def test_one_bad_artifact_does_not_break_the_whole_listing(
+        self, client, workspace, seeded, tmp_path
+    ):
+        """Reported per record, not raised — the caller needs to see which."""
+        req, artifact, run_id = seeded
+        good = tmp_path / "good.txt"
+        good.write_text("second gate output")
+        attach_evidence(workspace, req.id, Gate.SEC, str(good), GateOutcome.PASSED, run_id)
+        artifact.write_text("forged")
+
+        r = client.get(f"/api/v2/proof/runs/{run_id}/evidence", params=_params(workspace))
+
+        assert r.status_code == 200
+        by_gate = {e["gate"]: e["verified"] for e in r.json()["evidence"]}
+        assert by_gate == {"unit": False, "sec": True}

--- a/web-ui/src/__tests__/components/proof/GateEvidencePanel.test.tsx
+++ b/web-ui/src/__tests__/components/proof/GateEvidencePanel.test.tsx
@@ -91,3 +91,46 @@ describe('GateEvidencePanel', () => {
     expect(screen.queryByText('Show full output')).not.toBeInTheDocument();
   });
 });
+
+describe('tampered evidence (#952)', () => {
+  const tampered = {
+    req_id: 'REQ-1',
+    gate: 'unit',
+    // The backend downgrades an unverified record, so a client that ignores
+    // `verified` still never renders it green.
+    satisfied: false,
+    status: 'unverifiable' as const,
+    artifact_path: '/w/a.txt',
+    artifact_checksum: 'abc',
+    timestamp: '2026-01-01T00:00:00Z',
+    run_id: 'run-1',
+    verified: false,
+    tamper_detail: 'does not match its recorded checksum',
+    artifact_text: null,
+  };
+
+  it('shows a tampered badge rather than pass or cannot-verify', () => {
+    render(<GateEvidencePanel evidence={[tampered]} />);
+    expect(screen.getByText('tampered')).toBeInTheDocument();
+    expect(screen.queryByText('pass')).not.toBeInTheDocument();
+    expect(screen.queryByText('cannot verify')).not.toBeInTheDocument();
+  });
+
+  it('explains why the artifact contents are withheld', async () => {
+    render(<GateEvidencePanel evidence={[tampered]} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(
+      screen.getByText(/does not match the checksum recorded with this evidence/i)
+    ).toBeInTheDocument();
+  });
+
+  it('leaves verified evidence rendering as a pass', () => {
+    render(
+      <GateEvidencePanel
+        evidence={[{ ...tampered, satisfied: true, status: 'passed', verified: true, tamper_detail: null }]}
+      />
+    );
+    expect(screen.getByText('pass')).toBeInTheDocument();
+    expect(screen.queryByText('tampered')).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/proof/GateEvidencePanel.tsx
+++ b/web-ui/src/components/proof/GateEvidencePanel.tsx
@@ -39,7 +39,11 @@ function GateEvidenceRow({ ev }: GateEvidenceRowProps) {
         className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-muted/30 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
       >
         <span className="font-mono text-xs text-muted-foreground w-16 shrink-0 capitalize">{ev.gate}</span>
-        {ev.status === 'unverifiable' ? (
+        {ev.verified === false ? (
+          <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">
+            tampered
+          </span>
+        ) : ev.status === 'unverifiable' ? (
           <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
             cannot verify
           </span>
@@ -59,7 +63,13 @@ function GateEvidenceRow({ ev }: GateEvidenceRowProps) {
 
       {expanded && (
         <div className="px-4 pb-3">
-          {!hasText ? (
+          {ev.verified === false ? (
+            <p className="text-xs text-red-700 dark:text-red-400">
+              Artifact does not match the checksum recorded with this evidence, so
+              its contents are not shown.
+              {ev.tamper_detail ? ` (${ev.tamper_detail})` : ''}
+            </p>
+          ) : !hasText ? (
             <p className="text-xs text-muted-foreground italic">No output captured</p>
           ) : (
             <>

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -397,6 +397,12 @@ export interface ProofEvidence {
   artifact_checksum: string;
   timestamp: string;
   run_id: string;
+  // False when the stored artifact no longer matches its recorded checksum, or
+  // has been deleted (#952). The backend also downgrades such a record to
+  // satisfied=false / status='unverifiable', so a client that ignores these two
+  // fields still never renders it green.
+  verified?: boolean;
+  tamper_detail?: string | null;
 }
 
 export interface ProofStatusResponse {


### PR DESCRIPTION
Closes #952.

Four defects in one invariant: stored proof must stay uniquely attributable, verifiable on read, and safe to render.

## The four

**1. A waiver expiring today was already expired.** `expires.isoformat() <= today` treats the expiry date as the first *invalid* day, so a waiver spuriously blocked the #731 merge gate on its last valid day — and `date.today()` is the machine's local date, which disagrees with the UTC timestamps everywhere else in the ledger. Now UTC, compared as `date` objects (not isoformat strings, so a malformed value can't quietly go lexicographic), with `<`.

**2. `run_id` was `str(uuid4())[:8]`.** 32 bits: by the birthday bound two runs in a workspace collide around 600 runs, and a collision merges evidence across runs — a passing run absorbs a failing run's artifacts. Both generation sites (the runner and the v2 router, which mints the id up front so its response matches the evidence rows) now share `_new_run_id()` returning a full UUID.

**3. Checksums were computed and stored but never verified on read.** The compliance claim was unenforced. Added `verify_evidence` + `EvidenceTamperError`. Per the issue's design note the digest binds **run id, gate and canonical path** as a length-prefixed header, not the bytes alone — so a genuinely passing artifact cannot be transplanted into another run's evidence and still verify.

**4. Title and description were interpolated raw into generated stubs.** A newline escaped whatever line context held them — Python docstring, `//` comment, markdown heading — and the next line landed as code; an apostrophe broke the E2E `test('...')` literal open. Now collapsed to a single line with docstring delimiters neutralized, and the JS literal built with `json.dumps` (JSON string syntax is a subset of JavaScript's).

## What review changed

`codex review` ran six times and the CI reviewer twice. Five passes found real problems in my own fix — all of them, worth stating plainly:

**P1 — I wired the verification into dead code.** `verify_evidence` went into `check_obligation_satisfied`, which has *no production callers*. The #731 merge gate asks only for `status=OPEN` requirements, so a requirement already recorded SATISFIED kept that status after its artifact was edited, and the merge went through until someone happened to run a full proof again. The integrity claim was still unenforced — just relocated.

Fixed with `evidence.list_blocking_requirements`: OPEN requirements **plus** SATISFIED ones whose evidence no longer verifies. Both merge gates — API (`pr_v2`) and CLI (`pr_commands`) — now use it, with a test asserting neither reverts to the raw status query.

**P2 — my fix would have been worse than the bug.** It blocked on *any* historical evidence row. Proof runs accumulate rows, and deleting last month's superseded artifacts is routine housekeeping — so that cleanup would have wedged the merge gate permanently. Now only the newest passing row per gate is verified, judged per gate so a stale-but-intact UNIT artifact cannot mask a tampered SEC one.

**P2 — verification never reached the public read paths.** AC3 says *reads*. `GET /api/v2/proof/requirements/{id}/evidence` and `/runs/{id}/evidence` still served `satisfied` straight from the ledger alongside the artifact's *current* bytes, so editing a file after a passing run showed a pass next to forged text.

**P2 — and adding `verified: false` beside an unchanged `satisfied: true` fixed nothing a user sees.** Every existing client renders green from `satisfied`/`status`. So an unverified record now serializes as `satisfied=false, status="unverifiable"` — the existing vocabulary every client already renders as not-green — with `verified`/`tamper_detail` carrying the precise reason. `GateEvidencePanel` additionally shows a distinct red **tampered** badge and explains why the contents are withheld.

**P2 — an unreadable artifact crashed instead of blocking.** `FileNotFoundError` is only one kind of `OSError`; an artifact replaced by a directory or made unreadable raised `IsADirectoryError`/`PermissionError`, which 500'd the endpoints and took down the merge gate before it could block the requirement or honor an override.

Plus, from the CI reviewer: **a description ending in a single quote produced a `SyntaxError` in six templates** — not a `\"\"\"` run, so my collapse missed it, and those templates butt `{description}` straight against their own closing delimiter. A trailing backslash breaks the same way. Both now get a separating space.

The final pass was clean.

## Verification

```
AC1  waiver expiring TODAY    -> expired? False  status=waived
     waiver expired YESTERDAY -> expired? True   status=open
AC2  run_id -> 275c0ff2-a42b-409e-93ad-c6ab20ad72dd  (len 36, was 8)  all distinct: True
AC3  intact artifact -> merge blocked by: ['REQ-B']
     edited artifact -> EvidenceTamperError
     merge now blocked by: ['REQ-B', 'REQ-C']
AC4  python stub still parses: True   docstring delimiters: 4 (balanced)
     e2e literal: test("He said \"stop\" import os; os.system(\"rm -rf /\")", async ({ page }) => {
```

## Tests

`tests/core/test_proof9_evidence_integrity_952.py` — 69 tests, plus 9 in `tests/ui/test_proof_evidence_read_verification_952.py` and 3 web-UI cases. All RED first. One class per AC, plus the two review findings:

- a waiver expiring today, yesterday, tomorrow, and a source-level check that local `date.today()` stays out of the ledger
- two runs' evidence staying separable, and no source truncating a UUID again
- artifacts mutated, deleted, and **transplanted into another run**
- a hostile title carrying a quote *and* a newline through **every** gate's template, with Python stubs required to `ast.parse` and the E2E literal required to round-trip through `json.loads`
- tampered evidence blocking both merge gates; superseded-artifact cleanup **not** blocking them

`tests/ -k "proof or pr_v2 or pr_commands"`: **363 passed**. `ruff check .` clean.

Web UI: **1103 tests pass**, `npm run build` succeeds. (The 25 `tsc --noEmit` errors are all pre-existing, in unrelated test files.)

## Known limitations

- Verification accepts the pre-#952 bytes-only digest as well as the bound one, so evidence recorded before this change does not all become "tampered" at once. Legacy rows still detect modification; they cannot detect a transplant. New writes are always bound, so that path drains as runs happen.
- A SATISFIED requirement with **no** evidence rows does not block. That is a pre-existing state in older ledgers, not a tamper signal, and treating it as one would wedge every workspace that has it.
- A tampered requirement blocks the merge gate and reads as unverifiable, but its *stored* status stays SATISFIED until the next proof run — the gate and the read paths are the enforcement points, not a background reconciler.