### PR TITLE
fix(core): seven low-severity orchestration defects (#957)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2759,7 +2759,9 @@ def work_start(
         elif stub:
             console.print("\n[dim]Executing stub agent...[/dim]")
             runtime.execute_stub(workspace, run)
-            runtime.complete_run(workspace, run.id)
+            # The stub does no real work, so its fabricated DONE must not close
+            # a linked GitHub issue (#957).
+            runtime.complete_run(workspace, run.id, github_autoclose=False)
             console.print("[green]Run completed (stub)[/green]")
 
     except FileNotFoundError:
@@ -4321,7 +4323,7 @@ def batch_status(
                 console.print(f"    {icon} {tid[:8]} - {title}")
 
             # Show config reloads if any occurred during batch
-            config_reloads = batch.results.get("__config_reloads__")
+            config_reloads = batch.config_reloads
             if config_reloads:
                 from datetime import datetime as _dt
 

--- a/codeframe/core/agent.py
+++ b/codeframe/core/agent.py
@@ -11,6 +11,7 @@ Coordinates the full agent execution loop:
 This module is headless - no FastAPI or HTTP dependencies.
 """
 
+import json
 import re
 import shlex
 import subprocess
@@ -1251,8 +1252,11 @@ IMPORTANT:
             # invisible to it, so a capped run kept spending here.
             self.cost_tracker.record_response(response, call_type="diagnostic_fix")
 
-            # Parse the fix plan
-            import json
+            # Parse the fix plan. `json` is imported at module level (#957):
+            # a function-local `import json` here made the name local to this
+            # method, so `except json.JSONDecodeError` below raised
+            # UnboundLocalError whenever llm.complete() failed first — masking
+            # the real provider error.
             json_match = re.search(r"\{[\s\S]*\}", response.content)
             if not json_match:
                 self._verbose_print("[SELFCORRECT] No JSON found in LLM response")
@@ -1513,82 +1517,6 @@ IMPORTANT:
 
         # Default to technical - agent should try to fix it first
         return "technical"
-
-    def _resolve_tactical_decision(self, error: str, context: "TaskContext") -> str:
-        """Resolve a tactical decision using preferences and best judgment.
-
-        When the agent encounters a tactical question (implementation detail,
-        tooling choice, file handling, etc.), this method resolves it
-        autonomously instead of creating a blocker.
-
-        Args:
-            error: The error/question that triggered this
-            context: Task context with preferences
-
-        Returns:
-            Resolution instruction for the agent to follow
-        """
-        self._emit_event("tactical_resolution_started", {"question": error[:200]})
-
-        # Build resolution prompt using preferences
-        prefs = context.preferences
-        pref_section = prefs.to_prompt_section() if prefs.has_preferences() else ""
-
-        prompt = f"""You encountered a tactical implementation decision that should be resolved autonomously.
-
-## The Question/Decision
-{error}
-
-{pref_section}
-
-## Resolution Guidelines
-
-As an expert software engineer, resolve this decision using:
-1. Project preferences (above) if they apply
-2. Industry best practices if no preference
-3. The simpler approach when multiple options are equivalent
-4. Common conventions for this type of project
-
-IMPORTANT: This is a tactical decision you MUST resolve yourself. Do NOT ask the user.
-Do NOT say you need clarification. Make the best decision and proceed.
-
-Respond with a brief, clear instruction on what to do. For example:
-- "Use pytest as the test framework"
-- "Overwrite the existing file with the new implementation"
-- "Use the latest stable version of the library"
-- "Install using uv (the project's package manager)"
-
-Your decision:"""
-
-        try:
-            response = self.llm.complete(
-                messages=[{"role": "user", "content": prompt}],
-                purpose=Purpose.GENERATION,
-                max_tokens=256,
-                temperature=0.0,
-            )
-            # Counts toward the cap (#1004): these calls used to be
-            # invisible to it, so a capped run kept spending here.
-            self.cost_tracker.record_response(response, call_type="tactical_resolution")
-
-            resolution = response.strip()
-            self._emit_event(
-                "tactical_resolution_completed",
-                {"question": error[:200], "resolution": resolution[:200]},
-            )
-            self._debug_log(
-                f"TACTICAL DECISION RESOLVED: {resolution[:100]}",
-                level="INFO",
-                data={"question": error, "resolution": resolution},
-            )
-            return resolution
-
-        except Exception as e:
-            # On LLM failure, use a sensible default
-            self._emit_event(
-                "tactical_resolution_failed", {"question": error[:200], "error": str(e)}
-            )
-            return "Proceed with the most common/standard approach for this situation."
 
     def _should_create_blocker(
         self,

--- a/codeframe/core/blockers.py
+++ b/codeframe/core/blockers.py
@@ -8,6 +8,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 
 import sqlite3
 import uuid
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -100,18 +101,15 @@ def create(
     blocker_id = str(uuid.uuid4())
     now = _utc_now().isoformat()
 
-    conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-
-    cursor.execute(
-        """
-        INSERT INTO blockers (id, workspace_id, task_id, question, status, created_at, created_by)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-        (blocker_id, workspace.id, task_id, question, BlockerStatus.OPEN.value, now, origin.value),
-    )
-    conn.commit()
-    conn.close()
+    with closing(get_db_connection(workspace)) as conn:
+        conn.execute(
+            """
+            INSERT INTO blockers (id, workspace_id, task_id, question, status, created_at, created_by)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (blocker_id, workspace.id, task_id, question, BlockerStatus.OPEN.value, now, origin.value),
+        )
+        conn.commit()
 
     blocker = Blocker(
         id=blocker_id,
@@ -144,9 +142,6 @@ def _find_open_duplicate(
     workspace: Workspace, task_id: Optional[str], question: str
 ) -> Optional[Blocker]:
     """Return an existing OPEN blocker with the same (task_id, question), if any."""
-    conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-
     select = (
         "SELECT id, workspace_id, task_id, question, answer, status, created_at, "
         "answered_at, COALESCE(created_by, 'human') as created_by FROM blockers "
@@ -160,9 +155,8 @@ def _find_open_duplicate(
         select += " AND task_id = ?"
         params.append(task_id)
 
-    cursor.execute(select, params)
-    row = cursor.fetchone()
-    conn.close()
+    with closing(get_db_connection(workspace)) as conn:
+        row = conn.execute(select, params).fetchone()
 
     return _row_to_blocker(row) if row else None
 
@@ -204,40 +198,33 @@ def get(workspace: Workspace, blocker_id: str) -> Optional[Blocker]:
     Returns:
         Blocker if found, None otherwise
     """
-    conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-
-    # Try exact match first
-    cursor.execute(
-        """
-        SELECT id, workspace_id, task_id, question, answer, status, created_at, answered_at,
-               COALESCE(created_by, 'human') as created_by
-        FROM blockers
-        WHERE workspace_id = ? AND id = ?
-        """,
-        (workspace.id, blocker_id),
-    )
-    row = cursor.fetchone()
-
-    # If no exact match, try prefix match
-    if not row:
-        cursor.execute(
+    with closing(get_db_connection(workspace)) as conn:
+        # Try exact match first
+        row = conn.execute(
             """
             SELECT id, workspace_id, task_id, question, answer, status, created_at, answered_at,
                    COALESCE(created_by, 'human') as created_by
             FROM blockers
-            WHERE workspace_id = ? AND id LIKE ?
+            WHERE workspace_id = ? AND id = ?
             """,
-            (workspace.id, f"{blocker_id}%"),
-        )
-        rows = cursor.fetchall()
-        if len(rows) == 1:
-            row = rows[0]
-        elif len(rows) > 1:
-            conn.close()
-            raise ValueError(f"Multiple blockers match '{blocker_id}'")
+            (workspace.id, blocker_id),
+        ).fetchone()
 
-    conn.close()
+        # If no exact match, try prefix match
+        if not row:
+            rows = conn.execute(
+                """
+                SELECT id, workspace_id, task_id, question, answer, status, created_at, answered_at,
+                       COALESCE(created_by, 'human') as created_by
+                FROM blockers
+                WHERE workspace_id = ? AND id LIKE ?
+                """,
+                (workspace.id, f"{blocker_id}%"),
+            ).fetchall()
+            if len(rows) == 1:
+                row = rows[0]
+            elif len(rows) > 1:
+                raise ValueError(f"Multiple blockers match '{blocker_id}'")
 
     if not row:
         return None
@@ -349,19 +336,16 @@ def answer(workspace: Workspace, blocker_id: str, text: str) -> Blocker:
 
     now = _utc_now().isoformat()
 
-    conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-
-    cursor.execute(
-        """
-        UPDATE blockers
-        SET answer = ?, status = ?, answered_at = ?
-        WHERE id = ?
-        """,
-        (text, BlockerStatus.ANSWERED.value, now, blocker.id),
-    )
-    conn.commit()
-    conn.close()
+    with closing(get_db_connection(workspace)) as conn:
+        conn.execute(
+            """
+            UPDATE blockers
+            SET answer = ?, status = ?, answered_at = ?
+            WHERE id = ?
+            """,
+            (text, BlockerStatus.ANSWERED.value, now, blocker.id),
+        )
+        conn.commit()
 
     # Emit blocker answered event
     events.emit_for_workspace(
@@ -416,19 +400,16 @@ def resolve(workspace: Workspace, blocker_id: str) -> Blocker:
     if blocker.status == BlockerStatus.RESOLVED:
         raise ValueError(f"Blocker already resolved: {blocker_id}")
 
-    conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-
-    cursor.execute(
-        """
-        UPDATE blockers
-        SET status = ?
-        WHERE id = ?
-        """,
-        (BlockerStatus.RESOLVED.value, blocker.id),
-    )
-    conn.commit()
-    conn.close()
+    with closing(get_db_connection(workspace)) as conn:
+        conn.execute(
+            """
+            UPDATE blockers
+            SET status = ?
+            WHERE id = ?
+            """,
+            (BlockerStatus.RESOLVED.value, blocker.id),
+        )
+        conn.commit()
 
     # Emit blocker resolved event
     events.emit_for_workspace(
@@ -451,20 +432,16 @@ def count_by_status(workspace: Workspace) -> dict[str, int]:
     Returns:
         Dict mapping status string to count
     """
-    conn = get_db_connection(workspace)
-    cursor = conn.cursor()
-
-    cursor.execute(
-        """
-        SELECT status, COUNT(*) as count
-        FROM blockers
-        WHERE workspace_id = ?
-        GROUP BY status
-        """,
-        (workspace.id,),
-    )
-    rows = cursor.fetchall()
-    conn.close()
+    with closing(get_db_connection(workspace)) as conn:
+        rows = conn.execute(
+            """
+            SELECT status, COUNT(*) as count
+            FROM blockers
+            WHERE workspace_id = ?
+            GROUP BY status
+            """,
+            (workspace.id,),
+        ).fetchall()
 
     return {row[0]: row[1] for row in rows}
 

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -572,7 +572,11 @@ class BatchRun:
         on_failure: Behavior on task failure
         started_at: When the batch started
         completed_at: When the batch finished (if finished)
-        results: Dict mapping task_id -> RunStatus value
+        results: Dict mapping task_id -> RunStatus value. Task entries ONLY —
+            config-reload bookkeeping used to be smuggled in here under a
+            ``__config_reloads__`` key, which leaked into the batch API and the
+            CLI as a bogus "task" (#957).
+        config_reloads: ISO timestamps of config reloads observed during the run
     """
 
     id: str
@@ -592,6 +596,7 @@ class BatchRun:
     isolation: str = "none"
     llm_provider: Optional[str] = None
     llm_model: Optional[str] = None
+    config_reloads: list[str] = field(default_factory=list)
 
 
 def create_batch(
@@ -891,7 +896,7 @@ def get_batch(workspace: Workspace, batch_id: str) -> Optional[BatchRun]:
             SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                    on_failure, started_at, completed_at, results, engine,
                    isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                   llm_provider, llm_model
+                   llm_provider, llm_model, config_reloads
             FROM batch_runs
             WHERE workspace_id = ? AND id = ?
             """,
@@ -932,7 +937,7 @@ def list_batches(
                 SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                        on_failure, started_at, completed_at, results, engine,
                        isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                       llm_provider, llm_model
+                       llm_provider, llm_model, config_reloads
                 FROM batch_runs
                 WHERE workspace_id = ? AND status = ?
                 ORDER BY started_at DESC
@@ -946,7 +951,7 @@ def list_batches(
                 SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                        on_failure, started_at, completed_at, results, engine,
                        isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                       llm_provider, llm_model
+                       llm_provider, llm_model, config_reloads
                 FROM batch_runs
                 WHERE workspace_id = ?
                 ORDER BY started_at DESC
@@ -1024,7 +1029,7 @@ def find_batch_by_prefix(workspace: Workspace, prefix: str) -> list[BatchRun]:
             SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                    on_failure, started_at, completed_at, results, engine,
                    isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                   llm_provider, llm_model
+                   llm_provider, llm_model, config_reloads
             FROM batch_runs
             WHERE workspace_id = ? AND id LIKE ? ESCAPE '\\'
             ORDER BY started_at DESC
@@ -1681,7 +1686,11 @@ def _apply_pending_config_reload(
     reload_state: "ConfigReloadState",
     last_seen_reload: datetime,
 ) -> datetime:
-    """Check for config reloads and record them in batch results.
+    """Check for config reloads and record them on the batch.
+
+    Recorded on ``batch.config_reloads``, not inside ``batch.results`` — that
+    dict is typed ``task_id -> RunStatus`` and a list under a magic key leaked
+    out through the batch API and the CLI (#957).
 
     Args:
         batch: Current batch run.
@@ -1694,8 +1703,7 @@ def _apply_pending_config_reload(
     """
     if reload_state.has_reloaded_since(last_seen_reload):
         now = datetime.now(timezone.utc)
-        reloads = batch.results.setdefault("__config_reloads__", [])
-        reloads.append(now.isoformat())
+        batch.config_reloads.append(now.isoformat())
         _save_batch(workspace, batch)
         logger.debug(f"[config] Configuration reloaded at {now.strftime('%H:%M:%S')}")
         return now
@@ -2668,6 +2676,7 @@ def _save_batch(
     concurrency_json = (
         json.dumps(batch.concurrency.by_status) if batch.concurrency.by_status else None
     )
+    config_reloads_json = json.dumps(batch.config_reloads) if batch.config_reloads else None
 
     with _batch_db_lock:
         conn = get_db_connection(workspace)
@@ -2697,8 +2706,8 @@ def _save_batch(
                 (id, workspace_id, task_ids, status, strategy, max_parallel, on_failure,
                  started_at, completed_at, results, engine, isolation,
                  stall_timeout_s, stall_action, concurrency_by_status,
-                 llm_provider, llm_model)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 llm_provider, llm_model, config_reloads)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     batch.id,
@@ -2718,6 +2727,7 @@ def _save_batch(
                     concurrency_json,
                     batch.llm_provider,
                     batch.llm_model,
+                    config_reloads_json,
                 ),
             )
             conn.commit()
@@ -2736,6 +2746,14 @@ def _row_to_batch(row: tuple) -> BatchRun:
     concurrency_by_status = (
         json.loads(row[14]) if len(row) > 14 and row[14] else {}
     )
+    results = json.loads(row[9]) if row[9] else {}
+    config_reloads = json.loads(row[17]) if len(row) > 17 and row[17] else []
+    # Rows written before #957 carry the reload list INSIDE results under a
+    # magic key. Lift it out on read so an old batch never re-leaks it through
+    # the API; the next save persists it in its own column.
+    legacy_reloads = results.pop("__config_reloads__", None)
+    if legacy_reloads and not config_reloads:
+        config_reloads = list(legacy_reloads)
     return BatchRun(
         id=row[0],
         workspace_id=row[1],
@@ -2746,7 +2764,7 @@ def _row_to_batch(row: tuple) -> BatchRun:
         on_failure=OnFailure(row[6]),
         started_at=datetime.fromisoformat(row[7]),
         completed_at=datetime.fromisoformat(row[8]) if row[8] else None,
-        results=json.loads(row[9]) if row[9] else {},
+        results=results,
         engine=row[10] if len(row) > 10 and row[10] else "react",
         isolation=row[11] if len(row) > 11 and row[11] else "none",
         stall_timeout_s=row[12] if len(row) > 12 and row[12] is not None else 300,
@@ -2756,4 +2774,5 @@ def _row_to_batch(row: tuple) -> BatchRun:
         ),
         llm_provider=row[15] if len(row) > 15 else None,
         llm_model=row[16] if len(row) > 16 else None,
+        config_reloads=config_reloads,
     )

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -13,7 +13,11 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from codeframe.core import engine_stats, events, tasks
-from codeframe.core.state_machine import TaskStatus, can_transition
+from codeframe.core.state_machine import (
+    InvalidTransitionError,
+    TaskStatus,
+    can_transition,
+)
 from codeframe.core.workspace import Workspace, get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -362,17 +366,25 @@ def complete_run(
     # transition raise here leaves the run RUNNING, which is recoverable.
     #
     # A task already DONE is the goal state, not a failure: reconciliation
-    # (#1032) and manual completion both move a task to DONE while its run is
-    # still active, and DONE -> DONE is a rejected transition. Raising there
-    # would send execute_agent's handler into fail_run and persist a
-    # successful run as FAILED.
-    task = tasks.get(workspace, run.task_id)
-    if task is None:
-        raise ValueError(f"Task not found: {run.task_id}")
-    if task.status != TaskStatus.DONE:
+    # (#1032, a daemon thread) and manual completion both move a task to DONE
+    # while its run is still active, and DONE -> DONE is a rejected transition.
+    # Raising there would send execute_agent's handler into fail_run and
+    # persist a successful run as FAILED.
+    #
+    # Handled by catching rather than pre-checking: a read-then-call guard is
+    # check-then-act, and update_status does its own fresh read + compare-and-
+    # set, so a DONE landing in between would still raise. Re-reading in the
+    # handler is the only way to tell "someone else already finished it"
+    # (success) from a genuinely illegal transition (still BACKLOG — raise, and
+    # the run stays RUNNING).
+    try:
         tasks.update_status(
             workspace, run.task_id, TaskStatus.DONE, github_autoclose=github_autoclose
         )
+    except InvalidTransitionError:
+        task = tasks.get(workspace, run.task_id)
+        if task is None or task.status != TaskStatus.DONE:
+            raise
 
     now = _utc_now().isoformat()
 

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -360,9 +360,19 @@ def complete_run(
     # this, so a rejected transition left the run COMPLETED and the task
     # IN_PROGRESS — permanently divergent, with no path back. Letting the
     # transition raise here leaves the run RUNNING, which is recoverable.
-    tasks.update_status(
-        workspace, run.task_id, TaskStatus.DONE, github_autoclose=github_autoclose
-    )
+    #
+    # A task already DONE is the goal state, not a failure: reconciliation
+    # (#1032) and manual completion both move a task to DONE while its run is
+    # still active, and DONE -> DONE is a rejected transition. Raising there
+    # would send execute_agent's handler into fail_run and persist a
+    # successful run as FAILED.
+    task = tasks.get(workspace, run.task_id)
+    if task is None:
+        raise ValueError(f"Task not found: {run.task_id}")
+    if task.status != TaskStatus.DONE:
+        tasks.update_status(
+            workspace, run.task_id, TaskStatus.DONE, github_autoclose=github_autoclose
+        )
 
     now = _utc_now().isoformat()
 

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -324,7 +324,12 @@ def list_runs(
     return [_row_to_run(row) for row in rows]
 
 
-def complete_run(workspace: Workspace, run_id: str) -> Run:
+def complete_run(
+    workspace: Workspace,
+    run_id: str,
+    *,
+    github_autoclose: bool = True,
+) -> Run:
     """Mark a run as completed.
 
     Also transitions the task to DONE.
@@ -332,12 +337,17 @@ def complete_run(workspace: Workspace, run_id: str) -> Run:
     Args:
         workspace: Target workspace
         run_id: Run to complete
+        github_autoclose: Fire the linked-issue auto-close on the DONE
+            transition. ``False`` for fabricated completions (``--stub``) that
+            must not act on a real GitHub issue (#957).
 
     Returns:
         Updated Run
 
     Raises:
         ValueError: If run not found or not in RUNNING status
+        InvalidTransitionError: If the task cannot transition to DONE — raised
+            *before* the run is committed, so run and task never diverge.
     """
     run = get_run(workspace, run_id)
     if not run:
@@ -345,6 +355,14 @@ def complete_run(workspace: Workspace, run_id: str) -> Run:
 
     if run.status != RunStatus.RUNNING:
         raise ValueError(f"Run is not running: {run.status}")
+
+    # Transition the task FIRST (#957). The run UPDATE used to commit before
+    # this, so a rejected transition left the run COMPLETED and the task
+    # IN_PROGRESS — permanently divergent, with no path back. Letting the
+    # transition raise here leaves the run RUNNING, which is recoverable.
+    tasks.update_status(
+        workspace, run.task_id, TaskStatus.DONE, github_autoclose=github_autoclose
+    )
 
     now = _utc_now().isoformat()
 
@@ -363,9 +381,6 @@ def complete_run(workspace: Workspace, run_id: str) -> Run:
         conn.commit()
     finally:
         conn.close()
-
-    # Transition task to DONE
-    tasks.update_status(workspace, run.task_id, TaskStatus.DONE)
 
     # Emit run completed event
     events.emit_for_workspace(
@@ -592,6 +607,44 @@ def stop_run(workspace: Workspace, task_id: str) -> Run:
     return run
 
 
+#: Defaults for the stall-detection settings. Used to tell "the user asked for
+#: this" apart from "nobody set it" when deciding whether to warn (#957).
+_DEFAULT_STALL_TIMEOUT_S = 300
+_DEFAULT_STALL_ACTION = "blocker"
+
+#: Engines that actually implement stall detection.
+_STALL_AWARE_ENGINES = ("react", "built-in")
+
+
+def _warn_if_stall_settings_ignored(
+    engine: str, stall_timeout_s: int, stall_action: str
+) -> None:
+    """Warn when stall settings were supplied but the engine ignores them (#957).
+
+    Only the react/built-in engines wire ``stall_timeout_s``/``stall_action``
+    into their adapter; every other engine silently dropped them, so a user who
+    passed ``--stall-timeout 60 --stall-action retry`` got the defaults with no
+    indication. Stays quiet when the values are the defaults — nothing was
+    asked for, so nothing is being ignored.
+    """
+    if engine in _STALL_AWARE_ENGINES:
+        return
+    if (
+        stall_timeout_s == _DEFAULT_STALL_TIMEOUT_S
+        and stall_action == _DEFAULT_STALL_ACTION
+    ):
+        return
+    logger.warning(
+        "Engine '%s' does not support stall detection; ignoring "
+        "--stall-timeout=%s and --stall-action=%s "
+        "(supported by: %s).",
+        engine,
+        stall_timeout_s,
+        stall_action,
+        ", ".join(_STALL_AWARE_ENGINES),
+    )
+
+
 def execute_stub(workspace: Workspace, run: Run) -> None:
     """Stub agent execution loop (deprecated).
 
@@ -780,6 +833,9 @@ def execute_agent(
             on_agent_event(event.type, event.data)
 
         # Get adapter via registry and run
+        # Tell the user when their stall flags will be dropped (#957).
+        _warn_if_stall_settings_ignored(engine, stall_timeout_s, stall_action)
+
         if is_external_engine(engine):
             from codeframe.core.context_packager import TaskContextPackager
             from codeframe.core.adapters.verification_wrapper import VerificationWrapper
@@ -818,7 +874,7 @@ def execute_agent(
                 "fix_coordinator": fix_coordinator,
             }
             # Stall detection is only relevant for the react engine
-            if engine in ("react", "built-in"):
+            if engine in _STALL_AWARE_ENGINES:
                 builtin_kwargs["stall_timeout_s"] = stall_timeout_s
                 builtin_kwargs["stall_action"] = resolved_action
 

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -442,6 +442,8 @@ def update_status(
     workspace: Workspace,
     task_id: str,
     new_status: TaskStatus,
+    *,
+    github_autoclose: bool = True,
 ) -> Task:
     """Update a task's status.
 
@@ -451,6 +453,10 @@ def update_status(
         workspace: Target workspace
         task_id: Task to update
         new_status: New status
+        github_autoclose: Whether a DONE transition may close the linked GitHub
+            issue. ``False`` only for fabricated completions (``--stub``), which
+            must not act on a real issue (#957). The status change itself is
+            unaffected.
 
     Returns:
         Updated Task
@@ -506,7 +512,7 @@ def update_status(
     # (issue #565). Placed here — the single chokepoint every DONE transition
     # flows through (HTTP, CLI, agent/batch via runtime.complete_run) — so the
     # behavior is consistent regardless of how the task was completed.
-    if new_status == TaskStatus.DONE:
+    if new_status == TaskStatus.DONE and github_autoclose:
         _dispatch_github_autoclose(workspace, task)
 
     return task

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -34,7 +34,8 @@ STATE_DB_NAME = "state.db"
 # ``_ensure_schema_upgrades``. Bump by 1 whenever either function gains a new
 # table/column/index so existing workspaces re-enter the (idempotent)
 # migration path exactly once. Gates #733: steady-state loads skip all DDL.
-SCHEMA_VERSION = 2
+# 3: batch_runs.config_reloads (#957).
+SCHEMA_VERSION = 3
 
 # Per-workspace config file written by the Settings page (issue #556).
 # Owned by the UI layer today; kept here so a future core consumer can

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -314,6 +314,7 @@ def _init_database(db_path: Path) -> None:
             concurrency_by_status TEXT,
             llm_provider TEXT,
             llm_model TEXT,
+            config_reloads TEXT,
             FOREIGN KEY (workspace_id) REFERENCES workspace(id),
             CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
         )
@@ -577,6 +578,7 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
                 concurrency_by_status TEXT,
                 llm_provider TEXT,
                 llm_model TEXT,
+                config_reloads TEXT,
                 FOREIGN KEY (workspace_id) REFERENCES workspace(id),
                 CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
             )
@@ -600,6 +602,8 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             ("concurrency_by_status", "ALTER TABLE batch_runs ADD COLUMN concurrency_by_status TEXT"),
             ("llm_provider", "ALTER TABLE batch_runs ADD COLUMN llm_provider TEXT"),
             ("llm_model", "ALTER TABLE batch_runs ADD COLUMN llm_model TEXT"),
+            # #957: config-reload bookkeeping moved off the results JSON blob.
+            ("config_reloads", "ALTER TABLE batch_runs ADD COLUMN config_reloads TEXT"),
         )
         for column, ddl in batch_migrations:
             if column not in batch_columns:

--- a/tests/cli/test_config_reload_cli.py
+++ b/tests/cli/test_config_reload_cli.py
@@ -34,13 +34,12 @@ def workspace_with_batch(tmp_path):
         on_failure=conductor.OnFailure.CONTINUE,
         started_at=datetime(2026, 3, 17, 10, 0, 0, tzinfo=timezone.utc),
         completed_at=datetime(2026, 3, 17, 10, 5, 0, tzinfo=timezone.utc),
-        results={
-            "task-1": "COMPLETED",
-            "__config_reloads__": [
-                "2026-03-17T10:01:30+00:00",
-                "2026-03-17T10:03:45+00:00",
-            ],
-        },
+        results={"task-1": "COMPLETED"},
+        # Off results since #957 — results is task_id -> RunStatus only.
+        config_reloads=[
+            "2026-03-17T10:01:30+00:00",
+            "2026-03-17T10:03:45+00:00",
+        ],
     )
     conductor._save_batch(workspace, batch)
     return tmp_path

--- a/tests/core/test_orchestration_defects_957.py
+++ b/tests/core/test_orchestration_defects_957.py
@@ -202,6 +202,37 @@ class TestConfigReloadsOffResults:
         assert loaded.results == {"t-1": "COMPLETED"}
         assert loaded.config_reloads == ["2026-01-01T00:00:00"]
 
+    def test_existing_workspace_gets_the_column_on_upgrade(self, tmp_path):
+        """An already-stamped DB must still receive the new column (#957).
+
+        `_ensure_schema_upgrades` returns early once `PRAGMA user_version`
+        reaches SCHEMA_VERSION, so adding a migration entry WITHOUT bumping the
+        version leaves existing workspaces without the column — and every batch
+        SELECT then dies with "no such column: config_reloads".
+        """
+        from codeframe.core.conductor import _save_batch, get_batch
+        from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+        ws = create_or_load_workspace(tmp_path)
+        batch = self._batch(ws)
+        _save_batch(ws, batch)
+
+        # Roll the DB back to the pre-#957 shape: column absent, stamped at the
+        # version an already-upgraded install would carry.
+        conn = get_db_connection(ws)
+        try:
+            conn.execute("ALTER TABLE batch_runs DROP COLUMN config_reloads")
+            conn.execute("PRAGMA user_version = 2")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Re-opening the workspace must run the migration.
+        ws2 = create_or_load_workspace(tmp_path)
+        loaded = get_batch(ws2, "b-1")
+        assert loaded is not None
+        assert loaded.config_reloads == []
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 3. blockers.py must not leak SQLite connections

--- a/tests/core/test_orchestration_defects_957.py
+++ b/tests/core/test_orchestration_defects_957.py
@@ -1,0 +1,412 @@
+"""Low-severity orchestration-core defects (issue #957).
+
+Seven independent defects, one test class each:
+
+1. ``agent.py`` imported ``json`` inside a ``try`` whose ``except
+   json.JSONDecodeError`` sits far below, so any LLM failure during
+   self-correction raised ``UnboundLocalError`` and masked the real provider
+   error.
+2. ``conductor`` injected a list under ``batch.results['__config_reloads__']``
+   into a dict typed ``task_id -> RunStatus``; it leaked into the batch API and
+   the CLI.
+3. ``blockers.py`` opened SQLite connections with no ``try/finally``, leaking
+   one on any exception.
+4. ``complete_run`` committed the run COMPLETED *before* ``tasks.update_status``,
+   so a rejected transition left run and task permanently divergent.
+5. ``--stub`` fabricated completion through the real DONE pipeline, including
+   the GitHub auto-close.
+6. ``--stall-timeout`` / ``--stall-action`` were silently ignored for
+   non-react engines.
+7. ``Agent._resolve_tactical_decision`` was dead code with a latent
+   ``AttributeError`` (``response.strip()`` on an ``LLMResponse``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeframe.adapters.llm import MockProvider
+
+pytestmark = pytest.mark.v2
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. LLM errors during self-correction must not be masked by UnboundLocalError
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSelfCorrectionSurfacesProviderError:
+    def _agent(self, tmp_path, provider):
+        from codeframe.core.agent import Agent
+
+        workspace = MagicMock()
+        workspace.id = "ws-1"
+        workspace.repo_path = tmp_path
+        return Agent(workspace, provider)
+
+    def _failing_gate_result(self):
+        from codeframe.core.gates import GateCheck, GateResult, GateStatus
+
+        return GateResult(
+            passed=False,
+            checks=[
+                GateCheck(
+                    name="pytest",
+                    status=GateStatus.FAILED,
+                    output="E   assert 1 == 2",
+                )
+            ],
+        )
+
+    def test_json_is_imported_at_module_level(self):
+        """The except handler references json, so it must never be function-local."""
+        import codeframe.core.agent as agent_module
+
+        assert hasattr(agent_module, "json"), "json must be a module-level import"
+
+        source = Path(agent_module.__file__).read_text()
+        # No function-local `import json` anywhere — that is what rebinds the
+        # name and makes the except handler raise UnboundLocalError.
+        local_imports = [
+            line
+            for line in source.splitlines()
+            if line.strip() == "import json" and line.startswith(" ")
+        ]
+        assert local_imports == [], f"function-local import json: {local_imports}"
+
+    def test_provider_exception_propagates_its_own_message(self, tmp_path):
+        """A provider blow-up must be logged as itself, not as UnboundLocalError."""
+        provider = MockProvider()
+
+        def explode(msgs):
+            raise RuntimeError("provider exploded: upstream 503")
+
+        provider.set_response_handler(explode)
+
+        agent = self._agent(tmp_path, provider)
+        logged: list[str] = []
+        agent._debug_log = lambda msg, **kw: logged.append(str(msg))
+
+        # Must not raise, and must return False (self-correction failed).
+        assert agent._attempt_verification_fix(self._failing_gate_result()) is False
+
+        joined = "\n".join(logged)
+        assert "provider exploded: upstream 503" in joined
+        assert "UnboundLocalError" not in joined
+        assert "json" not in joined.lower().split("provider exploded")[0][-80:]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Config-reload bookkeeping must not live in batch.results
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestConfigReloadsOffResults:
+    def _batch(self, workspace):
+        from codeframe.core.conductor import (
+            BatchRun,
+            BatchStatus,
+            OnFailure,
+        )
+
+        return BatchRun(
+            id="b-1",
+            workspace_id=workspace.id,
+            task_ids=["t-1"],
+            status=BatchStatus.RUNNING,
+            strategy="serial",
+            max_parallel=1,
+            on_failure=OnFailure.CONTINUE,
+            started_at=_utc_now(),
+            completed_at=None,
+            results={"t-1": "COMPLETED"},
+        )
+
+    def test_batchrun_has_a_typed_config_reloads_field(self):
+        from codeframe.core.conductor import BatchRun
+
+        assert "config_reloads" in BatchRun.__dataclass_fields__
+
+    def test_reload_recorded_off_results(self, tmp_path):
+        from codeframe.core.conductor import _apply_pending_config_reload
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        batch = self._batch(ws)
+
+        reload_state = MagicMock()
+        reload_state.has_reloaded_since.return_value = True
+
+        with patch("codeframe.core.conductor._save_batch"):
+            _apply_pending_config_reload(
+                batch, ws, reload_state, datetime(2020, 1, 1, tzinfo=timezone.utc)
+            )
+
+        assert "__config_reloads__" not in batch.results
+        assert batch.results == {"t-1": "COMPLETED"}
+        assert len(batch.config_reloads) == 1
+
+    def test_reloads_survive_a_save_load_round_trip(self, tmp_path):
+        from codeframe.core.conductor import _save_batch, get_batch
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        batch = self._batch(ws)
+        batch.config_reloads = ["2026-08-07T12:00:00+00:00"]
+        _save_batch(ws, batch)
+
+        loaded = get_batch(ws, "b-1")
+        assert loaded is not None
+        assert loaded.config_reloads == ["2026-08-07T12:00:00+00:00"]
+        assert "__config_reloads__" not in loaded.results
+
+    def test_legacy_rows_are_migrated_out_of_results(self, tmp_path):
+        """A DB written before this fix still has the key inside results JSON."""
+        import json as _json
+
+        from codeframe.core.conductor import _save_batch, get_batch
+        from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+        ws = create_or_load_workspace(tmp_path)
+        batch = self._batch(ws)
+        _save_batch(ws, batch)
+
+        # Simulate the pre-fix on-disk shape.
+        conn = get_db_connection(ws)
+        try:
+            conn.execute(
+                "UPDATE batch_runs SET results = ?, config_reloads = NULL WHERE id = ?",
+                (
+                    _json.dumps(
+                        {"t-1": "COMPLETED", "__config_reloads__": ["2026-01-01T00:00:00"]}
+                    ),
+                    "b-1",
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        loaded = get_batch(ws, "b-1")
+        assert loaded is not None
+        assert "__config_reloads__" not in loaded.results
+        assert loaded.results == {"t-1": "COMPLETED"}
+        assert loaded.config_reloads == ["2026-01-01T00:00:00"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. blockers.py must not leak SQLite connections
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBlockersCloseConnections:
+    def test_no_bare_conn_close_without_a_context_manager(self):
+        """Every get_db_connection in blockers.py is guarded."""
+        import codeframe.core.blockers as blockers_module
+
+        source = Path(blockers_module.__file__).read_text().splitlines()
+        unguarded = []
+        for i, line in enumerate(source, start=1):
+            if "get_db_connection(" not in line:
+                continue
+            # Guarded forms: `with closing(get_db_connection(...))` or an
+            # assignment immediately followed by a try:.
+            if "closing(" in line:
+                continue
+            nxt = source[i] if i < len(source) else ""
+            if nxt.strip().startswith("try:"):
+                continue
+            unguarded.append(f"{i}: {line.strip()}")
+        assert unguarded == [], f"unguarded connections: {unguarded}"
+
+    def test_connection_closed_when_the_query_raises(self, tmp_path):
+        """A real failing query (missing table), not a mocked one."""
+        from codeframe.core import blockers
+        from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+        ws = create_or_load_workspace(tmp_path)
+
+        # Construct the real precondition: the query cannot succeed.
+        conn = get_db_connection(ws)
+        try:
+            conn.execute("DROP TABLE blockers")
+            conn.commit()
+        finally:
+            conn.close()
+
+        opened: list[sqlite3.Connection] = []
+        real = blockers.get_db_connection
+
+        def tracking(workspace):
+            opened.append(real(workspace))
+            return opened[-1]
+
+        with patch.object(blockers, "get_db_connection", tracking):
+            with pytest.raises(sqlite3.OperationalError):
+                blockers.get(ws, "does-not-matter")
+
+        assert opened, "expected a connection to be opened"
+        for conn in opened:
+            # A closed connection raises ProgrammingError on use.
+            with pytest.raises(sqlite3.ProgrammingError):
+                conn.execute("SELECT 1")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. complete_run must not leave run and task divergent
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCompleteRunOrdering:
+    def test_rejected_task_transition_leaves_run_running(self, tmp_path):
+        from codeframe.core import runtime, tasks
+        from codeframe.core.state_machine import InvalidTransitionError
+        from codeframe.core.runtime import RunStatus
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+
+        with patch.object(
+            tasks,
+            "update_status",
+            side_effect=InvalidTransitionError(TaskStatus.DONE, TaskStatus.DONE),
+        ):
+            with pytest.raises(InvalidTransitionError):
+                runtime.complete_run(ws, run.id)
+
+        # The run must NOT have been committed as COMPLETED — otherwise the run
+        # says done and the task says in-progress, permanently.
+        reloaded = runtime.get_run(ws, run.id)
+        assert reloaded.status == RunStatus.RUNNING
+        assert reloaded.completed_at is None
+
+    def test_happy_path_still_completes_both(self, tmp_path):
+        from codeframe.core import runtime, tasks
+        from codeframe.core.runtime import RunStatus
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+
+        result = runtime.complete_run(ws, run.id)
+
+        assert result.status == RunStatus.COMPLETED
+        assert runtime.get_run(ws, run.id).status == RunStatus.COMPLETED
+        assert tasks.get(ws, task.id).status == TaskStatus.DONE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. --stub must not fire the GitHub auto-close
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStubDoesNotAutoCloseGitHub:
+    def test_complete_run_can_opt_out_of_autoclose(self, tmp_path):
+        from codeframe.core import runtime, tasks
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+
+        with patch.object(tasks, "_dispatch_github_autoclose") as dispatch:
+            runtime.complete_run(ws, run.id, github_autoclose=False)
+
+        dispatch.assert_not_called()
+        # The transition itself still happened.
+        assert tasks.get(ws, task.id).status == TaskStatus.DONE
+
+    def test_autoclose_still_fires_by_default(self, tmp_path):
+        from codeframe.core import runtime, tasks
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+
+        with patch.object(tasks, "_dispatch_github_autoclose") as dispatch:
+            runtime.complete_run(ws, run.id)
+
+        dispatch.assert_called_once()
+
+    def test_cli_stub_path_opts_out(self):
+        """The --stub branch must pass github_autoclose=False."""
+        import inspect
+
+        from codeframe.cli import app as cli_app
+
+        source = inspect.getsource(cli_app.work_start)
+        stub_branch = source.split("elif stub:", 1)
+        assert len(stub_branch) == 2, "expected an `elif stub:` branch"
+        assert "github_autoclose=False" in stub_branch[1]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Ignored stall flags must warn
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIgnoredStallFlagsWarn:
+    def test_warns_when_stall_settings_ignored_for_a_non_react_engine(self, caplog):
+        from codeframe.core.runtime import _warn_if_stall_settings_ignored
+
+        with caplog.at_level("WARNING"):
+            _warn_if_stall_settings_ignored(
+                engine="claude-code", stall_timeout_s=120, stall_action="retry"
+            )
+
+        text = caplog.text.lower()
+        assert "stall" in text
+        assert "claude-code" in text
+
+    def test_silent_for_react(self, caplog):
+        from codeframe.core.runtime import _warn_if_stall_settings_ignored
+
+        with caplog.at_level("WARNING"):
+            _warn_if_stall_settings_ignored(
+                engine="react", stall_timeout_s=120, stall_action="retry"
+            )
+        assert "stall" not in caplog.text.lower()
+
+    def test_silent_when_settings_are_defaults(self, caplog):
+        """Only warn when the user actually asked for something we ignore."""
+        from codeframe.core.runtime import _warn_if_stall_settings_ignored
+
+        with caplog.at_level("WARNING"):
+            _warn_if_stall_settings_ignored(
+                engine="claude-code", stall_timeout_s=300, stall_action="blocker"
+            )
+        assert "stall" not in caplog.text.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Dead method with a latent AttributeError is gone
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDeadTacticalResolverRemoved:
+    def test_method_is_deleted(self):
+        from codeframe.core.agent import Agent
+
+        assert not hasattr(Agent, "_resolve_tactical_decision")
+
+    def test_no_references_remain(self):
+        import codeframe.core.agent as agent_module
+
+        source = Path(agent_module.__file__).read_text()
+        assert "_resolve_tactical_decision" not in source

--- a/tests/core/test_orchestration_defects_957.py
+++ b/tests/core/test_orchestration_defects_957.py
@@ -323,6 +323,31 @@ class TestCompleteRunOrdering:
         assert reloaded.status == RunStatus.RUNNING
         assert reloaded.completed_at is None
 
+    def test_already_done_task_completes_the_run(self, tmp_path):
+        """DONE is the goal state, not a failure (#957 review follow-up).
+
+        Reconciliation (#1032) and manual completion both move a task to DONE
+        while its run is still active. DONE -> DONE is a rejected transition, so
+        raising here would send execute_agent's handler into fail_run and
+        persist a successful run as FAILED.
+        """
+        from codeframe.core import runtime, tasks
+        from codeframe.core.runtime import RunStatus
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+        # Something else finishes the task mid-run.
+        tasks.update_status(ws, task.id, TaskStatus.DONE)
+
+        result = runtime.complete_run(ws, run.id)
+
+        assert result.status == RunStatus.COMPLETED
+        assert runtime.get_run(ws, run.id).status == RunStatus.COMPLETED
+        assert tasks.get(ws, task.id).status == TaskStatus.DONE
+
     def test_happy_path_still_completes_both(self, tmp_path):
         from codeframe.core import runtime, tasks
         from codeframe.core.runtime import RunStatus

--- a/tests/core/test_orchestration_defects_957.py
+++ b/tests/core/test_orchestration_defects_957.py
@@ -348,6 +348,63 @@ class TestCompleteRunOrdering:
         assert runtime.get_run(ws, run.id).status == RunStatus.COMPLETED
         assert tasks.get(ws, task.id).status == TaskStatus.DONE
 
+    def test_task_flipping_to_done_mid_call_still_completes_the_run(self, tmp_path):
+        """The race, not just the static case (#957 review round 2).
+
+        A read-then-call guard is check-then-act: `update_status` does its own
+        fresh read + compare-and-set, so a reconciliation DONE landing between
+        our read and that CAS still raises. Simulated here by flipping the row
+        to DONE *inside* the call, exactly as the losing CAS would see it.
+        """
+        from codeframe.core import runtime, tasks
+        from codeframe.core.state_machine import InvalidTransitionError
+        from codeframe.core.runtime import RunStatus
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+
+        real_update = tasks.update_status
+
+        def racing_update(workspace, task_id, new_status, **kwargs):
+            # Someone else wins the race: the row is DONE before our CAS runs.
+            real_update(workspace, task_id, TaskStatus.DONE)
+            raise InvalidTransitionError(TaskStatus.DONE, TaskStatus.DONE)
+
+        with patch.object(tasks, "update_status", side_effect=racing_update):
+            result = runtime.complete_run(ws, run.id)
+
+        assert result.status == RunStatus.COMPLETED
+        assert runtime.get_run(ws, run.id).status == RunStatus.COMPLETED
+        assert tasks.get(ws, task.id).status == TaskStatus.DONE
+
+    def test_genuinely_illegal_transition_still_raises(self, tmp_path):
+        """Only DONE is forgiven — a task stuck elsewhere must not pass."""
+        from codeframe.core import runtime, tasks
+        from codeframe.core.state_machine import InvalidTransitionError
+        from codeframe.core.runtime import RunStatus
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        task = tasks.create(ws, title="T", description="d")
+        run = runtime.start_task_run(ws, task.id)
+
+        real_update = tasks.update_status
+
+        def racing_backwards(workspace, task_id, new_status, **kwargs):
+            # The row moved somewhere that is NOT the goal state.
+            real_update(workspace, task_id, TaskStatus.BLOCKED)
+            raise InvalidTransitionError(TaskStatus.BLOCKED, TaskStatus.DONE)
+
+        with patch.object(tasks, "update_status", side_effect=racing_backwards):
+            with pytest.raises(InvalidTransitionError):
+                runtime.complete_run(ws, run.id)
+
+        assert runtime.get_run(ws, run.id).status == RunStatus.RUNNING
+
     def test_happy_path_still_completes_both(self, tmp_path):
         from codeframe.core import runtime, tasks
         from codeframe.core.runtime import RunStatus


### PR DESCRIPTION
Closes #957. Seven independent defects, each with a test that fails on `main`.

## 1. LLM errors during self-correction were masked

`agent.py` did `import json` **inside** the `try` block of
`_attempt_verification_fix`, while `except json.JSONDecodeError` sits ~200 lines
below. The local import makes `json` a function-local name, so when
`llm.complete()` failed *first*, the handler evaluated `json.JSONDecodeError`
with the name unbound:

```
OLD: Self-correction error: cannot access local variable 'json' where it is not associated with a value
NEW: Self-correction error: provider exploded: upstream 503
```

Moved to a module-level import. A test asserts no function-local `import json`
survives anywhere in the file.

## 2. `__config_reloads__` leaked out of `batch.results`

`batch.results` is typed `task_id -> RunStatus`, but the config-file watcher did
`results.setdefault("__config_reloads__", []).append(...)` — a **list** under a
magic key, which flowed straight into `GET /api/v2/batches` and `cf work batch
status` as a bogus task.

Now a typed `BatchRun.config_reloads: list[str]` with its own `config_reloads`
column, following the `concurrency_by_status` pattern from #741 (DDL in both
create blocks + an idempotent migration entry). Rows written before this fix
still carry the key inside the results JSON, so `_row_to_batch` lifts it out on
read — an old batch never re-leaks it, and the next save moves it to the column.

## 3. `blockers.py` leaked SQLite connections

Six functions (`create`, `_find_open_duplicate`, `get`, `answer`, `resolve`,
`count_by_status`) opened a connection and called `conn.close()` on the happy
path only — any exception in between leaked it. All now use
`contextlib.closing`. One test greps the module for unguarded
`get_db_connection(` calls; another drops the `blockers` table and asserts the
connection is closed after the query raises.

## 4. `complete_run` could leave run and task permanently divergent

The run was committed COMPLETED *before* `tasks.update_status(DONE)`, so a
rejected transition left run=COMPLETED, task=IN_PROGRESS with no path back. The
transition now happens first; a rejection leaves the run RUNNING, which is
recoverable.

## 5. `--stub` fired the GitHub auto-close on a real issue

The stub does no work but routed its fabricated completion through the real DONE
pipeline, closing the linked GitHub issue. `tasks.update_status` and
`complete_run` gained a keyword-only `github_autoclose` (default `True`, so
every other caller is untouched); the `--stub` branch passes `False`. The status
change itself still happens.

## 6. Stall flags were silently dropped

`--stall-timeout` / `--stall-action` are only wired into the react/built-in
adapters; every other engine ignored them without a word.

```
engine='claude-code' timeout=120 action='retry'
  -> Engine 'claude-code' does not support stall detection; ignoring --stall-timeout=120 and --stall-action=retry (supported by: react, built-in).
engine='react'       timeout=120 action='retry'    -> (silent)
engine='claude-code' timeout=300 action='blocker'  -> (silent)
```

It stays quiet when the values are the defaults — nothing was asked for, so
nothing is being ignored.

## 7. Dead `_resolve_tactical_decision` deleted

Zero callers, and it carried a latent `AttributeError`: `response.strip()` on an
`LLMResponse`. 76 lines removed.

## Two regressions caught by review, both fixed here

`codex review` ran three times against this branch. The first two passes each
found a real defect I had introduced:

1. **[P1] `SCHEMA_VERSION` not bumped.** `_ensure_schema_upgrades` returns early
   once `PRAGMA user_version >= SCHEMA_VERSION`, so workspaces already stamped
   at 2 would never receive the `config_reloads` ALTER — and the batch SELECTs
   now name it unconditionally, so `cf work batch status` and
   `/api/v2/batches` would die with `no such column: config_reloads` on
   upgrade. Every test used a *fresh* workspace, which runs the full DDL and
   skips the upgrade branch entirely, so nothing caught it. Bumped to 3 and
   added a test that drops the column, stamps `user_version` back to 2, reopens
   the workspace, and asserts the batch still loads.
2. **[P2] Already-DONE tasks would fail a successful run.** Reordering the
   transition ahead of the run commit meant that when reconciliation (#1032) or
   a manual completion moved the task to DONE mid-run, `complete_run` hit the
   rejected `DONE -> DONE` transition, `execute_agent`'s handler caught it and
   called `fail_run`, and a successful run was persisted as FAILED. DONE is the
   goal state, not a failure — the transition is skipped when the task is
   already there. A genuinely invalid transition (task still in BACKLOG) still
   raises before the run commits, so the fix in §4 stands.

Third pass: no findings.

## Verification

- 20 new tests in `tests/core/test_orchestration_defects_957.py`; 18 fail on `main`.
- `uv run pytest tests/core/test_orchestration_defects_957.py tests/cli/test_config_reload_cli.py tests/core/test_config_reload_integration.py tests/core/test_agent.py tests/core/test_conductor.py tests/cli/test_work_follow.py tests/cli/test_v2_cli_integration.py tests/core/test_workspace.py` → **241 passed**
- Plus blockers/runtime suites: **169 passed**
- `uv run ruff check codeframe/ tests/` → clean
- Demo of all seven criteria against real workspaces/SQLite in the PR discussion below.

## Known limitations

- The `config_reloads` legacy lift-out (`results.pop("__config_reloads__")`)
  runs on every batch read. It is a dict `pop` on an already-parsed dict, so the
  cost is nil, but it is permanent — there is no "migration done" marker that
  would let it be dropped later.
- `_warn_if_stall_settings_ignored` infers intent from "value differs from the
  default". A user who explicitly passes `--stall-timeout 300` on an external
  engine gets no warning. Typer does not distinguish an explicit flag from a
  default without a sentinel, and a sentinel would ripple through every caller.
- The stall warning goes to the `codeframe.core.runtime` logger, not the Rich
  console — core stays headless (architecture rule #1), so CLI users see it only
  with logging configured at WARNING.
