### PR TITLE
fix(core): plumb cloud_timeout_minutes and stop wiping manual dependencies (#959)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -577,6 +577,9 @@ class BatchRun:
             ``__config_reloads__`` key, which leaked into the batch API and the
             CLI as a bogus "task" (#957).
         config_reloads: ISO timestamps of config reloads observed during the run
+        cloud_timeout_minutes: Sandbox timeout for the cloud engine (1-60).
+            Persisted so `resume` restores the user's value instead of silently
+            falling back to the callee default of 30 (#959).
     """
 
     id: str
@@ -597,6 +600,7 @@ class BatchRun:
     llm_provider: Optional[str] = None
     llm_model: Optional[str] = None
     config_reloads: list[str] = field(default_factory=list)
+    cloud_timeout_minutes: int = 30
 
 
 def create_batch(
@@ -677,6 +681,9 @@ def create_batch(
         isolation=isolation,
         llm_provider=llm_provider,
         llm_model=llm_model,
+        # Persisted (#959): this used to be accepted and dropped, so the
+        # callee default of 30 always won and --cloud-timeout was a no-op.
+        cloud_timeout_minutes=cloud_timeout_minutes,
     )
 
     # Save to database
@@ -896,7 +903,7 @@ def get_batch(workspace: Workspace, batch_id: str) -> Optional[BatchRun]:
             SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                    on_failure, started_at, completed_at, results, engine,
                    isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                   llm_provider, llm_model, config_reloads
+                   llm_provider, llm_model, config_reloads, cloud_timeout_minutes
             FROM batch_runs
             WHERE workspace_id = ? AND id = ?
             """,
@@ -937,7 +944,7 @@ def list_batches(
                 SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                        on_failure, started_at, completed_at, results, engine,
                        isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                       llm_provider, llm_model, config_reloads
+                       llm_provider, llm_model, config_reloads, cloud_timeout_minutes
                 FROM batch_runs
                 WHERE workspace_id = ? AND status = ?
                 ORDER BY started_at DESC
@@ -951,7 +958,7 @@ def list_batches(
                 SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                        on_failure, started_at, completed_at, results, engine,
                        isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                       llm_provider, llm_model, config_reloads
+                       llm_provider, llm_model, config_reloads, cloud_timeout_minutes
                 FROM batch_runs
                 WHERE workspace_id = ?
                 ORDER BY started_at DESC
@@ -1029,7 +1036,7 @@ def find_batch_by_prefix(workspace: Workspace, prefix: str) -> list[BatchRun]:
             SELECT id, workspace_id, task_ids, status, strategy, max_parallel,
                    on_failure, started_at, completed_at, results, engine,
                    isolation, stall_timeout_s, stall_action, concurrency_by_status,
-                   llm_provider, llm_model, config_reloads
+                   llm_provider, llm_model, config_reloads, cloud_timeout_minutes
             FROM batch_runs
             WHERE workspace_id = ? AND id LIKE ? ESCAPE '\\'
             ORDER BY started_at DESC
@@ -1357,6 +1364,7 @@ def _run_serial_resume(
                 stall_timeout_s=batch.stall_timeout_s, stall_action=batch.stall_action,
                 worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
                 llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+                cloud_timeout_minutes=batch.cloud_timeout_minutes,
             )
         finally:
             exec_ctx.cleanup()
@@ -1555,6 +1563,7 @@ def _run_retries(
                     stall_timeout_s=batch.stall_timeout_s, stall_action=batch.stall_action,
                     worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
                     llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+                    cloud_timeout_minutes=batch.cloud_timeout_minutes,
                 )
             finally:
                 exec_ctx.cleanup()
@@ -1801,6 +1810,7 @@ def _execute_serial(
                     stall_timeout_s=batch.stall_timeout_s, stall_action=batch.stall_action,
                     worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
                     llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+                    cloud_timeout_minutes=batch.cloud_timeout_minutes,
                 )
 
                 # If task is BLOCKED, try supervisor resolution
@@ -1814,6 +1824,7 @@ def _execute_serial(
                             stall_timeout_s=batch.stall_timeout_s, stall_action=batch.stall_action,
                             worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
                             llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+                            cloud_timeout_minutes=batch.cloud_timeout_minutes,
                         )
             finally:
                 exec_ctx.cleanup()
@@ -2341,6 +2352,7 @@ def _execute_single_task(
             stall_action=batch.stall_action,
             worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
             llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+            cloud_timeout_minutes=batch.cloud_timeout_minutes,
         )
 
         # If task is BLOCKED, try supervisor resolution
@@ -2356,6 +2368,7 @@ def _execute_single_task(
                     stall_action=batch.stall_action,
                     worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
                     llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+                    cloud_timeout_minutes=batch.cloud_timeout_minutes,
                 )
     finally:
         exec_ctx.cleanup()
@@ -2471,6 +2484,7 @@ def _execute_group_parallel(
                 stall_action=batch.stall_action,
                 worktree_path=exec_ctx.workspace_path if exec_ctx.workspace_path != workspace.repo_path else None,
                 llm_provider=batch.llm_provider, llm_model=batch.llm_model,
+                cloud_timeout_minutes=batch.cloud_timeout_minutes,
             )
         finally:
             exec_ctx.cleanup()
@@ -2705,8 +2719,8 @@ def _save_batch(
                 (id, workspace_id, task_ids, status, strategy, max_parallel, on_failure,
                  started_at, completed_at, results, engine, isolation,
                  stall_timeout_s, stall_action, concurrency_by_status,
-                 llm_provider, llm_model, config_reloads)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 llm_provider, llm_model, config_reloads, cloud_timeout_minutes)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     batch.id,
@@ -2727,6 +2741,7 @@ def _save_batch(
                     batch.llm_provider,
                     batch.llm_model,
                     config_reloads_json,
+                    batch.cloud_timeout_minutes,
                 ),
             )
             conn.commit()
@@ -2774,4 +2789,7 @@ def _row_to_batch(row: tuple) -> BatchRun:
         llm_provider=row[15] if len(row) > 15 else None,
         llm_model=row[16] if len(row) > 16 else None,
         config_reloads=config_reloads,
+        cloud_timeout_minutes=(
+            row[18] if len(row) > 18 and row[18] is not None else 30
+        ),
     )

--- a/codeframe/core/dependency_analyzer.py
+++ b/codeframe/core/dependency_analyzer.py
@@ -11,6 +11,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import json
+import logging
 import re
 from typing import Optional
 
@@ -18,6 +19,8 @@ from codeframe.core import tasks as task_module
 from codeframe.core.workspace import Workspace
 from codeframe.core.tasks import Task
 from codeframe.adapters.llm.base import Purpose
+
+logger = logging.getLogger(__name__)
 
 
 DEPENDENCY_ANALYSIS_SYSTEM_PROMPT = """You are a software project task analyzer. Your job is to analyze a list of development tasks and identify dependencies between them.
@@ -198,19 +201,57 @@ def apply_inferred_dependencies(
     workspace: Workspace,
     dependencies: dict[str, list[str]],
 ) -> None:
-    """Apply inferred dependencies to tasks in the workspace.
+    """Merge inferred dependencies into each task's existing ``depends_on``.
 
-    Updates each task's depends_on field with the inferred dependencies.
-    Only updates tasks that have non-empty dependency lists to preserve
-    any existing manual/explicit dependencies.
+    Inferred edges are **added to** the task's current dependencies, never
+    substituted for them. ``update_depends_on`` replaces the list wholesale, so
+    passing the inferred list straight through silently discarded a
+    hand-curated dependency — and persisted the loss for every future run
+    (#959). Existing edges keep their order and come first.
+
+    An inferred edge that would close a cycle is dropped with a warning: the
+    merge can create one that neither set had alone (manual ``A -> B`` plus
+    inferred ``B -> A``). The manual edge is explicit user intent, so the
+    inferred one loses.
 
     Args:
         workspace: Workspace containing the tasks
         dependencies: Dict mapping task_id -> list of dependency task_ids
     """
-    for task_id, deps in dependencies.items():
-        # Only update when there are inferred dependencies to apply
-        # Empty list means no dependencies found - don't clear existing ones
-        if deps:
-            task_module.update_depends_on(workspace, task_id, deps)
+    from codeframe.core.dependency_graph import detect_cycle
+
+    # Working copy of the whole workspace graph, so a cycle check sees edges
+    # added earlier in this same call.
+    graph: dict[str, list[str]] = {
+        t.id: list(t.depends_on or []) for t in task_module.list_tasks(workspace, limit=None)
+    }
+
+    for task_id, inferred in dependencies.items():
+        if not inferred:
+            # No inference for this task — leave whatever is already there.
+            continue
+        existing = graph.get(task_id)
+        if existing is None:
+            continue  # Task vanished between analysis and apply.
+
+        merged = list(existing)
+        for dep in inferred:
+            if dep == task_id or dep in merged or dep not in graph:
+                continue
+            merged.append(dep)
+            graph[task_id] = merged
+            cycle = detect_cycle(graph)
+            if cycle:
+                merged.pop()
+                graph[task_id] = merged
+                logger.warning(
+                    "Dropping inferred dependency %s -> %s: it would create a "
+                    "cycle (%s). Existing dependencies are kept.",
+                    task_id,
+                    dep,
+                    " -> ".join(cycle),
+                )
+
+        if merged != existing:
+            task_module.update_depends_on(workspace, task_id, merged)
 

--- a/codeframe/core/dependency_analyzer.py
+++ b/codeframe/core/dependency_analyzer.py
@@ -218,8 +218,6 @@ def apply_inferred_dependencies(
         workspace: Workspace containing the tasks
         dependencies: Dict mapping task_id -> list of dependency task_ids
     """
-    from codeframe.core.dependency_graph import detect_cycle
-
     # Working copy of the whole workspace graph, so a cycle check sees edges
     # added earlier in this same call.
     graph: dict[str, list[str]] = {
@@ -238,20 +236,51 @@ def apply_inferred_dependencies(
         for dep in inferred:
             if dep == task_id or dep in merged or dep not in graph:
                 continue
-            merged.append(dep)
-            graph[task_id] = merged
-            cycle = detect_cycle(graph)
-            if cycle:
-                merged.pop()
-                graph[task_id] = merged
+            path = _path_to(graph, dep, task_id)
+            if path is not None:
                 logger.warning(
                     "Dropping inferred dependency %s -> %s: it would create a "
                     "cycle (%s). Existing dependencies are kept.",
                     task_id,
                     dep,
-                    " -> ".join(cycle),
+                    " -> ".join([task_id, *path]),
                 )
+                continue
+            merged.append(dep)
+            graph[task_id] = merged
 
         if merged != existing:
             task_module.update_depends_on(workspace, task_id, merged)
+
+
+def _path_to(
+    graph: dict[str, list[str]], start: str, target: str
+) -> Optional[list[str]]:
+    """Return a dependency path from ``start`` to ``target``, or ``None``.
+
+    Adding the edge ``target -> start`` closes a cycle exactly when ``target``
+    is already reachable from ``start``. Asking that directly — rather than
+    adding the edge and running a whole-graph cycle detector — keeps the check
+    honest when the graph *already* contains an unrelated cycle: a global
+    detector would return that pre-existing cycle, so every inferred edge would
+    be dropped and the warning would blame the wrong pair. ``update_depends_on``
+    performs no cycle validation, so a pre-existing cycle is reachable.
+
+    The visited set also means a pre-existing cycle anywhere in the graph
+    terminates this walk instead of hanging it.
+    """
+    if start == target:
+        return [start]
+    stack: list[tuple[str, list[str]]] = [(start, [start])]
+    seen = {start}
+    while stack:
+        node, path = stack.pop()
+        for nxt in graph.get(node, []):
+            if nxt == target:
+                return path + [nxt]
+            if nxt in seen:
+                continue
+            seen.add(nxt)
+            stack.append((nxt, path + [nxt]))
+    return None
 

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -35,7 +35,8 @@ STATE_DB_NAME = "state.db"
 # table/column/index so existing workspaces re-enter the (idempotent)
 # migration path exactly once. Gates #733: steady-state loads skip all DDL.
 # 3: batch_runs.config_reloads (#957).
-SCHEMA_VERSION = 3
+# 4: batch_runs.cloud_timeout_minutes (#959).
+SCHEMA_VERSION = 4
 
 # Per-workspace config file written by the Settings page (issue #556).
 # Owned by the UI layer today; kept here so a future core consumer can
@@ -316,6 +317,7 @@ def _init_database(db_path: Path) -> None:
             llm_provider TEXT,
             llm_model TEXT,
             config_reloads TEXT,
+            cloud_timeout_minutes INTEGER NOT NULL DEFAULT 30,
             FOREIGN KEY (workspace_id) REFERENCES workspace(id),
             CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
         )
@@ -580,6 +582,7 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
                 llm_provider TEXT,
                 llm_model TEXT,
                 config_reloads TEXT,
+                cloud_timeout_minutes INTEGER NOT NULL DEFAULT 30,
                 FOREIGN KEY (workspace_id) REFERENCES workspace(id),
                 CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
             )
@@ -605,6 +608,8 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             ("llm_model", "ALTER TABLE batch_runs ADD COLUMN llm_model TEXT"),
             # #957: config-reload bookkeeping moved off the results JSON blob.
             ("config_reloads", "ALTER TABLE batch_runs ADD COLUMN config_reloads TEXT"),
+            # #959: the user's --cloud-timeout must survive a resume.
+            ("cloud_timeout_minutes", "ALTER TABLE batch_runs ADD COLUMN cloud_timeout_minutes INTEGER NOT NULL DEFAULT 30"),
         )
         for column, ddl in batch_migrations:
             if column not in batch_columns:

--- a/tests/core/test_batch_timeout_and_deps_959.py
+++ b/tests/core/test_batch_timeout_and_deps_959.py
@@ -250,6 +250,50 @@ class TestManualDependenciesSurvive:
         assert tasks.get(ws, b.id).depends_on == [], "cyclic inferred edge must drop"
         assert "cycle" in caplog.text.lower()
 
+    def test_a_preexisting_unrelated_cycle_does_not_block_valid_edges(self, tmp_path):
+        """The guard must blame the edge being added, not any cycle anywhere.
+
+        `update_depends_on` performs no cycle validation, so a workspace can
+        already hold one. A whole-graph cycle detector would return that
+        pre-existing cycle for every inferred edge — dropping valid, unrelated
+        edges and misattributing the cause in the warning.
+        """
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, b, c = self._three_tasks(ws)
+        d = tasks.create(ws, title="D", description="")
+
+        # Pre-existing A <-> B cycle, persisted directly (no validation stops it).
+        tasks.update_depends_on(ws, a.id, [b.id])
+        tasks.update_depends_on(ws, b.id, [a.id])
+
+        # An unrelated inferred edge C -> D must still be applied.
+        apply_inferred_dependencies(ws, {c.id: [d.id]})
+
+        assert tasks.get(ws, c.id).depends_on == [d.id]
+        # The pre-existing cycle is left exactly as it was.
+        assert tasks.get(ws, a.id).depends_on == [b.id]
+        assert tasks.get(ws, b.id).depends_on == [a.id]
+
+    def test_a_longer_cycle_is_still_caught(self, tmp_path):
+        """A -> B -> C plus inferred C -> A closes a three-node cycle."""
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, b, c = self._three_tasks(ws)
+
+        tasks.update_depends_on(ws, a.id, [b.id])
+        tasks.update_depends_on(ws, b.id, [c.id])
+
+        apply_inferred_dependencies(ws, {c.id: [a.id]})
+
+        assert tasks.get(ws, c.id).depends_on == [], "cyclic edge should be dropped"
+
     def test_docstring_matches_behaviour(self):
         from codeframe.core.dependency_analyzer import apply_inferred_dependencies
 

--- a/tests/core/test_batch_timeout_and_deps_959.py
+++ b/tests/core/test_batch_timeout_and_deps_959.py
@@ -1,0 +1,257 @@
+"""cloud_timeout_minutes plumbing + manual-dependency preservation (issue #959).
+
+Two defects:
+
+1. ``start_batch``/``create_batch`` accept ``cloud_timeout_minutes`` and the CLI
+   passes it, but it was never stored on ``BatchRun`` nor forwarded to
+   ``_execute_task_subprocess`` — so the callee default of 30 always won and
+   ``cf work batch run --engine cloud --cloud-timeout 60`` was silently
+   ignored, including after a resume.
+2. ``apply_inferred_dependencies``' docstring promised it preserves existing
+   manual dependencies, but ``update_depends_on`` replaces ``depends_on``
+   wholesale — so under ``--strategy auto`` a hand-curated dependency was
+   silently replaced by the LLM-inferred one and persisted for every future
+   run.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. cloud_timeout_minutes reaches the child command
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCloudTimeoutPlumbing:
+    def test_batchrun_carries_the_field(self):
+        from codeframe.core.conductor import BatchRun
+
+        assert "cloud_timeout_minutes" in BatchRun.__dataclass_fields__
+
+    def test_create_batch_persists_the_user_value(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.conductor import create_batch, get_batch
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        t = tasks.create(ws, title="T", description="")
+        tasks.update_status(ws, t.id, TaskStatus.READY)
+
+        batch = create_batch(
+            ws, task_ids=[t.id], engine="cloud", isolation="none",
+            cloud_timeout_minutes=60,
+        )
+        assert batch.cloud_timeout_minutes == 60
+
+        # Survives the round trip — resume must restore it.
+        reloaded = get_batch(ws, batch.id)
+        assert reloaded.cloud_timeout_minutes == 60
+
+    def test_default_is_still_30(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.conductor import create_batch, get_batch
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        t = tasks.create(ws, title="T", description="")
+        tasks.update_status(ws, t.id, TaskStatus.READY)
+
+        batch = create_batch(ws, task_ids=[t.id], engine="cloud")
+        assert get_batch(ws, batch.id).cloud_timeout_minutes == 30
+
+    def test_existing_workspace_gets_the_column_on_upgrade(self, tmp_path):
+        """A DB already stamped at the previous SCHEMA_VERSION must migrate.
+
+        `_ensure_schema_upgrades` returns early once user_version reaches
+        SCHEMA_VERSION, so adding a migration entry without bumping the version
+        leaves existing workspaces without the column — and every batch SELECT,
+        which now names it unconditionally, dies. (Learned the hard way in #957.)
+        """
+        from codeframe.core import tasks
+        from codeframe.core.conductor import create_batch, get_batch
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+        ws = create_or_load_workspace(tmp_path)
+        t = tasks.create(ws, title="T", description="")
+        tasks.update_status(ws, t.id, TaskStatus.READY)
+        batch = create_batch(ws, task_ids=[t.id], cloud_timeout_minutes=55)
+
+        # Roll back to the pre-#959 shape.
+        conn = get_db_connection(ws)
+        try:
+            conn.execute("ALTER TABLE batch_runs DROP COLUMN cloud_timeout_minutes")
+            conn.execute("PRAGMA user_version = 3")
+            conn.commit()
+        finally:
+            conn.close()
+
+        ws2 = create_or_load_workspace(tmp_path)
+        reloaded = get_batch(ws2, batch.id)
+        assert reloaded is not None
+        # Column re-added with its default; the old value is gone, which is
+        # expected — the point is that reads do not blow up.
+        assert reloaded.cloud_timeout_minutes == 30
+
+    def test_every_subprocess_call_site_forwards_it(self):
+        """All seven call sites must pass batch.cloud_timeout_minutes."""
+        import inspect
+
+        from codeframe.core import conductor
+
+        source = inspect.getsource(conductor)
+        # Exclude the definition itself.
+        calls = source.count("_execute_task_subprocess(\n") - source.count(
+            "def _execute_task_subprocess(\n"
+        )
+        forwards = source.count("cloud_timeout_minutes=batch.cloud_timeout_minutes")
+        assert calls == 7, f"call-site count changed: {calls}"
+        assert forwards == calls, (
+            f"{calls} call sites but {forwards} forward cloud_timeout_minutes"
+        )
+
+    def test_child_command_carries_the_value_after_a_resume(self, tmp_path):
+        """The acceptance criterion: resume must not silently fall back to 30."""
+        from codeframe.core import conductor, tasks
+        from codeframe.core.conductor import BatchStatus, create_batch, resume_batch
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        t = tasks.create(ws, title="T", description="")
+        tasks.update_status(ws, t.id, TaskStatus.READY)
+
+        batch = create_batch(
+            ws, task_ids=[t.id], engine="cloud", cloud_timeout_minutes=45,
+        )
+        # Mark it FAILED so resume has something to re-run.
+        batch.status = BatchStatus.FAILED
+        batch.results = {t.id: "FAILED"}
+        conductor._save_batch(ws, batch)
+
+        seen: list[list[str]] = []
+
+        def fake_popen(cmd, **kwargs):
+            seen.append(cmd)
+            raise RuntimeError("stop here — the command line is what we assert on")
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            try:
+                resume_batch(ws, batch.id)
+            except Exception:
+                pass
+
+        assert seen, "expected a child process to be launched"
+        cmd = seen[0]
+        assert "--cloud-timeout" in cmd
+        assert cmd[cmd.index("--cloud-timeout") + 1] == "45"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Manual dependencies survive inference
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestManualDependenciesSurvive:
+    def _three_tasks(self, ws):
+        from codeframe.core import tasks
+
+        a = tasks.create(ws, title="A", description="")
+        b = tasks.create(ws, title="B", description="")
+        c = tasks.create(ws, title="C", description="")
+        return a, b, c
+
+    def test_manual_dependency_is_not_replaced(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, b, c = self._three_tasks(ws)
+
+        # Hand-curated: C depends on A.
+        tasks.update_depends_on(ws, c.id, [a.id])
+        # The LLM infers C depends on B instead.
+        apply_inferred_dependencies(ws, {c.id: [b.id]})
+
+        deps = set(tasks.get(ws, c.id).depends_on)
+        assert a.id in deps, "manual dependency was wiped"
+        assert b.id in deps, "inferred dependency was not applied"
+
+    def test_inference_still_applies_when_there_are_no_manual_deps(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, b, c = self._three_tasks(ws)
+
+        apply_inferred_dependencies(ws, {c.id: [a.id, b.id]})
+        assert set(tasks.get(ws, c.id).depends_on) == {a.id, b.id}
+
+    def test_no_duplicates_when_inference_repeats_a_manual_dep(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, _b, c = self._three_tasks(ws)
+
+        tasks.update_depends_on(ws, c.id, [a.id])
+        apply_inferred_dependencies(ws, {c.id: [a.id]})
+
+        assert tasks.get(ws, c.id).depends_on == [a.id]
+
+    def test_empty_inference_leaves_manual_deps_alone(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, _b, c = self._three_tasks(ws)
+
+        tasks.update_depends_on(ws, c.id, [a.id])
+        apply_inferred_dependencies(ws, {c.id: []})
+
+        assert tasks.get(ws, c.id).depends_on == [a.id]
+
+    def test_an_inferred_edge_that_would_cycle_is_dropped(self, tmp_path, caplog):
+        """Merging can create a cycle that replacing would not.
+
+        Manual A->B plus inferred B->A is a cycle even though neither set has
+        one alone. The manual edge is user intent, so the *inferred* edge loses.
+        """
+        from codeframe.core import tasks
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a, b, _c = self._three_tasks(ws)
+
+        tasks.update_depends_on(ws, a.id, [b.id])  # manual: A depends on B
+
+        with caplog.at_level("WARNING"):
+            apply_inferred_dependencies(ws, {b.id: [a.id]})  # inferred: B on A
+
+        assert tasks.get(ws, a.id).depends_on == [b.id], "manual edge must survive"
+        assert tasks.get(ws, b.id).depends_on == [], "cyclic inferred edge must drop"
+        assert "cycle" in caplog.text.lower()
+
+    def test_docstring_matches_behaviour(self):
+        from codeframe.core.dependency_analyzer import apply_inferred_dependencies
+
+        doc = apply_inferred_dependencies.__doc__ or ""
+        assert "merge" in doc.lower() or "preserv" in doc.lower()

--- a/tests/core/test_dependency_analyzer.py
+++ b/tests/core/test_dependency_analyzer.py
@@ -231,7 +231,8 @@ class TestApplyInferredDependencies:
 
         dependencies = {
             task_ids[0]: [],  # Empty - should not overwrite existing
-            task_ids[1]: [task_ids[0]],  # This creates a cycle but we're just testing apply logic
+            # task1 -> task0 closes a cycle against the manual edge above.
+            task_ids[1]: [task_ids[0]],
         }
 
         apply_inferred_dependencies(workspace, dependencies)
@@ -240,9 +241,14 @@ class TestApplyInferredDependencies:
         updated_task0 = tasks.get(workspace, task_ids[0])
         assert updated_task0.depends_on == [task_ids[1]]  # Original dependency preserved
 
-        # Task 1 was updated since it had non-empty dependency list
+        # Task 1's inferred edge is DROPPED because it would close a cycle
+        # (#959). This assertion used to expect [task_ids[0]] — i.e. it pinned
+        # the old behaviour of persisting a known-cyclic graph, which
+        # create_execution_plan then refuses to schedule. The test's own comment
+        # acknowledged it ("this creates a cycle but we're just testing apply
+        # logic"), so the cycle was incidental to what it meant to check.
         updated_task1 = tasks.get(workspace, task_ids[1])
-        assert updated_task1.depends_on == [task_ids[0]]
+        assert updated_task1.depends_on == []
 
 
 class TestAutoStrategyIntegration:


### PR DESCRIPTION
Closes #959. Two defects, both silent — no error, just the wrong thing.

## 1. `--cloud-timeout` was accepted and dropped

`create_batch` takes `cloud_timeout_minutes` and the CLI passes it, but it was never stored on `BatchRun`. Since `execute_batch(workspace, batch)` only receives the batch, the value had no way to reach `_execute_task_subprocess`, whose default of 30 always won. `cf work batch run --engine cloud --cloud-timeout 60` did nothing.

Now a persisted `BatchRun.cloud_timeout_minutes` with its own column (DDL in both create blocks + an idempotent migration, `SCHEMA_VERSION` 3 → 4 so already-stamped workspaces actually receive it), forwarded at **all seven** `_execute_task_subprocess` call sites: serial, parallel, both supervisor retries, resume, and the two auto-strategy paths.

Persisting it is what satisfies the acceptance criterion about resume — the value has to survive a reload, not just live in the call frame:

```
child command after RESUME: ... --stall-action blocker --cloud-timeout 45
--cloud-timeout value carried through = 45     (OLD: 30, on every path)
```

A test counts call sites against forwards, so a new one added later without the parameter fails rather than silently regressing.

## 2. `--strategy auto` silently replaced hand-curated dependencies

`apply_inferred_dependencies`' docstring promised it preserved existing manual dependencies. It didn't — it passed the inferred list straight to `update_depends_on`, which replaces `depends_on` wholesale. A hand-curated edge was overwritten by whatever the LLM inferred, and persisted that way for every future run.

It now merges. Existing edges keep their order and come first; inferred ones are appended; duplicates collapse:

```
hand-curated: C depends on [A]
LLM infers  : C depends on [B]
result      : C depends on ['A', 'B']        (OLD: ['B'])

no manual deps                   manual=[]    inferred=['A'] -> ['A']
inference repeats a manual dep   manual=['A'] inferred=['A'] -> ['A']
empty inference                  manual=['A'] inferred=[]    -> ['A']
```

### Merging can create a cycle that replacing wouldn't

Manual `A → B` plus inferred `B → A` is a cycle even though neither set has one alone — so this needed handling that the wholesale replace never did. An inferred edge that would close a cycle is dropped with a warning; the manual edge is explicit user intent, so the inferred one loses:

```
hand-curated: X depends on [Y]
LLM infers  : Y depends on [X]   <- would close a cycle
result      : X -> ['Y'], Y -> []
warned      : Dropping inferred dependency <Y> -> <X>: it would create a cycle
              (<X> -> <Y> -> <X>). Existing dependencies are kept.
```

The check runs against a working copy of the whole workspace graph, so it also catches a cycle formed across several edges applied in the same call, not just a two-node flip.

## One existing test asserted the old behaviour

`tests/core/test_dependency_analyzer.py::test_only_updates_tasks_with_dependencies` deliberately built a cycle and asserted it was persisted. Its own comment called that incidental — *"this creates a cycle but we're just testing apply logic"* — and `create_execution_plan` refuses to schedule a cyclic graph, so the assertion was pinning a bug rather than protecting behaviour.

I changed the assertion to expect the edge dropped, and left the reasoning in the test body rather than deleting it, so the change is visible to the next reader. The test's actual subject (an empty inferred list must not clear existing deps) is untouched and still passes. Flagging it explicitly since editing a test to make a change pass is normally the wrong move.

## Verification

- 12 new tests in `tests/core/test_batch_timeout_and_deps_959.py`; 7 fail on `main`.
- Includes an upgrade-path test (drop the column, stamp `user_version` back to 3, reopen) — a fresh workspace runs the full DDL and would never have caught a missing `SCHEMA_VERSION` bump.
- `uv run pytest tests/core/ tests/cli/` → **4227 passed**, 13 skipped
- `uv run ruff check codeframe/ tests/` → clean
- `codex review --base main` → no findings (first pass)
- Demo of both criteria against real workspaces/SQLite in the PR discussion below.

## Known limitations

- Rolling a workspace back to a pre-#959 build after this migration leaves the column present but unread — harmless, but the stored value is lost if the column is later dropped and re-added (the upgrade test asserts reads survive, not that the value does).
- The cycle guard drops the offending inferred edge and keeps going; it does not try to find an alternative ordering that would satisfy both. Given the manual edge wins by design, there isn't one to find.
- `update_depends_on`'s docstring still claims it raises on "circular dependency detected" — it validates existence and self-reference only. The cycle check added here lives in the caller. Correcting that docstring (or adding the check) is out of scope for this issue but worth a follow-up.
