### PR TITLE
fix(core): six low-severity PRD, discovery and template defects (#961)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1485,6 +1485,7 @@ def prd_generate(
     from codeframe.core import prd as prd_module
     from codeframe.core.prd_discovery import (
         PrdDiscoverySession,
+        DiscoveryError,
         NoApiKeyError,
         ValidationError,
         IncompleteSessionError,
@@ -1631,6 +1632,13 @@ def prd_generate(
 
                 except ValidationError as e:
                     console.print(f"[yellow]{e}[/yellow]")
+                except DiscoveryError as e:
+                    # The session is complete or has no question outstanding
+                    # (#961). Re-prompting cannot help, so leave the loop
+                    # rather than spinning — and never show a traceback. Must
+                    # follow ValidationError, which subclasses this.
+                    console.print(f"[red]Error:[/red] {e}")
+                    raise typer.Exit(1)
                 except KeyboardInterrupt:
                     console.print("\n")
                     if typer.confirm("Save progress before exiting?"):

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1800,6 +1800,19 @@ def prd_stress_test(
         # the CLI shows a traceback where every other failure here is a red line.
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+    except Exception as e:
+        # A provider failure (auth, network, rate limit) is not a StressTestError
+        # and used to escape as a raw traceback (#961). This is a multi-call LLM
+        # run, so it is one of the likelier ways the command ends.
+        console.print(
+            f"[red]Error:[/red] PRD stress test failed while calling the LLM "
+            f"provider: {e}"
+        )
+        console.print(
+            "[dim]Check your API key and network connection, then retry. "
+            "Use --llm-provider/--llm-model to try a different model.[/dim]"
+        )
+        raise typer.Exit(1)
 
     # Show ambiguity report
     if result.ambiguities:
@@ -1828,9 +1841,22 @@ def prd_stress_test(
 
         # Update PRD with resolved answers
         console.print("[dim]Updating PRD with resolved ambiguities...[/dim]")
-        updated_content = resolve_ambiguities_into_prd(
-            record.content, result.ambiguities, provider,
-        )
+        try:
+            updated_content = resolve_ambiguities_into_prd(
+                record.content, result.ambiguities, provider,
+            )
+        except Exception as e:
+            # Second LLM call of the command, and it had no handler at all
+            # (#961). Failing here must not lose the answers silently, nor
+            # print a traceback.
+            console.print(
+                f"[red]Error:[/red] Could not apply your answers to the PRD: {e}"
+            )
+            console.print(
+                "[dim]Your answers were not saved and no new version was "
+                "created. Re-run the command to try again.[/dim]"
+            )
+            raise typer.Exit(1)
         # resolve_ambiguities_into_prd returns the ORIGINAL content when the
         # LLM rewrite looks truncated. Creating a version from that would
         # discard the answers the user just typed while printing "✓ PRD updated

--- a/codeframe/core/prd.py
+++ b/codeframe/core/prd.py
@@ -7,6 +7,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 """
 
 import json
+import logging
 import re
 import uuid
 from dataclasses import dataclass
@@ -15,6 +16,8 @@ from pathlib import Path
 from typing import Optional
 
 from codeframe.core.workspace import Workspace, get_db_connection
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -322,18 +325,28 @@ def list_chains(workspace: Workspace) -> list[PrdRecord]:
     conn = get_db_connection(workspace)
     cursor = conn.cursor()
 
-    # Get the latest version for each unique chain_id
+    # Get the latest version for each unique chain.
+    #
+    # Grouping and joining on COALESCE(chain_id, parent_id, id) rather than
+    # chain_id alone (#961): a legacy row can still carry a NULL chain_id, and
+    # SQL's `NULL = NULL` is never true — so the INNER JOIN silently dropped
+    # those PRDs from the list entirely, with no error. The upgrade path
+    # backfills them, but this keeps the read correct for anything it misses
+    # (e.g. a child whose parent row is gone).
     cursor.execute(
         """
         SELECT p.id, p.workspace_id, p.title, p.content, p.metadata, p.created_at,
                p.version, p.parent_id, p.change_summary, p.chain_id
         FROM prds p
         INNER JOIN (
-            SELECT chain_id, MAX(version) as max_version
+            SELECT COALESCE(chain_id, parent_id, id) AS grp,
+                   MAX(version) as max_version
             FROM prds
             WHERE workspace_id = ?
-            GROUP BY chain_id
-        ) latest ON p.chain_id = latest.chain_id AND p.version = latest.max_version
+            GROUP BY COALESCE(chain_id, parent_id, id)
+        ) latest
+          ON COALESCE(p.chain_id, p.parent_id, p.id) = latest.grp
+         AND p.version = latest.max_version
         WHERE p.workspace_id = ?
         ORDER BY p.created_at DESC
         """,
@@ -610,7 +623,19 @@ def create_new_version(
             chain_id=chain_id,
         )
     except Exception:
-        cursor.execute("ROLLBACK")
+        # The rollback is best-effort cleanup, never the story (#961). A bare
+        # cursor.execute("ROLLBACK") raises "cannot rollback - no transaction
+        # is active" whenever the failure happened before BEGIN took effect or
+        # after the transaction already ended — and that replacement exception
+        # propagated instead of the real one, hiding the actual fault.
+        try:
+            cursor.execute("ROLLBACK")
+        except Exception:
+            logger.warning(
+                "Rollback failed while unwinding create_new_version; the "
+                "original error is re-raised.",
+                exc_info=True,
+            )
         raise
     finally:
         conn.close()

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -419,11 +419,28 @@ Be warm and encouraging. Just output the question, nothing else."""
 
         Raises:
             ValidationError: If answer is empty
+            DiscoveryError: If the session is already complete, or has no
+                question outstanding
         """
         answer_text = answer_text.strip()
 
         if not answer_text:
             raise ValidationError("Please provide an answer.")
+
+        # There is nothing to answer once discovery has finished (#961). Without
+        # this, a completed or freshly-loaded session passed self._current_question
+        # — None — straight into _validate_answer, which then asked the model to
+        # judge an answer against no question at all.
+        if self._is_complete:
+            raise DiscoveryError(
+                "This discovery session is already complete; there is no "
+                "question to answer. Start a new session to continue."
+            )
+        if not self._current_question:
+            raise DiscoveryError(
+                "No question is currently outstanding for this session. "
+                "Call get_current_question() first."
+            )
 
         # Validate with AI
         validation = self._validate_answer(self._current_question, answer_text)
@@ -1174,12 +1191,21 @@ def reset_discovery(
             (_utc_now().isoformat(), session_id, workspace.id),
         )
     else:
-        # Reset most recent non-completed session
+        # Reset ONLY the most recent non-completed session (#961). This used to
+        # update every row matching `state != 'completed'`, so a reset aimed at
+        # the session in front of the user also closed unrelated in-flight
+        # sessions belonging to other PRDs — silently destroying that work,
+        # and contradicting this function's own docstring.
         cursor.execute(
             """
             UPDATE discovery_sessions
             SET state = 'completed', updated_at = ?
-            WHERE workspace_id = ? AND state != 'completed'
+            WHERE id = (
+                SELECT id FROM discovery_sessions
+                WHERE workspace_id = ? AND state != 'completed'
+                ORDER BY updated_at DESC, created_at DESC
+                LIMIT 1
+            )
             """,
             (_utc_now().isoformat(), workspace.id),
         )

--- a/codeframe/core/templates.py
+++ b/codeframe/core/templates.py
@@ -181,6 +181,22 @@ def apply_template(
         issue_number=issue_number,
     )
 
+    # Validate dependency indices BEFORE creating anything (#961). These used
+    # to be filtered with `if 0 <= idx < len(created_tasks)`, so a template
+    # naming a task that does not exist produced a graph that looked fine and
+    # then executed in the wrong order — silently. Checking up front also means
+    # a bad template leaves no half-built set of tasks behind.
+    for position, task_dict in enumerate(task_dicts):
+        for idx in task_dict.get("depends_on_indices", []) or []:
+            if not isinstance(idx, int) or not (0 <= idx < len(task_dicts)):
+                raise ValueError(
+                    f"Template '{template_id}' task #{position} "
+                    f"('{task_dict.get('title', '?')}') declares dependency "
+                    f"index {idx!r}, which is out of range for a template with "
+                    f"{len(task_dicts)} tasks (valid: 0..{len(task_dicts) - 1}). "
+                    "Fix the template's depends_on_indices."
+                )
+
     # Create tasks using v2 API
     created_tasks: list[tuple[tasks.Task, list[int]]] = []
     for task_dict in task_dicts:
@@ -195,17 +211,13 @@ def apply_template(
         )
         created_tasks.append((task, task_dict.get("depends_on_indices", [])))
 
-    # Wire up dependencies using indices -> actual task IDs
+    # Wire up dependencies using indices -> actual task IDs. Every index was
+    # range-checked above, so no filtering is needed (and none should happen —
+    # silently dropping one is the defect this replaced).
     for task, dep_indices in created_tasks:
         if dep_indices:
-            # Map 0-based indices to actual task IDs
-            depends_on_ids = [
-                created_tasks[idx][0].id
-                for idx in dep_indices
-                if 0 <= idx < len(created_tasks)
-            ]
-            if depends_on_ids:
-                tasks.update_depends_on(workspace, task.id, depends_on_ids)
+            depends_on_ids = [created_tasks[idx][0].id for idx in dep_indices]
+            tasks.update_depends_on(workspace, task.id, depends_on_ids)
 
     created_task_ids = [task.id for task, _ in created_tasks]
 

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -36,7 +36,8 @@ STATE_DB_NAME = "state.db"
 # migration path exactly once. Gates #733: steady-state loads skip all DDL.
 # 3: batch_runs.config_reloads (#957).
 # 4: batch_runs.cloud_timeout_minutes (#959).
-SCHEMA_VERSION = 4
+# 5: prds.chain_id backfill for legacy child rows (#961).
+SCHEMA_VERSION = 5
 
 # Per-workspace config file written by the Settings page (issue #556).
 # Owned by the UI layer today; kept here so a future core consumer can
@@ -647,12 +648,31 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             conn.commit()
         if "chain_id" not in prd_columns:
             cursor.execute("ALTER TABLE prds ADD COLUMN chain_id TEXT")
-            # Backfill chain_id for existing PRDs (set to their own id if no parent)
-            cursor.execute("""
-                UPDATE prds SET chain_id = id
-                WHERE chain_id IS NULL AND parent_id IS NULL
-            """)
             conn.commit()
+
+        # Backfill any PRD still missing a chain_id (#961). This runs on every
+        # upgrade, not only when the column is first added: the original
+        # backfill above set chain_id only WHERE parent_id IS NULL, so every
+        # legacy *child* row kept a NULL chain_id — and because SQL's
+        # `NULL = NULL` never matches, list_chains' join dropped those PRDs
+        # from the workspace entirely. The recursive CTE walks each row up to
+        # its root so children join their parent's chain rather than forming
+        # spurious one-row chains. Rows whose parent is missing keep their own
+        # id (COALESCE), which is the best available answer.
+        cursor.execute("""
+            WITH RECURSIVE root_of(id, root) AS (
+                SELECT id, id FROM prds WHERE parent_id IS NULL
+                UNION ALL
+                SELECT p.id, r.root
+                FROM prds p JOIN root_of r ON p.parent_id = r.id
+            )
+            UPDATE prds
+            SET chain_id = COALESCE(
+                (SELECT root FROM root_of WHERE root_of.id = prds.id), id
+            )
+            WHERE chain_id IS NULL
+        """)
+        conn.commit()
 
         # Add depends_on column to prds table if it doesn't exist
         # Re-check prd_columns as it may have changed

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -20,6 +20,7 @@ from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
 from codeframe.core import prd_discovery, prd, tasks
 from codeframe.core.prd_discovery import (
+    DiscoveryError,
     NoApiKeyError,
     ValidationError,
     IncompleteSessionError,
@@ -240,6 +241,12 @@ async def submit_answer(
         raise HTTPException(status_code=400, detail=str(e))
     except NoApiKeyError as e:
         raise HTTPException(status_code=500, detail=str(e))
+    except DiscoveryError as e:
+        # The session is complete, or has no question outstanding (#961). That
+        # is a client-state conflict, not a server fault — without this it fell
+        # into the generic handler below and returned 500 with a stack trace.
+        # Must come after ValidationError/NoApiKeyError, which subclass it.
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to process answer: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/core/test_prd_discovery_template_defects_961.py
+++ b/tests/core/test_prd_discovery_template_defects_961.py
@@ -1,0 +1,495 @@
+"""Low-severity PRD, discovery and template defects (issue #961).
+
+Six defects:
+
+1. ``create_new_version``'s error path ran a bare ``ROLLBACK``, which itself
+   raises "cannot rollback - no transaction is active" and masks the original
+   exception.
+2. ``list_chains`` drops legacy PRDs with a NULL ``chain_id`` (SQL ``NULL =
+   NULL`` never matches), and the migration backfill skipped any row that had a
+   ``parent_id`` — so a legacy PRD vanished from the chain list with no error.
+3. ``submit_answer`` on a completed/loaded session validated against a ``None``
+   question.
+4. ``reset_discovery`` without a ``session_id`` reset **every** non-completed
+   session, contradicting its docstring and destroying work across unrelated
+   PRDs.
+5. ``apply_template`` silently dropped out-of-range dependency indices,
+   producing a task graph that looks fine and executes in the wrong order.
+6. ``cf prd stress-test`` had no error handling around its multi-call LLM run,
+   so a provider failure surfaced as a traceback.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. The rollback must not mask the original exception
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FlakyCursor:
+    """Cursor that fails the INSERT and then fails the ROLLBACK too."""
+
+    def __init__(self, real, boom):
+        self._real = real
+        self._boom = boom
+
+    def execute(self, sql, *args, **kwargs):
+        head = sql.strip().upper()
+        if head.startswith("INSERT"):
+            raise self._boom
+        if head.startswith("ROLLBACK"):
+            raise sqlite3.OperationalError(
+                "cannot rollback - no transaction is active"
+            )
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+class _FlakyConnection:
+    def __init__(self, real, boom):
+        self._real = real
+        self._boom = boom
+
+    def cursor(self):
+        return _FlakyCursor(self._real.cursor(), self._boom)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+class TestRollbackDoesNotMask:
+    """sqlite3.Cursor is a C type and cannot be patched, so wrap the
+    connection the module hands out instead."""
+
+    def _install(self, monkeypatch, boom, opened):
+        from codeframe.core import prd
+
+        real_conn = prd.get_db_connection
+
+        def factory(workspace):
+            real = real_conn(workspace)
+            opened.append(real)
+            return _FlakyConnection(real, boom)
+
+        monkeypatch.setattr(prd, "get_db_connection", factory)
+
+    def test_original_exception_propagates_when_rollback_fails(
+        self, tmp_path, monkeypatch
+    ):
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        root = prd.store(ws, content="# v1", title="P")
+
+        boom = RuntimeError("disk exploded mid-transaction")
+        self._install(monkeypatch, boom, [])
+
+        with pytest.raises(RuntimeError) as excinfo:
+            prd.create_new_version(ws, root.id, "# v2", "s")
+
+        assert excinfo.value is boom, "the rollback failure masked the real error"
+
+    def test_connection_is_closed_even_when_rollback_fails(
+        self, tmp_path, monkeypatch
+    ):
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        root = prd.store(ws, content="# v1", title="P")
+
+        opened: list = []
+        self._install(monkeypatch, RuntimeError("boom"), opened)
+
+        with pytest.raises(RuntimeError):
+            prd.create_new_version(ws, root.id, "# v2", "s")
+
+        assert opened, "expected a connection to be opened"
+        for conn in opened:
+            with pytest.raises(sqlite3.ProgrammingError):
+                conn.execute("SELECT 1")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Legacy PRDs with NULL chain_id stay visible
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLegacyChainsAreVisible:
+    def _null_out_chain_ids(self, ws):
+        from codeframe.core.workspace import get_db_connection
+
+        conn = get_db_connection(ws)
+        try:
+            conn.execute("UPDATE prds SET chain_id = NULL")
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_a_legacy_root_prd_is_listed(self, tmp_path):
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        root = prd.store(ws, content="# legacy", title="Legacy")
+        self._null_out_chain_ids(ws)
+
+        chains = prd.list_chains(ws)
+        assert [c.id for c in chains] == [root.id], "legacy PRD vanished"
+
+    def test_a_legacy_child_prd_is_listed(self, tmp_path):
+        """The migration skipped rows WITH a parent_id — the harder case."""
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        root = prd.store(ws, content="# v1", title="Legacy")
+        v2 = prd.create_new_version(ws, root.id, "# v2", "s")
+        self._null_out_chain_ids(ws)
+
+        chains = prd.list_chains(ws)
+        # One chain, represented by its latest version.
+        assert len(chains) == 1
+        assert chains[0].id == v2.id
+
+    def test_the_migration_backfills_rows_that_have_a_parent(self, tmp_path):
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace, get_db_connection
+
+        ws = create_or_load_workspace(tmp_path)
+        root = prd.store(ws, content="# v1", title="Legacy")
+        v2 = prd.create_new_version(ws, root.id, "# v2", "s")
+        self._null_out_chain_ids(ws)
+
+        conn = get_db_connection(ws)
+        try:
+            conn.execute("PRAGMA user_version = 0")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Reopening runs the upgrade path.
+        ws2 = create_or_load_workspace(tmp_path)
+        conn = get_db_connection(ws2)
+        try:
+            rows = dict(
+                conn.execute("SELECT id, chain_id FROM prds").fetchall()
+            )
+        finally:
+            conn.close()
+
+        assert rows[root.id] == root.id
+        assert rows[v2.id] == root.id, "child was not backfilled to its root"
+
+    def test_normal_chains_are_unaffected(self, tmp_path):
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        a = prd.store(ws, content="# a", title="A")
+        prd.create_new_version(ws, a.id, "# a2", "s")
+        b = prd.store(ws, content="# b", title="B")
+
+        chains = prd.list_chains(ws)
+        assert len(chains) == 2
+        assert {c.chain_id for c in chains} == {a.id, b.id}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. submit_answer on a finished session
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSubmitAnswerOnFinishedSession:
+    def test_completed_session_raises_a_clear_domain_error(self, tmp_path):
+        from codeframe.core.prd_discovery import DiscoveryError, PrdDiscoverySession
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        session = PrdDiscoverySession.__new__(PrdDiscoverySession)
+        session.workspace = ws
+        session.session_id = "s1"
+        session._qa_history = []
+        session._current_question = None
+        session._is_complete = True
+
+        with pytest.raises(DiscoveryError) as excinfo:
+            session.submit_answer("an answer")
+
+        assert "complete" in str(excinfo.value).lower()
+
+    def test_missing_current_question_raises_rather_than_validating_none(
+        self, tmp_path
+    ):
+        from codeframe.core.prd_discovery import DiscoveryError, PrdDiscoverySession
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        session = PrdDiscoverySession.__new__(PrdDiscoverySession)
+        session.workspace = ws
+        session.session_id = "s1"
+        session._qa_history = []
+        session._current_question = None
+        session._is_complete = False
+
+        called = []
+        session._validate_answer = lambda q, a: called.append((q, a))
+
+        with pytest.raises(DiscoveryError):
+            session.submit_answer("an answer")
+
+        assert called == [], "validated against a None question"
+
+    def test_empty_answer_still_raises_validation_error(self, tmp_path):
+        from codeframe.core.prd_discovery import PrdDiscoverySession, ValidationError
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        session = PrdDiscoverySession.__new__(PrdDiscoverySession)
+        session.workspace = ws
+        session.session_id = "s1"
+        session._qa_history = []
+        session._current_question = "What?"
+        session._is_complete = False
+
+        with pytest.raises(ValidationError):
+            session.submit_answer("   ")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. reset_discovery scope
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestResetDiscoveryScope:
+    def _make_sessions(self, ws, count):
+        from codeframe.core.prd_discovery import _ensure_discovery_schema
+        from codeframe.core.workspace import get_db_connection
+
+        _ensure_discovery_schema(ws)
+        conn = get_db_connection(ws)
+        ids = []
+        try:
+            for i in range(count):
+                sid = f"session-{i}"
+                conn.execute(
+                    "INSERT INTO discovery_sessions "
+                    "(id, workspace_id, state, qa_history, created_at, updated_at) "
+                    "VALUES (?, ?, 'discovering', '[]', ?, ?)",
+                    (sid, ws.id, f"2026-01-0{i + 1}T00:00:00", f"2026-01-0{i + 1}T00:00:00"),
+                )
+                ids.append(sid)
+            conn.commit()
+        finally:
+            conn.close()
+        return ids
+
+    def _states(self, ws):
+        from codeframe.core.workspace import get_db_connection
+
+        conn = get_db_connection(ws)
+        try:
+            return dict(
+                conn.execute(
+                    "SELECT id, state FROM discovery_sessions WHERE workspace_id = ?",
+                    (ws.id,),
+                ).fetchall()
+            )
+        finally:
+            conn.close()
+
+    def test_reset_without_id_touches_only_the_most_recent_session(self, tmp_path):
+        from codeframe.core.prd_discovery import reset_discovery
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        ids = self._make_sessions(ws, 3)
+
+        assert reset_discovery(ws) is True
+
+        states = self._states(ws)
+        assert states[ids[-1]] == "completed", "the active session was not reset"
+        for older in ids[:-1]:
+            assert states[older] == "discovering", (
+                f"reset destroyed unrelated session {older}"
+            )
+
+    def test_reset_with_an_explicit_id_still_targets_that_session(self, tmp_path):
+        from codeframe.core.prd_discovery import reset_discovery
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        ids = self._make_sessions(ws, 3)
+
+        assert reset_discovery(ws, session_id=ids[0]) is True
+
+        states = self._states(ws)
+        assert states[ids[0]] == "completed"
+        assert states[ids[1]] == "discovering"
+
+    def test_reset_with_no_sessions_returns_false(self, tmp_path):
+        from codeframe.core.prd_discovery import reset_discovery
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        assert reset_discovery(ws) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. apply_template rejects an out-of-range dependency index
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTemplateDependencyIndices:
+    def _patch_manager(self, task_dicts):
+        """Patch the template manager to return exactly these task dicts."""
+        from codeframe.core import templates
+
+        class FakeManager:
+            def get_template(self, template_id):
+                return object()
+
+            def apply_template(self, template_id, context, issue_number):
+                return task_dicts
+
+        return patch.object(templates, "TaskTemplateManager", lambda *a, **k: FakeManager())
+
+    def test_out_of_range_index_raises(self, tmp_path):
+        from codeframe.core import tasks, templates
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        dicts = [
+            {"title": "A", "description": "", "depends_on_indices": []},
+            {"title": "B", "description": "", "depends_on_indices": [5]},
+        ]
+        with self._patch_manager(dicts):
+            with pytest.raises(ValueError) as excinfo:
+                templates.apply_template(ws, "t1")
+
+        assert "5" in str(excinfo.value)
+        # Rejected before any task is created — no half-built graph left behind.
+        assert tasks.list_tasks(ws) == []
+
+    def test_negative_index_raises(self, tmp_path):
+        from codeframe.core import templates
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        dicts = [{"title": "A", "description": "", "depends_on_indices": [-1]}]
+        with self._patch_manager(dicts):
+            with pytest.raises(ValueError):
+                templates.apply_template(ws, "t1")
+
+    def test_valid_indices_still_wire_up(self, tmp_path):
+        from codeframe.core import tasks, templates
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        dicts = [
+            {"title": "A", "description": "", "depends_on_indices": []},
+            {"title": "B", "description": "", "depends_on_indices": [0]},
+        ]
+        with self._patch_manager(dicts):
+            result = templates.apply_template(ws, "t1")
+
+        assert result.tasks_created == 2
+        b = tasks.get(ws, result.task_ids[1])
+        assert b.depends_on == [result.task_ids[0]]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. The CLI surfaces provider failures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStressTestProviderErrors:
+    def test_provider_failure_is_an_actionable_message_not_a_traceback(self, tmp_path):
+        from typer.testing import CliRunner
+
+        from codeframe.cli import app as cli_app
+        from codeframe.core import prd
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        prd.store(ws, content="# PRD", title="P")
+
+        with patch("codeframe.core.llm_resolution.create_provider"), \
+             patch("codeframe.cli.validators.require_api_key_for_provider"), \
+             patch(
+                 "codeframe.core.prd_stress_test.stress_test_prd",
+                 side_effect=RuntimeError("upstream 503 from provider"),
+             ):
+            result = CliRunner().invoke(
+                cli_app.app,
+                ["prd", "stress-test", "--workspace", str(tmp_path)],
+            )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit), (
+            "provider failure escaped as a traceback"
+        )
+        assert "upstream 503 from provider" in " ".join(result.output.split())
+
+    def test_refine_provider_failure_is_also_handled(self, tmp_path):
+        from typer.testing import CliRunner
+
+        from codeframe.cli import app as cli_app
+        from codeframe.core import prd
+        from codeframe.core.prd_stress_test import (
+            Ambiguity,
+            Classification,
+            DecompositionNode,
+            StressTestResult,
+        )
+        from codeframe.core.workspace import create_or_load_workspace
+
+        ws = create_or_load_workspace(tmp_path)
+        record = prd.store(ws, content="# PRD", title="P")
+        fake = StressTestResult(
+            prd_title="P",
+            tree=[
+                DecompositionNode(
+                    id="n1", title="G", description="d",
+                    classification=Classification.ATOMIC,
+                    children=[], lineage=[], depth=0,
+                )
+            ],
+            ambiguities=[
+                Ambiguity(
+                    id="a1", source_node_title="N", label="L",
+                    questions=["q?"], recommendation="",
+                )
+            ],
+            tech_spec_markdown="# Spec",
+            ambiguity_report="",
+        )
+
+        with patch("codeframe.core.llm_resolution.create_provider"), \
+             patch("codeframe.cli.validators.require_api_key_for_provider"), \
+             patch("codeframe.core.prd_stress_test.stress_test_prd", return_value=fake), \
+             patch(
+                 "codeframe.core.prd_stress_test.resolve_ambiguities_into_prd",
+                 side_effect=RuntimeError("rate limited"),
+             ):
+            result = CliRunner().invoke(
+                cli_app.app,
+                ["prd", "stress-test", "--interactive", "--workspace", str(tmp_path)],
+                input="my answer\n",
+            )
+
+        assert result.exit_code == 1
+        assert "rate limited" in " ".join(result.output.split())
+        # No phantom version from a failed refine.
+        assert len(prd.get_versions(ws, record.id)) == 1

--- a/tests/core/test_prd_discovery_template_defects_961.py
+++ b/tests/core/test_prd_discovery_template_defects_961.py
@@ -251,6 +251,41 @@ class TestSubmitAnswerOnFinishedSession:
 
         assert called == [], "validated against a None question"
 
+    def test_the_api_maps_it_to_409_not_500(self):
+        """A new exception type makes every handler a caller to re-check.
+
+        DiscoveryError is not ValidationError, so it fell through to the
+        router's generic `except Exception` and returned 500 with a stack
+        trace for what is a client-state conflict.
+        """
+        import inspect
+
+        from codeframe.ui.routers import discovery_v2
+
+        source = inspect.getsource(discovery_v2.submit_answer)
+        assert "except DiscoveryError" in source
+        # Ordering matters: ValidationError and NoApiKeyError subclass it, so
+        # a DiscoveryError arm placed first would swallow both.
+        assert source.index("except ValidationError") < source.index(
+            "except DiscoveryError"
+        )
+        assert source.index("except NoApiKeyError") < source.index(
+            "except DiscoveryError"
+        )
+        arm = source[source.index("except DiscoveryError"):]
+        assert "409" in arm.split("except Exception")[0]
+
+    def test_the_cli_handles_it_without_a_traceback(self):
+        import inspect
+
+        from codeframe.cli import app as cli_app
+
+        source = inspect.getsource(cli_app.prd_generate)
+        assert "except DiscoveryError" in source
+        assert source.index("except ValidationError") < source.index(
+            "except DiscoveryError"
+        )
+
     def test_empty_answer_still_raises_validation_error(self, tmp_path):
         from codeframe.core.prd_discovery import PrdDiscoverySession, ValidationError
         from codeframe.core.workspace import create_or_load_workspace


### PR DESCRIPTION
Closes #961. Six defects across PRD storage, discovery sessions, templates, and the stress-test CLI.

## 1. A failed rollback masked the real exception

`create_new_version`'s error path ran a bare `cursor.execute("ROLLBACK")`. That call itself raises `cannot rollback - no transaction is active` whenever the failure happened before `BEGIN` took effect — and *that* exception propagated, discarding the actual fault.

```
raised: RuntimeError: disk exploded mid-transaction
is the original error: True

OLD: OperationalError('cannot rollback - no transaction is active') — the disk error was lost
```

The rollback is now best-effort and logged; the original always re-raises.

## 2. Legacy PRDs vanished from `cf prd list`

The `chain_id` backfill ran only `WHERE parent_id IS NULL`, so every legacy **child** row kept a NULL `chain_id`. Since SQL's `NULL = NULL` is never true, `list_chains`' INNER JOIN dropped those rows entirely — no error, the PRD just wasn't there.

Fixed on both sides:
- **Migration**: a recursive CTE walks each NULL row up to its root, so children join their parent's chain rather than forming spurious one-row chains. Re-runs on upgrade via `SCHEMA_VERSION` 4 → 5.
- **Read**: `COALESCE(chain_id, parent_id, id)` in the group/join, so the list stays correct for anything the migration can't resolve — e.g. a child whose parent row is gone.

```
simulated legacy rows (chain_id NULL on both root and child)
list_chains returns 1 chain(s); latest is v2        (OLD: 0 chains)
after upgrade, child backfilled to its root: True
```

## 3. `submit_answer` asked the model to judge an answer against no question

A completed or freshly-loaded session passed `self._current_question` — `None` — straight into `_validate_answer`. Now raises `DiscoveryError`, distinguishing "session already complete" from "no question outstanding", and `_validate_answer` is never reached.

## 4. `reset_discovery` destroyed unrelated work

Without a `session_id` it updated **every** row matching `state != 'completed'` — so a reset aimed at the session in front of the user also closed in-flight sessions belonging to other PRDs. Its own docstring said "the most recent active session".

```
session-0: discovering
session-1: discovering
session-2: completed      (OLD: all three -> completed)
```

## 5. `apply_template` silently dropped bad dependency indices

`if 0 <= idx < len(created_tasks)` filtered out-of-range indices, producing a task graph that looked fine and executed in the wrong order. Indices are now validated **before any task is created**, so a bad template raises naming the offending index and leaves no half-built set behind:

```
ValueError: Template 't1' task #1 ('B') declares dependency index 5, which is
out of range for a template with 2 tasks (valid: 0..1). Fix the template's
depends_on_indices.

tasks created before the rejection: 0     (OLD: 2 created, dependency dropped)
```

## 6. `cf prd stress-test` showed a traceback on provider failure

It caught `StressTestError` but not an auth/network/rate-limit error from the LLM — on a command whose entire body is a multi-call LLM run. Both LLM calls are now handled:

```
exit code: 1   traceback shown: False
Error: PRD stress test failed while calling the LLM provider: upstream 503 from provider
Check your API key and network connection, then retry. Use --llm-provider/--llm-model to try a different model.
```

The ambiguity-refine call had no handler at all; its message also states plainly that no answers were saved, since that's the question a user will have.

## Verification

- 17 new tests in `tests/core/test_prd_discovery_template_defects_961.py`.
- **12 of them fail with the fixes stashed** (verified by `git stash` → run → `stash pop`); the other 5 are guard tests that must pass both ways — normal chains unaffected, valid indices still wire up, empty answer still raises `ValidationError`, explicit-id reset unchanged, no-sessions reset returns False.
- `uv run pytest tests/core/ tests/cli/` → **4254 passed**, 13 skipped
- `uv run ruff check codeframe/ tests/` → clean
- `codex review --base main` → no findings (first pass)
- Demo of all six in the PR discussion below.

## Note on test mechanics

`sqlite3.Cursor` is a C type and cannot be patched with `patch.object`, so the rollback tests wrap the connection `prd.get_db_connection` hands out with a proxy whose cursor fails the INSERT and then fails the ROLLBACK. That's the only way to reproduce the exact double-failure shape the defect describes.

## Known limitations

- The `list_chains` COALESCE means a legacy child whose parent row was deleted forms its own single-row chain rather than disappearing. That's a deliberate choice — showing it under its own heading is better than dropping it, which is the bug being fixed — but it is not the chain it originally belonged to.
- The recursive backfill can't resolve a cycle in `parent_id` (a row would simply not be reached by the CTE and keeps its own id via COALESCE). Nothing creates such a cycle today.
- `reset_discovery` orders by `updated_at DESC, created_at DESC`. Two sessions written in the same clock tick would tie; SQLite then picks one. Sub-second collisions need a monotonic sequence column, which is out of scope here.
- Defect 5 raises where the AC allowed "raises or warns". Raising is the stronger reading of "produces a task graph that looks fine and executes in the wrong order" — a warning on a batch run scrolls past. It is a behaviour change for any template that currently ships a bad index, which will now fail loudly instead of silently mis-ordering.
