### PR TITLE
fix(auth): configuration timing and auth-disabled degradations (#963)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,6 +431,20 @@ JWT_LIFETIME_SECONDS=86400            # JWT validity window; default 24h (was 7d
                                       # expiry. The web UI also ships a CSP
                                       # (web-ui/security-headers.js) to contain
                                       # XSS-based token exfiltration.
+                                      # Read when the JWT strategy is BUILT, not
+                                      # at import (#963) — it used to be a
+                                      # module-level int(os.getenv(...)) that
+                                      # ran before .env loaded, so setting this
+                                      # the documented way silently kept the
+                                      # default. KNOWN LIMITATION: logout does
+                                      # not revoke. POST /auth/jwt/logout only
+                                      # tells the client to drop its copy;
+                                      # verification is stateless signature
+                                      # checking with no server-side denylist
+                                      # (the `sessions` table is unused), so a
+                                      # leaked token stays valid for up to this
+                                      # lifetime. This value IS the mitigation —
+                                      # lower it if tokens may leak.
 
 # Outbound webhook SSRF guard (#656, #746) — default OFF (block)
 CODEFRAME_ALLOW_PRIVATE_WEBHOOKS=1    # Allow webhook URLs whose host resolves to

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -116,7 +116,7 @@ async def get_current_user(
     # open without a ticket" — a different decision than this issue asks for.
     on_ticket_path = request is not None and _query_ticket_allowed(request.url.path)
     if not auth_required() and not on_ticket_path:
-        operator = await _local_operator_user()
+        operator = await _local_operator_user(request)
         if operator is not None:
             return operator
         logger.error(
@@ -187,7 +187,18 @@ async def _authenticate_bearer_token(token: str) -> User:
         )
 
 
-async def _local_operator_user() -> Optional[User]:
+def _app_db(request: Optional[Request]) -> Any:
+    """The control-plane Database this request will read and write."""
+    if request is None:
+        return None
+    db = getattr(getattr(request, "app", None), "state", None)
+    db = getattr(db, "db", None) if db is not None else None
+    if db is None:
+        db = getattr(getattr(request, "state", None), "db", None)
+    return db
+
+
+async def _local_operator_user(request: Optional[Request] = None) -> Optional[User]:
     """The account the auth-disabled synthetic principal acts as (#963).
 
     With ``CODEFRAME_AUTH_REQUIRED=false`` the principal used to carry
@@ -196,20 +207,68 @@ async def _local_operator_user() -> Optional[User]:
     revoke 404'd, and create 401'd because it required a JWT. The first thing a
     self-hosted evaluator tries, broken three ways.
 
-    Resolves to the lowest-id account, which is the ``admin@localhost`` row
-    every database seeds. Deliberately **not** cached: caching a row keyed to a
-    database path is the exact staleness bug this same issue fixes in
-    ``get_async_session_maker``, and this is a single indexed primary-key read.
+    Resolved from **this request's** database when one is attached, not from
+    the SQLAlchemy auth engine. The two are the same file in production but not
+    necessarily in tests or a split-database setup, and handing back an id from
+    a different database produces a foreign-key failure at write time.
+
+    Prefers the lowest-id **login-capable** account, falling back to the
+    lowest-id account overall only when none exists (a fresh local install,
+    where the seeded ``admin@localhost`` placeholder is all there is). The
+    preference matters because anything created under this identity — notably
+    an API key — outlives the auth mode that created it; see
+    ``_owner_is_login_capable`` for the other half of that guard.
+
+    Deliberately **not** cached: caching a row keyed to a database is the exact
+    staleness bug this same issue fixes in ``get_async_session_maker``.
 
     Returns ``None`` when no user row exists at all, which callers surface as
     401 rather than inventing an identity.
     """
+    from codeframe.auth.manager import DISABLED_PASSWORD
+
+    db = _app_db(request)
+    if db is not None:
+        try:
+            row = db.conn.execute(
+                "SELECT id, email, is_active, is_superuser FROM users "
+                "WHERE hashed_password != ? ORDER BY id LIMIT 1",
+                (DISABLED_PASSWORD,),
+            ).fetchone()
+            if row is None:
+                row = db.conn.execute(
+                    "SELECT id, email, is_active, is_superuser FROM users "
+                    "ORDER BY id LIMIT 1"
+                ).fetchone()
+        except Exception as e:
+            logger.error("Could not resolve the local operator account: %s", e)
+            return None
+        if row is None:
+            return None
+        user = User()
+        user.id = row[0]
+        user.email = row[1]
+        user.is_active = bool(row[2])
+        user.is_superuser = bool(row[3])
+        user.hashed_password = ""
+        return user
+
+    # No request-scoped database: fall back to the auth engine.
     from sqlalchemy import select
 
     from codeframe.auth.manager import get_async_session_maker
 
     async_session_maker = get_async_session_maker()
     async with async_session_maker() as session:
+        result = await session.execute(
+            select(User)
+            .where(User.hashed_password != DISABLED_PASSWORD)
+            .order_by(User.id)
+            .limit(1)
+        )
+        user = result.scalar_one_or_none()
+        if user is not None:
+            return user
         result = await session.execute(select(User).order_by(User.id).limit(1))
         return result.scalar_one_or_none()
 
@@ -337,6 +396,39 @@ def _owner_is_active(db: Any, user_id: Any) -> bool:
         return False
 
     return bool(row[0]) if row is not None else False
+
+
+def _owner_is_login_capable(db: Any, user_id: Any) -> bool:
+    """Whether the key's owner is an account someone can actually log in as.
+
+    Guards a cross-mode escalation (#963 review): with auth disabled, key
+    creation is attributed to the local operator, which on a fresh install is
+    the seeded ``admin@localhost`` placeholder — ``is_active=1``,
+    ``is_superuser=1``, and a password of ``!DISABLED!`` that no one can use.
+    A key minted that way is a durable admin credential created without anyone
+    authenticating; when auth is later switched on and the server exposed, it
+    would keep working, because key auth otherwise checks only is_active and
+    is_superuser.
+
+    Enforced only while auth is required — with auth off the placeholder IS the
+    operator, and refusing it would re-break the flow this issue fixes.
+
+    Fails closed: a missing or unreadable row denies.
+    """
+    if not auth_required():
+        return True
+    try:
+        from codeframe.auth.manager import DISABLED_PASSWORD
+
+        row = db.conn.execute(
+            "SELECT hashed_password FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+    except Exception as e:
+        logger.error(f"Could not verify API key owner's login capability: {e}")
+        return False
+    if row is None:
+        return False
+    return row[0] != DISABLED_PASSWORD
 
 
 def _scopes_within_owner_grant(db: Any, key_record: Dict[str, Any]) -> list:
@@ -554,6 +646,18 @@ def _resolve_api_key(api_key: str, request: Optional[Request]) -> Optional[Dict[
             )
             return None
 
+        # A key owned by an account nobody can log in as is not a credential
+        # anyone authenticated to create (#963 review). Refused while auth is
+        # enforced, so a key minted in local auth-off mode cannot survive into
+        # an exposed deployment.
+        if not _owner_is_login_capable(db, key_record["user_id"]):
+            logger.warning(
+                "API key auth failed: owner (user_id=%s) cannot log in "
+                "(placeholder account); refusing while auth is enforced.",
+                key_record["user_id"],
+            )
+            return None
+
         # Refresh last_used_at at most once per key per window (#902) — this is
         # an UPDATE+COMMIT, and doing it on every request made each
         # authenticated call a database writer.
@@ -641,7 +745,7 @@ async def require_auth(
     if not auth_required():
         # A stable, real user_id (#963): api_keys.user_id is a NOT NULL foreign
         # key, so None made list/create/revoke fail in three different ways.
-        operator = await _local_operator_user()
+        operator = await _local_operator_user(request)
         return _resolve({
             "type": "disabled",
             "user_id": getattr(operator, "id", None),

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -229,29 +229,9 @@ async def _local_operator_user(request: Optional[Request] = None) -> Optional[Us
 
     db = _app_db(request)
     if db is not None:
-        try:
-            row = db.conn.execute(
-                "SELECT id, email, is_active, is_superuser FROM users "
-                "WHERE hashed_password != ? ORDER BY id LIMIT 1",
-                (DISABLED_PASSWORD,),
-            ).fetchone()
-            if row is None:
-                row = db.conn.execute(
-                    "SELECT id, email, is_active, is_superuser FROM users "
-                    "ORDER BY id LIMIT 1"
-                ).fetchone()
-        except Exception as e:
-            logger.error("Could not resolve the local operator account: %s", e)
-            return None
-        if row is None:
-            return None
-        user = User()
-        user.id = row[0]
-        user.email = row[1]
-        user.is_active = bool(row[2])
-        user.is_superuser = bool(row[3])
-        user.hashed_password = ""
-        return user
+        # Offloaded like _resolve_api_key: db.conn.execute is blocking sqlite,
+        # and this runs on every request while auth is disabled.
+        return await run_in_threadpool(_local_operator_row, db, DISABLED_PASSWORD)
 
     # No request-scoped database: fall back to the auth engine. Best-effort —
     # an unreachable or unmigrated database means "no operator to act as", not
@@ -265,20 +245,53 @@ async def _local_operator_user(request: Optional[Request] = None) -> Optional[Us
 
         async_session_maker = get_async_session_maker()
         async with async_session_maker() as session:
+            base = select(User).where(User.is_active.is_(True))
             result = await session.execute(
-                select(User)
-                .where(User.hashed_password != DISABLED_PASSWORD)
+                base.where(User.hashed_password != DISABLED_PASSWORD)
                 .order_by(User.id)
                 .limit(1)
             )
             user = result.scalar_one_or_none()
             if user is not None:
                 return user
-            result = await session.execute(select(User).order_by(User.id).limit(1))
+            result = await session.execute(base.order_by(User.id).limit(1))
             return result.scalar_one_or_none()
     except Exception as e:
         logger.debug("No local operator account resolvable: %s", e)
         return None
+
+
+def _local_operator_row(db: Any, disabled_password: str) -> Optional[User]:
+    """Blocking half of :func:`_local_operator_user`. Runs on a worker thread.
+
+    Only ``is_active`` accounts are eligible. Every other identity path in this
+    module enforces that — ``_load_active_user`` for JWTs, ``_owner_is_active``
+    for API keys — and nothing downstream re-checks the resolved operator, so
+    without it a deactivated account would still be handed read+write+admin.
+    """
+    try:
+        row = db.conn.execute(
+            "SELECT id, email, is_active, is_superuser FROM users "
+            "WHERE is_active = 1 AND hashed_password != ? ORDER BY id LIMIT 1",
+            (disabled_password,),
+        ).fetchone()
+        if row is None:
+            row = db.conn.execute(
+                "SELECT id, email, is_active, is_superuser FROM users "
+                "WHERE is_active = 1 ORDER BY id LIMIT 1"
+            ).fetchone()
+    except Exception as e:
+        logger.error("Could not resolve the local operator account: %s", e)
+        return None
+    if row is None:
+        return None
+    user = User()
+    user.id = row[0]
+    user.email = row[1]
+    user.is_active = bool(row[2])
+    user.is_superuser = bool(row[3])
+    user.hashed_password = ""
+    return user
 
 
 async def _load_active_user(user_id: int) -> User:
@@ -806,8 +819,16 @@ async def authenticate_websocket(
     session-chat sockets cannot drift from the REST behavior of ``require_auth()``:
 
     - When auth is disabled (``CODEFRAME_AUTH_REQUIRED`` falsy), returns
-      ``(True, None)`` without requiring a ticket — the same synthetic local
-      principal (``user_id=None``) REST admits in no-auth mode.
+      ``(True, None)`` without requiring a ticket.
+
+      **This no longer matches REST.** Since #963 the REST no-auth principal
+      resolves to a real account (``_local_operator_user``) so that API-key
+      operations, which need a NOT NULL ``users.id``, work at all. WebSocket
+      auth still admits an anonymous ``user_id=None``. The divergence is
+      deliberate for now: nothing on these sockets writes a row keyed to the
+      principal, so there is no foreign key to satisfy and no durable artifact
+      to attribute — the reason REST needed a real id does not apply here.
+      Align them if a WS path ever persists per-user state.
     - Otherwise redeems the ``?ticket=<value>`` query parameter — a short-lived,
       single-use value minted by ``POST /auth/stream-ticket`` (issue #745), not
       a JWT — then loads the active DB user it names. On success returns

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -253,24 +253,32 @@ async def _local_operator_user(request: Optional[Request] = None) -> Optional[Us
         user.hashed_password = ""
         return user
 
-    # No request-scoped database: fall back to the auth engine.
-    from sqlalchemy import select
+    # No request-scoped database: fall back to the auth engine. Best-effort —
+    # an unreachable or unmigrated database means "no operator to act as", not
+    # a failed request. Letting OperationalError escape here turned "auth is
+    # disabled, let them through" into a 500 wherever DATABASE_PATH pointed at
+    # nothing usable.
+    try:
+        from sqlalchemy import select
 
-    from codeframe.auth.manager import get_async_session_maker
+        from codeframe.auth.manager import get_async_session_maker
 
-    async_session_maker = get_async_session_maker()
-    async with async_session_maker() as session:
-        result = await session.execute(
-            select(User)
-            .where(User.hashed_password != DISABLED_PASSWORD)
-            .order_by(User.id)
-            .limit(1)
-        )
-        user = result.scalar_one_or_none()
-        if user is not None:
-            return user
-        result = await session.execute(select(User).order_by(User.id).limit(1))
-        return result.scalar_one_or_none()
+        async_session_maker = get_async_session_maker()
+        async with async_session_maker() as session:
+            result = await session.execute(
+                select(User)
+                .where(User.hashed_password != DISABLED_PASSWORD)
+                .order_by(User.id)
+                .limit(1)
+            )
+            user = result.scalar_one_or_none()
+            if user is not None:
+                return user
+            result = await session.execute(select(User).order_by(User.id).limit(1))
+            return result.scalar_one_or_none()
+    except Exception as e:
+        logger.debug("No local operator account resolvable: %s", e)
+        return None
 
 
 async def _load_active_user(user_id: int) -> User:

--- a/codeframe/auth/dependencies.py
+++ b/codeframe/auth/dependencies.py
@@ -106,6 +106,24 @@ async def get_current_user(
         if ticket:
             return await _authenticate_stream_ticket(ticket)
 
+    # Auth disabled (local opt-out): act as the local operator rather than
+    # rejecting (#963). require_auth already degrades this way; this path did
+    # not, so POST /api/auth/api-keys returned 401 with auth switched off.
+    #
+    # Deliberately NOT applied to the ticket-gated SSE routes. Those demand a
+    # single-use ticket regardless of auth mode today, and relaxing that here
+    # would widen the change from "the api-keys router works" to "SSE streams
+    # open without a ticket" — a different decision than this issue asks for.
+    on_ticket_path = request is not None and _query_ticket_allowed(request.url.path)
+    if not auth_required() and not on_ticket_path:
+        operator = await _local_operator_user()
+        if operator is not None:
+            return operator
+        logger.error(
+            "Auth is disabled but the database holds no user row to act as; "
+            "rejecting the request."
+        )
+
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Not authenticated",
@@ -167,6 +185,33 @@ async def _authenticate_bearer_token(token: str) -> User:
             detail="Authentication failed",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+
+async def _local_operator_user() -> Optional[User]:
+    """The account the auth-disabled synthetic principal acts as (#963).
+
+    With ``CODEFRAME_AUTH_REQUIRED=false`` the principal used to carry
+    ``user_id=None``. ``api_keys.user_id`` is ``NOT NULL REFERENCES users(id)``,
+    so every key operation broke in a different way: list returned nothing,
+    revoke 404'd, and create 401'd because it required a JWT. The first thing a
+    self-hosted evaluator tries, broken three ways.
+
+    Resolves to the lowest-id account, which is the ``admin@localhost`` row
+    every database seeds. Deliberately **not** cached: caching a row keyed to a
+    database path is the exact staleness bug this same issue fixes in
+    ``get_async_session_maker``, and this is a single indexed primary-key read.
+
+    Returns ``None`` when no user row exists at all, which callers surface as
+    401 rather than inventing an identity.
+    """
+    from sqlalchemy import select
+
+    from codeframe.auth.manager import get_async_session_maker
+
+    async_session_maker = get_async_session_maker()
+    async with async_session_maker() as session:
+        result = await session.execute(select(User).order_by(User.id).limit(1))
+        return result.scalar_one_or_none()
 
 
 async def _load_active_user(user_id: int) -> User:
@@ -249,11 +294,27 @@ async def get_current_user_optional(
     """Get currently authenticated user, or None if not authenticated.
 
     Non-raising version for endpoints that optionally use authentication.
+
+    Deliberately does **not** fall back to the local-operator identity when
+    auth is disabled (#963). "Optional auth" means "tell me who authenticated,
+    if anyone" — with auth off nobody did, and inventing an identity here would
+    silently change what every optional-auth endpoint sees.
     """
-    try:
-        return await get_current_user(request, credentials)
-    except HTTPException:
-        return None
+    if credentials and getattr(credentials, "credentials", None):
+        try:
+            return await _authenticate_bearer_token(credentials.credentials)
+        except HTTPException:
+            return None
+
+    if request is not None and _query_ticket_allowed(request.url.path):
+        ticket = request.query_params.get("ticket")
+        if ticket:
+            try:
+                return await _authenticate_stream_ticket(ticket)
+            except HTTPException:
+                return None
+
+    return None
 
 
 # =============================================================================
@@ -384,28 +445,81 @@ async def get_api_key_auth(
     return await run_in_threadpool(_resolve_api_key, api_key, request)
 
 
+# Process-wide fallback database for API-key auth, keyed on the resolved
+# DATABASE_PATH (#963). Two things were wrong before: it was constructed AND
+# schema-initialised *per request*, and its default was
+# ``os.path.join(os.getcwd(), ".codeframe", "state.db")`` — so a server started
+# outside a workspace scattered SQLite files wherever it happened to run, then
+# authenticated against the empty database it had just created. There is no
+# cwd default any more; without DATABASE_PATH the key is simply refused.
+_fallback_db_lock = threading.Lock()
+_fallback_db: Any = None
+_fallback_db_path: Optional[str] = None
+
+
+def _shared_fallback_db() -> Any:
+    """Return a cached Database for DATABASE_PATH, or ``None`` if unset.
+
+    Keyed on the resolved path so a changed DATABASE_PATH rebuilds rather than
+    serving a handle to the previous database — the same staleness trap #963
+    fixes in ``get_async_session_maker``.
+    """
+    global _fallback_db, _fallback_db_path
+
+    db_path = os.getenv("DATABASE_PATH")
+    if not db_path:
+        return None
+
+    with _fallback_db_lock:
+        if _fallback_db is not None and _fallback_db_path == db_path:
+            return _fallback_db
+        if _fallback_db is not None:
+            try:
+                _fallback_db.close()
+            except Exception:
+                pass
+            _fallback_db = None
+        from codeframe.platform_store.database import Database
+
+        logger.warning(
+            "No db on app.state; using the DATABASE_PATH fallback for API-key "
+            "auth. The server should attach its control-plane store instead."
+        )
+        db = Database(db_path)
+        db.initialize()
+        _fallback_db = db
+        _fallback_db_path = db_path
+        return _fallback_db
+
+
+def reset_fallback_db() -> None:
+    """Drop the cached fallback database (tests, and DATABASE_PATH changes)."""
+    global _fallback_db, _fallback_db_path
+    with _fallback_db_lock:
+        if _fallback_db is not None:
+            try:
+                _fallback_db.close()
+            except Exception:
+                pass
+        _fallback_db = None
+        _fallback_db_path = None
+
+
 def _resolve_api_key(api_key: str, request: Optional[Request]) -> Optional[Dict[str, Any]]:
     """Blocking half of :func:`get_api_key_auth`. Runs on a worker thread."""
-    fallback_db = None
     try:
         # Get database from app state (singleton) or request state
         db = getattr(request.app.state, "db", None)
         if db is None:
             db = getattr(request.state, "db", None)
         if db is None:
-            # Fallback: create a short-lived connection. There is no request
-            # cleanup middleware, so it is closed in the finally below (#760).
-            logger.warning("No db in app.state, creating fallback connection for API key auth")
-            import os
-            from codeframe.platform_store.database import Database
-
-            db_path = os.getenv(
-                "DATABASE_PATH",
-                os.path.join(os.getcwd(), ".codeframe", "state.db")
+            db = _shared_fallback_db()
+        if db is None:
+            logger.error(
+                "API key auth attempted with no database on app.state and no "
+                "DATABASE_PATH set; rejecting the key."
             )
-            fallback_db = Database(db_path)
-            fallback_db.initialize()
-            db = fallback_db
+            return None
 
         # Extract prefix and look up key
         try:
@@ -466,9 +580,6 @@ def _resolve_api_key(api_key: str, request: Optional[Request]) -> Optional[Dict[
         # to no-auth (returns None) per this module's degrade-to-401 policy.
         logger.error(f"API key authentication error: {e}", exc_info=True)
         return None
-    finally:
-        if fallback_db is not None:
-            fallback_db.close()
 
 
 async def require_auth(
@@ -528,10 +639,14 @@ async def require_auth(
     # Auth disabled (local opt-out): return a synthetic local-admin principal
     # instead of raising. Real credentials above always take precedence.
     if not auth_required():
+        # A stable, real user_id (#963): api_keys.user_id is a NOT NULL foreign
+        # key, so None made list/create/revoke fail in three different ways.
+        operator = await _local_operator_user()
         return _resolve({
             "type": "disabled",
-            "user_id": None,
+            "user_id": getattr(operator, "id", None),
             "scopes": [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN],
+            "user": operator,
         })
 
     # No authentication provided

--- a/codeframe/auth/manager.py
+++ b/codeframe/auth/manager.py
@@ -83,7 +83,36 @@ def refresh_secret() -> str:
 # These must match the JWTStrategy defaults from FastAPI Users
 JWT_ALGORITHM = "HS256"
 JWT_AUDIENCE = ["fastapi-users:auth"]
-JWT_LIFETIME_SECONDS = int(os.getenv("JWT_LIFETIME_SECONDS", "86400"))  # 24h (#657)
+#: Fallback when JWT_LIFETIME_SECONDS is unset or unparseable. 24h (#657).
+JWT_LIFETIME_DEFAULT_SECONDS = 86400
+
+
+def jwt_lifetime_seconds() -> int:
+    """Resolve the JWT lifetime **now**, not at import (#963).
+
+    This used to be a module-level ``int(os.getenv(...))``. Import happens
+    before ``.env`` is loaded, so an operator who set JWT_LIFETIME_SECONDS the
+    documented way silently got the 24h default — a security control that did
+    not apply and never said so.
+    """
+    raw = os.getenv("JWT_LIFETIME_SECONDS")
+    if raw is None:
+        return JWT_LIFETIME_DEFAULT_SECONDS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "JWT_LIFETIME_SECONDS=%r is not an integer; using the %ss default.",
+            raw, JWT_LIFETIME_DEFAULT_SECONDS,
+        )
+        return JWT_LIFETIME_DEFAULT_SECONDS
+    if value <= 0:
+        logger.warning(
+            "JWT_LIFETIME_SECONDS=%s is not positive; using the %ss default.",
+            value, JWT_LIFETIME_DEFAULT_SECONDS,
+        )
+        return JWT_LIFETIME_DEFAULT_SECONDS
+    return value
 
 # NOTE: The default-secret warning is intentionally NOT emitted at import time.
 # Importing this module must stay silent so it never leaks onto the CLI (the
@@ -159,11 +188,20 @@ def get_engine():
 
 
 def get_async_session_maker():
-    """Get or create the async session maker."""
+    """Get or create the async session maker.
+
+    Resolves the engine FIRST (#963). This used to short-circuit on its own
+    cache, so ``get_engine``'s path-change check never ran and the maker kept
+    handing out sessions bound to the previous DATABASE_PATH. Calling
+    ``get_engine()`` first lets that check fire — it clears
+    ``_async_session_maker`` on a change — so the maker is rebuilt against the
+    database actually in effect.
+    """
     global _async_session_maker
+    engine = get_engine()
     if _async_session_maker is None:
         _async_session_maker = async_sessionmaker(
-            get_engine(),
+            engine,
             class_=AsyncSession,
             expire_on_commit=False,
         )
@@ -316,8 +354,21 @@ bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
 
 
 def get_jwt_strategy() -> JWTStrategy:
-    """JWT strategy for authentication."""
-    return JWTStrategy(secret=SECRET, lifetime_seconds=JWT_LIFETIME_SECONDS)
+    """JWT strategy for authentication.
+
+    The lifetime is resolved per call so a value loaded from ``.env`` after
+    import is honoured (#963).
+
+    **Known limitation — logout does not revoke.** ``POST /auth/jwt/logout``
+    only tells the client to drop its copy; the token itself stays valid until
+    it expires, because verification is stateless signature-checking with no
+    server-side denylist (the ``sessions`` table is unused). A leaked token is
+    therefore usable for up to JWT_LIFETIME_SECONDS. The mitigating control is
+    that lifetime — default 24h (#657), and now actually configurable — plus
+    the web UI's CSP against XSS exfiltration. Real revocation needs a
+    denylist checked on every request; tracked separately.
+    """
+    return JWTStrategy(secret=SECRET, lifetime_seconds=jwt_lifetime_seconds())
 
 
 # Authentication backend

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -50,7 +50,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     Returns:
         JWT token string
     """
-    from codeframe.auth.manager import SECRET, JWT_LIFETIME_SECONDS
+    from codeframe.auth.manager import SECRET, jwt_lifetime_seconds
 
     if secret is None:
         secret = SECRET
@@ -58,7 +58,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     payload = {
         "sub": str(user_id),  # User ID as string
         "aud": ["fastapi-users:auth"],
-        "exp": datetime.now(timezone.utc) + timedelta(seconds=JWT_LIFETIME_SECONDS),
+        "exp": datetime.now(timezone.utc) + timedelta(seconds=jwt_lifetime_seconds()),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 

--- a/tests/auth/test_api_key_auth_errors.py
+++ b/tests/auth/test_api_key_auth_errors.py
@@ -48,19 +48,52 @@ async def test_transient_db_error_surfaced_at_warning_plus(caplog):
 
 
 @pytest.mark.asyncio
-async def test_fallback_db_is_closed(monkeypatch):
-    """When no db is in state, the fallback Database is created and then closed."""
+async def test_fallback_db_is_cached_not_rebuilt_per_request(monkeypatch, tmp_path):
+    """The fallback is now process-wide, keyed on DATABASE_PATH (#963).
+
+    This replaced ``test_fallback_db_is_closed``, which asserted the fallback
+    Database was constructed and closed on every request. That per-request
+    construct-initialise-close cycle was the defect: it also defaulted to
+    ``os.getcwd()``, so a server started outside a workspace scattered SQLite
+    files and then authenticated against the empty database it had just made.
+    """
+    from codeframe.auth.dependencies import reset_fallback_db
+
     fallback = MagicMock()
-    fallback.api_keys.get_all_by_prefix.return_value = []  # key not found -> returns None
+    fallback.api_keys.get_all_by_prefix.return_value = []  # key not found
 
     ctor = MagicMock(return_value=fallback)
     monkeypatch.setattr("codeframe.platform_store.database.Database", ctor)
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "state.db"))
+    reset_fallback_db()
 
     full_key, _hash, _prefix = generate_api_key()
     request = _fake_request(app_db=None, req_db=None)
 
-    result = await get_api_key_auth(api_key=full_key, request=request)
+    assert await get_api_key_auth(api_key=full_key, request=request) is None
+    assert await get_api_key_auth(api_key=full_key, request=request) is None
 
-    assert result is None
+    # Built once across both requests, and not closed between them.
     ctor.assert_called_once()
-    fallback.close.assert_called_once()
+    fallback.close.assert_not_called()
+
+    reset_fallback_db()
+
+
+@pytest.mark.asyncio
+async def test_no_database_path_refuses_rather_than_using_cwd(monkeypatch, tmp_path):
+    """Without DATABASE_PATH the key is refused — no cwd default (#963)."""
+    from codeframe.auth.dependencies import reset_fallback_db
+
+    ctor = MagicMock()
+    monkeypatch.setattr("codeframe.platform_store.database.Database", ctor)
+    monkeypatch.delenv("DATABASE_PATH", raising=False)
+    reset_fallback_db()
+
+    full_key, _hash, _prefix = generate_api_key()
+    request = _fake_request(app_db=None, req_db=None)
+
+    assert await get_api_key_auth(api_key=full_key, request=request) is None
+    ctor.assert_not_called()
+
+    reset_fallback_db()

--- a/tests/auth/test_auth_config_timing_963.py
+++ b/tests/auth/test_auth_config_timing_963.py
@@ -232,6 +232,114 @@ class TestApiKeysWorkWithAuthDisabled:
         assert resp.status_code == 201, resp.text
 
 
+class TestAuthOffKeysDoNotSurviveIntoAnExposedDeployment:
+    """A key minted with auth off must not become a durable admin credential.
+
+    Found in review of this issue: with auth off, key creation is attributed to
+    the local operator, which on a fresh install is the seeded
+    ``admin@localhost`` placeholder — is_active=1, is_superuser=1, and a
+    password nobody can use. Turn auth on afterwards and that key kept working,
+    because key auth otherwise checks only is_active/is_superuser. A durable
+    admin credential created without anyone authenticating.
+    """
+
+    def _db_with(self, tmp_path, *, real_account: bool):
+        from codeframe.auth.manager import DISABLED_PASSWORD, reset_auth_engine
+        from codeframe.platform_store.database import Database
+
+        db_path = tmp_path / "state.db"
+        reset_auth_engine()
+        db = Database(db_path)
+        db.initialize()
+        db.conn.execute(
+            "INSERT OR REPLACE INTO users (id, email, name, hashed_password, "
+            "is_active, is_superuser, is_verified, email_verified) "
+            "VALUES (1, 'admin@localhost', 'Admin', ?, 1, 1, 1, 1)",
+            (DISABLED_PASSWORD,),
+        )
+        if real_account:
+            db.conn.execute(
+                "INSERT OR REPLACE INTO users (id, email, name, hashed_password, "
+                "is_active, is_superuser, is_verified, email_verified) "
+                "VALUES (2, 'real@example.com', 'Real', '$2b$12$abcdefghij', 1, 1, 1, 1)"
+            )
+        db.conn.commit()
+        return db, db_path
+
+    @pytest.mark.asyncio
+    async def test_a_placeholder_owned_key_is_refused_once_auth_is_on(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        from codeframe.auth import dependencies
+        from codeframe.core.api_key_service import ApiKeyService
+
+        db, db_path = self._db_with(tmp_path, real_account=False)
+        monkeypatch.setenv("DATABASE_PATH", str(db_path))
+        created = ApiKeyService(db).create_api_key(
+            user_id=1, name="local", scopes=["read", "admin"]
+        )
+
+        request = MagicMock()
+        request.app.state.db = db
+        request.state.db = db
+
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        assert await dependencies.get_api_key_auth(
+            request=request, api_key=created.key
+        ) is not None, "the key must still work in the mode that created it"
+
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        assert await dependencies.get_api_key_auth(
+            request=request, api_key=created.key
+        ) is None, "a placeholder-owned key survived into an authenticated deployment"
+
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_a_real_accounts_key_is_unaffected(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from codeframe.auth import dependencies
+        from codeframe.core.api_key_service import ApiKeyService
+
+        db, db_path = self._db_with(tmp_path, real_account=True)
+        monkeypatch.setenv("DATABASE_PATH", str(db_path))
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
+        created = ApiKeyService(db).create_api_key(
+            user_id=2, name="real", scopes=["read"]
+        )
+
+        request = MagicMock()
+        request.app.state.db = db
+        request.state.db = db
+
+        assert await dependencies.get_api_key_auth(
+            request=request, api_key=created.key
+        ) is not None
+
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_the_local_operator_prefers_a_login_capable_account(
+        self, tmp_path, monkeypatch
+    ):
+        from codeframe.auth import dependencies
+        from codeframe.auth.manager import reset_auth_engine
+
+        db, db_path = self._db_with(tmp_path, real_account=True)
+        db.close()
+        monkeypatch.setenv("DATABASE_PATH", str(db_path))
+        reset_auth_engine()
+
+        operator = await dependencies._local_operator_user()
+        assert operator is not None
+        assert operator.id == 2, "resolved the disabled placeholder over a real account"
+
+        reset_auth_engine()
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 4. The API-key fallback never writes a database into cwd
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/auth/test_auth_config_timing_963.py
+++ b/tests/auth/test_auth_config_timing_963.py
@@ -1,0 +1,297 @@
+"""Auth configuration timing and auth-disabled degradations (issue #963).
+
+Five defects:
+
+1. ``JWT_LIFETIME_SECONDS`` was read at import time — before ``.env`` is
+   loaded — so an operator who set it the documented way silently got the 24h
+   default. A security control that does not apply and never says so.
+2. ``get_async_session_maker`` cached a session maker that went stale after
+   ``DATABASE_PATH`` changed: it never consulted the engine's path-change
+   check, so it kept handing out a maker bound to the old database.
+3. With ``CODEFRAME_AUTH_REQUIRED=false`` the synthetic principal carried
+   ``user_id=None``, so ``/api/auth/api-keys`` returned an empty list, 404'd on
+   revoke, and 401'd on create — the first thing a self-hosted evaluator tries,
+   broken three ways.
+4. The API-key auth fallback constructed and schema-initialised a brand-new
+   ``Database`` under ``os.getcwd()`` per request, littering SQLite files.
+5. Logout is a no-op. Documented as a known limitation (see the test at the
+   bottom), which the acceptance criteria allow.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. JWT lifetime is read when the strategy is built
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestJwtLifetimeIsReadLate:
+    def test_env_set_after_import_is_observed(self, monkeypatch):
+        from codeframe.auth import manager
+
+        # The module is already imported — exactly the situation an operator
+        # is in when .env is loaded during server startup.
+        monkeypatch.setenv("JWT_LIFETIME_SECONDS", "3600")
+        strategy = manager.get_jwt_strategy()
+
+        assert strategy.lifetime_seconds == 3600
+
+    def test_default_is_still_24h(self, monkeypatch):
+        from codeframe.auth import manager
+
+        monkeypatch.delenv("JWT_LIFETIME_SECONDS", raising=False)
+        assert manager.get_jwt_strategy().lifetime_seconds == 86400
+
+    def test_an_unparseable_value_falls_back_to_the_default(self, monkeypatch):
+        from codeframe.auth import manager
+
+        monkeypatch.setenv("JWT_LIFETIME_SECONDS", "not-a-number")
+        assert manager.get_jwt_strategy().lifetime_seconds == 86400
+
+    def test_no_module_level_constant_freezes_the_value(self):
+        """A module-level int would be re-frozen at the next import."""
+        from codeframe.auth import manager
+
+        source = Path(manager.__file__).read_text()
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("JWT_LIFETIME_SECONDS ="):
+                assert "getenv" not in stripped, (
+                    "lifetime is still resolved at import time: " + stripped
+                )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. The session maker follows DATABASE_PATH
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSessionMakerFollowsDatabasePath:
+    def test_changing_database_path_rebuilds_the_maker(self, tmp_path, monkeypatch):
+        from codeframe.auth import manager
+
+        manager.reset_auth_engine()
+
+        first = tmp_path / "a.db"
+        monkeypatch.setenv("DATABASE_PATH", str(first))
+        maker_a = manager.get_async_session_maker()
+        engine_a = manager.get_engine()
+
+        second = tmp_path / "b.db"
+        monkeypatch.setenv("DATABASE_PATH", str(second))
+        maker_b = manager.get_async_session_maker()
+        engine_b = manager.get_engine()
+
+        assert maker_a is not maker_b, "stale session maker reused after path change"
+        assert engine_a is not engine_b
+        assert str(second) in str(engine_b.url)
+
+        manager.reset_auth_engine()
+
+    def test_same_path_reuses_the_maker(self, tmp_path, monkeypatch):
+        from codeframe.auth import manager
+
+        manager.reset_auth_engine()
+        monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "a.db"))
+
+        assert manager.get_async_session_maker() is manager.get_async_session_maker()
+
+        manager.reset_auth_engine()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. With auth off, all three API-key operations work
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def auth_off_client(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from codeframe.auth import router as auth_router
+    from codeframe.auth.manager import reset_auth_engine
+    from codeframe.platform_store.database import Database
+    from tests.conftest import setup_test_user
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setenv("DATABASE_PATH", str(db_path))
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+    reset_auth_engine()
+
+    db = Database(db_path)
+    db.initialize()
+    setup_test_user(db, user_id=1)
+
+    app = FastAPI()
+    app.include_router(auth_router.router)
+    app.state.db = db
+    yield TestClient(app, raise_server_exceptions=False)
+    db.close()
+    reset_auth_engine()
+
+
+class TestApiKeysWorkWithAuthDisabled:
+    """The first thing a self-hosted evaluator tries (#963)."""
+
+    def test_create_succeeds(self, auth_off_client):
+        resp = auth_off_client.post(
+            "/api/auth/api-keys", json={"name": "local", "scopes": ["read"]}
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["key"].startswith("cf_")
+
+    def test_list_returns_the_key_that_was_just_created(self, auth_off_client):
+        auth_off_client.post(
+            "/api/auth/api-keys", json={"name": "local", "scopes": ["read"]}
+        )
+
+        resp = auth_off_client.get("/api/auth/api-keys")
+        assert resp.status_code == 200, resp.text
+        names = [k["name"] for k in resp.json()]
+        assert names == ["local"], f"list did not see the key: {resp.json()}"
+
+    def test_revoke_succeeds(self, auth_off_client):
+        created = auth_off_client.post(
+            "/api/auth/api-keys", json={"name": "local", "scopes": ["read"]}
+        ).json()
+
+        resp = auth_off_client.delete(f"/api/auth/api-keys/{created['id']}")
+        assert resp.status_code == 200, resp.text
+
+        remaining = auth_off_client.get("/api/auth/api-keys").json()
+        assert [k for k in remaining if k["is_active"]] == []
+
+    def test_the_principal_is_stable_across_requests(self, auth_off_client):
+        """Two creates must land under the same identity, or list breaks."""
+        auth_off_client.post(
+            "/api/auth/api-keys", json={"name": "one", "scopes": ["read"]}
+        )
+        auth_off_client.post(
+            "/api/auth/api-keys", json={"name": "two", "scopes": ["read"]}
+        )
+
+        listed = auth_off_client.get("/api/auth/api-keys").json()
+        assert sorted(k["name"] for k in listed) == ["one", "two"]
+
+    def test_admin_key_creation_still_follows_the_resolved_account(
+        self, auth_off_client
+    ):
+        """Admin is a property of the user row, not of auth being off (#898).
+
+        The fixture's operator is is_superuser=0, so an admin-scoped key is
+        refused — the same rule as with auth on. A real install resolves to the
+        seeded admin@localhost row (is_superuser=1); covered below.
+        """
+        resp = auth_off_client.post(
+            "/api/auth/api-keys", json={"name": "adm", "scopes": ["read", "admin"]}
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_a_superuser_operator_may_mint_an_admin_key(self, tmp_path, monkeypatch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from codeframe.auth import router as auth_router
+        from codeframe.auth.manager import reset_auth_engine
+        from codeframe.platform_store.database import Database
+
+        db_path = tmp_path / "state.db"
+        monkeypatch.setenv("DATABASE_PATH", str(db_path))
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        reset_auth_engine()
+
+        db = Database(db_path)
+        db.initialize()
+        db.conn.execute(
+            "INSERT OR REPLACE INTO users (id, email, name, hashed_password, "
+            "is_active, is_superuser, is_verified, email_verified) "
+            "VALUES (1, 'admin@localhost', 'Admin', '!DISABLED!', 1, 1, 1, 1)"
+        )
+        db.conn.commit()
+
+        app = FastAPI()
+        app.include_router(auth_router.router)
+        app.state.db = db
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/auth/api-keys", json={"name": "adm", "scopes": ["read", "admin"]}
+        )
+        db.close()
+        reset_auth_engine()
+
+        assert resp.status_code == 201, resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. The API-key fallback never writes a database into cwd
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestApiKeyFallbackDoesNotLitter:
+    def test_no_database_is_constructed_at_cwd(self):
+        """The cwd-relative default is what created stray .codeframe dirs."""
+        import inspect
+
+        from codeframe.auth import dependencies
+
+        source = inspect.getsource(dependencies)
+        # Check executable lines only — the removal is explained in a comment
+        # that necessarily names the old call (same trap as #962's jinja test).
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if "os.getcwd()" in line.split("#", 1)[0]
+        ]
+        assert offenders == [], (
+            f"API-key auth still resolves a database path from the cwd: {offenders}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_request_without_an_app_database_creates_no_files(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from codeframe.auth import dependencies
+
+        cwd = Path.cwd()
+        os.chdir(tmp_path)
+        try:
+            request = MagicMock()
+            request.app.state.db = None
+            request.state.db = None
+            # A syntactically valid key that cannot resolve to anything.
+            await dependencies.get_api_key_auth(
+                request=request, api_key="cf_deadbeefdeadbeefdeadbeef"
+            )
+        except Exception:
+            pass  # Rejecting the key is fine; creating files is not.
+        finally:
+            os.chdir(cwd)
+
+        stray = list(tmp_path.rglob("*.db"))
+        assert stray == [], f"request created database files: {stray}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Logout's limitation is documented
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLogoutLimitationIsDocumented:
+    def test_the_no_op_is_stated_where_a_reader_will_find_it(self):
+        from codeframe.auth import manager
+
+        source = Path(manager.__file__).read_text().lower()
+        assert "logout" in source
+        # The mitigating control must be named alongside it, not left implicit.
+        window = source[source.index("logout") - 2000 : source.index("logout") + 3000]
+        assert "jwt_lifetime_seconds" in window or "lifetime" in window

--- a/tests/auth/test_auth_config_timing_963.py
+++ b/tests/auth/test_auth_config_timing_963.py
@@ -322,6 +322,38 @@ class TestAuthOffKeysDoNotSurviveIntoAnExposedDeployment:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_a_deactivated_account_is_never_the_local_operator(
+        self, tmp_path, monkeypatch
+    ):
+        """is_active must gate this like every other identity path (review).
+
+        Nothing downstream re-checks the resolved operator — it is handed
+        [read, write, admin] directly — so a deactivated lowest-id account
+        would otherwise become the local admin. `_load_active_user` (JWT) and
+        `_owner_is_active` (API keys) both enforce this; this path was the odd
+        one out.
+        """
+        from unittest.mock import MagicMock
+
+        from codeframe.auth import dependencies
+
+        db, _ = self._db_with(tmp_path, real_account=True)
+        # Deactivate the real account; only the placeholder and it exist.
+        db.conn.execute("UPDATE users SET is_active = 0 WHERE id = 2")
+        db.conn.commit()
+
+        request = MagicMock()
+        request.app.state.db = db
+        request.state.db = db
+
+        operator = await dependencies._local_operator_user(request)
+        assert operator is None or operator.id != 2, (
+            "a deactivated account was handed read+write+admin"
+        )
+
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_the_local_operator_prefers_a_login_capable_account(
         self, tmp_path, monkeypatch
     ):

--- a/tests/auth/test_auth_mode.py
+++ b/tests/auth/test_auth_mode.py
@@ -49,7 +49,12 @@ class TestRequireAuthBypass:
         monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
         result = await require_auth(api_key_auth=None, jwt_user=None)
         assert result["type"] == "disabled"
-        assert result["user_id"] is None
+        # user_id used to be None. api_keys.user_id is a NOT NULL foreign key,
+        # so that made list/create/revoke fail three different ways with auth
+        # off; the principal now resolves to the local operator row (#963).
+        # No user exists in this bare unit test, so it degrades to None here —
+        # the populated case is covered in test_auth_config_timing_963.py.
+        assert "user_id" in result
         assert result["scopes"] == [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN]
 
     @pytest.mark.asyncio

--- a/tests/auth/test_query_param_token.py
+++ b/tests/auth/test_query_param_token.py
@@ -135,13 +135,37 @@ class TestQueryParamTicketOnSSERoutes:
 
 
 class TestQueryParamTicketRejectedElsewhere:
-    def test_query_ticket_rejected_on_plain_route(self, app_with_user):
+    def test_query_ticket_rejected_on_plain_route(self, app_with_user, monkeypatch):
         """A valid ticket must NOT authenticate non-SSE routes — query
-        credentials are SSE-only (codex review P2)."""
+        credentials are SSE-only (codex review P2).
+
+        Pinned with auth ON. With auth OFF every ordinary route resolves to the
+        local operator (#963), so a 401 there would be measuring the auth mode
+        rather than the ticket rule this test exists for.
+        """
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "true")
         client = TestClient(app_with_user)
         ticket = mint_ticket(user_id=1)
         resp = client.get(f"{PLAIN_PATH}?ticket={ticket}")
         assert resp.status_code == 401
+
+    def test_query_ticket_still_does_not_identify_a_user_with_auth_off(
+        self, app_with_user, monkeypatch
+    ):
+        """With auth off the route opens, but NOT because of the ticket (#963).
+
+        The ticket must remain unredeemed: the identity comes from the
+        local-operator fallback, not from a query credential on a plain route.
+        """
+        monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+        client = TestClient(app_with_user)
+        ticket = mint_ticket(user_id=1)
+        resp = client.get(f"{PLAIN_PATH}?ticket={ticket}")
+        assert resp.status_code == 200
+        # Single-use: still redeemable, so the request did not consume it.
+        from codeframe.auth.stream_tickets import redeem_ticket
+
+        assert redeem_ticket(ticket) == 1
 
     def test_header_works_on_plain_route(self, app_with_user):
         client = TestClient(app_with_user)

--- a/tests/auth/test_stream_ticket_endpoint.py
+++ b/tests/auth/test_stream_ticket_endpoint.py
@@ -86,11 +86,20 @@ class TestStreamTicketEndpointAuthDisabled:
         body = resp.json()
         assert isinstance(body["ticket"], str) and body["ticket"]
 
-    def test_auth_disabled_ticket_redeems_to_none_user(self, auth_client, monkeypatch):
+    def test_auth_disabled_ticket_redeems_to_the_local_operator(
+        self, auth_client, monkeypatch
+    ):
+        """Was ``redeems_to_none_user`` before #963.
+
+        The auth-disabled principal now resolves to a real user row instead of
+        carrying user_id=None — that is the whole point of the change, since a
+        None identity broke every API-key operation. A ticket minted in this
+        mode therefore redeems to that operator rather than to None.
+        """
         monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
         resp = auth_client.post("/auth/stream-ticket")
         ticket = resp.json()["ticket"]
-        assert redeem_ticket(ticket) is None
+        assert redeem_ticket(ticket) == 1
 
 
 class TestStreamTicketScopeEnforcement:

--- a/tests/cli/test_api_key_commands.py
+++ b/tests/cli/test_api_key_commands.py
@@ -45,7 +45,7 @@ def db(tmp_path):
             id, email, name, hashed_password,
             is_active, is_superuser, is_verified, email_verified
         )
-        VALUES (1, 'test@example.com', 'Test User', '!DISABLED!', 1, 0, 1, 1)
+        VALUES (1, 'test@example.com', 'Test User', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 0, 1, 1)
         """
     )
     db.conn.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,7 @@ def setup_test_user(db, user_id: int = 1) -> None:
             id, email, name, hashed_password,
             is_active, is_superuser, is_verified, email_verified
         )
-        VALUES (?, 'test@example.com', 'Test User', '!DISABLED!', 1, 0, 1, 1)
+        VALUES (?, 'test@example.com', 'Test User', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 0, 1, 1)
         """,
         (user_id,),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     Returns:
         JWT token string
     """
-    from codeframe.auth.manager import SECRET, JWT_LIFETIME_SECONDS
+    from codeframe.auth.manager import SECRET, jwt_lifetime_seconds
 
     if secret is None:
         secret = SECRET
@@ -171,7 +171,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     payload = {
         "sub": str(user_id),
         "aud": ["fastapi-users:auth"],
-        "exp": datetime.now(timezone.utc) + timedelta(seconds=JWT_LIFETIME_SECONDS),
+        "exp": datetime.now(timezone.utc) + timedelta(seconds=jwt_lifetime_seconds()),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 

--- a/tests/core/test_api_key_service.py
+++ b/tests/core/test_api_key_service.py
@@ -43,8 +43,8 @@ def db(tmp_path):
             is_active, is_superuser, is_verified, email_verified
         )
         VALUES
-            (?, 'a@example.com', 'User A', '!DISABLED!', 1, 0, 1, 1),
-            (?, 'b@example.com', 'User B', '!DISABLED!', 1, 0, 1, 1)
+            (?, 'a@example.com', 'User A', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 0, 1, 1),
+            (?, 'b@example.com', 'User B', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 0, 1, 1)
         """,
         (USER_A, USER_B),
     )

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -44,7 +44,7 @@ def setup_test_user(db, user_id: int = 1) -> None:
             id, email, name, hashed_password,
             is_active, is_superuser, is_verified, email_verified
         )
-        VALUES (?, 'test@example.com', 'Test User', '!DISABLED!', 1, 0, 1, 1)
+        VALUES (?, 'test@example.com', 'Test User', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 0, 1, 1)
         """,
         (user_id,),
     )

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -18,7 +18,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     Returns:
         JWT token string
     """
-    from codeframe.auth.manager import SECRET, JWT_LIFETIME_SECONDS
+    from codeframe.auth.manager import SECRET, jwt_lifetime_seconds
 
     if secret is None:
         secret = SECRET
@@ -26,7 +26,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     payload = {
         "sub": str(user_id),
         "aud": ["fastapi-users:auth"],
-        "exp": datetime.now(timezone.utc) + timedelta(seconds=JWT_LIFETIME_SECONDS),
+        "exp": datetime.now(timezone.utc) + timedelta(seconds=jwt_lifetime_seconds()),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -45,7 +45,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     Returns:
         JWT token string
     """
-    from codeframe.auth.manager import SECRET, JWT_LIFETIME_SECONDS
+    from codeframe.auth.manager import SECRET, jwt_lifetime_seconds
 
     if secret is None:
         secret = SECRET
@@ -53,7 +53,7 @@ def create_test_jwt_token(user_id: int = 1, secret: str = None) -> str:
     payload = {
         "sub": str(user_id),
         "aud": ["fastapi-users:auth"],
-        "exp": datetime.now(timezone.utc) + timedelta(seconds=JWT_LIFETIME_SECONDS),
+        "exp": datetime.now(timezone.utc) + timedelta(seconds=jwt_lifetime_seconds()),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 

--- a/tests/ui/test_v2_auth_enforcement.py
+++ b/tests/ui/test_v2_auth_enforcement.py
@@ -173,9 +173,20 @@ def test_valid_api_key_not_401(auth_app, monkeypatch, tmp_path):
 
     db = Database(db_path)
     db.initialize()
+    # A real key belongs to a real account. The only user a fresh database
+    # seeds is the admin@localhost placeholder, whose password is the
+    # '!DISABLED!' sentinel — keys owned by an account nobody can log in as are
+    # refused while auth is enforced (#963), because that is how a key minted
+    # in local auth-off mode would otherwise survive into an exposed server.
+    db.conn.execute(
+        "INSERT OR REPLACE INTO users (id, email, name, hashed_password, "
+        "is_active, is_superuser, is_verified, email_verified) "
+        "VALUES (2, 'real@example.com', 'Real', '$2b$12$abcdefghij', 1, 1, 1, 1)"
+    )
+    db.conn.commit()
     full_key, key_hash, prefix = generate_api_key()
     db.api_keys.create(
-        user_id=1,
+        user_id=2,
         name="enforcement-test",
         key_hash=key_hash,
         prefix=prefix,

--- a/tests/ui/test_v2_scope_enforcement.py
+++ b/tests/ui/test_v2_scope_enforcement.py
@@ -51,8 +51,8 @@ def scoped_app(tmp_path, monkeypatch):
             id, email, name, hashed_password,
             is_active, is_superuser, is_verified, email_verified
         ) VALUES
-            (1, 'test@example.com', 'Test', '!DISABLED!', 1, 0, 1, 1),
-            (2, 'admin@example.com', 'Admin', '!DISABLED!', 1, 1, 1, 1)
+            (1, 'test@example.com', 'Test', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 0, 1, 1),
+            (2, 'admin@example.com', 'Admin', '$2b$12$testtesttesttesttesttestesttesttesttesttesttesttesttestte', 1, 1, 1, 1)
         """
     )
     db.conn.commit()


### PR DESCRIPTION
Closes #963. Five defects in auth configuration and the auth-disabled path.

## 1. `JWT_LIFETIME_SECONDS` never applied

It was a module-level `int(os.getenv(...))`, evaluated at import — before `.env` is loaded. An operator who set it the documented way silently got the 24h default: a security control that did not apply and never said so.

```
unset                    -> 86400s
set to 3600 after import -> 3600s      (OLD: 86400 — the value was already frozen)
unparseable              -> 86400s + a warning
```

Resolved in `jwt_lifetime_seconds()` when the strategy is built. The four test conftests that imported the frozen constant call the function instead.

## 2. The session maker outlived its database

`get_async_session_maker` short-circuited on its own cache, so `get_engine`'s path-change check — the thing that clears the maker — never ran, and sessions kept hitting the previous `DATABASE_PATH`. It now resolves the engine first.

## 3. With auth off, API keys were broken three ways

The synthetic principal carried `user_id=None`. `api_keys.user_id` is `NOT NULL REFERENCES users(id)`, so the first thing a self-hosted evaluator tries failed in three different ways: list returned nothing, revoke 404'd, create 401'd (it required a JWT).

```
create -> 201
list   -> 200, ['local']
revoke -> 200
local operator -> id=2 email=real@example.com
```

**Scoped deliberately.** The fallback is *not* applied to:
- `get_current_user_optional` — "optional auth" means "who authenticated", and nobody did. Inventing an identity there would silently change what every optional-auth endpoint sees.
- the ticket-gated SSE routes — those demand a single-use ticket in every auth mode. Relaxing that is a different decision than this issue asks for.

Admin-scoped key creation still checks `is_superuser` on the resolved row, so #898 holds.

## 4. The API-key fallback littered SQLite files

It constructed **and schema-initialised** a new `Database` per request, defaulting to `os.getcwd()` — scattering `.codeframe/state.db` wherever the server happened to start, then authenticating against the empty database it had just created. Now a process-wide cache keyed on `DATABASE_PATH`, with no cwd default: without that variable the key is refused.

```
files created under cwd: none
```

## 5. Logout stays a no-op — documented

Real revocation needs a denylist checked on every request; that is a feature, not a fix, and the AC allows documenting instead. Stated on `get_jwt_strategy` and in `CLAUDE.md` beside the setting, naming the token lifetime as the mitigating control — which item 1 finally makes configurable.

## A privilege escalation I introduced, then closed

`codex review` caught this on the first pass and it is the most important thing in the PR. With auth off, key creation is attributed to the local operator — on a fresh install, the seeded `admin@localhost` placeholder (`is_active=1`, `is_superuser=1`, password `!DISABLED!`). Turn auth on afterwards and expose the server, and that key kept working, because key auth otherwise checks only `is_active`/`is_superuser`. **A durable admin credential created without anyone authenticating.**

```
admin key minted with auth OFF, owned by the seeded placeholder
  works with auth off : True
  works with auth ON  : False   <- must be False     (OLD: True)
```

Closed on both ends, per the reviewer's two suggestions:
- `_local_operator_user` prefers the lowest-id **login-capable** account, falling back to the placeholder only when no real account exists yet.
- `_owner_is_login_capable` refuses a key whose owner carries the disabled sentinel — but only while auth is enforced, since with auth off the placeholder *is* the operator. This half also covers keys created before this change.

## A second flaw the full suite surfaced

My first version of `_local_operator_user` read the SQLAlchemy auth engine while the request writes to `request.app.state.db`. Same file in production, different in tests and any split-database setup — so the resolved id could fail a foreign key at write time (29 failures in `test_interactive_sessions_api.py`). It now resolves from the request's own database.

## Test fixtures, not the guard

Six fixtures seeded ordinary API-key owners with `'!DISABLED!'` as a convenience. That string means "cannot log in", so using it for accounts meant to be ordinary is what collided with the new guard. They now carry a bcrypt-shaped placeholder. `tests/api/conftest.py` keeps the sentinel — it seeds `admin@localhost` deliberately.

Four existing tests asserted the old behaviour and were updated **with the reasoning inline**: the per-request fallback close (that cycle is the defect), the `user_id=None` principal (×2), and a plain-route ticket rejection that now needs auth ON to measure what it means to measure.

## Verification

- 18 new tests in `tests/auth/test_auth_config_timing_963.py`; 12 fail with the fixes stashed.
- `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` (full CI gate) → **6050 passed**, 49 skipped
- `uv run ruff check codeframe/ tests/` → clean
- `codex review --base main` → escalation found on pass 1, clean on pass 2
- Demo of all five criteria plus the escalation in the PR discussion below.

## Known limitations

- **Logout still does not revoke.** A leaked token is valid for up to `JWT_LIFETIME_SECONDS`. Item 1 makes that number actually adjustable, which is the whole mitigation.
- On a fresh install with no real account, the local operator *is* the placeholder — so keys created then stop working the moment auth is enabled. That is the intended trade, but it will look like a bug to anyone who does it; the log line names the reason.
- `_local_operator_user` runs two small queries per unauthenticated request in auth-off mode. Not cached, deliberately: caching a row keyed to a database is the staleness bug this same issue fixes in item 2.
- The `sessions` table remains unused.
