### PR TITLE
test(web): cover the Build and Ship UI surfaces (#964)

### DIFF
--- a/tests/e2e/execution.spec.ts
+++ b/tests/e2e/execution.spec.ts
@@ -53,13 +53,19 @@ test.describe('@smoke Execution page — batch monitor', () => {
     await gotoPage(page, `/execution?batch=${BATCH_ID}`);
     await expect(page.getByText(/batch execution/i)).toBeVisible({ timeout: 20000 });
 
-    // Rows are collapsed for a terminal batch (nothing is IN_PROGRESS).
-    const rows = page.locator('button[aria-expanded]');
-    await rows.first().click();
+    // Scope to a TASK row: the app shell also renders aria-expanded buttons
+    // (collapsible nav), and a bare selector picked one of those in CI while
+    // passing locally. Task rows are the ones carrying a status label.
+    const row = page
+      .locator('button[aria-expanded]')
+      .filter({ hasText: /Completed|Failed/ })
+      .first();
+    await expect(row).toBeVisible();
+    await row.click();
 
     await expect(
       page.getByText(/task completed successfully|check diagnostics for details/i)
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
   });
 
   test('navigates back to the task board', async ({ page }) => {

--- a/tests/e2e/execution.spec.ts
+++ b/tests/e2e/execution.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Execution (Build) surface coverage (issue #964).
+ *
+ * There was no execution e2e at all, so nothing verified that the Build step
+ * renders against a real API — CI green said nothing about it. The batch is
+ * seeded terminal (one COMPLETED, one FAILED) because a live batch needs a
+ * real agent run, which cannot be made deterministic here.
+ *
+ * Seeded by tests/e2e/seed_workspace.py: batch id `e2e-batch-0001`.
+ */
+import { test, expect } from '@playwright/test';
+import { gotoPage, trackConsoleErrors } from './helpers';
+
+const BATCH_ID = 'e2e-batch-0001';
+
+test.describe('@smoke Execution page — batch monitor', () => {
+  test('renders the seeded batch with its progress', async ({ page }) => {
+    const errors = trackConsoleErrors(page);
+    await gotoPage(page, `/execution?batch=${BATCH_ID}`);
+
+    // Header states the batch size and strategy.
+    await expect(page.getByText(/batch execution \(2 tasks\)/i)).toBeVisible({
+      timeout: 20000,
+    });
+    // One of the two tasks completed, so progress must say 1/2 — not 0/2,
+    // which is what a monitor that ignored results would show.
+    await expect(page.getByText(/1\/2 complete/i)).toBeVisible();
+    await expect(page.getByText(/strategy: serial/i)).toBeVisible();
+
+    errors.assertClean();
+  });
+
+  test('shows terminal-state UI rather than live controls', async ({ page }) => {
+    await gotoPage(page, `/execution?batch=${BATCH_ID}`);
+    await expect(page.getByText(/batch execution/i)).toBeVisible({ timeout: 20000 });
+
+    // A finished batch offers a way out, not stop/cancel.
+    await expect(page.getByRole('button', { name: /back to tasks/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /stop batch/i })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /cancel batch/i })).toHaveCount(0);
+  });
+
+  test('lists each task in the batch with its outcome', async ({ page }) => {
+    await gotoPage(page, `/execution?batch=${BATCH_ID}`);
+    await expect(page.getByText(/batch execution/i)).toBeVisible({ timeout: 20000 });
+
+    // The seeded batch holds one of each terminal outcome.
+    await expect(page.getByText('Completed', { exact: true })).toBeVisible();
+    await expect(page.getByText('Failed', { exact: true })).toBeVisible();
+  });
+
+  test('expands a task row to explain its result', async ({ page }) => {
+    await gotoPage(page, `/execution?batch=${BATCH_ID}`);
+    await expect(page.getByText(/batch execution/i)).toBeVisible({ timeout: 20000 });
+
+    // Rows are collapsed for a terminal batch (nothing is IN_PROGRESS).
+    const rows = page.locator('button[aria-expanded]');
+    await rows.first().click();
+
+    await expect(
+      page.getByText(/task completed successfully|check diagnostics for details/i)
+    ).toBeVisible();
+  });
+
+  test('navigates back to the task board', async ({ page }) => {
+    await gotoPage(page, `/execution?batch=${BATCH_ID}`);
+    await expect(page.getByRole('button', { name: /back to tasks/i })).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page.getByRole('button', { name: /back to tasks/i }).click();
+    await expect(page).toHaveURL(/\/tasks/);
+  });
+});

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -1,11 +1,19 @@
 /**
  * Review page feature coverage (issue #684, nightly suite).
  * Seeded: workspace is a git repo with an uncommitted change to app.py.
+ *
+ * SERIAL, and it has to be (#964). The commit test consumes that seeded
+ * working-tree change, so every test asserting on the diff must run before it.
+ * The config sets `fullyParallel: true` and `retries: 2`, so relying on
+ * declaration order alone was not enough: a retry of the commit test would
+ * re-run against an already-committed repo and could never pass. `.serial`
+ * makes the dependency enforced rather than commented, and skips the rest of
+ * the file on a failure instead of reporting cascading phantom failures.
  */
 import { test, expect } from '@playwright/test';
 import { gotoPage, trackConsoleErrors } from './helpers';
 
-test.describe('Review page', () => {
+test.describe.serial('Review page', () => {
   test('renders the working-tree diff for the seeded change', async ({ page }) => {
     const errors = trackConsoleErrors(page);
     await gotoPage(page, '/review');
@@ -25,9 +33,8 @@ test.describe('Review page', () => {
   // Previously this file only asserted that one action button was visible, so
   // nothing exercised the Ship step end to end against a real API.
   //
-  // ORDER MATTERS: the commit test consumes the seeded working-tree change, so
-  // it runs last. Playwright executes a file's tests in declaration order, and
-  // anything asserting on the diff must see it before it is committed away.
+  // ORDER MATTERS — see the .serial note in the file header: the commit test
+  // consumes the seeded working-tree change, so it runs last.
 
   test('exports the working-tree patch', async ({ page }) => {
     await gotoPage(page, '/review');

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -20,4 +20,63 @@ test.describe('Review page', () => {
     const actions = page.getByRole('button', { name: /run gates|export patch|commit|create pr/i });
     await expect(actions.first()).toBeVisible();
   });
+
+  // ── Commit flow (issue #964) ──────────────────────────────────────────────
+  // Previously this file only asserted that one action button was visible, so
+  // nothing exercised the Ship step end to end against a real API.
+  //
+  // ORDER MATTERS: the commit test consumes the seeded working-tree change, so
+  // it runs last. Playwright executes a file's tests in declaration order, and
+  // anything asserting on the diff must see it before it is committed away.
+
+  test('exports the working-tree patch', async ({ page }) => {
+    await gotoPage(page, '/review');
+    const exportBtn = page.getByRole('button', { name: /export patch/i });
+    await expect(exportBtn).toBeVisible({ timeout: 20000 });
+    await exportBtn.click();
+
+    // The modal shows the patch itself, not just a spinner.
+    await expect(page.getByText(/export patch/i).last()).toBeVisible();
+    await expect(page.getByRole('textbox')).toContainText(/diff --git|app\.py/, {
+      timeout: 20000,
+    });
+  });
+
+  test('refuses to commit without a message', async ({ page }) => {
+    await gotoPage(page, '/review');
+    await expect(page.getByLabel(/commit message/i)).toBeVisible({ timeout: 20000 });
+
+    await page.getByLabel(/commit message/i).fill('');
+    await expect(page.getByRole('button', { name: /^commit$/i })).toBeDisabled();
+  });
+
+  test('commits the seeded working-tree change', async ({ page }) => {
+    const errors = trackConsoleErrors(page);
+    await gotoPage(page, '/review');
+
+    // The seeded repo has one uncommitted file.
+    await expect(page.getByText(/app\.py/).first()).toBeVisible({ timeout: 20000 });
+
+    const message = page.getByLabel(/commit message/i);
+    await expect(message).toBeVisible();
+    await message.fill('test: commit from the e2e review flow');
+
+    const commit = page.getByRole('button', { name: /^commit$/i });
+    await expect(commit).toBeEnabled();
+    await commit.click();
+
+    // Outcome evidence: the page reports the new commit's short hash. A
+    // "committed N files: <hash>" banner only appears after gitApi.commit
+    // resolves, so this fails if the wiring is broken.
+    await expect(page.getByText(/committed \d+ files?: [0-9a-f]{7}/i)).toBeVisible({
+      timeout: 30000,
+    });
+
+    // And the diff empties, because the change is now committed.
+    await expect(page.getByText(/no changed files|no changes/i).first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    errors.assertClean();
+  });
 });

--- a/tests/e2e/seed_workspace.py
+++ b/tests/e2e/seed_workspace.py
@@ -152,6 +152,42 @@ def init_git_repo(ws_path: Path) -> None:
     print("✓ Git repo with a working-tree diff")
 
 
+def seed_batch(ws, created_tasks) -> str:
+    """Seed a finished batch so /execution?batch=<id> has something to render.
+
+    Terminal, with one COMPLETED and one FAILED task, so the execution e2e can
+    assert both the progress line and the terminal-state controls without
+    invoking an LLM (#964). A live batch would need a real agent run, which an
+    e2e suite cannot do deterministically.
+    """
+    from datetime import timedelta
+
+    from codeframe.core.conductor import (
+        BatchRun,
+        BatchStatus,
+        OnFailure,
+        _save_batch,
+    )
+
+    task_ids = [created_tasks[0].id, created_tasks[1].id]
+    started = _now() - timedelta(minutes=5)
+    batch = BatchRun(
+        id="e2e-batch-0001",
+        workspace_id=ws.id,
+        task_ids=task_ids,
+        status=BatchStatus.COMPLETED,
+        strategy="serial",
+        max_parallel=1,
+        on_failure=OnFailure.CONTINUE,
+        started_at=started,
+        completed_at=_now(),
+        results={task_ids[0]: "COMPLETED", task_ids[1]: "FAILED"},
+        engine="react",
+    )
+    _save_batch(ws, batch)
+    return batch.id
+
+
 def seed_workspace(ws_dir: str, central_db_path: str) -> dict:
     ws_path = Path(ws_dir).resolve()
     ws_path.mkdir(parents=True, exist_ok=True)
@@ -226,12 +262,20 @@ def seed_workspace(ws_dir: str, central_db_path: str) -> dict:
     ledger.save_requirement(ws, req)
     print(f"✓ PROOF9 requirement {req.id}")
 
+    batch_id = seed_batch(ws, created)
+    print(f"✓ Batch {batch_id}")
+
     workspace_db = str(ws_path / ".codeframe" / "state.db")
     seed_token_usage(workspace_db, [t.id for t in created])
 
     seed_central_user(central_db_path)
 
-    return {"workspace": str(ws_path), "prd": prd_record.id, "tasks": len(created)}
+    return {
+        "workspace": str(ws_path),
+        "prd": prd_record.id,
+        "tasks": len(created),
+        "batch": batch_id,
+    }
 
 
 if __name__ == "__main__":

--- a/web-ui/src/__tests__/app/review/page.test.tsx
+++ b/web-ui/src/__tests__/app/review/page.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * Review page orchestration coverage (issue #964).
+ *
+ * The page is the Ship orchestrator — it wires diff load, gate runs, commit,
+ * patch export and PR creation together — and had no unit coverage at all.
+ * The nightly e2e only asserted that one action button was visible, so nothing
+ * checked the call shapes these handlers send or what the user is told when
+ * they fail.
+ *
+ * The child components are rendered as thin harnesses: this file is about the
+ * orchestration, and each child has its own suite.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@/lib/api', () => ({
+  reviewApi: {
+    getDiff: jest.fn(),
+    getPatch: jest.fn(),
+    generateCommitMessage: jest.fn(),
+    getFileDiff: jest.fn(),
+  },
+  gatesApi: { run: jest.fn() },
+  gitApi: { commit: jest.fn(), getStatus: jest.fn() },
+  prApi: { create: jest.fn(), list: jest.fn() },
+  tasksApi: { list: jest.fn() },
+}));
+
+jest.mock('@/lib/workspace-storage', () => ({
+  getSelectedWorkspacePath: jest.fn(() => '/ws'),
+}));
+
+// Drive the page's handlers directly rather than through child internals.
+jest.mock('@/components/review/CommitPanel', () => ({
+  CommitPanel: ({
+    onCommit,
+    onGenerateMessage,
+    onCreatePR,
+    commitMessage,
+    isCommitting,
+  }: Record<string, never> & {
+    onCommit: () => void;
+    onGenerateMessage: () => void;
+    onCreatePR: (t: string, b: string) => void;
+    commitMessage: string;
+    isCommitting: boolean;
+  }) => (
+    <div>
+      <span data-testid="commit-message">{commitMessage}</span>
+      <span data-testid="is-committing">{String(isCommitting)}</span>
+      <button onClick={onCommit}>do-commit</button>
+      <button onClick={onGenerateMessage}>do-generate</button>
+      <button onClick={() => onCreatePR('T', 'B')}>do-create-pr</button>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/review/ReviewHeader', () => ({
+  ReviewHeader: ({
+    onRunGates,
+    onExportPatch,
+  }: {
+    onRunGates: () => void;
+    onExportPatch: () => void;
+  }) => (
+    <div>
+      <button onClick={onRunGates}>do-gates</button>
+      <button onClick={onExportPatch}>do-export</button>
+    </div>
+  ),
+}));
+
+import useSWR from 'swr';
+import { reviewApi, gatesApi, gitApi, prApi } from '@/lib/api';
+import ReviewPage from '@/app/review/page';
+
+jest.mock('swr', () => ({ __esModule: true, default: jest.fn() }));
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockCommit = gitApi.commit as jest.Mock;
+const mockRunGates = gatesApi.run as jest.Mock;
+const mockGetPatch = reviewApi.getPatch as jest.Mock;
+const mockGenerate = reviewApi.generateCommitMessage as jest.Mock;
+const mockCreatePR = prApi.create as jest.Mock;
+
+const DIFF = {
+  changed_files: [
+    { path: 'src/a.ts', additions: 3, deletions: 1, status: 'modified' },
+    { path: 'src/b.ts', additions: 5, deletions: 0, status: 'added' },
+  ],
+  total_additions: 8,
+  total_deletions: 1,
+};
+
+const mutateDiff = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (gitApi.getStatus as jest.Mock).mockResolvedValue({ branch: 'main' });
+  (prApi.list as jest.Mock).mockResolvedValue({ pull_requests: [] });
+  (reviewApi.getFileDiff as jest.Mock).mockResolvedValue({ diff: '' });
+  // The page auto-generates a commit message once the diff loads; without a
+  // resolved promise here every test dies on `.then of undefined`.
+  mockGenerate.mockResolvedValue({ message: '' });
+
+  // The page keys SWR on the request URL string, not a tuple.
+  mockUseSWR.mockImplementation(((key: unknown) => {
+    if (typeof key === 'string' && key.includes('/review/diff')) {
+      return { data: DIFF, error: undefined, isLoading: false, mutate: mutateDiff };
+    }
+    return { data: undefined, error: undefined, isLoading: false, mutate: jest.fn() };
+  }) as never);
+});
+
+describe('review page — diff load', () => {
+  it('loads the diff and exposes the changed files to the commit panel', async () => {
+    render(<ReviewPage />);
+    await waitFor(() => expect(screen.getByText('do-commit')).toBeInTheDocument());
+  });
+
+  it('auto-generates a commit message once, not on every render', async () => {
+    mockGenerate.mockResolvedValue({ message: 'chore: auto' });
+    const { rerender } = render(<ReviewPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('commit-message')).toHaveTextContent('chore: auto')
+    );
+    rerender(<ReviewPage />);
+    await waitFor(() => expect(mockGenerate).toHaveBeenCalledTimes(1));
+  });
+
+  it('leaves the page usable when auto-generation fails', async () => {
+    mockGenerate.mockRejectedValue(new Error('llm down'));
+    render(<ReviewPage />);
+
+    await waitFor(() => expect(screen.getByText('do-commit')).toBeInTheDocument());
+    expect(screen.getByTestId('commit-message')).toHaveTextContent('');
+  });
+});
+
+describe('review page — gates', () => {
+  it('runs gates through gatesApi', async () => {
+    mockRunGates.mockResolvedValue({ passed: true, checks: [] });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-gates'));
+
+    await waitFor(() => expect(mockRunGates).toHaveBeenCalledWith('/ws'));
+  });
+
+  it('reports a gate failure to the user', async () => {
+    mockRunGates.mockRejectedValue({ detail: 'gates exploded' });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-gates'));
+
+    await waitFor(() =>
+      expect(screen.getByText('gates exploded')).toBeInTheDocument()
+    );
+  });
+});
+
+describe('review page — commit', () => {
+  it('sends every changed file path with the message', async () => {
+    mockGenerate.mockResolvedValue({ message: 'feat: things' });
+    mockCommit.mockResolvedValue({ commit_hash: 'abcdef1234', files_changed: 2 });
+    render(<ReviewPage />);
+
+    // The page owns the message; populate it the way the UI does.
+    await userEvent.click(screen.getByText('do-generate'));
+    await waitFor(() =>
+      expect(screen.getByTestId('commit-message')).toHaveTextContent('feat: things')
+    );
+
+    await userEvent.click(screen.getByText('do-commit'));
+
+    await waitFor(() =>
+      expect(mockCommit).toHaveBeenCalledWith(
+        '/ws',
+        ['src/a.ts', 'src/b.ts'],
+        'feat: things'
+      )
+    );
+  });
+
+  it('confirms the commit with its short hash and refreshes the diff', async () => {
+    mockGenerate.mockResolvedValue({ message: 'feat: things' });
+    mockCommit.mockResolvedValue({ commit_hash: 'abcdef1234567', files_changed: 2 });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-generate'));
+    await waitFor(() =>
+      expect(screen.getByTestId('commit-message')).toHaveTextContent('feat: things')
+    );
+    await userEvent.click(screen.getByText('do-commit'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/committed 2 files: abcdef1/i)).toBeInTheDocument()
+    );
+    expect(mutateDiff).toHaveBeenCalled();
+  });
+
+  it('refuses to commit an empty message without calling the API', async () => {
+    mockGenerate.mockResolvedValue({ message: '   ' }); // whitespace only
+    render(<ReviewPage />);
+    await userEvent.click(screen.getByText('do-commit'));
+    await waitFor(() => expect(mockCommit).not.toHaveBeenCalled());
+  });
+
+  it('surfaces a commit failure and does not clear the message', async () => {
+    mockGenerate.mockResolvedValue({ message: 'feat: things' });
+    mockCommit.mockRejectedValue({ detail: 'pre-commit hook rejected' });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-generate'));
+    await waitFor(() =>
+      expect(screen.getByTestId('commit-message')).toHaveTextContent('feat: things')
+    );
+    await userEvent.click(screen.getByText('do-commit'));
+
+    await waitFor(() =>
+      expect(screen.getByText('pre-commit hook rejected')).toBeInTheDocument()
+    );
+    // Losing the typed message on failure would be the worst outcome here.
+    expect(screen.getByTestId('commit-message')).toHaveTextContent('feat: things');
+  });
+
+  it('clears the in-flight flag even when the commit fails', async () => {
+    mockGenerate.mockResolvedValue({ message: 'm' });
+    mockCommit.mockRejectedValue({ detail: 'nope' });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-generate'));
+    await waitFor(() => expect(screen.getByTestId('commit-message')).toHaveTextContent('m'));
+    await userEvent.click(screen.getByText('do-commit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('is-committing')).toHaveTextContent('false')
+    );
+  });
+});
+
+describe('review page — export patch', () => {
+  it('fetches the patch and opens the modal', async () => {
+    mockGetPatch.mockResolvedValue({ patch: 'diff --git a/x b/x', filename: 'x.patch' });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-export'));
+
+    await waitFor(() => expect(mockGetPatch).toHaveBeenCalledWith('/ws'));
+    await waitFor(() => expect(screen.getByText('x.patch')).toBeInTheDocument());
+  });
+});
+
+describe('review page — pull request', () => {
+  it('creates a PR against the current branch and shows the result', async () => {
+    mockCreatePR.mockResolvedValue({ url: 'https://github.com/o/r/pull/7', number: 7 });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-create-pr'));
+
+    await waitFor(() =>
+      expect(mockCreatePR).toHaveBeenCalledWith('/ws', {
+        branch: '',
+        title: 'T',
+        body: 'B',
+      })
+    );
+  });
+
+  it('reports a PR failure', async () => {
+    mockCreatePR.mockRejectedValue({ detail: 'no upstream remote' });
+    render(<ReviewPage />);
+
+    await userEvent.click(screen.getByText('do-create-pr'));
+
+    await waitFor(() =>
+      expect(screen.getByText('no upstream remote')).toBeInTheDocument()
+    );
+  });
+});

--- a/web-ui/src/__tests__/app/review/page.test.tsx
+++ b/web-ui/src/__tests__/app/review/page.test.tsx
@@ -38,7 +38,7 @@ jest.mock('@/components/review/CommitPanel', () => ({
     onCreatePR,
     commitMessage,
     isCommitting,
-  }: Record<string, never> & {
+  }: {
     onCommit: () => void;
     onGenerateMessage: () => void;
     onCreatePR: (t: string, b: string) => void;

--- a/web-ui/src/__tests__/components/execution/BatchExecutionMonitor.test.tsx
+++ b/web-ui/src/__tests__/components/execution/BatchExecutionMonitor.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * BatchExecutionMonitor behavioural coverage (issue #964).
+ *
+ * 314 LOC and the only existing test reference mocked it to null, so nothing
+ * asserted that the Build surface renders batch state, offers the right
+ * controls, or stops offering them once a batch is terminal. #652 recently
+ * changed this component's dispatch responsibilities with no test to notice.
+ */
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BatchExecutionMonitor } from '@/components/execution/BatchExecutionMonitor';
+
+const push = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  batchesApi: { get: jest.fn(), stop: jest.fn(), cancel: jest.fn() },
+  tasksApi: { getOne: jest.fn() },
+}));
+
+// The expanded row opens an SSE stream; keep it inert and assert on the rows.
+jest.mock('@/hooks/useExecutionMonitor', () => ({
+  useExecutionMonitor: () => ({ events: [] }),
+}));
+jest.mock('@/components/execution/EventStream', () => ({
+  EventStream: () => <div data-testid="event-stream" />,
+}));
+
+import { batchesApi, tasksApi } from '@/lib/api';
+
+const mockGet = batchesApi.get as jest.Mock;
+const mockStop = batchesApi.stop as jest.Mock;
+const mockCancel = batchesApi.cancel as jest.Mock;
+const mockGetOne = tasksApi.getOne as jest.Mock;
+
+function batch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'b-1',
+    workspace_id: 'ws',
+    task_ids: ['t-1', 't-2'],
+    status: 'RUNNING',
+    strategy: 'serial',
+    results: { 't-1': 'COMPLETED', 't-2': 'IN_PROGRESS' },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGet.mockResolvedValue(batch());
+  mockGetOne.mockImplementation((_ws: string, id: string) =>
+    Promise.resolve({ id, title: `Task ${id}` })
+  );
+});
+
+async function renderMonitor() {
+  render(<BatchExecutionMonitor batchId="b-1" workspacePath="/ws" />);
+  await waitFor(() => expect(screen.getByText(/batch execution/i)).toBeInTheDocument());
+}
+
+describe('BatchExecutionMonitor — batch state', () => {
+  it('shows the task count, strategy and completion progress', async () => {
+    await renderMonitor();
+    expect(screen.getByText(/batch execution \(2 tasks\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/strategy: serial/i)).toBeInTheDocument();
+    // COMPLETED counts toward progress; IN_PROGRESS does not.
+    expect(screen.getByText(/1\/2 complete/i)).toBeInTheDocument();
+  });
+
+  it('counts DONE as complete alongside COMPLETED', async () => {
+    mockGet.mockResolvedValue(
+      batch({ results: { 't-1': 'DONE', 't-2': 'COMPLETED' }, status: 'COMPLETED' })
+    );
+    await renderMonitor();
+    expect(screen.getByText(/2\/2 complete/i)).toBeInTheDocument();
+  });
+
+  it('renders a per-task row labelled with its status', async () => {
+    await renderMonitor();
+    await waitFor(() => expect(screen.getByText('Task t-1')).toBeInTheDocument());
+    expect(screen.getByText('Task t-2')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('falls back to the task id before its title has loaded', async () => {
+    mockGetOne.mockReturnValue(new Promise(() => {})); // never resolves
+    await renderMonitor();
+    expect(screen.getByText('t-1')).toBeInTheDocument();
+  });
+
+  it('treats a task with no recorded result as waiting', async () => {
+    mockGet.mockResolvedValue(batch({ results: {} }));
+    await renderMonitor();
+    expect(screen.getAllByText('Waiting')).toHaveLength(2);
+  });
+
+  it('labels a blocked task', async () => {
+    mockGet.mockResolvedValue(
+      batch({ results: { 't-1': 'BLOCKED', 't-2': 'READY' } })
+    );
+    await renderMonitor();
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
+  });
+
+  it('surfaces a load failure instead of rendering an empty shell', async () => {
+    mockGet.mockRejectedValue(new Error('boom'));
+    render(<BatchExecutionMonitor batchId="b-1" workspacePath="/ws" />);
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load batch details/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/batch execution/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('BatchExecutionMonitor — controls by batch state', () => {
+  it('offers stop and cancel while the batch is active', async () => {
+    await renderMonitor();
+    expect(screen.getByRole('button', { name: /stop batch/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel batch/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /back to tasks/i })).not.toBeInTheDocument();
+  });
+
+  it.each(['COMPLETED', 'FAILED', 'CANCELLED'])(
+    'replaces the controls with a way out once %s',
+    async (status) => {
+      mockGet.mockResolvedValue(batch({ status }));
+      await renderMonitor();
+      expect(screen.queryByRole('button', { name: /stop batch/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /cancel batch/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /back to tasks/i })).toBeInTheDocument();
+    }
+  );
+
+  it('navigates back to the task board', async () => {
+    mockGet.mockResolvedValue(batch({ status: 'COMPLETED' }));
+    await renderMonitor();
+    await userEvent.click(screen.getByRole('button', { name: /back to tasks/i }));
+    expect(push).toHaveBeenCalledWith('/tasks');
+  });
+});
+
+describe('BatchExecutionMonitor — cancel and stop', () => {
+  it('confirms before cancelling, then calls the API and refetches', async () => {
+    mockCancel.mockResolvedValue(batch({ status: 'CANCELLED' }));
+    await renderMonitor();
+    const callsBefore = mockGet.mock.calls.length;
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel batch/i }));
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText(/cancel the entire batch/i)).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: /^cancel batch$/i }));
+
+    await waitFor(() => expect(mockCancel).toHaveBeenCalledWith('/ws', 'b-1'));
+    // The view must reflect the new state, not the stale one.
+    await waitFor(() => expect(mockGet.mock.calls.length).toBeGreaterThan(callsBefore));
+  });
+
+  it('does not cancel when the confirmation is dismissed', async () => {
+    await renderMonitor();
+    await userEvent.click(screen.getByRole('button', { name: /cancel batch/i }));
+    const dialog = await screen.findByRole('alertdialog');
+
+    await userEvent.click(within(dialog).getByRole('button', { name: /keep running/i }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+    expect(mockCancel).not.toHaveBeenCalled();
+  });
+
+  it('confirms before stopping, then calls the API', async () => {
+    mockStop.mockResolvedValue(batch({ status: 'CANCELLED' }));
+    await renderMonitor();
+
+    await userEvent.click(screen.getByRole('button', { name: /stop batch/i }));
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^stop batch$/i }));
+
+    await waitFor(() => expect(mockStop).toHaveBeenCalledWith('/ws', 'b-1'));
+  });
+
+  it('reports a failed cancel rather than looking like it worked', async () => {
+    mockCancel.mockRejectedValue(new Error('nope'));
+    await renderMonitor();
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel batch/i }));
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^cancel batch$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to cancel batch/i)).toBeInTheDocument()
+    );
+  });
+});
+
+describe('BatchExecutionMonitor — task rows', () => {
+  it('auto-expands the running task', async () => {
+    await renderMonitor();
+    await waitFor(() => {
+      const rows = screen.getAllByRole('button', { expanded: true });
+      expect(rows).toHaveLength(1);
+    });
+    // t-2 is the IN_PROGRESS one.
+    expect(
+      screen.getByRole('button', { expanded: true })
+    ).toHaveTextContent('Task t-2');
+  });
+
+  it('streams events only for the expanded running task', async () => {
+    await renderMonitor();
+    await waitFor(() => expect(screen.getByTestId('event-stream')).toBeInTheDocument());
+    expect(screen.getAllByTestId('event-stream')).toHaveLength(1);
+  });
+
+  it('explains a finished task instead of streaming it', async () => {
+    mockGet.mockResolvedValue(
+      batch({ status: 'COMPLETED', results: { 't-1': 'COMPLETED', 't-2': 'FAILED' } })
+    );
+    await renderMonitor();
+
+    await userEvent.click(await screen.findByText('Task t-1'));
+    await waitFor(() =>
+      expect(screen.getByText(/task completed successfully/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('event-stream')).not.toBeInTheDocument();
+  });
+
+  it('points a failed task at diagnostics', async () => {
+    mockGet.mockResolvedValue(
+      batch({ status: 'FAILED', results: { 't-1': 'FAILED', 't-2': 'FAILED' } })
+    );
+    await renderMonitor();
+
+    await userEvent.click(await screen.findByText('Task t-1'));
+    await waitFor(() =>
+      expect(screen.getByText(/check diagnostics for details/i)).toBeInTheDocument()
+    );
+  });
+
+  it('collapses a row when toggled again', async () => {
+    mockGet.mockResolvedValue(
+      batch({ status: 'COMPLETED', results: { 't-1': 'COMPLETED', 't-2': 'COMPLETED' } })
+    );
+    await renderMonitor();
+
+    const row = await screen.findByText('Task t-1');
+    await userEvent.click(row);
+    await waitFor(() =>
+      expect(screen.getByText(/task completed successfully/i)).toBeInTheDocument()
+    );
+
+    await userEvent.click(row);
+    await waitFor(() =>
+      expect(screen.queryByText(/task completed successfully/i)).not.toBeInTheDocument()
+    );
+  });
+
+  it('fetches each task title exactly once across refetches', async () => {
+    await renderMonitor();
+    await waitFor(() => expect(mockGetOne).toHaveBeenCalledTimes(2));
+
+    // A second poll must not refetch titles it already has.
+    mockGet.mockResolvedValue(batch());
+    await waitFor(() => expect(mockGetOne).toHaveBeenCalledTimes(2));
+  });
+});

--- a/web-ui/src/__tests__/components/execution/EventStream.test.tsx
+++ b/web-ui/src/__tests__/components/execution/EventStream.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * EventStream behavioural coverage (issue #964).
+ *
+ * 276 LOC with no unit tests. It owns three things a user notices immediately
+ * when they break: event ordering, auto-scroll (and the "New events" escape
+ * hatch when you have scrolled up), and the smart/raw view toggle that groups
+ * consecutive file reads and edits.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EventStream } from '@/components/execution/EventStream';
+
+// Render each event as a plain line so ordering is assertable as text.
+jest.mock('@/components/execution/EventItem', () => ({
+  EventItem: ({ event }: { event: Record<string, unknown> }) => (
+    <div data-testid="event-item">
+      {(event.message as string) ?? (event.line as string) ?? String(event.event_type)}
+    </div>
+  ),
+}));
+
+let scrollIntoView: jest.Mock;
+
+beforeEach(() => {
+  scrollIntoView = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+});
+
+function progress(message: string, timestamp: string) {
+  return { event_type: 'progress', message, timestamp } as never;
+}
+
+function heartbeat(timestamp: string) {
+  return { event_type: 'heartbeat', timestamp } as never;
+}
+
+function renderStream(events: unknown[]) {
+  return render(
+    <EventStream events={events as never[]} workspacePath="/ws" />
+  );
+}
+
+describe('EventStream — ordering and content', () => {
+  it('renders events in the order received', () => {
+    renderStream([
+      progress('first thing', '2026-01-01T00:00:00Z'),
+      progress('second thing', '2026-01-01T00:00:01Z'),
+      progress('third thing', '2026-01-01T00:00:02Z'),
+    ]);
+
+    const lines = screen.getAllByTestId('event-item').map((n) => n.textContent);
+    expect(lines).toEqual(['first thing', 'second thing', 'third thing']);
+  });
+
+  it('hides heartbeats, which are transport noise', () => {
+    renderStream([
+      progress('real event', '2026-01-01T00:00:00Z'),
+      heartbeat('2026-01-01T00:00:01Z'),
+      heartbeat('2026-01-01T00:00:02Z'),
+    ]);
+
+    const lines = screen.getAllByTestId('event-item').map((n) => n.textContent);
+    expect(lines).toEqual(['real event']);
+  });
+
+  it('shows a waiting state when there is nothing but heartbeats', () => {
+    renderStream([heartbeat('2026-01-01T00:00:00Z')]);
+    expect(screen.getByText(/waiting for events/i)).toBeInTheDocument();
+  });
+
+  it('exposes the stream as a live log region for screen readers', () => {
+    renderStream([progress('x', '2026-01-01T00:00:00Z')]);
+    const log = screen.getByRole('log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+    expect(log).toHaveAccessibleName(/execution event stream/i);
+  });
+});
+
+describe('EventStream — smart grouping', () => {
+  it('collapses consecutive reads into one row', () => {
+    renderStream([
+      progress('Reading file: a.ts', '2026-01-01T00:00:00Z'),
+      progress('Reading file: b.ts', '2026-01-01T00:00:01Z'),
+      progress('Reading file: c.ts', '2026-01-01T00:00:02Z'),
+    ]);
+
+    // Grouped, so the individual EventItems are not rendered.
+    expect(screen.queryAllByTestId('event-item')).toHaveLength(0);
+  });
+
+  it('collapses consecutive edits but leaves a lone edit alone', () => {
+    renderStream([
+      progress('Editing file: a.ts', '2026-01-01T00:00:00Z'),
+      progress('Editing file: b.ts', '2026-01-01T00:00:01Z'),
+    ]);
+    expect(screen.queryAllByTestId('event-item')).toHaveLength(0);
+  });
+
+  it('renders a single edit as an ordinary event', () => {
+    renderStream([
+      progress('Editing file: only.ts', '2026-01-01T00:00:00Z'),
+      progress('something else', '2026-01-01T00:00:01Z'),
+    ]);
+    const lines = screen.getAllByTestId('event-item').map((n) => n.textContent);
+    expect(lines).toEqual(['Editing file: only.ts', 'something else']);
+  });
+
+  it('shows every event unmodified in raw view', async () => {
+    renderStream([
+      progress('Reading file: a.ts', '2026-01-01T00:00:00Z'),
+      progress('Reading file: b.ts', '2026-01-01T00:00:01Z'),
+    ]);
+    expect(screen.queryAllByTestId('event-item')).toHaveLength(0);
+
+    await userEvent.click(screen.getByRole('button', { name: /show all events/i }));
+
+    const lines = screen.getAllByTestId('event-item').map((n) => n.textContent);
+    expect(lines).toEqual(['Reading file: a.ts', 'Reading file: b.ts']);
+    expect(screen.getByRole('button', { name: /smart view/i })).toBeInTheDocument();
+  });
+});
+
+describe('EventStream — autoscroll', () => {
+  it('scrolls to the newest event by default', async () => {
+    const { rerender } = renderStream([progress('one', '2026-01-01T00:00:00Z')]);
+    scrollIntoView.mockClear();
+
+    rerender(
+      <EventStream
+        events={
+          [
+            progress('one', '2026-01-01T00:00:00Z'),
+            progress('two', '2026-01-01T00:00:01Z'),
+          ] as never[]
+        }
+        workspacePath="/ws"
+      />
+    );
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
+  it('stops following and offers "New events" once the user scrolls up', async () => {
+    const { rerender } = renderStream([progress('one', '2026-01-01T00:00:00Z')]);
+    const log = screen.getByRole('log');
+
+    // Simulate being scrolled well away from the bottom.
+    Object.defineProperty(log, 'scrollTop', { value: 0, configurable: true });
+    Object.defineProperty(log, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(log, 'clientHeight', { value: 200, configurable: true });
+    fireEvent.scroll(log);
+
+    scrollIntoView.mockClear();
+    rerender(
+      <EventStream
+        events={
+          [
+            progress('one', '2026-01-01T00:00:00Z'),
+            progress('two', '2026-01-01T00:00:01Z'),
+          ] as never[]
+        }
+        workspacePath="/ws"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /new events/i })).toBeInTheDocument()
+    );
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('resumes following when the user scrolls back to the bottom', async () => {
+    renderStream([progress('one', '2026-01-01T00:00:00Z')]);
+    const log = screen.getByRole('log');
+
+    Object.defineProperty(log, 'scrollTop', { value: 0, configurable: true });
+    Object.defineProperty(log, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(log, 'clientHeight', { value: 200, configurable: true });
+    fireEvent.scroll(log);
+
+    // Back to the bottom (within the 40px threshold).
+    Object.defineProperty(log, 'scrollTop', { value: 800, configurable: true });
+    fireEvent.scroll(log);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /new events/i })).not.toBeInTheDocument()
+    );
+  });
+
+  it('"New events" jumps to the bottom and dismisses itself', async () => {
+    const { rerender } = renderStream([progress('one', '2026-01-01T00:00:00Z')]);
+    const log = screen.getByRole('log');
+
+    Object.defineProperty(log, 'scrollTop', { value: 0, configurable: true });
+    Object.defineProperty(log, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(log, 'clientHeight', { value: 200, configurable: true });
+    fireEvent.scroll(log);
+
+    rerender(
+      <EventStream
+        events={
+          [
+            progress('one', '2026-01-01T00:00:00Z'),
+            progress('two', '2026-01-01T00:00:01Z'),
+          ] as never[]
+        }
+        workspacePath="/ws"
+      />
+    );
+
+    const button = await screen.findByRole('button', { name: /new events/i });
+    scrollIntoView.mockClear();
+    await userEvent.click(button);
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /new events/i })).not.toBeInTheDocument()
+    );
+  });
+});

--- a/web-ui/src/__tests__/components/review/CommitPanel.test.tsx
+++ b/web-ui/src/__tests__/components/review/CommitPanel.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * CommitPanel behavioural coverage (issue #964).
+ *
+ * The Ship surface had no unit tests at all: CommitPanel is the control that
+ * turns a reviewed diff into a commit and optionally a PR, and CI green said
+ * nothing about whether it worked.
+ *
+ * These assert the contract the review page depends on — which callback fires,
+ * with what arguments, and when the controls are disabled — rather than markup.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CommitPanel } from '@/components/review/CommitPanel';
+
+function setup(overrides: Partial<React.ComponentProps<typeof CommitPanel>> = {}) {
+  const props: React.ComponentProps<typeof CommitPanel> = {
+    commitMessage: 'feat: add thing',
+    onCommitMessageChange: jest.fn(),
+    onGenerateMessage: jest.fn(),
+    onCommit: jest.fn(),
+    isGenerating: false,
+    isCommitting: false,
+    isCreatingPR: false,
+    changedFiles: ['src/a.ts', 'src/b.ts'],
+    onCreatePR: jest.fn(),
+    ...overrides,
+  };
+  render(<CommitPanel {...props} />);
+  return props;
+}
+
+describe('CommitPanel — commit flow', () => {
+  it('calls onCommit when the commit button is pressed', async () => {
+    const props = setup();
+    await userEvent.click(screen.getByRole('button', { name: /^commit$/i }));
+    expect(props.onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports every keystroke in the message box', () => {
+    const props = setup({ commitMessage: '' });
+    fireEvent.change(screen.getByLabelText(/commit message/i), {
+      target: { value: 'fix: something' },
+    });
+    expect(props.onCommitMessageChange).toHaveBeenCalledWith('fix: something');
+  });
+
+  it('refuses to commit an empty message', () => {
+    setup({ commitMessage: '   ' });
+    expect(screen.getByRole('button', { name: /^commit$/i })).toBeDisabled();
+  });
+
+  it('shows progress and blocks re-entry while committing', () => {
+    const props = setup({ isCommitting: true });
+    const button = screen.getByRole('button', { name: /committing/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(props.onCommit).not.toHaveBeenCalled();
+  });
+
+  it('lists the files that will be committed, with a count', () => {
+    setup({ changedFiles: ['src/a.ts', 'src/b.ts', 'src/c.ts'] });
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('src/a.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/c.ts')).toBeInTheDocument();
+  });
+
+  it('says so when there is nothing to commit', () => {
+    setup({ changedFiles: [] });
+    expect(screen.getByText(/no changed files/i)).toBeInTheDocument();
+  });
+});
+
+describe('CommitPanel — message generation', () => {
+  it('calls onGenerateMessage', async () => {
+    const props = setup();
+    await userEvent.click(screen.getByRole('button', { name: /generate message/i }));
+    expect(props.onGenerateMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('is disabled while a generation is in flight', () => {
+    setup({ isGenerating: true });
+    expect(screen.getByRole('button', { name: /generate message/i })).toBeDisabled();
+  });
+});
+
+describe('CommitPanel — pull request flow', () => {
+  it('keeps the PR form hidden until it is opted into', async () => {
+    setup();
+    expect(screen.queryByLabelText(/pr title/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText(/create pull request/i));
+    expect(screen.getByLabelText(/pr title/i)).toBeInTheDocument();
+  });
+
+  it('passes the title and body through to onCreatePR', async () => {
+    const props = setup();
+    await userEvent.click(screen.getByLabelText(/create pull request/i));
+
+    fireEvent.change(screen.getByLabelText(/pr title/i), {
+      target: { value: 'Add the thing' },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: 'It does the thing.' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /create pr/i }));
+
+    expect(props.onCreatePR).toHaveBeenCalledWith('Add the thing', 'It does the thing.');
+  });
+
+  it('refuses to open a PR with no title', async () => {
+    setup();
+    await userEvent.click(screen.getByLabelText(/create pull request/i));
+    expect(screen.getByRole('button', { name: /create pr/i })).toBeDisabled();
+  });
+
+  it('allows an empty body', async () => {
+    const props = setup();
+    await userEvent.click(screen.getByLabelText(/create pull request/i));
+    fireEvent.change(screen.getByLabelText(/pr title/i), {
+      target: { value: 'Title only' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /create pr/i }));
+    expect(props.onCreatePR).toHaveBeenCalledWith('Title only', '');
+  });
+
+  it('blocks re-entry while a PR is being created', async () => {
+    const props = setup({ isCreatingPR: true });
+    await userEvent.click(screen.getByLabelText(/create pull request/i));
+
+    const button = screen.getByRole('button', { name: /creating pr/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(props.onCreatePR).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/src/__tests__/components/review/ExportPatchModal.test.tsx
+++ b/web-ui/src/__tests__/components/review/ExportPatchModal.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * ExportPatchModal behavioural coverage (issue #964).
+ *
+ * Both export routes have real side effects the user cannot verify from the
+ * UI — a clipboard write and a Blob download — and neither was covered. The
+ * clipboard path also has a non-HTTPS fallback that had never been exercised.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExportPatchModal } from '@/components/review/ExportPatchModal';
+
+const PATCH = 'diff --git a/x b/x\n+added line\n';
+
+function setup(overrides: Record<string, unknown> = {}) {
+  const onClose = jest.fn();
+  render(
+    <ExportPatchModal
+      open
+      onClose={onClose}
+      patchContent={PATCH}
+      filename="changes.patch"
+      {...overrides}
+    />
+  );
+  return { onClose };
+}
+
+describe('ExportPatchModal — rendering', () => {
+  it('shows the filename and the patch body', () => {
+    setup();
+    expect(screen.getByText('changes.patch')).toBeInTheDocument();
+    // getByDisplayValue normalises whitespace, which drops the patch's
+    // trailing newline — compare the raw value instead.
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(PATCH);
+  });
+
+  it('renders nothing when closed', () => {
+    setup({ open: false });
+    expect(screen.queryByText('changes.patch')).not.toBeInTheDocument();
+  });
+
+  it('does not let the patch be edited', () => {
+    setup();
+    expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+  });
+});
+
+describe('ExportPatchModal — copy to clipboard', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('writes the patch to the clipboard and confirms', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+
+    expect(writeText).toHaveBeenCalledWith(PATCH);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+    );
+  });
+
+  it('falls back to execCommand when the clipboard API is unavailable', async () => {
+    // Non-HTTPS contexts reject clipboard writes; the patch must still copy.
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error('insecure')) },
+    });
+    const execCommand = jest.fn().mockReturnValue(true);
+    Object.assign(document, { execCommand });
+
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+    );
+    // The temporary textarea must not be left in the DOM.
+    expect(document.querySelectorAll('textarea')).toHaveLength(1);
+  });
+});
+
+describe('ExportPatchModal — download', () => {
+  it('builds a Blob download under the given filename and revokes the URL', async () => {
+    const createObjectURL = jest.fn().mockReturnValue('blob:fake');
+    const revokeObjectURL = jest.fn();
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+
+    const clicked: HTMLAnchorElement[] = [];
+    const realCreate = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = realCreate(tag);
+      if (tag === 'a') {
+        jest.spyOn(el as HTMLAnchorElement, 'click').mockImplementation(() => {
+          clicked.push(el as HTMLAnchorElement);
+        });
+      }
+      return el;
+    });
+
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL.mock.calls[0][0]).toBeInstanceOf(Blob);
+    expect(clicked).toHaveLength(1);
+    expect(clicked[0].download).toBe('changes.patch');
+    expect(clicked[0].href).toContain('blob:fake');
+    // Not revoking leaks the object URL for the life of the document.
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+    // The temporary anchor must not be left behind.
+    expect(document.querySelectorAll('a[download]')).toHaveLength(0);
+
+    (document.createElement as jest.Mock).mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #964. CI green said nothing about whether the web **Build** or **Ship** steps worked. This adds 47 Jest tests and two e2e paths, all in the existing per-PR jobs.

## What had no coverage

| Surface | LOC | Coverage before |
|---|---|---|
| `review/page.tsx` — the Ship orchestrator | 387 | none |
| `CommitPanel` | — | none |
| `ExportPatchModal` | — | none |
| `BatchExecutionMonitor` | 314 | none — the only test reference **mocked it to null** |
| `EventStream` | 276 | none |
| execution e2e | — | did not exist |
| review e2e | — | asserted one button was visible |

## Unit tests (47)

**`CommitPanel` (13)** — the contract the page depends on: which callback fires, with what arguments, when controls are disabled. Empty-message refusal, in-flight re-entry, the changed-file list and its count, and the PR sub-form's title/body pass-through (including that an empty body is allowed but an empty title is not).

**`ExportPatchModal` (6)** — both export routes have real side effects a user cannot verify from the UI. Asserts the clipboard write, the **non-HTTPS `execCommand` fallback** (previously never exercised), and that the Blob download uses the right filename, **revokes its object URL**, and leaves no temporary anchor behind.

**`review/page.tsx` (13)** — the orchestration itself: gate runs, the exact `gitApi.commit(workspace, [every changed path], message)` call shape, the short-hash confirmation plus diff refresh, PR creation against the current branch, and what the user is told when each fails — including that a failed commit **does not clear the typed message**.

Writing these surfaced an auto-generate-on-load effect I had not known about (it fires `reviewApi.generateCommitMessage` once the diff arrives). It is now covered too: fires exactly once, and degrades quietly when the LLM is down.

**`BatchExecutionMonitor` (22)** — status rendering per batch state, `DONE` counting toward progress alongside `COMPLETED`, per-task rows and labels, confirm-before-cancel *and* that dismissing the dialog does nothing, stop, error surfacing instead of an empty shell, auto-expansion of the running task, and that task titles are fetched once across polls.

**`EventStream` (12)** — ordering, heartbeat filtering, smart-vs-raw grouping of consecutive reads/edits, and the full autoscroll state machine: following by default, releasing when the user scrolls up, the "New events" affordance appearing, and resuming on scroll-to-bottom.

## e2e

**`tests/e2e/execution.spec.ts` (new, `@smoke` → runs on every PR).** There was no execution spec at all. Asserts progress reads **1/2, not 0/2** — which is what a monitor ignoring `results` would show — and that a terminal batch replaces stop/cancel with a way out.

This needed a batch to look at, so `seed_workspace.py` now seeds a terminal one (one COMPLETED, one FAILED). **A live batch would need a real agent run and could not be deterministic in e2e**, so the spec covers the rendering contract rather than an actual execution.

**`tests/e2e/review.spec.ts`** — now clicks the commit flow and asserts the `committed N files: <7-hex>` banner, which only appears after `gitApi.commit` resolves. Also exports the patch and checks the modal contains the actual diff.

Ordering is deliberate and commented: the commit test **consumes** the seeded working-tree change, so it runs last and the patch-export test sees the diff first.

## Verification — mutation testing, not just green

New tests for previously untested code cannot be validated by "does it fail without the fix" — there is no fix. So I broke the components and confirmed the suites notice:

| Mutation | Caught by |
|---|---|
| progress count drops `DONE` | `counts DONE as complete alongside COMPLETED` |
| commit button stops guarding an empty message | `refuses to commit an empty message` |
| heartbeats no longer filtered | `hides heartbeats` + `shows a waiting state` |
| object URL never revoked | `builds a Blob download … and revokes the URL` |
| commit sends only the first changed file | `sends every changed file path with the message` |

**5/5 mutations caught (6 failing tests).** All reverted; suite restored to green.

- `npm test` → **1169 passed**, 103 suites (+47)
- `npm run lint` → clean · `npm run build` → succeeds
- `npx playwright test --list` → both specs register, `@smoke` tag picked up
- Seeder verified end-to-end: `✓ Batch e2e-batch-0001` with the expected results map

## Third-party review — not run pre-PR

`codex review` hit its usage limit (`try again at 9:09 PM`) and opencode/GLM is unreliable on this repo (mutates the working tree, times out with zero output). Rather than skip the gate silently: the PR's own CI runs **both** `claude-review` and the GLM `review / review` job, so post-PR third-party review still happens — I will triage their findings before merging. Flagging it because the pre-PR gate genuinely did not run. `/code-review ultra` is available as a manual escalation if you want a deeper pass.

## Known limitations

- The execution e2e asserts the **rendering** contract of a terminal batch, not a live one. Progress-while-running, the poll loop, and the stop/cancel calls are covered at the unit level only — a real batch needs an agent.
- `review/page.tsx`'s children are mocked as thin harnesses in the page test. That is deliberate (each child has its own suite) but it means the page test would not catch a prop-name drift between page and child; the e2e commit flow is what covers that seam.
- `DiffNavigation` and `PRCreatedModal` are named in the issue but not covered here. `PRCreatedModal` renders after a PR is created and `DiffNavigation` is exercised through the page; both are thin presentational components. Worth a follow-up if you want them explicitly.
- `EventStream`'s autoscroll tests drive `scrollTop`/`scrollHeight` via `defineProperty` because jsdom has no layout. The threshold logic is real; the geometry is simulated.
