### PR TITLE
test(web): close the API contract and DiscoveryPanel coverage gaps (#965)

### DIFF
--- a/web-ui/jest.config.js
+++ b/web-ui/jest.config.js
@@ -28,6 +28,25 @@ const customJestConfig = {
   // Jest 30 dropped 'json-summary' from the default reporters; CI's coverage
   // threshold gate reads coverage/coverage-summary.json, so request it explicitly.
   coverageReporters: ['json', 'json-summary', 'lcov', 'text', 'clover'],
+  // Per-file floor for DiscoveryPanel, which sat at 0% (issue #965). The
+  // repo-wide gate is a 65% check in CI; this is enforced by the runner so
+  // `npm run test:coverage` fails locally too. Set below the achieved 94%/73%
+  // so ordinary refactoring does not trip it — it guards against the coverage
+  // *disappearing*, not against small movements.
+  //
+  // Deliberately only this file. A per-file threshold also fails when someone
+  // runs `--coverage` over a subset that excludes the file, so each entry is a
+  // small DX tax. src/lib/api.ts is not listed because its contract suite has
+  // a stronger, subset-safe guard: a test that fails when a new *Api namespace
+  // is exported without contract cases.
+  coverageThreshold: {
+    './src/components/prd/DiscoveryPanel.tsx': {
+      statements: 85,
+      branches: 65,
+      functions: 90,
+      lines: 85,
+    },
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/web-ui/src/__tests__/components/prd/DiscoveryPanel.test.tsx
+++ b/web-ui/src/__tests__/components/prd/DiscoveryPanel.test.tsx
@@ -1,0 +1,408 @@
+/**
+ * DiscoveryPanel behavioural coverage (issue #965).
+ *
+ * 304 LOC orchestrating the Think phase's marquee Socratic flow, at 0%
+ * statement and branch coverage with no e2e mention — so a broken resume or a
+ * swallowed submit error shipped green.
+ *
+ * These cover the four paths the issue names: start, resume, submit-answer
+ * error handling, and generate-PRD.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DiscoveryPanel } from '@/components/prd/DiscoveryPanel';
+
+jest.mock('@/lib/api', () => ({
+  discoveryApi: {
+    start: jest.fn(),
+    getStatus: jest.fn(),
+    submitAnswer: jest.fn(),
+    generatePrd: jest.fn(),
+    reset: jest.fn(),
+  },
+  prdApi: { getLatest: jest.fn() },
+}));
+
+// Thin harnesses: the transcript and input have their own concerns; this file
+// is about the orchestration between them and the API.
+jest.mock('@/components/prd/DiscoveryTranscript', () => ({
+  DiscoveryTranscript: ({
+    messages,
+    isThinking,
+  }: {
+    messages: { role: string; content: string }[];
+    isThinking: boolean;
+  }) => (
+    <div>
+      <span data-testid="thinking">{String(isThinking)}</span>
+      <ul data-testid="transcript">
+        {messages.map((m, i) => (
+          <li key={i}>{`${m.role}: ${m.content}`}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/prd/DiscoveryInput', () => ({
+  DiscoveryInput: ({
+    onSubmit,
+    disabled,
+  }: {
+    onSubmit: (a: string) => void;
+    disabled: boolean;
+  }) => (
+    <button disabled={disabled} onClick={() => onSubmit('my answer')}>
+      submit-answer
+    </button>
+  ),
+}));
+
+import { discoveryApi, prdApi } from '@/lib/api';
+
+const mockStart = discoveryApi.start as jest.Mock;
+const mockStatus = discoveryApi.getStatus as jest.Mock;
+const mockSubmit = discoveryApi.submitAnswer as jest.Mock;
+const mockGenerate = discoveryApi.generatePrd as jest.Mock;
+const mockReset = discoveryApi.reset as jest.Mock;
+const mockGetLatest = prdApi.getLatest as jest.Mock;
+
+const onPrdGenerated = jest.fn();
+const onClose = jest.fn();
+
+function renderPanel() {
+  return render(
+    <DiscoveryPanel
+      workspacePath="/ws"
+      onPrdGenerated={onPrdGenerated}
+      onClose={onClose}
+    />
+  );
+}
+
+function transcript(): string[] {
+  return Array.from(
+    screen.getByTestId('transcript').querySelectorAll('li')
+  ).map((li) => li.textContent ?? '');
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStatus.mockResolvedValue({ session_id: null, state: 'idle' });
+  mockStart.mockResolvedValue({
+    session_id: 's-1',
+    question: { text: 'What problem are you solving?' },
+  });
+});
+
+// ── Start ────────────────────────────────────────────────────────────────
+
+describe('DiscoveryPanel — start', () => {
+  it('checks for an existing session before starting a new one', async () => {
+    renderPanel();
+    await waitFor(() => expect(mockStatus).toHaveBeenCalledWith('/ws'));
+    await waitFor(() => expect(mockStart).toHaveBeenCalledWith('/ws'));
+  });
+
+  it('shows the first question once a session starts', async () => {
+    renderPanel();
+    await waitFor(() =>
+      expect(transcript().join('\n')).toContain('What problem are you solving?')
+    );
+  });
+
+  it('starts fresh anyway when the status check fails', async () => {
+    // A broken status endpoint must not strand the user with no session.
+    mockStatus.mockRejectedValue(new Error('offline'));
+    renderPanel();
+    await waitFor(() => expect(mockStart).toHaveBeenCalledWith('/ws'));
+  });
+
+  it('surfaces a failure to start rather than sitting silent', async () => {
+    mockStart.mockRejectedValue({ detail: 'no API key configured' });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText('no API key configured')).toBeInTheDocument()
+    );
+  });
+
+  it('opens the answer input only once discovery is under way', async () => {
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'submit-answer' })).toBeInTheDocument()
+    );
+  });
+});
+
+// ── Resume ───────────────────────────────────────────────────────────────
+
+describe('DiscoveryPanel — resume', () => {
+  beforeEach(() => {
+    mockStatus.mockResolvedValue({
+      session_id: 's-existing',
+      state: 'discovering',
+      progress: { answered_count: 3 },
+      current_question: { text: 'Who are the users?' },
+    });
+  });
+
+  it('offers to resume instead of silently starting a new session', async () => {
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resume/i })).toBeInTheDocument()
+    );
+    expect(screen.getByText(/3 questions answered/i)).toBeInTheDocument();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('restores the outstanding question when resumed', async () => {
+    renderPanel();
+    await userEvent.click(await screen.findByRole('button', { name: /resume/i }));
+
+    const text = transcript().join('\n');
+    expect(text).toContain('Resuming your previous session');
+    expect(text).toContain('Who are the users?');
+    // And the input opens so the user can actually answer it.
+    expect(screen.getByRole('button', { name: 'submit-answer' })).toBeEnabled();
+  });
+
+  it('singularises the count for a single answered question', async () => {
+    mockStatus.mockResolvedValue({
+      session_id: 's-existing',
+      state: 'discovering',
+      progress: { answered_count: 1 },
+      current_question: { text: 'Q?' },
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(/1 question answered/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/1 questions answered/i)).not.toBeInTheDocument();
+  });
+
+  it('"Start Fresh" resets the old session before starting a new one', async () => {
+    mockReset.mockResolvedValue(undefined);
+    renderPanel();
+    await userEvent.click(await screen.findByRole('button', { name: /start fresh/i }));
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith('/ws'));
+    await waitFor(() => expect(mockStart).toHaveBeenCalledWith('/ws'));
+  });
+
+  it('reports a failed reset instead of leaving a dead panel', async () => {
+    mockReset.mockRejectedValue({ detail: 'reset failed' });
+    renderPanel();
+    await userEvent.click(await screen.findByRole('button', { name: /start fresh/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('reset failed')).toBeInTheDocument()
+    );
+  });
+
+  it('goes straight to the completed state for a finished session', async () => {
+    mockStatus.mockResolvedValue({ session_id: 's-done', state: 'completed' });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /generate prd/i })).toBeInTheDocument()
+    );
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+});
+
+// ── Submit answer ────────────────────────────────────────────────────────
+
+describe('DiscoveryPanel — submit answer', () => {
+  async function startedPanel() {
+    renderPanel();
+    await screen.findByRole('button', { name: 'submit-answer' });
+  }
+
+  it('sends the answer for the current session', async () => {
+    mockSubmit.mockResolvedValue({ accepted: true, feedback: 'Good.' });
+    await startedPanel();
+
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() =>
+      expect(mockSubmit).toHaveBeenCalledWith('s-1', 'my answer', '/ws')
+    );
+  });
+
+  it('echoes the answer and appends the next question', async () => {
+    mockSubmit.mockResolvedValue({
+      accepted: true,
+      feedback: 'Good.',
+      next_question: { text: 'And the constraints?' },
+    });
+    await startedPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() => {
+      const text = transcript().join('\n');
+      expect(text).toContain('user: my answer');
+      expect(text).toContain('Good.');
+      expect(text).toContain('And the constraints?');
+    });
+  });
+
+  it('appends the follow-up when an answer is not accepted', async () => {
+    mockSubmit.mockResolvedValue({
+      accepted: false,
+      feedback: 'Too vague.',
+      follow_up: 'Which users specifically?',
+    });
+    await startedPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() =>
+      expect(transcript().join('\n')).toContain('Which users specifically?')
+    );
+  });
+
+  it('offers PRD generation once discovery completes', async () => {
+    mockSubmit.mockResolvedValue({
+      accepted: true,
+      feedback: 'That is everything.',
+      is_complete: true,
+    });
+    await startedPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /generate prd/i })).toBeInTheDocument()
+    );
+  });
+
+  it('surfaces a submit failure rather than swallowing it', async () => {
+    // The defect this issue names: a swallowed submit error ships green.
+    mockSubmit.mockRejectedValue({ detail: 'rate limited' });
+    await startedPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('rate limited')).toBeInTheDocument()
+    );
+  });
+
+  it('clears the thinking state even when the submit fails', async () => {
+    mockSubmit.mockRejectedValue({ detail: 'boom' });
+    await startedPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('thinking')).toHaveTextContent('false')
+    );
+    // The input must be usable again, not stuck disabled.
+    expect(screen.getByRole('button', { name: 'submit-answer' })).toBeEnabled();
+  });
+
+  it('keeps the user answer in the transcript after a failure', async () => {
+    mockSubmit.mockRejectedValue({ detail: 'boom' });
+    await startedPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'submit-answer' }));
+
+    await waitFor(() =>
+      expect(transcript().join('\n')).toContain('user: my answer')
+    );
+  });
+});
+
+// ── Generate PRD ─────────────────────────────────────────────────────────
+
+describe('DiscoveryPanel — generate PRD', () => {
+  beforeEach(() => {
+    mockStatus.mockResolvedValue({ session_id: 's-done', state: 'completed' });
+  });
+
+  it('generates then hands the full PRD to the parent', async () => {
+    mockGenerate.mockResolvedValue({ prd_id: 'p-1' });
+    mockGetLatest.mockResolvedValue({ id: 'p-1', content: '# PRD' });
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /generate prd/i })
+    );
+
+    await waitFor(() =>
+      expect(mockGenerate).toHaveBeenCalledWith('s-done', '/ws')
+    );
+    // The generate response is a summary; the panel must fetch the real PRD.
+    await waitFor(() => expect(mockGetLatest).toHaveBeenCalledWith('/ws'));
+    expect(onPrdGenerated).toHaveBeenCalledWith({ id: 'p-1', content: '# PRD' });
+  });
+
+  it('blocks re-entry while generating', async () => {
+    let resolve: (v: unknown) => void = () => {};
+    mockGenerate.mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderPanel();
+
+    const button = await screen.findByRole('button', { name: /generate prd/i });
+    await userEvent.click(button);
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /generating prd/i })).toBeDisabled()
+    );
+    resolve({});
+  });
+
+  it('reports a generation failure and does not notify the parent', async () => {
+    mockGenerate.mockRejectedValue({ detail: 'discovery incomplete' });
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /generate prd/i })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('discovery incomplete')).toBeInTheDocument()
+    );
+    expect(onPrdGenerated).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure to fetch the generated PRD', async () => {
+    mockGenerate.mockResolvedValue({ prd_id: 'p-1' });
+    mockGetLatest.mockRejectedValue({ detail: 'could not load PRD' });
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /generate prd/i })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('could not load PRD')).toBeInTheDocument()
+    );
+    expect(onPrdGenerated).not.toHaveBeenCalled();
+  });
+
+  it('re-enables the button after a failure', async () => {
+    mockGenerate.mockRejectedValue({ detail: 'nope' });
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /generate prd/i })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /generate prd/i })).toBeEnabled()
+    );
+  });
+});
+
+// ── Panel chrome ─────────────────────────────────────────────────────────
+
+describe('DiscoveryPanel — chrome', () => {
+  it('closes on request', async () => {
+    renderPanel();
+    await userEvent.click(
+      await screen.findByRole('button', { name: /close discovery panel/i })
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('offers start-over only once a session exists', async () => {
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /start over/i })).toBeInTheDocument()
+    );
+  });
+});

--- a/web-ui/src/__tests__/lib/api.contract.test.ts
+++ b/web-ui/src/__tests__/lib/api.contract.test.ts
@@ -12,13 +12,32 @@
  * body serialization, so `config` holds exactly what would go on the wire. No
  * network, no msw/jsdom polyfills.
  */
+import { readFileSync } from 'fs';
+
 import type { AxiosAdapter, InternalAxiosRequestConfig } from 'axios';
 
 import api, {
   workspaceApi,
   tasksApi,
   eventsApi,
+  blockersApi,
+  batchesApi,
+  prdApi,
+  discoveryApi,
+  reviewApi,
+  gatesApi,
+  gitApi,
+  proofApi,
+  prApi,
+  sessionsApi,
+  settingsApi,
+  proofConfigApi,
+  workspaceConfigApi,
+  notificationsApi,
+  integrationsApi,
+  costsApi,
 } from '@/lib/api';
+import * as apiModule from '@/lib/api';
 import { setToken } from '@/lib/auth';
 
 // jsdom 30's window.location is non-configurable; the 401 interceptor imports
@@ -187,6 +206,603 @@ describe('api.ts request contract', () => {
     it('getRecent forwards limit and since_id', async () => {
       await eventsApi.getRecent('/ws', { limit: 5, sinceId: 42 });
       expect(captured.params).toEqual({ workspace_path: '/ws', limit: 5, since_id: 42 });
+    });
+  });
+
+
+  describe('blockersApi', () => {
+    it('getAll → GET /api/v2/blockers with workspace_path only', async () => {
+      await blockersApi.getAll('/ws');
+      expect(captured.method).toBe('get');
+      expect(captured.url).toBe('/api/v2/blockers');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('getAll omits status/limit when not supplied, forwards when they are', async () => {
+      await blockersApi.getAll('/ws', { status: 'OPEN' as never, limit: 5 });
+      expect(captured.params).toEqual({ workspace_path: '/ws', status: 'OPEN', limit: 5 });
+    });
+
+    it('getForTask → GET /api/v2/blockers?task_id=', async () => {
+      await blockersApi.getForTask('/ws', 't-1');
+      expect(captured.url).toBe('/api/v2/blockers');
+      expect(captured.params).toEqual({ workspace_path: '/ws', task_id: 't-1' });
+    });
+
+    it('answer → POST /api/v2/blockers/:id/answer with {answer}', async () => {
+      await blockersApi.answer('/ws', 'b 1', 'because');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/blockers/b%201/answer');
+      expect(captured.body).toEqual({ answer: 'because' });
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('resolve → POST /api/v2/blockers/:id/resolve', async () => {
+      await blockersApi.resolve('/ws', 'b-1');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/blockers/b-1/resolve');
+      expect(captured.body).toEqual({});
+    });
+  });
+
+  describe('batchesApi', () => {
+    it('list → GET /api/v2/batches', async () => {
+      await batchesApi.list('/ws');
+      expect(captured.method).toBe('get');
+      expect(captured.url).toBe('/api/v2/batches');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('list forwards status and limit when supplied', async () => {
+      await batchesApi.list('/ws', { status: 'RUNNING', limit: 3 });
+      expect(captured.params).toEqual({ workspace_path: '/ws', status: 'RUNNING', limit: 3 });
+    });
+
+    it('get → GET /api/v2/batches/:id, id encoded', async () => {
+      await batchesApi.get('/ws', 'b/1');
+      expect(captured.url).toBe('/api/v2/batches/b%2F1');
+    });
+
+    it('stop → POST /api/v2/batches/:id/stop', async () => {
+      await batchesApi.stop('/ws', 'b-1');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/batches/b-1/stop');
+      expect(captured.body).toEqual({});
+    });
+
+    it('cancel → POST /api/v2/batches/:id/cancel', async () => {
+      await batchesApi.cancel('/ws', 'b-1');
+      expect(captured.url).toBe('/api/v2/batches/b-1/cancel');
+    });
+  });
+
+  describe('prdApi', () => {
+    it('getAll → GET /api/v2/prd', async () => {
+      await prdApi.getAll('/ws');
+      expect(captured.method).toBe('get');
+      expect(captured.url).toBe('/api/v2/prd');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('getLatest → GET /api/v2/prd/latest', async () => {
+      await prdApi.getLatest('/ws');
+      expect(captured.url).toBe('/api/v2/prd/latest');
+    });
+
+    it('getById → GET /api/v2/prd/:id', async () => {
+      await prdApi.getById('p-1', '/ws');
+      expect(captured.url).toBe('/api/v2/prd/p-1');
+    });
+
+    it('create → POST /api/v2/prd with {content} and optional title/metadata', async () => {
+      await prdApi.create('/ws', '# doc');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/prd');
+      expect(captured.body).toEqual({ content: '# doc' });
+
+      await prdApi.create('/ws', '# doc', 'T', { a: 1 });
+      expect(captured.body).toEqual({ content: '# doc', title: 'T', metadata: { a: 1 } });
+    });
+
+    it('delete → DELETE /api/v2/prd/:id', async () => {
+      await prdApi.delete('p-1', '/ws');
+      expect(captured.method).toBe('delete');
+      expect(captured.url).toBe('/api/v2/prd/p-1');
+    });
+
+    it('getVersions → GET /api/v2/prd/:id/versions', async () => {
+      await prdApi.getVersions('p-1', '/ws');
+      expect(captured.url).toBe('/api/v2/prd/p-1/versions');
+    });
+
+    it('createVersion → POST with snake_case change_summary', async () => {
+      await prdApi.createVersion('p-1', '/ws', '# v2', 'why');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/prd/p-1/versions');
+      expect(captured.body).toEqual({ content: '# v2', change_summary: 'why' });
+    });
+
+    it('diff omits version params unless given', async () => {
+      await prdApi.diff('p-1', '/ws');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+
+      await prdApi.diff('p-1', '/ws', 1, 2);
+      expect(captured.params).toEqual({ workspace_path: '/ws', version1: 1, version2: 2 });
+    });
+
+    it('diff forwards version 0, which a truthy check would drop', async () => {
+      await prdApi.diff('p-1', '/ws', 0, 2);
+      expect(captured.params).toEqual({ workspace_path: '/ws', version1: 0, version2: 2 });
+    });
+
+    it('refineStressTest → POST /api/v2/prd/stress-test/refine with {prd_id, answers}', async () => {
+      const answers = [{ label: 'L', questions: ['q?'], answer: 'a' }];
+      await prdApi.refineStressTest('p-1', '/ws', answers);
+      expect(captured.url).toBe('/api/v2/prd/stress-test/refine');
+      expect(captured.body).toEqual({ prd_id: 'p-1', answers });
+    });
+  });
+
+  describe('discoveryApi', () => {
+    it('start → POST /api/v2/discovery/start', async () => {
+      await discoveryApi.start('/ws');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/discovery/start');
+      expect(captured.body).toEqual({});
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('getStatus → GET /api/v2/discovery/status', async () => {
+      await discoveryApi.getStatus('/ws');
+      expect(captured.method).toBe('get');
+      expect(captured.url).toBe('/api/v2/discovery/status');
+    });
+
+    it('submitAnswer → POST /api/v2/discovery/:sessionId/answer with {answer}', async () => {
+      await discoveryApi.submitAnswer('s-1', 'my answer', '/ws');
+      expect(captured.url).toBe('/api/v2/discovery/s-1/answer');
+      expect(captured.body).toEqual({ answer: 'my answer' });
+    });
+
+    it('generatePrd → POST /api/v2/discovery/:sessionId/generate-prd', async () => {
+      await discoveryApi.generatePrd('s-1', '/ws');
+      expect(captured.url).toBe('/api/v2/discovery/s-1/generate-prd');
+      expect(captured.body).toEqual({});
+
+      await discoveryApi.generatePrd('s-1', '/ws', 'lean');
+      expect(captured.body).toEqual({ template_id: 'lean' });
+    });
+
+    it('reset → POST /api/v2/discovery/reset', async () => {
+      await discoveryApi.reset('/ws');
+      expect(captured.url).toBe('/api/v2/discovery/reset');
+    });
+
+    it('generateTasks → POST /api/v2/discovery/generate-tasks', async () => {
+      await discoveryApi.generateTasks('/ws');
+      expect(captured.url).toBe('/api/v2/discovery/generate-tasks');
+    });
+  });
+
+  describe('reviewApi', () => {
+    it('getDiff → GET /api/v2/review/diff, staged omitted unless true', async () => {
+      await reviewApi.getDiff('/ws');
+      expect(captured.method).toBe('get');
+      expect(captured.url).toBe('/api/v2/review/diff');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+
+      await reviewApi.getDiff('/ws', true);
+      expect(captured.params).toEqual({ workspace_path: '/ws', staged: true });
+    });
+
+    it('getPatch → GET /api/v2/review/patch', async () => {
+      await reviewApi.getPatch('/ws');
+      expect(captured.url).toBe('/api/v2/review/patch');
+    });
+
+    it('generateCommitMessage → POST /api/v2/review/commit-message', async () => {
+      await reviewApi.generateCommitMessage('/ws');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/review/commit-message');
+      expect(captured.body).toEqual({});
+    });
+  });
+
+  describe('gatesApi', () => {
+    it('run → POST /api/v2/gates/run, defaulting gates to null and verbose to false', async () => {
+      await gatesApi.run('/ws');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/gates/run');
+      expect(captured.body).toEqual({ gates: null, verbose: false });
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('run forwards an explicit gate list', async () => {
+      await gatesApi.run('/ws', { gates: ['lint'], verbose: true });
+      expect(captured.body).toEqual({ gates: ['lint'], verbose: true });
+    });
+  });
+
+  describe('gitApi', () => {
+    it('getStatus → GET /api/v2/git/status', async () => {
+      await gitApi.getStatus('/ws');
+      expect(captured.method).toBe('get');
+      expect(captured.url).toBe('/api/v2/git/status');
+    });
+
+    it('commit → POST /api/v2/git/commit with {files, message}', async () => {
+      await gitApi.commit('/ws', ['a.ts', 'b.ts'], 'msg');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/git/commit');
+      expect(captured.body).toEqual({ files: ['a.ts', 'b.ts'], message: 'msg' });
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+  });
+
+  describe('proofApi', () => {
+    it('getStatus → GET /api/v2/proof/status', async () => {
+      await proofApi.getStatus('/ws');
+      expect(captured.url).toBe('/api/v2/proof/status');
+    });
+
+    it('listRequirements omits status unless supplied', async () => {
+      await proofApi.listRequirements('/ws');
+      expect(captured.url).toBe('/api/v2/proof/requirements');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+
+      await proofApi.listRequirements('/ws', 'OPEN' as never);
+      expect(captured.params).toEqual({ workspace_path: '/ws', status: 'OPEN' });
+    });
+
+    it('getRequirement → GET /api/v2/proof/requirements/:id', async () => {
+      await proofApi.getRequirement('/ws', 'REQ-1');
+      expect(captured.url).toBe('/api/v2/proof/requirements/REQ-1');
+    });
+
+    it('getEvidence → GET /api/v2/proof/requirements/:id/evidence', async () => {
+      await proofApi.getEvidence('/ws', 'REQ-1');
+      expect(captured.url).toBe('/api/v2/proof/requirements/REQ-1/evidence');
+    });
+
+    it('capture → POST /api/v2/proof/requirements with the body verbatim', async () => {
+      const body = { title: 'T', description: 'd' } as never;
+      await proofApi.capture('/ws', body);
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/proof/requirements');
+      expect(captured.body).toEqual({ title: 'T', description: 'd' });
+    });
+
+    it('waive → POST /api/v2/proof/requirements/:id/waive', async () => {
+      await proofApi.waive('/ws', 'REQ-1', { reason: 'r' } as never);
+      expect(captured.url).toBe('/api/v2/proof/requirements/REQ-1/waive');
+      expect(captured.body).toEqual({ reason: 'r' });
+    });
+
+    it('startRun → POST /api/v2/proof/run', async () => {
+      await proofApi.startRun('/ws', { gates: [] } as never);
+      expect(captured.url).toBe('/api/v2/proof/run');
+    });
+
+    it('getRun → GET /api/v2/proof/runs/:id', async () => {
+      await proofApi.getRun('/ws', 'r-1');
+      expect(captured.url).toBe('/api/v2/proof/runs/r-1');
+    });
+
+    it('listRuns → GET /api/v2/proof/runs with a default limit of 5', async () => {
+      await proofApi.listRuns('/ws');
+      expect(captured.params).toEqual({ workspace_path: '/ws', limit: 5 });
+    });
+
+    it('getRunDetail → GET /api/v2/proof/runs/:id/evidence', async () => {
+      await proofApi.getRunDetail('/ws', 'r-1');
+      expect(captured.url).toBe('/api/v2/proof/runs/r-1/evidence');
+    });
+  });
+
+  describe('prApi', () => {
+    it('create → POST /api/v2/pr with the request verbatim', async () => {
+      await prApi.create('/ws', { branch: '', title: 'T', body: 'B' });
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/pr');
+      expect(captured.body).toEqual({ branch: '', title: 'T', body: 'B' });
+    });
+
+    it('getStatus → GET /api/v2/pr/status?pr_number=', async () => {
+      await prApi.getStatus('/ws', 7);
+      expect(captured.params).toEqual({ workspace_path: '/ws', pr_number: 7 });
+    });
+
+    it('merge defaults the method to squash and omits override keys', async () => {
+      await prApi.merge('/ws', 7);
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/pr/7/merge');
+      expect(captured.body).toEqual({ method: 'squash' });
+    });
+
+    it('merge sends override and its reason together', async () => {
+      await prApi.merge('/ws', 7, { override: true, override_reason: 'because' });
+      expect(captured.body).toEqual({
+        method: 'squash',
+        override: true,
+        override_reason: 'because',
+      });
+    });
+
+    it('list defaults state to open', async () => {
+      await prApi.list('/ws');
+      expect(captured.params).toEqual({ workspace_path: '/ws', state: 'open' });
+    });
+
+    it('getHistory omits limit unless supplied', async () => {
+      await prApi.getHistory('/ws');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+      await prApi.getHistory('/ws', 10);
+      expect(captured.params).toEqual({ workspace_path: '/ws', limit: 10 });
+    });
+
+    it('getFiles → GET /api/v2/pr/:n/files and unwraps .files', async () => {
+      stubResponseData = { files: ['a.ts'] };
+      const files = await prApi.getFiles('/ws', 7);
+      expect(captured.url).toBe('/api/v2/pr/7/files');
+      expect(files).toEqual(['a.ts']);
+    });
+  });
+
+  describe('sessionsApi', () => {
+    it('getAll → GET /api/v2/sessions and wraps the array', async () => {
+      stubResponseData = [{ id: 's1' }];
+      const res = await sessionsApi.getAll('/ws');
+      expect(captured.url).toBe('/api/v2/sessions');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+      expect(res).toEqual({ sessions: [{ id: 's1' }], total: 1 });
+    });
+
+    it('getAll forwards a state filter', async () => {
+      stubResponseData = [];
+      await sessionsApi.getAll('/ws', { state: 'active' as never });
+      expect(captured.params).toEqual({ workspace_path: '/ws', state: 'active' });
+    });
+
+    it('create → POST /api/v2/sessions with the payload verbatim', async () => {
+      await sessionsApi.create({ workspace_path: '/ws' } as never);
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/sessions');
+      expect(captured.body).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('getOne encodes the session id', async () => {
+      await sessionsApi.getOne('s/1');
+      expect(captured.url).toBe('/api/v2/sessions/s%2F1');
+    });
+
+    it('getMessages maps created_at to createdAt', async () => {
+      stubResponseData = [
+        { id: 'm1', role: 'user', content: 'hi', created_at: '2026-01-01T00:00:00Z' },
+      ];
+      const msgs = await sessionsApi.getMessages('s-1', { limit: 10 });
+      expect(captured.url).toBe('/api/v2/sessions/s-1/messages');
+      expect(captured.params).toEqual({ limit: 10 });
+      expect(msgs).toEqual([
+        { id: 'm1', role: 'user', content: 'hi', createdAt: '2026-01-01T00:00:00Z' },
+      ]);
+    });
+
+    it('end → DELETE /api/v2/sessions/:id', async () => {
+      await sessionsApi.end('s-1');
+      expect(captured.method).toBe('delete');
+      expect(captured.url).toBe('/api/v2/sessions/s-1');
+    });
+  });
+
+  describe('settingsApi', () => {
+    it('get → GET /api/v2/settings', async () => {
+      await settingsApi.get('/ws');
+      expect(captured.url).toBe('/api/v2/settings');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('update → PUT /api/v2/settings with the body verbatim', async () => {
+      await settingsApi.update('/ws', { engine: 'react' } as never);
+      expect(captured.method).toBe('put');
+      expect(captured.body).toEqual({ engine: 'react' });
+    });
+
+    it('getKeys → GET /api/v2/settings/keys with no params', async () => {
+      await settingsApi.getKeys();
+      expect(captured.url).toBe('/api/v2/settings/keys');
+      expect(captured.params).toBeUndefined();
+    });
+
+    it('storeKey → PUT /api/v2/settings/keys/:provider with {value}', async () => {
+      await settingsApi.storeKey('anthropic' as never, 'sk-1');
+      expect(captured.method).toBe('put');
+      expect(captured.url).toBe('/api/v2/settings/keys/anthropic');
+      expect(captured.body).toEqual({ value: 'sk-1' });
+    });
+
+    it('removeKey → DELETE /api/v2/settings/keys/:provider', async () => {
+      await settingsApi.removeKey('anthropic' as never);
+      expect(captured.method).toBe('delete');
+      expect(captured.url).toBe('/api/v2/settings/keys/anthropic');
+    });
+
+    it('verifyKey sends value:null when omitted', async () => {
+      await settingsApi.verifyKey('anthropic' as never);
+      expect(captured.url).toBe('/api/v2/settings/verify-key');
+      expect(captured.body).toEqual({ provider: 'anthropic', value: null });
+    });
+  });
+
+  describe('proofConfigApi', () => {
+    it('getConfig → GET /api/v2/proof/config', async () => {
+      await proofConfigApi.getConfig('/ws');
+      expect(captured.url).toBe('/api/v2/proof/config');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+    });
+
+    it('updateConfig → PUT /api/v2/proof/config', async () => {
+      await proofConfigApi.updateConfig('/ws', { strictness: 'strict' } as never);
+      expect(captured.method).toBe('put');
+      expect(captured.body).toEqual({ strictness: 'strict' });
+    });
+  });
+
+  describe('workspaceConfigApi', () => {
+    it('getConfig → GET /api/v2/workspaces/config', async () => {
+      await workspaceConfigApi.getConfig('/ws');
+      expect(captured.url).toBe('/api/v2/workspaces/config');
+    });
+
+    it('updateConfig → PUT /api/v2/workspaces/config', async () => {
+      await workspaceConfigApi.updateConfig('/ws', { tech_stack: 'py' } as never);
+      expect(captured.method).toBe('put');
+      expect(captured.body).toEqual({ tech_stack: 'py' });
+    });
+  });
+
+  describe('notificationsApi', () => {
+    it('get → GET /api/v2/settings/notifications', async () => {
+      await notificationsApi.get('/ws');
+      expect(captured.url).toBe('/api/v2/settings/notifications');
+    });
+
+    it('update → PUT /api/v2/settings/notifications', async () => {
+      await notificationsApi.update('/ws', { enabled: true, url: 'u' } as never);
+      expect(captured.method).toBe('put');
+      expect(captured.body).toEqual({ enabled: true, url: 'u' });
+    });
+
+    it('test → POST /api/v2/settings/notifications/test with no body', async () => {
+      await notificationsApi.test('/ws');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/settings/notifications/test');
+      expect(captured.body).toBeUndefined();
+    });
+  });
+
+  describe('integrationsApi', () => {
+    it('getStatus → GET /api/v2/integrations/github/status', async () => {
+      await integrationsApi.getStatus('/ws');
+      expect(captured.url).toBe('/api/v2/integrations/github/status');
+    });
+
+    it('connect → POST .../connect with {pat, repo}', async () => {
+      await integrationsApi.connect('/ws', 'ghp_x', 'o/r');
+      expect(captured.method).toBe('post');
+      expect(captured.url).toBe('/api/v2/integrations/github/connect');
+      expect(captured.body).toEqual({ pat: 'ghp_x', repo: 'o/r' });
+    });
+
+    it('disconnect → DELETE .../disconnect', async () => {
+      await integrationsApi.disconnect('/ws');
+      expect(captured.method).toBe('delete');
+      expect(captured.url).toBe('/api/v2/integrations/github/disconnect');
+    });
+
+    it('getIssues sends snake_case per_page and defaults page/search/label', async () => {
+      await integrationsApi.getIssues('/ws');
+      expect(captured.url).toBe('/api/v2/integrations/github/issues');
+      expect(captured.params).toEqual({
+        workspace_path: '/ws',
+        page: 1,
+        per_page: 25,
+        search: '',
+        label: '',
+      });
+    });
+
+    it('getIssues forwards explicit paging and filters', async () => {
+      await integrationsApi.getIssues('/ws', { page: 3, perPage: 50, search: 'bug', label: 'ui' });
+      expect(captured.params).toEqual({
+        workspace_path: '/ws',
+        page: 3,
+        per_page: 50,
+        search: 'bug',
+        label: 'ui',
+      });
+    });
+
+    it('importIssues → POST .../import with snake_case issue_numbers', async () => {
+      await integrationsApi.importIssues('/ws', [1, 2]);
+      expect(captured.url).toBe('/api/v2/integrations/github/import');
+      expect(captured.body).toEqual({ issue_numbers: [1, 2] });
+    });
+  });
+
+  describe('costsApi', () => {
+    it('getSummary → GET /api/v2/costs/summary?days=', async () => {
+      await costsApi.getSummary('/ws', 7);
+      expect(captured.url).toBe('/api/v2/costs/summary');
+      expect(captured.params).toEqual({ workspace_path: '/ws', days: 7 });
+    });
+
+    it('getTopTasks defaults days=30 and limit=10', async () => {
+      await costsApi.getTopTasks('/ws');
+      expect(captured.url).toBe('/api/v2/costs/tasks');
+      expect(captured.params).toEqual({ workspace_path: '/ws', days: 30, limit: 10 });
+    });
+
+    it('getByAgent defaults days=30', async () => {
+      await costsApi.getByAgent('/ws');
+      expect(captured.url).toBe('/api/v2/costs/by-agent');
+      expect(captured.params).toEqual({ workspace_path: '/ws', days: 30 });
+    });
+  });
+
+  // ── Coverage guard (issue #965) ────────────────────────────────────────
+  //
+  // The whole point of this file is that every OTHER suite mocks @/lib/api, so
+  // a wrong method, path, renamed query param or reshaped body passes green
+  // everywhere else. That guarantee is only as good as its coverage, and it
+  // previously covered 3 of 19 namespaces. This guard fails when a namespace
+  // is added without a contract case, so the gap cannot silently reopen.
+
+  describe('coverage guard', () => {
+    const COVERED = new Set([
+      'workspaceApi',
+      'tasksApi',
+      'eventsApi',
+      'blockersApi',
+      'batchesApi',
+      'prdApi',
+      'discoveryApi',
+      'reviewApi',
+      'gatesApi',
+      'gitApi',
+      'proofApi',
+      'prApi',
+      'sessionsApi',
+      'settingsApi',
+      'proofConfigApi',
+      'workspaceConfigApi',
+      'notificationsApi',
+      'integrationsApi',
+      'costsApi',
+    ]);
+
+    it('every exported *Api namespace has contract cases in this file', () => {
+      const exported = Object.keys(apiModule).filter((k) => k.endsWith('Api'));
+      const uncovered = exported.filter((n) => !COVERED.has(n));
+      expect(uncovered).toEqual([]);
+    });
+
+    it('the covered list has no stale entries', () => {
+      const exported = new Set(
+        Object.keys(apiModule).filter((k) => k.endsWith('Api'))
+      );
+      const stale = [...COVERED].filter((n) => !exported.has(n));
+      expect(stale).toEqual([]);
+    });
+
+    it('each covered namespace has a describe block naming it', () => {
+      // Cheap structural check: the source of this file must mention every
+      // covered namespace inside a describe(...) header, so an entry cannot be
+      // added to COVERED without actual cases behind it.
+      const src = readFileSync(__filename, 'utf8');
+      const missing = [...COVERED].filter(
+        (n) => !src.includes(`describe('${n}'`)
+      );
+      expect(missing).toEqual([]);
     });
   });
 

--- a/web-ui/src/__tests__/lib/api.contract.test.ts
+++ b/web-ui/src/__tests__/lib/api.contract.test.ts
@@ -209,7 +209,6 @@ describe('api.ts request contract', () => {
     });
   });
 
-
   describe('blockersApi', () => {
     it('getAll → GET /api/v2/blockers with workspace_path only', async () => {
       await blockersApi.getAll('/ws');
@@ -312,7 +311,10 @@ describe('api.ts request contract', () => {
 
     it('getVersions → GET /api/v2/prd/:id/versions', async () => {
       await prdApi.getVersions('p-1', '/ws');
+      expect(captured.method).toBe('get');
       expect(captured.url).toBe('/api/v2/prd/p-1/versions');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
+      expect(captured.body).toBeUndefined();
     });
 
     it('createVersion → POST with snake_case change_summary', async () => {
@@ -456,12 +458,16 @@ describe('api.ts request contract', () => {
 
     it('getRequirement → GET /api/v2/proof/requirements/:id', async () => {
       await proofApi.getRequirement('/ws', 'REQ-1');
+      expect(captured.method).toBe('get');
       expect(captured.url).toBe('/api/v2/proof/requirements/REQ-1');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
     });
 
     it('getEvidence → GET /api/v2/proof/requirements/:id/evidence', async () => {
       await proofApi.getEvidence('/ws', 'REQ-1');
+      expect(captured.method).toBe('get');
       expect(captured.url).toBe('/api/v2/proof/requirements/REQ-1/evidence');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
     });
 
     it('capture → POST /api/v2/proof/requirements with the body verbatim', async () => {
@@ -478,14 +484,19 @@ describe('api.ts request contract', () => {
       expect(captured.body).toEqual({ reason: 'r' });
     });
 
-    it('startRun → POST /api/v2/proof/run', async () => {
-      await proofApi.startRun('/ws', { gates: [] } as never);
+    it('startRun → POST /api/v2/proof/run with the body verbatim', async () => {
+      await proofApi.startRun('/ws', { gates: ['unit'], strictness: 'strict' } as never);
+      expect(captured.method).toBe('post');
       expect(captured.url).toBe('/api/v2/proof/run');
+      expect(captured.body).toEqual({ gates: ['unit'], strictness: 'strict' });
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
     });
 
     it('getRun → GET /api/v2/proof/runs/:id', async () => {
       await proofApi.getRun('/ws', 'r-1');
+      expect(captured.method).toBe('get');
       expect(captured.url).toBe('/api/v2/proof/runs/r-1');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
     });
 
     it('listRuns → GET /api/v2/proof/runs with a default limit of 5', async () => {
@@ -495,7 +506,9 @@ describe('api.ts request contract', () => {
 
     it('getRunDetail → GET /api/v2/proof/runs/:id/evidence', async () => {
       await proofApi.getRunDetail('/ws', 'r-1');
+      expect(captured.method).toBe('get');
       expect(captured.url).toBe('/api/v2/proof/runs/r-1/evidence');
+      expect(captured.params).toEqual({ workspace_path: '/ws' });
     });
   });
 
@@ -628,8 +641,14 @@ describe('api.ts request contract', () => {
 
     it('verifyKey sends value:null when omitted', async () => {
       await settingsApi.verifyKey('anthropic' as never);
+      expect(captured.method).toBe('post');
       expect(captured.url).toBe('/api/v2/settings/verify-key');
       expect(captured.body).toEqual({ provider: 'anthropic', value: null });
+    });
+
+    it('verifyKey forwards a supplied value', async () => {
+      await settingsApi.verifyKey('anthropic' as never, 'sk-live');
+      expect(captured.body).toEqual({ provider: 'anthropic', value: 'sk-live' });
     });
   });
 


### PR DESCRIPTION
Closes #965. 106 new tests across the two gaps the issue names.

## 1. `api.contract.test.ts`: 3 of 19 namespaces → 19 of 19

This file exists because **every other suite mocks `@/lib/api`** — so a wrong method, path, renamed query param or reshaped body passes green everywhere else. That guarantee covered `workspaceApi`, `tasksApi` and `eventsApi` while 39 suites hand-mocked the module.

Added cases pinning method + URL + params + body for the other 16: `blockersApi`, `batchesApi`, `prdApi`, `discoveryApi`, `reviewApi`, `gatesApi`, `gitApi`, `proofApi`, `prApi`, `sessionsApi`, `settingsApi`, `proofConfigApi`, `workspaceConfigApi`, `notificationsApi`, `integrationsApi`, `costsApi`.

They target the drift that is easy to introduce and invisible without them:

- **snake_case boundaries** — `change_summary`, `issue_numbers`, `per_page`, `pr_number`, `template_id`
- **id encoding** — `b/1` → `b%2F1`
- **conditional params** that must be *omitted*, not sent as `undefined`
- **client-side defaults** the server never sees stated: gates `null`/`false`, PR method `squash`, costs `days=30`/`limit=10`, proof `listRuns` `limit=5`, PR list `state=open`
- **response reshaping** — `getFiles` unwrapping `.files`, sessions mapping `created_at` → `createdAt`

`prdApi.diff` gets an explicit **version 0** case: the client correctly uses `!== undefined`, and a truthy check would silently drop version 0. That is exactly the kind of edit this file is meant to catch.

### A guard so the gap cannot reopen

Three tests fail when:
1. a new `*Api` namespace is exported without contract cases,
2. the covered list goes stale (names a namespace that no longer exists),
3. a name is added to the covered list without a matching `describe` block behind it.

Verified by adding a throwaway `fakeNewApi` export — the guard named it and failed:
```
+   "fakeNewApi"
Tests: 1 failed, 2 passed
```

## 2. `DiscoveryPanel`: 0% → 94% statements, 73% branches

304 LOC orchestrating the Think phase's Socratic flow, with no coverage and no e2e mention. 25 tests over the four paths the issue names:

- **start** — status is checked before starting; a *failed* status check still starts a session rather than stranding the user; a failure to start is surfaced.
- **resume** — the answered-count prompt, question restoration into the transcript, singular/plural (`1 question` vs `3 questions`), and "Start Fresh" resetting before starting.
- **submit-answer** — accepted, not-accepted-with-follow-up, completion, and **the swallowed-error case the issue calls out**: error shown, thinking cleared, input re-enabled, and the user's answer retained in the transcript.
- **generate-PRD** — generate *then* fetch the full PRD (the generate response is only a summary), re-entry blocked while in flight, and both failure points reported without notifying the parent.

### Enforcement

A per-file `coverageThreshold` in `jest.config.js`, set **below** the achieved figures so it guards against the coverage *disappearing* rather than against small movements. Verified it fires by raising it temporarily.

Deliberately only this file. A per-file threshold also fails when someone runs `--coverage` over a subset that excludes it, so each entry is a small DX tax — and `api.ts` has the better, subset-safe protection in its own guard test.

## Verification — mutation testing

Test-only work, so "does it fail without the fix" does not apply. I broke the code under test and confirmed the suites notice:

| Mutation | Caught by |
|---|---|
| `change_summary` → `changeSummary` | `createVersion → POST with snake_case change_summary` |
| `per_page` → `perPage` | both `integrationsApi.getIssues` cases |
| PR merge default `squash` → `merge` | both `prApi.merge` cases |
| `version1 !== undefined` → truthy check | `diff forwards version 0` |
| submit-answer error swallowed | `surfaces a submit failure rather than swallowing it` |

**5/5 caught (7 failing tests).** All reverted; suite restored to green.

- `npm test` → **1275 passed**, 104 suites (+106)
- `npm run test:coverage` → `DiscoveryPanel.tsx 94.11% / 73.21%`, `api.ts 98.03% / 95.83%`
- `npm run lint` → clean · `npm run build` → succeeds

## Third-party review — not run pre-PR

`codex review` is still rate-limited (`try again at 9:09 PM`, same as on #1097) and opencode/GLM is unreliable on this repo. The PR's CI runs **both** `claude-review` and the GLM `review / review` job, so post-PR third-party review still happens and I will triage before merging — but flagging that the pre-PR gate genuinely did not run.

## Known limitations

- The contract tests pin what the **client** sends, not that the server accepts it. A rename coordinated wrongly across both sides would still pass here; that is what the e2e suite is for.
- The coverage guard checks that a namespace *has* a `describe` block, not that every **method** within it is covered. Adding a method to an existing namespace will not trip it. Method-level enforcement would need reflection over the namespace object and is a bigger change.
- `DiscoveryPanel`'s branch coverage is 73%: the uncovered branches are `questionText`'s shape fallbacks (lines 35–36) for question objects that use neither `.text` nor `.question`.
- `DiscoveryTranscript` and `DiscoveryInput` are mocked as thin harnesses — this file covers the orchestration between them and the API, not their internals.
