### PR TITLE
fix(engine): gate the experimental cloud engine behind an opt-in (#966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,14 @@ Several of these change defaults and will require configuration on an existing d
 - **`scripts/lifecycle --mode api|web` exits 3** instead of reporting success for stubs
   that only ever raised `NotImplementedError` (#948).
 - Root documentation was brought back in line with the shipped product (#950).
+- **The cloud engine is experimental and gated (#966).** `--engine cloud` (E2B) now
+  refuses to run unless `CODEFRAME_ENABLE_CLOUD_ENGINE=1` is set, and it is gone from
+  `cf engines list`, the `--engine` help, the config validator's suggestions, and the
+  docs that counted it as shipped. **This breaks existing `--engine cloud` invocations**
+  — set the variable to keep them working. E2B execution is out of launch scope and does
+  not work end to end; the known defects are recorded under `CODEFRAME_ENABLE_CLOUD_ENGINE`
+  in `CLAUDE.md` as the checklist for lifting the gate. `--isolation cloud` was never
+  implemented and is unchanged.
 
 ## [0.9.1] - 2026-06-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,47 @@ CODEFRAME_ENABLE_TEST_ENDPOINTS=1     # Registers the integration-test-only
                                       # production — leave unset except in CI /
                                       # WebSocket integration test runs.
 
+# Experimental cloud engine (#966) — default OFF (refuse)
+CODEFRAME_ENABLE_CLOUD_ENGINE=1       # Unlock `--engine cloud` (the E2B adapter).
+                                      # Off by default and off the advertised
+                                      # surface: it is out of launch scope and
+                                      # does not currently work end-to-end, but
+                                      # it was reachable and listed next to the
+                                      # engines that do. `resolve_engine` and
+                                      # `get_external_adapter` now both refuse it
+                                      # (so CODEFRAME_ENGINE=cloud is not a way
+                                      # around the flag) with a message naming
+                                      # this variable. IsolationLevel.CLOUD is a
+                                      # separate thing and stays unimplemented.
+                                      #
+                                      # KNOWN DEFECTS — the price of lifting the
+                                      # gate. Deliberately NOT fixed in #966;
+                                      # this is the checklist for whoever makes
+                                      # the engine real:
+                                      #   1. Wrong package. `_INSTALL_CMD` runs
+                                      #      `pip install codeframe`, but the
+                                      #      project publishes as `codeframe-ai`
+                                      #      — every sandbox installs someone
+                                      #      else's package or nothing.
+                                      #   2. `CommandExitException` from the E2B
+                                      #      SDK is not handled, so a non-zero
+                                      #      command in the sandbox surfaces as
+                                      #      an unhandled traceback instead of a
+                                      #      failed run.
+                                      #   3. No working sync-back: results
+                                      #      produced in the sandbox do not
+                                      #      reliably land in the workspace, so a
+                                      #      "successful" run can leave nothing
+                                      #      behind.
+                                      #   4. File upload is unbatched (one
+                                      #      round-trip per file) — unusable on a
+                                      #      real repo.
+                                      #   5. The adapter's tests mock with
+                                      #      non-autospec mocks, so they pass
+                                      #      against signatures the SDK does not
+                                      #      have — they are not evidence the
+                                      #      engine works.
+
 # Delegated-agent HOME sandbox (#996) — default ON (sandboxed)
 CODEFRAME_AGENT_INHERIT_HOME=1        # Run delegated coding CLIs (claude-code,
                                       # codex, opencode, kilocode) with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Shipped pages: `/`, `/prd`, `/tasks`, `/execution`, `/execution/[taskId]`, `/blo
 Testing: `cd web-ui && npm test` must pass; `npm run build` must succeed. The `frontend-tests` CI job enforces this on every PR.
 
 ### What's implemented
-Full feature list in `docs/PRODUCT_ROADMAP.md`. Key capabilities: ReAct agent execution, batch execution (serial/parallel/auto), task dependencies, stall detection, self-correction, GitHub PR workflow, SSE streaming, API auth, rate limiting, OpenAPI docs, multi-provider LLM (Anthropic/OpenAI-compatible), agent adapters (ClaudeCode/Codex/OpenCode/Kilocode), worktree isolation, E2B cloud execution, interactive agent sessions (WebSocket chat + XTerm.js terminal), PROOF9 quality system (gate runs, per-gate evidence, run history).
+Full feature list in `docs/PRODUCT_ROADMAP.md`. Key capabilities: ReAct agent execution, batch execution (serial/parallel/auto), task dependencies, stall detection, self-correction, GitHub PR workflow, SSE streaming, API auth, rate limiting, OpenAPI docs, multi-provider LLM (Anthropic/OpenAI-compatible), agent adapters (ClaudeCode/Codex/OpenCode/Kilocode), worktree isolation, interactive agent sessions (WebSocket chat + XTerm.js terminal), PROOF9 quality system (gate runs, per-gate evidence, run history). E2B cloud execution exists but is EXPERIMENTAL and gated — see `CODEFRAME_ENABLE_CLOUD_ENGINE` below.
 
 ---
 

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -4200,6 +4200,17 @@ def batch_run(
         console.print(f"  Tasks: {len(ids_to_execute)}")
         console.print(f"  On failure: {on_failure}")
 
+        # Ahead of the dry-run return: a preview of an engine that would be
+        # refused is misleading, and this is also the pre-run guard that keeps
+        # the gate from raising after conductor.start_batch (#966).
+        from codeframe.core.engine_registry import resolve_engine
+
+        try:
+            resolve_engine(engine)
+        except ValueError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1)
+
         if dry_run:
             console.print("\n[dim]Dry run - showing tasks without executing:[/dim]")
             for i, tid in enumerate(ids_to_execute):
@@ -4209,16 +4220,7 @@ def batch_run(
             return
 
         # Validate API key before batch execution
-        from codeframe.core.engine_registry import (
-            is_external_engine,
-            resolve_engine,
-        )
-
-        try:
-            resolve_engine(engine)
-        except ValueError as exc:
-            console.print(f"[red]Error:[/red] {exc}")
-            raise typer.Exit(1)
+        from codeframe.core.engine_registry import is_external_engine
 
         if engine == "codex":
             # Not the OpenAI key check: `codex login` is the common way in

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2634,7 +2634,7 @@ def work_start(
     engine: Optional[str] = typer.Option(
         None,
         "--engine",
-        help="Agent engine: react (default), plan (legacy), claude-code, codex, opencode, kilocode, cloud, or built-in",
+        help="Agent engine: react (default), plan (legacy), claude-code, codex, opencode, kilocode, or built-in",
     ),
     stall_timeout: int = typer.Option(
         300,
@@ -2656,7 +2656,7 @@ def work_start(
     cloud_timeout: int = typer.Option(
         30,
         "--cloud-timeout",
-        help="Sandbox timeout in minutes for --engine cloud (1-60, default: 30)",
+        help="Sandbox timeout in minutes for the experimental cloud engine (1-60, default: 30)",
     ),
     llm_provider: Optional[str] = typer.Option(
         None,
@@ -2681,7 +2681,6 @@ def work_start(
         codeframe work start abc123 --execute --dry-run
         codeframe work start abc123 --execute --verbose
         codeframe work start abc123 --execute --isolation worktree
-        codeframe work start abc123 --execute --engine cloud --cloud-timeout 45
         codeframe work start abc123 --execute --llm-provider openai --llm-model gpt-4o
     """
     from codeframe.core.workspace import get_workspace
@@ -2728,7 +2727,19 @@ def work_start(
 
         # Validate API key before creating run record (avoids dangling IN_PROGRESS state)
         if execute:
-            from codeframe.core.engine_registry import is_external_engine
+            from codeframe.core.engine_registry import (
+                is_external_engine,
+                resolve_engine,
+            )
+
+            # Same reason: execute_agent resolves the engine, and the gated
+            # cloud engine (#966) raises there — after the run record exists.
+            try:
+                resolve_engine(engine)
+            except ValueError as exc:
+                console.print(f"[red]Error:[/red] {exc}")
+                raise typer.Exit(1)
+
             if engine == "codex":
                 # Not the OpenAI key check: `codex login` is the common way in
                 # and sets no env var at all (#1010).
@@ -4049,7 +4060,7 @@ def batch_run(
     engine: Optional[str] = typer.Option(
         None,
         "--engine",
-        help="Agent engine: react (default), plan (legacy), claude-code, codex, opencode, kilocode, cloud, or built-in",
+        help="Agent engine: react (default), plan (legacy), claude-code, codex, opencode, kilocode, or built-in",
     ),
     stall_timeout: int = typer.Option(
         300,
@@ -4071,7 +4082,7 @@ def batch_run(
     cloud_timeout: int = typer.Option(
         30,
         "--cloud-timeout",
-        help="Sandbox timeout in minutes for --engine cloud (1-60, default: 30)",
+        help="Sandbox timeout in minutes for the experimental cloud engine (1-60, default: 30)",
     ),
     llm_provider: Optional[str] = typer.Option(
         None,
@@ -4198,7 +4209,17 @@ def batch_run(
             return
 
         # Validate API key before batch execution
-        from codeframe.core.engine_registry import is_external_engine
+        from codeframe.core.engine_registry import (
+            is_external_engine,
+            resolve_engine,
+        )
+
+        try:
+            resolve_engine(engine)
+        except ValueError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1)
+
         if engine == "codex":
             # Not the OpenAI key check: `codex login` is the common way in
             # and sets no env var at all (#1010).

--- a/codeframe/cli/engines_commands.py
+++ b/codeframe/cli/engines_commands.py
@@ -53,21 +53,20 @@ def engines_list() -> None:
     from codeframe.core.engine_registry import (
         ADVERTISED_ENGINES,
         EXTERNAL_ENGINES,
-        VALID_ENGINES,
         check_requirements,
-        cloud_engine_enabled,
+        suggestable_engines,
     )
 
     # Gated engines are absent unless opted in, and labelled when present —
     # this list is how a user picks an engine (#966).
-    listed = VALID_ENGINES if cloud_engine_enabled() else ADVERTISED_ENGINES
+    listed = suggestable_engines()
 
     table = Table(title="Available Engines")
     table.add_column("Engine", style="cyan")
     table.add_column("Type", style="dim")
     table.add_column("Requirements", style="green")
 
-    for engine in sorted(listed):
+    for engine in listed:
         engine_type = "external" if engine in EXTERNAL_ENGINES else "builtin"
         if engine == "built-in":
             engine_type = "alias → react"

--- a/codeframe/cli/engines_commands.py
+++ b/codeframe/cli/engines_commands.py
@@ -50,17 +50,29 @@ def _config_root() -> Optional[Path]:
 @engines_app.command("list")
 def engines_list() -> None:
     """List all available execution engines and their requirement status."""
-    from codeframe.core.engine_registry import VALID_ENGINES, EXTERNAL_ENGINES, check_requirements
+    from codeframe.core.engine_registry import (
+        ADVERTISED_ENGINES,
+        EXTERNAL_ENGINES,
+        VALID_ENGINES,
+        check_requirements,
+        cloud_engine_enabled,
+    )
+
+    # Gated engines are absent unless opted in, and labelled when present —
+    # this list is how a user picks an engine (#966).
+    listed = VALID_ENGINES if cloud_engine_enabled() else ADVERTISED_ENGINES
 
     table = Table(title="Available Engines")
     table.add_column("Engine", style="cyan")
     table.add_column("Type", style="dim")
     table.add_column("Requirements", style="green")
 
-    for engine in sorted(VALID_ENGINES):
+    for engine in sorted(listed):
         engine_type = "external" if engine in EXTERNAL_ENGINES else "builtin"
         if engine == "built-in":
             engine_type = "alias → react"
+        elif engine not in ADVERTISED_ENGINES:
+            engine_type = f"{engine_type}, EXPERIMENTAL"
 
         try:
             # The workspace root, so a builtin engine's requirement reflects the

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -260,11 +260,13 @@ class EnvironmentConfig:
                 )
 
         # Validate engine
-        from codeframe.core.engine_registry import VALID_ENGINES
+        from codeframe.core.engine_registry import ADVERTISED_ENGINES, VALID_ENGINES
         if self.engine not in VALID_ENGINES:
+            # Suggest only the advertised set — a gated engine is not a fix
+            # for a typo (#966).
             errors.append(
                 f"Invalid engine '{self.engine}'. "
-                f"Must be one of: {', '.join(sorted(VALID_ENGINES))}"
+                f"Must be one of: {', '.join(sorted(ADVERTISED_ENGINES))}"
             )
 
         # Validate agent budget

--- a/codeframe/core/config.py
+++ b/codeframe/core/config.py
@@ -260,13 +260,13 @@ class EnvironmentConfig:
                 )
 
         # Validate engine
-        from codeframe.core.engine_registry import ADVERTISED_ENGINES, VALID_ENGINES
+        from codeframe.core.engine_registry import VALID_ENGINES, suggestable_engines
         if self.engine not in VALID_ENGINES:
-            # Suggest only the advertised set — a gated engine is not a fix
-            # for a typo (#966).
+            # Membership is the full set; the suggestion is not — a gated
+            # engine is not a fix for a typo (#966).
             errors.append(
                 f"Invalid engine '{self.engine}'. "
-                f"Must be one of: {', '.join(sorted(ADVERTISED_ENGINES))}"
+                f"Must be one of: {', '.join(suggestable_engines())}"
             )
 
         # Validate agent budget

--- a/codeframe/core/engine_registry.py
+++ b/codeframe/core/engine_registry.py
@@ -37,6 +37,45 @@ BUILTIN_ENGINES = frozenset({
     "built-in",
 })
 
+# Engines offered to users. "cloud" is valid but NOT advertised (#966): E2B
+# execution is out of launch scope and does not currently work end to end, so
+# it stays reachable only behind an explicit opt-in. Keeping it in
+# VALID_ENGINES lets the gate below answer with a specific message instead of
+# "unknown engine".
+ADVERTISED_ENGINES = frozenset(VALID_ENGINES - {"cloud"})
+
+#: Opt-in for the experimental cloud engine (#966).
+CLOUD_ENGINE_OPT_IN_ENV = "CODEFRAME_ENABLE_CLOUD_ENGINE"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def cloud_engine_enabled() -> bool:
+    """Whether the experimental cloud engine has been opted into.
+
+    Read at call time, not import, so tests and a per-invocation environment
+    both take effect.
+    """
+    return os.environ.get(CLOUD_ENGINE_OPT_IN_ENV, "").strip().lower() in _TRUTHY
+
+
+def _reject_cloud_unless_enabled(engine: str) -> None:
+    """Raise unless the caller has opted into the experimental cloud engine.
+
+    Called from every entry point that can reach the E2B adapter — the CLI/env
+    resolution path AND the direct adapter lookups, because runtime calls those
+    without going through resolve_engine.
+    """
+    if engine != "cloud" or cloud_engine_enabled():
+        return
+    raise ValueError(
+        "The 'cloud' engine (E2B) is EXPERIMENTAL and unsupported. It is not "
+        "part of the supported surface and has known defects that can leave "
+        "your working tree inconsistent with what the gates then validate. "
+        f"To try it anyway, set {CLOUD_ENGINE_OPT_IN_ENV}=1. "
+        f"Supported engines: {', '.join(sorted(ADVERTISED_ENGINES))}."
+    )
+
 
 def resolve_engine(cli_engine: str | None = None) -> str:
     """Resolve which engine to use.
@@ -64,8 +103,10 @@ def resolve_engine(cli_engine: str | None = None) -> str:
     if engine not in VALID_ENGINES:
         raise ValueError(
             f"Invalid engine '{engine}'. "
-            f"Must be one of: {', '.join(sorted(VALID_ENGINES))}"
+            f"Must be one of: {', '.join(sorted(ADVERTISED_ENGINES))}"
         )
+
+    _reject_cloud_unless_enabled(engine)
 
     return engine
 
@@ -89,6 +130,8 @@ def get_external_adapter(engine: str, **kwargs: Any) -> AgentAdapter:
         ValueError: If engine is not an external engine.
         EnvironmentError: If the required binary is not installed.
     """
+    _reject_cloud_unless_enabled(engine)
+
     if engine == "claude-code":
         from codeframe.core.adapters.claude_code import ClaudeCodeAdapter
 

--- a/codeframe/core/engine_registry.py
+++ b/codeframe/core/engine_registry.py
@@ -59,6 +59,18 @@ def cloud_engine_enabled() -> bool:
     return os.environ.get(CLOUD_ENGINE_OPT_IN_ENV, "").strip().lower() in _TRUTHY
 
 
+def suggestable_engines() -> list[str]:
+    """The engine names to offer a user who named one that does not exist.
+
+    Every "must be one of" list goes through here so they cannot drift apart:
+    a gated engine is absent by default and present once opted into, in the
+    CLI's engine list, the config validator and the requirement check alike
+    (#966).
+    """
+    engines = VALID_ENGINES if cloud_engine_enabled() else ADVERTISED_ENGINES
+    return sorted(engines)
+
+
 def _reject_cloud_unless_enabled(engine: str) -> None:
     """Raise unless the caller has opted into the experimental cloud engine.
 
@@ -103,7 +115,7 @@ def resolve_engine(cli_engine: str | None = None) -> str:
     if engine not in VALID_ENGINES:
         raise ValueError(
             f"Invalid engine '{engine}'. "
-            f"Must be one of: {', '.join(sorted(ADVERTISED_ENGINES))}"
+            f"Must be one of: {', '.join(suggestable_engines())}"
         )
 
     _reject_cloud_unless_enabled(engine)
@@ -219,7 +231,7 @@ def check_requirements(
     if engine not in VALID_ENGINES:
         raise ValueError(
             f"Invalid engine '{engine}'. "
-            f"Must be one of: {', '.join(sorted(VALID_ENGINES))}"
+            f"Must be one of: {', '.join(suggestable_engines())}"
         )
 
     # Resolve alias

--- a/codeframe/core/sandbox/context.py
+++ b/codeframe/core/sandbox/context.py
@@ -6,9 +6,9 @@ conductor.py and agent adapters to run tasks in isolated environments.
 Isolation levels:
   NONE     — shared filesystem, preserves current behavior (default)
   WORKTREE — git worktree per task with merge-back (single-run path only; #787)
-  CLOUD    — not implemented, raises NotImplementedError. Cloud execution ships
-             as `--engine cloud` (the E2B adapter), which provisions its own
-             sandbox rather than going through an isolation level.
+  CLOUD    — not implemented, raises NotImplementedError. Cloud execution
+             exists only as an EXPERIMENTAL, unsupported engine gated behind
+             CODEFRAME_ENABLE_CLOUD_ENGINE (#966), not as an isolation level.
 
 Worktree scope (#787): worktree isolation is enabled for the in-process
 single-run path (``cf work start --isolation worktree`` → runtime.execute_agent),
@@ -101,10 +101,11 @@ def validate_isolation(isolation: IsolationLevel) -> None:
     """
     if isolation == IsolationLevel.CLOUD:
         raise NotImplementedError(
-            "IsolationLevel.CLOUD is not implemented. Cloud execution ships as an "
-            "engine, not an isolation level: use `--engine cloud` (the E2B adapter, "
-            "`pip install codeframe[cloud]` + E2B_API_KEY), which provisions its own "
-            "sandbox. For local isolation use `--isolation worktree`."
+            "IsolationLevel.CLOUD is not implemented. For local isolation use "
+            "`--isolation worktree`. Cloud execution exists only as an "
+            "EXPERIMENTAL, unsupported E2B engine (`--engine cloud`, gated behind "
+            "CODEFRAME_ENABLE_CLOUD_ENGINE=1) — see the known limitations in "
+            "CLAUDE.md before relying on it (#966)."
         )
 
 

--- a/docs/PRODUCT_ROADMAP.md
+++ b/docs/PRODUCT_ROADMAP.md
@@ -10,7 +10,7 @@ This document focuses on gaps in the web product that block the end-to-end visio
 ### Completed foundation (prior phases)
 - **Phases 1–2.5**: CLI foundation, FastAPI server layer, ReAct agent — all complete
 - **Phase 3**: Web UI core screens — PRD editor, task board, execution monitor, blocker resolution, diff reviewer, PROOF9 requirements table, interactive agent sessions (`/sessions`) — all complete
-- **Phase 4.A–4.D**: Agent adapter protocol (ClaudeCode/Codex/OpenCode/Kilocode), execution environment (worktree isolation, E2B cloud), multi-provider LLM (OpenAI-compatible adapter) — all complete
+- **Phase 4.A–4.D**: Agent adapter protocol (ClaudeCode/Codex/OpenCode/Kilocode), execution environment (worktree isolation), multi-provider LLM (OpenAI-compatible adapter) — all complete. E2B cloud execution is **not** complete: it is EXPERIMENTAL and gated behind `CODEFRAME_ENABLE_CLOUD_ENGINE` (#966)
 
 ---
 

--- a/tests/adapters/test_e2b_adapter.py
+++ b/tests/adapters/test_e2b_adapter.py
@@ -463,16 +463,20 @@ class TestEngineRegistry:
         from codeframe.core.engine_registry import BUILTIN_ENGINES
         assert "cloud" not in BUILTIN_ENGINES
 
-    def test_get_external_adapter_cloud_returns_e2b_adapter(self):
+    def test_get_external_adapter_cloud_returns_e2b_adapter(self, monkeypatch):
         from codeframe.core.engine_registry import get_external_adapter
         from codeframe.adapters.e2b.adapter import E2BAgentAdapter
 
+        # The engine is gated as experimental (#966); opt in to reach the adapter.
+        monkeypatch.setenv("CODEFRAME_ENABLE_CLOUD_ENGINE", "1")
         adapter = get_external_adapter("cloud", timeout_minutes=10)
         assert isinstance(adapter, E2BAgentAdapter)
         assert adapter._timeout_minutes == 10
 
-    def test_resolve_cloud_engine(self):
+    def test_resolve_cloud_engine(self, monkeypatch):
         from codeframe.core.engine_registry import resolve_engine
+
+        monkeypatch.setenv("CODEFRAME_ENABLE_CLOUD_ENGINE", "1")
         assert resolve_engine("cloud") == "cloud"
 
     def test_is_external_engine_cloud(self):

--- a/tests/core/test_cloud_engine_gate_966.py
+++ b/tests/core/test_cloud_engine_gate_966.py
@@ -298,3 +298,29 @@ class TestCliRefusesBeforeCreatingARun:
         assert runtime.get_latest_run(ws, task.id) is None, (
             "a run record was created for a refused engine"
         )
+
+    def test_batch_dry_run_refuses_too(self, tmp_path, monkeypatch):
+        """A dry-run preview of an engine that will be refused is a lie."""
+        from typer.testing import CliRunner
+
+        from codeframe.cli.app import app
+        from codeframe.core import tasks
+        from codeframe.core.tasks import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        monkeypatch.setenv("E2B_API_KEY", "not-the-thing-being-tested")
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ws = create_or_load_workspace(repo)
+        task = tasks.create(ws, title="anything", description="d")
+        tasks.update_status(ws, task.id, TaskStatus.READY)
+
+        result = CliRunner().invoke(
+            app,
+            ["work", "batch", "run", task.id[:8], "--dry-run", "--engine", "cloud",
+             "-w", str(repo)],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "experimental" in result.output.lower()

--- a/tests/core/test_cloud_engine_gate_966.py
+++ b/tests/core/test_cloud_engine_gate_966.py
@@ -219,6 +219,26 @@ class TestNotAdvertised:
         assert engine_errors, errors
         assert "cloud" not in engine_errors[0]
 
+    def test_check_requirements_does_not_suggest_it(self):
+        """`cf engines check <typo>` is a fourth list a user reads."""
+        from codeframe.core.engine_registry import check_requirements
+
+        with pytest.raises(ValueError) as excinfo:
+            check_requirements("nope")
+        assert "cloud" not in str(excinfo.value)
+
+    def test_every_suggestion_list_agrees(self, monkeypatch):
+        """Opted in, the suggestion lists include it — all of them or none."""
+        from codeframe.core.engine_registry import check_requirements, resolve_engine
+
+        monkeypatch.setenv(OPT_IN, "1")
+        messages = []
+        for call in (lambda: resolve_engine("nope"), lambda: check_requirements("nope")):
+            with pytest.raises(ValueError) as excinfo:
+                call()
+            messages.append(str(excinfo.value))
+        assert all("cloud" in m for m in messages), messages
+
     def test_the_known_limitations_are_recorded_for_lifting_the_gate(self):
         """AC3: the parked defects must be written down somewhere findable."""
         text = Path("CLAUDE.md").read_text()

--- a/tests/core/test_cloud_engine_gate_966.py
+++ b/tests/core/test_cloud_engine_gate_966.py
@@ -187,6 +187,38 @@ class TestNotAdvertised:
                 "saying it is experimental"
             )
 
+    def test_cf_engines_list_does_not_show_it(self):
+        """`cf engines list` is the list a user reads to pick an engine."""
+        from typer.testing import CliRunner
+
+        from codeframe.cli.app import app
+
+        result = CliRunner().invoke(app, ["engines", "list"])
+        assert result.exit_code == 0, result.output
+        assert "cloud" not in result.output.lower(), result.output
+
+    def test_cf_engines_list_shows_it_once_opted_in(self, monkeypatch):
+        """Opted in, it must appear — and be labelled, not blend in."""
+        from typer.testing import CliRunner
+
+        from codeframe.cli.app import app
+
+        monkeypatch.setenv(OPT_IN, "1")
+        result = CliRunner().invoke(app, ["engines", "list"])
+        assert result.exit_code == 0, result.output
+        assert "cloud" in result.output.lower()
+        assert "experimental" in result.output.lower()
+
+    def test_config_validation_does_not_suggest_it(self):
+        """A bad `engine:` in config.yaml must not advertise cloud as a fix."""
+        from codeframe.core.config import EnvironmentConfig
+
+        config = EnvironmentConfig(engine="nope")
+        errors = config.validate()
+        engine_errors = [e for e in errors if "Invalid engine" in e]
+        assert engine_errors, errors
+        assert "cloud" not in engine_errors[0]
+
     def test_the_known_limitations_are_recorded_for_lifting_the_gate(self):
         """AC3: the parked defects must be written down somewhere findable."""
         text = Path("CLAUDE.md").read_text()

--- a/tests/core/test_cloud_engine_gate_966.py
+++ b/tests/core/test_cloud_engine_gate_966.py
@@ -1,0 +1,248 @@
+"""The cloud engine is experimental and gated (issue #966).
+
+E2B cloud execution is out of launch scope, does not work, and was nonetheless
+advertised and reachable. Rather than fix a non-launch feature, it is put
+behind an explicit opt-in and taken off the advertised surface; the defects are
+recorded as the price of lifting the gate.
+
+These tests pin the two halves of that: unreachable without the opt-in,
+reachable with it, and absent from every list a user reads.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+OPT_IN = "CODEFRAME_ENABLE_CLOUD_ENGINE"
+
+
+@pytest.fixture(autouse=True)
+def _no_opt_in(monkeypatch):
+    """Default every test to the shipped state: gate closed."""
+    monkeypatch.delenv(OPT_IN, raising=False)
+    monkeypatch.delenv("CODEFRAME_ENGINE", raising=False)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unreachable without the opt-in
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGateClosedByDefault:
+    def test_resolve_engine_rejects_cloud(self):
+        from codeframe.core.engine_registry import resolve_engine
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_engine("cloud")
+
+        message = str(excinfo.value).lower()
+        assert "experimental" in message
+        assert "unsupported" in message
+        # The message must name the way in, or it is a dead end.
+        assert OPT_IN in str(excinfo.value)
+
+    def test_the_env_var_route_is_gated_too(self, monkeypatch):
+        """CODEFRAME_ENGINE=cloud must not be a way around the flag."""
+        from codeframe.core.engine_registry import resolve_engine
+
+        monkeypatch.setenv("CODEFRAME_ENGINE", "cloud")
+        with pytest.raises(ValueError, match="(?i)experimental"):
+            resolve_engine()
+
+    def test_get_external_adapter_rejects_cloud(self):
+        """Defence in depth: runtime calls this directly, not only via resolve."""
+        from codeframe.core.engine_registry import get_external_adapter
+
+        with pytest.raises(ValueError, match="(?i)experimental"):
+            get_external_adapter("cloud")
+
+    def test_get_adapter_rejects_cloud(self):
+        from codeframe.core.engine_registry import get_adapter
+
+        with pytest.raises(ValueError, match="(?i)experimental"):
+            get_adapter("cloud")
+
+    @pytest.mark.parametrize(
+        "engine", ["react", "plan", "built-in", "claude-code", "codex", "opencode", "kilocode"]
+    )
+    def test_every_other_engine_still_resolves(self, engine):
+        from codeframe.core.engine_registry import resolve_engine
+
+        assert resolve_engine(engine) in {engine, "react"}
+
+    def test_an_unknown_engine_still_reports_as_unknown(self):
+        """The cloud gate must not swallow ordinary typos."""
+        from codeframe.core.engine_registry import resolve_engine
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_engine("clod")
+        assert "experimental" not in str(excinfo.value).lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Reachable with the opt-in
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGateOpensWithOptIn:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+    def test_resolve_engine_accepts_cloud(self, monkeypatch, value):
+        from codeframe.core.engine_registry import resolve_engine
+
+        monkeypatch.setenv(OPT_IN, value)
+        assert resolve_engine("cloud") == "cloud"
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_falsy_values_keep_the_gate_shut(self, monkeypatch, value):
+        from codeframe.core.engine_registry import resolve_engine
+
+        monkeypatch.setenv(OPT_IN, value)
+        with pytest.raises(ValueError, match="(?i)experimental"):
+            resolve_engine("cloud")
+
+    def test_the_adapter_is_constructed_once_opted_in(self, monkeypatch):
+        """Past the gate, the real lookup runs — no silent no-op."""
+        from codeframe.core import engine_registry
+
+        monkeypatch.setenv(OPT_IN, "1")
+
+        built = {}
+
+        class FakeAdapter:
+            def __init__(self, timeout_minutes=30):
+                built["timeout_minutes"] = timeout_minutes
+
+        import sys
+        import types
+
+        module = types.ModuleType("codeframe.adapters.e2b.adapter")
+        module.E2BAgentAdapter = FakeAdapter
+        monkeypatch.setitem(sys.modules, "codeframe.adapters.e2b.adapter", module)
+
+        adapter = engine_registry.get_external_adapter("cloud", timeout_minutes=45)
+        assert isinstance(adapter, FakeAdapter)
+        assert built == {"timeout_minutes": 45}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Off the advertised surface
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNotAdvertised:
+    def test_cloud_is_not_in_the_advertised_engine_list(self):
+        from codeframe.core.engine_registry import ADVERTISED_ENGINES, VALID_ENGINES
+
+        assert "cloud" not in ADVERTISED_ENGINES
+        # Still valid, so the gate can produce a specific message rather than
+        # a generic "unknown engine".
+        assert "cloud" in VALID_ENGINES
+
+    def test_an_invalid_engine_message_does_not_offer_cloud(self):
+        from codeframe.core.engine_registry import resolve_engine
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_engine("nope")
+        assert "cloud" not in str(excinfo.value)
+
+    def test_cli_engine_help_does_not_list_cloud(self):
+        from codeframe.cli import app as cli_app
+
+        source = Path(inspect.getfile(cli_app)).read_text()
+        engine_help = [
+            line for line in source.splitlines()
+            if 'help="Agent engine:' in line
+        ]
+        assert engine_help, "expected --engine help strings"
+        for line in engine_help:
+            assert "cloud" not in line, f"cloud still advertised: {line.strip()}"
+
+    def test_cli_examples_do_not_demonstrate_the_cloud_engine(self):
+        from codeframe.cli import app as cli_app
+
+        source = Path(inspect.getfile(cli_app)).read_text()
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if "--engine cloud" in line and "experimental" not in line.lower()
+        ]
+        assert offenders == [], f"cloud shown as a normal option: {offenders}"
+
+    def test_isolation_cloud_does_not_point_at_the_engine_as_supported(self):
+        """The isolation error used to redirect users to `--engine cloud`."""
+        from codeframe.core.sandbox import context
+
+        source = Path(inspect.getfile(context)).read_text()
+        idx = source.find("IsolationLevel.CLOUD is not implemented")
+        assert idx != -1
+        message = source[idx : idx + 600]
+        if "--engine cloud" in message:
+            assert "experimental" in message.lower(), (
+                "the isolation error still recommends the cloud engine without "
+                "saying it is experimental"
+            )
+
+    def test_the_known_limitations_are_recorded_for_lifting_the_gate(self):
+        """AC3: the parked defects must be written down somewhere findable."""
+        text = Path("CLAUDE.md").read_text()
+        assert OPT_IN in text
+        lowered = text.lower()
+        # The checklist has to name what is actually broken, not just say
+        # "experimental" — otherwise lifting the gate has nothing to work from.
+        for topic in ["codeframe-ai", "commandexitexception", "sync"]:
+            assert topic in lowered, f"known-limitations note omits {topic}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Isolation level
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsolationCloudStillRejected:
+    def test_cloud_isolation_raises(self):
+        from codeframe.core.sandbox.context import IsolationLevel, create_execution_context
+
+        with pytest.raises(NotImplementedError):
+            create_execution_context("t-1", IsolationLevel.CLOUD, Path("/tmp"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The CLI must refuse before it creates state
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCliRefusesBeforeCreatingARun:
+    """The gate raises inside execute_agent, which runs *after* the run record
+    exists. Without a pre-run check that leaves a dangling IN_PROGRESS run —
+    exactly what the surrounding API-key checks were added to prevent."""
+
+    def test_work_start_execute_creates_no_run(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+
+        from codeframe.cli.app import app
+        from codeframe.core import runtime, tasks
+        from codeframe.core.workspace import create_or_load_workspace
+
+        monkeypatch.setenv("E2B_API_KEY", "not-the-thing-being-tested")
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ws = create_or_load_workspace(repo)
+        task = tasks.create(ws, title="anything", description="d")
+
+        result = CliRunner().invoke(
+            app,
+            ["work", "start", task.id[:8], "--execute", "--engine", "cloud",
+             "-w", str(repo)],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "experimental" in result.output.lower()
+        assert runtime.get_latest_run(ws, task.id) is None, (
+            "a run record was created for a refused engine"
+        )

--- a/tests/core/test_engine_registry.py
+++ b/tests/core/test_engine_registry.py
@@ -42,7 +42,10 @@ class TestResolveEngine:
         with pytest.raises(ValueError, match="Invalid engine"):
             resolve_engine("nonexistent")
 
-    def test_all_valid_engines_resolve(self):
+    def test_all_valid_engines_resolve(self, monkeypatch):
+        # cloud is gated as experimental (#966); opt in so this still covers
+        # every valid engine rather than quietly dropping one.
+        monkeypatch.setenv("CODEFRAME_ENABLE_CLOUD_ENGINE", "1")
         for engine in VALID_ENGINES:
             result = resolve_engine(engine)
             assert result in VALID_ENGINES


### PR DESCRIPTION
Closes #966.

E2B cloud execution is out of launch scope and does not work end to end, but it was listed next to the engines that do and was reachable with a plain `--engine cloud`. Per the issue, this **gates it rather than fixing it** — the five PARKED defects are deliberately untouched and recorded as the checklist for lifting the gate.

## The gate

`CODEFRAME_ENABLE_CLOUD_ENGINE=1` unlocks it. Closed by default:

```
$ cf work start <id> --execute --engine cloud
Error: The 'cloud' engine (E2B) is EXPERIMENTAL and unsupported. It is not
part of the supported surface and has known defects that can leave your
working tree inconsistent with what the gates then validate. To try it
anyway, set CODEFRAME_ENABLE_CLOUD_ENGINE=1. Supported engines: built-in,
claude-code, codex, kilocode, opencode, plan, react.
```

Both `resolve_engine` and `get_external_adapter` refuse it, so `CODEFRAME_ENGINE=cloud` is not a way around the flag. The message names the variable — a gate, not a dead end. `cloud` stays in `VALID_ENGINES` so the refusal is specific rather than a generic "unknown engine"; the new `ADVERTISED_ENGINES` set drives what gets offered.

**The gate is also checked before any run record is created.** `resolve_engine` runs inside `execute_agent`, which the CLI reaches *after* `start_task_run` — refusing there alone stranded an `IN_PROGRESS` run, the exact failure the neighbouring "validate API key before creating run record" block exists to prevent. Both the single-run and batch CLI paths now resolve the engine in that pre-run block. A test pins it by asserting `get_latest_run(...) is None`.

## Off the advertised surface

Five places, not one:

| Surface | Before | After |
|---|---|---|
| `--engine` help (×2) | listed `cloud` | advertised set only |
| worked examples in help | `--engine cloud --cloud-timeout 45` | removed |
| `cf engines list` | iterated `VALID_ENGINES` | `ADVERTISED_ENGINES`; opted-in it appears as `external, EXPERIMENTAL` |
| `EnvironmentConfig.validate` | suggested `cloud` for a typo'd engine | advertised set only |
| CLAUDE.md / PRODUCT_ROADMAP.md | counted under "all complete" | "EXPERIMENTAL and gated" |

`IsolationLevel.CLOUD` is a separate thing and stays unimplemented; its error no longer points at `--engine cloud` as a supported route.

## Known-limitations note (AC3)

`CLAUDE.md` → `CODEFRAME_ENABLE_CLOUD_ENGINE` records the five parked defects as a numbered lift-the-gate checklist: the `pip install codeframe` / `codeframe-ai` package-name bug, unhandled `CommandExitException`, broken sync-back, unbatched upload, and non-autospec mocks that make every failure branch dead code under a green suite. A test asserts the note names them, so it cannot silently drift.

## Verification

- **35 new tests** in `tests/core/test_cloud_engine_gate_966.py` — closed by default (incl. the env-var route and `get_adapter`/`get_external_adapter` defence in depth), open with the opt-in (5 truthy / 5 falsy values), absent from each advertised surface, no run record on refusal.
- **Mutation-checked**: neutering `_reject_cloud_unless_enabled` fails 9 tests; removing the CLI pre-run check fails the dangling-run test with a live `RUNNING` record.
- **Full gate green**: `pytest tests/ --ignore=tests/e2e -m "not lifecycle"` → **6085 passed, 49 skipped, 0 failed** (16m07s), run with `env -u DATABASE_PATH -u CODEFRAME_AUTH_REQUIRED -u ANTHROPIC_API_KEY -u AUTH_SECRET -u OPENAI_API_KEY` to mirror CI's ambient environment. `ruff check` clean.
- **Third-party review**: `codex review --base main` raised one [P2] — the execution path was gated but `cf engines list` and the config validator still offered it. Verified against the running CLI (cloud was visible in the table) and fixed in 6dba19f.

Three pre-existing tests were adjusted rather than weakened: two E2B registry tests and `test_all_valid_engines_resolve` now set the opt-in, so they still cover the cloud path instead of dropping it.

## Known limitations

- The cloud engine still does not work. That is the point — this PR makes it unreachable, not correct. All five PARKED criteria remain open by design.
- `check_requirements("cloud")` is still callable directly. It reports env-var presence and creates nothing, and `cf engines list` no longer surfaces it; gating a pure predicate would break the opted-in list rendering for no safety gain.
