### PR TITLE
fix(hooks): a stale lastfailed entry must not run the whole suite (#984)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,26 @@ repos:
     hooks:
       - id: pytest-check
         name: Run last failed tests (fast feedback)
-        # --lfnf none: when no tests failed previously (or no cache), run
-        # NOTHING instead of the whole suite. Keeps this a fast-feedback hook
-        # that only re-runs what you just broke; full validation is CI's job.
+        # Re-runs only what you previously broke; full validation is CI's job.
+        #
+        # NOT `pytest --lf --lfnf none` (#984): --lfnf none guards only the
+        # EMPTY cache. With a non-empty lastfailed whose node IDs no longer
+        # resolve — you renamed a test — pytest runs the WHOLE SUITE, carrying
+        # -x. Renaming a test therefore hung the next commit. The script prunes
+        # unresolvable node IDs first, so a stale cache selects nothing.
+        #
         # uv run: the project's canonical invocation (no fragile venv-activate
         # guessing / bare `pytest` that may not be on PATH).
+        # timeout: a pre-commit hook needs a wall-clock ceiling whatever it
+        # decides to run. 124 = timed out → warn and pass; never block a commit
+        # on a hook that hung.
         # exit 5 = "no tests collected" (the deselect-all no-op) → treat as pass.
-        entry: bash -c 'uv run pytest --lf --lfnf none -x; code=$?; [ "$code" -eq 5 ] && code=0; exit $code'
+        entry: >-
+          bash -c 'timeout 300 uv run python scripts/pretest_lastfailed.py;
+          code=$?; [ "$code" -eq 5 ] && code=0;
+          if [ "$code" -eq 124 ]; then
+          echo "pytest-check timed out after 300s, skipping (see #984)";
+          code=0; fi; exit $code'
         language: system
         pass_filenames: false
         files: \.py$

--- a/scripts/pretest_lastfailed.py
+++ b/scripts/pretest_lastfailed.py
@@ -183,8 +183,13 @@ def main(argv: list[str]) -> int:
     # live.py::test_x` aborts the whole session on the collection error before
     # running anything, so the failure you came to see never reports — you get
     # "1 error during collection" and debug the wrong thing. Running the
-    # resolvable node IDs first means the expected failure is what you see;
-    # a broken file is still reported after, and either one blocks the commit.
+    # resolvable node IDs first means the expected failure is what you see.
+    #
+    # -x applies ACROSS the groups, not just within them: if a live test fails
+    # we stop and never reach the broken file. That is the fail-fast contract,
+    # not an oversight — the broken neighbour surfaces on the next attempt,
+    # once the thing you were just shown is fixed. Either group blocks the
+    # commit on its own.
     node_ids = [item for item in selection if "::" in item]
     whole_files = [item for item in selection if "::" not in item]
 

--- a/scripts/pretest_lastfailed.py
+++ b/scripts/pretest_lastfailed.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Re-run previously-failed tests, without ever expanding to the full suite.
+
+``pytest --lf --lfnf none`` looks like it covers this, but ``--lfnf none``
+guards only the *empty* cache. When ``lastfailed`` is non-empty and its node IDs
+no longer resolve — a test that was renamed, moved or deleted — pytest falls
+back to its documented behaviour of running **everything** (issue #984).
+
+That made the pre-commit hook self-triggering in the most ordinary workflow:
+rename a test, and because the old name is still in the cache from the run where
+it failed, the very next commit runs the whole suite. With the pre-#979 suite
+that was hours, and the hook carries ``-x``, so it also aborted the commit on the
+first unrelated failure it happened to hit.
+
+So the selection is computed here instead: drop node IDs that can no longer be
+collected, and run only what is left. A cache full of stale entries selects
+nothing, which is what ``--lfnf none`` promised in the first place.
+
+Usage:
+    pretest_lastfailed.py                  # run the surviving failures
+    pretest_lastfailed.py --print-selection # print them, run nothing
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CACHE_RELATIVE = Path(".pytest_cache") / "v" / "cache" / "lastfailed"
+
+
+def read_lastfailed(root: Path) -> list[str]:
+    """Node IDs pytest recorded as failing, or [] if there is nothing usable.
+
+    Fails safe: an unreadable or malformed cache yields no selection. The one
+    outcome this must never produce is "I could not tell, so run everything".
+    """
+    path = root / CACHE_RELATIVE
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    return [key for key in data if isinstance(key, str) and key]
+
+
+def _file_of(node_id: str) -> str:
+    """The file part of a node ID (the whole thing for a collection-error key)."""
+    return node_id.split("::", 1)[0]
+
+
+def collectible(root: Path, files: list[str]) -> set[str]:
+    """Node IDs that still resolve, collected from *files* only.
+
+    Deliberately scoped to the files named in the cache — a handful — so this
+    can never become the full-suite collection it exists to prevent.
+    """
+    if not files:
+        return set()
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q",
+         "--no-header", "-p", "no:cacheprovider", *files],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    # Collection errors are fine: whatever did collect is still trustworthy,
+    # and anything that did not is exactly what we mean to drop.
+    return {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if "::" in line and not line.startswith(("ERROR", "E "))
+    }
+
+
+def select(root: Path) -> list[str]:
+    """The node IDs the hook should run: previously failed AND still present."""
+    recorded = read_lastfailed(root)
+    if not recorded:
+        return []
+
+    live_files = sorted({
+        f for f in (_file_of(n) for n in recorded) if (root / f).exists()
+    })
+    if not live_files:
+        return []
+
+    resolvable = collectible(root, live_files)
+
+    surviving = []
+    for node_id in recorded:
+        if "::" in node_id:
+            if node_id in resolvable:
+                surviving.append(node_id)
+        elif (root / node_id).exists():
+            # A whole-file key comes from a collection error; the file existing
+            # is the most we can check, and re-running it is the point.
+            surviving.append(node_id)
+    return surviving
+
+
+def main(argv: list[str]) -> int:
+    root = Path.cwd()
+    selection = select(root)
+
+    if "--print-selection" in argv:
+        print("\n".join(selection))
+        return 0
+
+    if not selection:
+        return 0
+
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-x", "--no-header", *selection],
+        cwd=root,
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/pretest_lastfailed.py
+++ b/scripts/pretest_lastfailed.py
@@ -179,10 +179,26 @@ def main(argv: list[str]) -> int:
     if not selection:
         return 0
 
-    return subprocess.run(
-        [sys.executable, "-m", "pytest", "-x", "--no-header", *selection],
-        cwd=root,
-    ).returncode
+    # Two invocations, node IDs first. A single `pytest -x broken.py
+    # live.py::test_x` aborts the whole session on the collection error before
+    # running anything, so the failure you came to see never reports — you get
+    # "1 error during collection" and debug the wrong thing. Running the
+    # resolvable node IDs first means the expected failure is what you see;
+    # a broken file is still reported after, and either one blocks the commit.
+    node_ids = [item for item in selection if "::" in item]
+    whole_files = [item for item in selection if "::" not in item]
+
+    for group in (node_ids, whole_files):
+        if not group:
+            continue
+        code = subprocess.run(
+            [sys.executable, "-m", "pytest", "-x", "--no-header", *group],
+            cwd=root,
+        ).returncode
+        # 5 == "no tests collected", the deselect-all no-op; not a failure.
+        if code not in (0, 5):
+            return code
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/pretest_lastfailed.py
+++ b/scripts/pretest_lastfailed.py
@@ -112,7 +112,11 @@ def collectible(root: Path, files: list[str]) -> tuple[set[str], set[str]]:
     }
     errored = set(_COLLECT_ERROR.findall(result.stdout))
 
-    if not resolved and not errored and _collected_something(result.stdout):
+    # Not `and not errored`: a broken file coexisting with a healthy one still
+    # populates `errored` (that regex is verbosity-independent) while `resolved`
+    # stays empty, which would slip past the guard and prune the healthy file's
+    # live failure as stale.
+    if not resolved and _collected_something(result.stdout):
         # pytest found tests but we could not read them — a format we do not
         # understand. Do not silently conclude "everything is stale": say so
         # and let the caller fall back to running the files themselves.

--- a/scripts/pretest_lastfailed.py
+++ b/scripts/pretest_lastfailed.py
@@ -24,11 +24,15 @@ Usage:
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 CACHE_RELATIVE = Path(".pytest_cache") / "v" / "cache" / "lastfailed"
+
+#: pytest banners a collection failure as "ERROR collecting <path>".
+_COLLECT_ERROR = re.compile(r"ERROR collecting (\S+)")
 
 
 def read_lastfailed(root: Path) -> list[str]:
@@ -52,14 +56,21 @@ def _file_of(node_id: str) -> str:
     return node_id.split("::", 1)[0]
 
 
-def collectible(root: Path, files: list[str]) -> set[str]:
-    """Node IDs that still resolve, collected from *files* only.
+def collectible(root: Path, files: list[str]) -> tuple[set[str], set[str]]:
+    """Inspect *files*, returning (node IDs that resolve, files that error).
 
     Deliberately scoped to the files named in the cache — a handful — so this
     can never become the full-suite collection it exists to prevent.
+
+    The two return values are different things and must not be conflated. A
+    node ID that simply stopped resolving is *stale*: the test was renamed, and
+    there is nothing to run. A file that raises during collection is *broken*:
+    you just made it un-importable, which is exactly what a pre-commit hook
+    should catch. Pruning the second along with the first would let the hook
+    pass on the change it exists to stop.
     """
     if not files:
-        return set()
+        return set(), set()
 
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "--collect-only", "-q",
@@ -68,13 +79,14 @@ def collectible(root: Path, files: list[str]) -> set[str]:
         capture_output=True,
         text=True,
     )
-    # Collection errors are fine: whatever did collect is still trustworthy,
-    # and anything that did not is exactly what we mean to drop.
-    return {
+
+    resolved = {
         line.strip()
         for line in result.stdout.splitlines()
-        if "::" in line and not line.startswith(("ERROR", "E "))
+        if "::" in line and not line.lstrip().startswith(("ERROR", "E "))
     }
+    errored = set(_COLLECT_ERROR.findall(result.stdout))
+    return resolved, errored
 
 
 def select(root: Path) -> list[str]:
@@ -89,11 +101,18 @@ def select(root: Path) -> list[str]:
     if not live_files:
         return []
 
-    resolvable = collectible(root, live_files)
+    resolvable, errored = collectible(root, live_files)
 
-    surviving = []
+    surviving: list[str] = []
     for node_id in recorded:
-        if "::" in node_id:
+        file_part = _file_of(node_id)
+        if file_part in errored:
+            # Broken, not stale — run the file so pytest re-raises the error
+            # and the commit is blocked. Once, however many of its node IDs
+            # are in the cache.
+            if file_part not in surviving:
+                surviving.append(file_part)
+        elif "::" in node_id:
             if node_id in resolvable:
                 surviving.append(node_id)
         elif (root / node_id).exists():

--- a/scripts/pretest_lastfailed.py
+++ b/scripts/pretest_lastfailed.py
@@ -34,6 +34,24 @@ CACHE_RELATIVE = Path(".pytest_cache") / "v" / "cache" / "lastfailed"
 #: pytest banners a collection failure as "ERROR collecting <path>".
 _COLLECT_ERROR = re.compile(r"ERROR collecting (\S+)")
 
+#: pytest reports the count either as the padded summary rule
+#: "===== 2 tests collected in 0.06s =====" or, at higher verbosity, as
+#: "collected 2 items" near the top. Deliberately not anchored to the line
+#: start — the summary is surrounded by "=" padding.
+_COLLECTED_COUNT = re.compile(r"(\d+) tests? collected|collected (\d+) items?")
+
+
+class CollectFormatError(RuntimeError):
+    """pytest collected tests in a shape this script could not parse."""
+
+
+def _collected_something(stdout: str) -> bool:
+    for match in _COLLECTED_COUNT.finditer(stdout):
+        count = match.group(1) or match.group(2)
+        if count and int(count) > 0:
+            return True
+    return False
+
 
 def read_lastfailed(root: Path) -> list[str]:
     """Node IDs pytest recorded as failing, or [] if there is nothing usable.
@@ -73,8 +91,15 @@ def collectible(root: Path, files: list[str]) -> tuple[set[str], set[str]]:
         return set(), set()
 
     result = subprocess.run(
+        # `-o addopts=` is load-bearing, not tidiness. Verbosity is a single
+        # counter: this repo's pytest.ini starts addopts with `-v`, so ini -v
+        # plus our -q nets to DEFAULT verbosity, and --collect-only then prints
+        # an indented <Module>/<Function> tree with no "::" on any line. Every
+        # node ID would parse as unresolvable and the hook would silently
+        # select nothing, forever. Clearing addopts also drops -m filters and
+        # coverage flags, none of which belong in a collection probe.
         [sys.executable, "-m", "pytest", "--collect-only", "-q",
-         "--no-header", "-p", "no:cacheprovider", *files],
+         "--no-header", "-p", "no:cacheprovider", "-o", "addopts=", *files],
         cwd=root,
         capture_output=True,
         text=True,
@@ -86,6 +111,13 @@ def collectible(root: Path, files: list[str]) -> tuple[set[str], set[str]]:
         if "::" in line and not line.lstrip().startswith(("ERROR", "E "))
     }
     errored = set(_COLLECT_ERROR.findall(result.stdout))
+
+    if not resolved and not errored and _collected_something(result.stdout):
+        # pytest found tests but we could not read them — a format we do not
+        # understand. Do not silently conclude "everything is stale": say so
+        # and let the caller fall back to running the files themselves.
+        raise CollectFormatError(result.stdout[-400:])
+
     return resolved, errored
 
 
@@ -101,7 +133,17 @@ def select(root: Path) -> list[str]:
     if not live_files:
         return []
 
-    resolvable, errored = collectible(root, live_files)
+    try:
+        resolvable, errored = collectible(root, live_files)
+    except CollectFormatError as exc:
+        # Bounded and loud: run the cached files rather than guess. Still only
+        # the handful named in the cache, never the whole suite.
+        print(
+            "pretest_lastfailed: could not parse pytest collection output; "
+            f"falling back to running {len(live_files)} cached file(s).\n{exc}",
+            file=sys.stderr,
+        )
+        return live_files
 
     surviving: list[str] = []
     for node_id in recorded:

--- a/tests/scripts/test_pretest_lastfailed_984.py
+++ b/tests/scripts/test_pretest_lastfailed_984.py
@@ -120,6 +120,46 @@ class TestEmptyAndMissingCache:
         assert _selection(project) == []
 
 
+class TestAFileThatStoppedCollectingIsBreakage:
+    """A syntax/import error is not staleness — it must block the commit.
+
+    The two look alike from the outside: a cached node ID that no longer
+    resolves. But a renamed test means "nothing to run", while a file that
+    fails to import means "you just broke this", and pruning it would let the
+    hook pass on exactly the change it exists to catch.
+    """
+
+    def test_a_broken_file_is_selected_not_pruned(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text("def bad(: pass\n")
+        assert _selection(project) == ["test_gt.py"]
+
+    def test_a_broken_file_fails_the_hook(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text("def bad(: pass\n")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=project, capture_output=True, text=True
+        )
+        assert result.returncode != 0, "a file that no longer imports let the commit through"
+
+    def test_an_import_error_counts_too_not_just_syntax(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text("import a_module_that_does_not_exist\n")
+        assert _selection(project) == ["test_gt.py"]
+
+    def test_a_healthy_file_is_unaffected_by_a_broken_neighbour(self, project):
+        """Only the broken file is selected; the renamed one stays pruned."""
+        (project / "test_other.py").write_text("def bad(: pass\n")
+        _write_lastfailed(
+            project,
+            ["test_gt.py::test_beta_fails", "test_other.py::test_whatever"],
+        )
+        (project / "test_gt.py").write_text(
+            SUITE.replace("test_beta_fails", "test_beta_renamed")
+        )
+        assert _selection(project) == ["test_other.py"]
+
+
 class TestWholeFileKeys:
     """A collection error records the file itself, with no `::`."""
 

--- a/tests/scripts/test_pretest_lastfailed_984.py
+++ b/tests/scripts/test_pretest_lastfailed_984.py
@@ -1,0 +1,166 @@
+"""The pre-commit fast-feedback hook must never expand to the full suite (#984).
+
+``pytest --lf --lfnf none`` guards only the *empty* cache. With a non-empty
+``lastfailed`` whose node IDs no longer resolve — a renamed, moved or deleted
+test — pytest falls back to running everything. Reproduced before the fix:
+
+    Case C (target exists):  1 test ran
+    Case A (target renamed): all 3 ran, with --lfnf none in effect
+
+That turns a no-op hook into a full-suite run carrying ``-x``. These tests pin
+the selection the hook makes, not its output, because the defect is entirely
+about *scope*.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "pretest_lastfailed.py"
+
+SUITE = """\
+def test_alpha_passes(): assert True
+def test_beta_fails(): assert False
+def test_gamma_passes(): assert True
+"""
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A tiny throwaway project with its own pytest cache."""
+    (tmp_path / "test_gt.py").write_text(SUITE)
+    (tmp_path / "pytest.ini").write_text("[pytest]\n")
+    return tmp_path
+
+
+def _write_lastfailed(project: Path, node_ids: list[str]) -> None:
+    cache = project / ".pytest_cache" / "v" / "cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "lastfailed").write_text(json.dumps({n: True for n in node_ids}))
+
+
+def _selection(project: Path) -> list[str]:
+    """What the hook would actually run, as node IDs."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--print-selection"],
+        cwd=project,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+class TestStaleCacheSelectsNothing:
+    """Case A — the bug."""
+
+    def test_a_renamed_test_selects_nothing(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text(
+            SUITE.replace("test_beta_fails", "test_beta_renamed")
+        )
+        assert _selection(project) == [], (
+            "a stale lastfailed entry expanded the hook's scope"
+        )
+
+    def test_a_deleted_file_selects_nothing(self, project):
+        _write_lastfailed(project, ["test_gone.py::test_x"])
+        assert _selection(project) == []
+
+    def test_a_deleted_test_within_a_live_file_selects_nothing(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text(
+            "def test_alpha_passes(): assert True\n"
+        )
+        assert _selection(project) == []
+
+
+class TestLiveCacheStillSelectsTheFailure:
+    """Case C — the behaviour that must survive the fix."""
+
+    def test_an_existing_failure_is_selected(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        assert _selection(project) == ["test_gt.py::test_beta_fails"]
+
+    def test_only_the_failure_is_selected_not_its_neighbours(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        selection = _selection(project)
+        assert "test_gt.py::test_alpha_passes" not in selection
+        assert "test_gt.py::test_gamma_passes" not in selection
+
+    def test_a_live_entry_survives_alongside_a_stale_one(self, project):
+        """The mixed case: prune the dead, keep the living."""
+        _write_lastfailed(
+            project,
+            ["test_gt.py::test_beta_fails", "test_gt.py::test_long_gone"],
+        )
+        assert _selection(project) == ["test_gt.py::test_beta_fails"]
+
+
+class TestEmptyAndMissingCache:
+    def test_no_cache_at_all_selects_nothing(self, project):
+        assert _selection(project) == []
+
+    def test_an_empty_cache_selects_nothing(self, project):
+        _write_lastfailed(project, [])
+        assert _selection(project) == []
+
+    def test_malformed_cache_selects_nothing_rather_than_everything(self, project):
+        """Fail safe: an unreadable cache must not mean 'run the suite'."""
+        cache = project / ".pytest_cache" / "v" / "cache"
+        cache.mkdir(parents=True, exist_ok=True)
+        (cache / "lastfailed").write_text("{not json")
+        assert _selection(project) == []
+
+
+class TestWholeFileKeys:
+    """A collection error records the file itself, with no `::`."""
+
+    def test_a_live_file_key_is_kept(self, project):
+        _write_lastfailed(project, ["test_gt.py"])
+        assert _selection(project) == ["test_gt.py"]
+
+    def test_a_dead_file_key_is_dropped(self, project):
+        _write_lastfailed(project, ["test_vanished.py"])
+        assert _selection(project) == []
+
+
+class TestItActuallyRuns:
+    """The script is a hook entry point, not just a selector."""
+
+    def _run(self, project: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            cwd=project,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_a_stale_cache_exits_zero_without_running_tests(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text(
+            SUITE.replace("test_beta_fails", "test_beta_renamed")
+        )
+        result = self._run(project)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "3 passed" not in result.stdout, "ran the whole file anyway"
+
+    def test_a_live_failure_still_fails_the_commit(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        result = self._run(project)
+        assert result.returncode != 0, "a real failure must still block the commit"
+
+    def test_a_fixed_failure_passes(self, project):
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        (project / "test_gt.py").write_text(
+            SUITE.replace("def test_beta_fails(): assert False",
+                          "def test_beta_fails(): assert True")
+        )
+        assert self._run(project).returncode == 0

--- a/tests/scripts/test_pretest_lastfailed_984.py
+++ b/tests/scripts/test_pretest_lastfailed_984.py
@@ -32,11 +32,20 @@ def test_gamma_passes(): assert True
 """
 
 
-@pytest.fixture
-def project(tmp_path: Path) -> Path:
+#: This repo's own pytest.ini starts addopts with `-v`. Verbosity is a single
+#: counter, so `-v` (ini) + `-q` (probe) nets to DEFAULT, and --collect-only
+#: then prints an indented <Module>/<Function> tree with no "::" anywhere. A
+#: bare ini hides that completely, which is why every fixture below is
+#: parametrized over both.
+INI_PLAIN = "[pytest]\n"
+INI_VERBOSE = "[pytest]\naddopts =\n    -v\n    --strict-markers\n"
+
+
+@pytest.fixture(params=[INI_PLAIN, INI_VERBOSE], ids=["plain-ini", "verbose-ini"])
+def project(request, tmp_path: Path) -> Path:
     """A tiny throwaway project with its own pytest cache."""
     (tmp_path / "test_gt.py").write_text(SUITE)
-    (tmp_path / "pytest.ini").write_text("[pytest]\n")
+    (tmp_path / "pytest.ini").write_text(request.param)
     return tmp_path
 
 
@@ -158,6 +167,54 @@ class TestAFileThatStoppedCollectingIsBreakage:
             SUITE.replace("test_beta_fails", "test_beta_renamed")
         )
         assert _selection(project) == ["test_other.py"]
+
+
+class TestUnparseableCollectionFallsBackLoudly:
+    """If the output shape is unreadable, do not conclude "all stale".
+
+    `-o addopts=` handles the ini, but a conftest can raise verbosity in code,
+    where no command-line flag can undo it. That prints the indented tree with
+    no "::" anywhere — indistinguishable, to a naive parser, from "nothing
+    resolved". Silently selecting nothing is the failure mode this whole issue
+    is about, so the parser refuses to guess.
+    """
+
+    def _make_verbose_conftest(self, project: Path) -> None:
+        (project / "conftest.py").write_text(
+            "def pytest_configure(config):\n"
+            "    config.option.verbose = max(config.option.verbose, 1)\n"
+        )
+
+    def test_it_falls_back_to_the_cached_files(self, project):
+        self._make_verbose_conftest(project)
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        assert _selection(project) == ["test_gt.py"], (
+            "unparseable collection silently selected nothing"
+        )
+
+    def test_it_says_so_on_stderr(self, project):
+        self._make_verbose_conftest(project)
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--print-selection"],
+            cwd=project, capture_output=True, text=True,
+        )
+        assert "could not parse" in result.stderr.lower(), result.stderr
+
+    def test_the_fallback_still_blocks_a_real_failure(self, project):
+        self._make_verbose_conftest(project)
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=project, capture_output=True, text=True
+        )
+        assert result.returncode != 0
+
+    def test_the_fallback_is_still_bounded_to_cached_files(self, project):
+        """Falling back must not become the full-suite run we are preventing."""
+        self._make_verbose_conftest(project)
+        (project / "test_untouched.py").write_text("def test_nope(): assert False\n")
+        _write_lastfailed(project, ["test_gt.py::test_beta_fails"])
+        assert "test_untouched.py" not in _selection(project)
 
 
 class TestWholeFileKeys:

--- a/tests/scripts/test_pretest_lastfailed_984.py
+++ b/tests/scripts/test_pretest_lastfailed_984.py
@@ -281,6 +281,28 @@ class TestAMixedSelectionReportsBoth:
         )
         assert result.returncode != 0
 
+    def test_a_live_failure_stops_before_the_broken_file_by_design(self, project):
+        """Fail-fast is the hook's contract, and it applies ACROSS groups too.
+
+        The hook carries -x. If a live failure fails, stopping there is the
+        intended behaviour, not an oversight — the broken neighbour surfaces on
+        the next attempt, once the thing you were shown is fixed. Pinned so the
+        early return reads as deliberate rather than as a missing loop.
+        """
+        (project / "test_broken.py").write_text("def bad(: pass\n")
+        _write_lastfailed(
+            project,
+            ["test_gt.py::test_beta_fails", "test_broken.py::test_x"],
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=project, capture_output=True, text=True
+        )
+        assert result.returncode != 0
+        assert "test_beta_fails" in result.stdout
+        assert "ERROR collecting" not in result.stdout, (
+            "the broken file ran anyway, defeating -x"
+        )
+
     def test_a_broken_file_is_reported_when_the_live_ones_pass(self, project):
         """Fail-fast must not hide the collection error behind a green run."""
         (project / "test_broken.py").write_text("def bad(: pass\n")

--- a/tests/scripts/test_pretest_lastfailed_984.py
+++ b/tests/scripts/test_pretest_lastfailed_984.py
@@ -248,6 +248,56 @@ class TestWholeFileKeys:
         assert _selection(project) == []
 
 
+class TestAMixedSelectionReportsBoth:
+    """A broken neighbour must not swallow the failure you came to see.
+
+    `pytest -x broken.py live.py::test_x` aborts the whole session on the
+    collection error before running anything, so the live failure never
+    executes or reports. The commit is still blocked — the safety invariant
+    holds — but the developer sees "1 error during collection" instead of
+    their assertion, which is the wrong thing to debug.
+    """
+
+    def test_the_live_failure_is_actually_reported(self, project):
+        (project / "test_broken.py").write_text("def bad(: pass\n")
+        _write_lastfailed(
+            project,
+            ["test_gt.py::test_beta_fails", "test_broken.py::test_x"],
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=project, capture_output=True, text=True
+        )
+        assert result.returncode != 0
+        assert "test_beta_fails" in result.stdout, (
+            "the live failure was swallowed by the broken neighbour's "
+            f"collection abort:\n{result.stdout[-800:]}"
+        )
+
+    def test_a_broken_file_alone_still_fails(self, project):
+        (project / "test_broken.py").write_text("def bad(: pass\n")
+        _write_lastfailed(project, ["test_broken.py::test_x"])
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=project, capture_output=True, text=True
+        )
+        assert result.returncode != 0
+
+    def test_a_broken_file_is_reported_when_the_live_ones_pass(self, project):
+        """Fail-fast must not hide the collection error behind a green run."""
+        (project / "test_broken.py").write_text("def bad(: pass\n")
+        (project / "test_gt.py").write_text(
+            SUITE.replace("def test_beta_fails(): assert False",
+                          "def test_beta_fails(): assert True")
+        )
+        _write_lastfailed(
+            project,
+            ["test_gt.py::test_beta_fails", "test_broken.py::test_x"],
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=project, capture_output=True, text=True
+        )
+        assert result.returncode != 0, "the collection error was not reported"
+
+
 class TestItActuallyRuns:
     """The script is a hook entry point, not just a selector."""
 

--- a/tests/scripts/test_pretest_lastfailed_984.py
+++ b/tests/scripts/test_pretest_lastfailed_984.py
@@ -209,6 +209,25 @@ class TestUnparseableCollectionFallsBackLoudly:
         )
         assert result.returncode != 0
 
+    def test_it_fires_even_when_one_file_also_errored(self, project):
+        """The mixed case: a broken file must not suppress the guard.
+
+        `errored` is populated by an "ERROR collecting" regex that does not
+        care about verbosity, so it stays non-empty while `resolved` is empty.
+        Gating the guard on `not errored` would let the healthy file's
+        still-failing test be pruned as stale.
+        """
+        self._make_verbose_conftest(project)
+        (project / "test_broken.py").write_text("def bad(: pass\n")
+        _write_lastfailed(
+            project,
+            ["test_gt.py::test_beta_fails", "test_broken.py::test_x"],
+        )
+        selection = _selection(project)
+        assert "test_gt.py" in selection, (
+            "the healthy file's live failure was pruned as stale"
+        )
+
     def test_the_fallback_is_still_bounded_to_cached_files(self, project):
         """Falling back must not become the full-suite run we are preventing."""
         self._make_verbose_conftest(project)


### PR DESCRIPTION
Closes #984.

## Reproduced first

```
Case C (target exists):  pytest --lf --lfnf none  ->  1 failed             (1 test ran)
Case A (target renamed): pytest --lf --lfnf none  ->  1 failed, 2 passed   (ALL 3 ran)
```

`--lfnf none` guards only the **empty** cache. With a non-empty `lastfailed` whose node IDs no longer resolve, pytest falls back to running everything — carrying `-x`, so it also aborts the commit on the first unrelated failure it hits. Self-triggering in the most ordinary workflow: rename a test, and the very next commit hangs.

Worth noting from the repro: the cache *grows* a second key rather than replacing one. After the rename it held both `test_beta_fails` and `test_beta_renamed`, so the stale entry never clears itself.

## Fix

`scripts/pretest_lastfailed.py` computes the selection instead of trusting `--lf`: read `lastfailed`, drop node IDs that can no longer be collected, run what's left. Collection is scoped to the handful of files named in the cache, so it can never become the full-suite pass it exists to prevent.

Before vs after, same repro, clean caches:

| | old (`--lf --lfnf none`) | new |
|---|---|---|
| **Case A** (renamed) | `1 failed, 2 passed` — all 3 ran | selection empty, **exit 0** |
| **Case C** (still exists) | `1 failed` | `test_gt.py::test_beta_fails`, **exit 1** |

Case C still blocks the commit, which is the property that must not regress.

### Why option 1, not the issue's weakly-preferred option 2

Option 2 ("scope to changed files") changes what the hook *means*. Pre-commit passes **changed** files, which are mostly `codeframe/**` source files — `pytest codeframe/core/workspace.py` collects nothing. So option 2 quietly degrades to "run the test files you edited" and drops the hook's actual value: re-running what you previously broke after a *source* change, which is the common case.

Option 3 taken as well, as the issue suggests: the hook runs under `timeout 300`, and exit 124 becomes a pass with a warning. A pre-commit hook needs a wall-clock ceiling whatever it decides to run.

### Fails safe

An unreadable or malformed cache selects nothing. The one outcome this must never produce is "I couldn't tell, so run everything" — pinned by `test_malformed_cache_selects_nothing_rather_than_everything`.

## The review caught a real hole I opened

codex [P2]: my first version pruned *any* node ID that didn't collect — and my code comment said "collection errors are fine". Wrong, and the mistake was conflating two things that look identical from outside:

- a node ID that stopped resolving because the test was **renamed** → stale, nothing to run, prune it
- a file that raises during collection because you just made it **un-importable** → broken, and exactly what a pre-commit hook exists to catch

Pruning the second along with the first meant a syntax error in a previously-failing test file gave an empty selection and exit 0 — the hook passing on the very change it should stop. `collectible()` now returns errored files separately (verified against real pytest output: `ERROR collecting <path>`, rc=2), and a cached node ID whose file errored selects the file so pytest re-raises and blocks the commit.

## Verification

- **23 test functions → 46 collected** in `tests/scripts/test_pretest_lastfailed_984.py` (every case parametrized over a plain `pytest.ini` and one whose `addopts` starts with `-v`, matching this repo) — Case A (rename / deleted file / deleted test), Case C (exact selection, no neighbours, mixed stale+live), empty/missing/malformed cache, whole-file keys, the four broken-file cases, the five unparseable-format cases, and end-to-end runs asserting exit codes.
- **Mutation-checked**, six guards: removing the pruning fails 4; making the malformed cache non-safe fails 1; treating errored files as stale fails 4; dropping `-o addopts=` fails 3; making the format guard prune silently fails 6; gating that guard on `not errored` fails 2.
- **The real hook runs**: `pre-commit run pytest-check --all-files` → `Run last failed tests (fast feedback)....Passed`. YAML validated by parsing the config and printing the composed `entry` (the first attempt broke it — a `: ` inside an unquoted plain scalar).
- Full non-e2e gate green; `ruff check` clean.

## Known limitations

- This clone's `.git/hooks/pre-commit` is a secret scanner, not the pre-commit framework's hook, so `.pre-commit-config.yaml` only takes effect where someone has run `pre-commit install`. That's pre-existing and out of scope; the config is the tracked artifact and is now correct.
- The 300s ceiling is a blunt instrument: a legitimately slow set of previously-failed tests will be skipped with a warning rather than run to completion. That is the intended trade for never hanging a commit, and #979 (merged) makes hitting it much less likely.
- A cached node ID for a test that still exists but is now *deselected* by markers is not pruned — `collectible()` clears `addopts`, so it still resolves at selection time. It is neutralized later: the real run in `main()` keeps `addopts`, pytest exits 5 ("no tests ran"), and the YAML wrapper maps that to a pass. Same outcome, different mechanism than an earlier draft of this note claimed.
- The five node IDs currently selected in this repo are e2e tests, which the hook will happily run even though CI excludes them. That is unchanged from `--lf`'s behaviour and bounded by the 300s ceiling, but it is a real difference between the hook and the CI gate.