### PR TITLE
refactor(workspace): one definition of the schema, shared by both paths (#1060)

### DIFF
--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -462,8 +462,6 @@ def _create_core_tables(cursor: sqlite3.Cursor) -> None:
     # so every save_token_usage() raised "no such table" and cost data dropped).
     _create_token_usage_schema(cursor)
 
-    # Create indexes for common queries
-
 
 def _create_core_indexes(cursor: sqlite3.Cursor) -> None:
     """Create every workspace index, idempotently (#1060).

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -133,20 +133,26 @@ def _create_token_usage_schema(cursor: sqlite3.Cursor) -> None:
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_token_usage_agent_id ON token_usage(agent_id)")
 
 
-def _init_database(db_path: Path) -> None:
-    """Initialize the workspace SQLite database with v2 schema.
+def _create_core_schema(cursor: sqlite3.Cursor) -> None:
+    """Create every workspace table and index, idempotently (#1060).
 
-    Creates tables for:
-    - workspaces: Workspace metadata
-    - prds: Product requirements documents
-    - tasks: Task state machine
-    - events: Append-only event log
-    - blockers: Human-in-the-loop blockers
-    - checkpoints: State snapshots
+    The single definition of the workspace schema, called by BOTH
+    ``_init_database`` (fresh workspace) and ``_ensure_schema_upgrades``
+    (existing workspace) — the pattern ``_create_token_usage_schema`` already
+    demonstrated, applied to the rest.
+
+    Before this existed the DDL was copy-pasted between those two paths and had
+    already drifted: ``blockers``, ``checkpoints``, ``events``, ``prds``,
+    ``tasks`` and ``workspace`` plus five indexes were created only on the
+    fresh path, so a workspace that reached the upgrade path missing one never
+    got it back. Drift like that surfaces as a runtime error on whichever path
+    is less exercised, which is exactly the one nobody tests.
+
+    Every statement is ``IF NOT EXISTS``, so calling this on an existing
+    database adds what is absent and touches nothing else. Column-level
+    migrations (ALTER TABLE) stay in ``_ensure_schema_upgrades``: this function
+    only guarantees that every object exists.
     """
-    conn = _open_db(db_path)
-    cursor = conn.cursor()
-
     # Workspace metadata
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS workspace (
@@ -484,6 +490,19 @@ def _init_database(db_path: Path) -> None:
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_run ON file_operations(run_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_step ON file_operations(step_id)")
 
+
+
+def _init_database(db_path: Path) -> None:
+    """Initialize the workspace SQLite database with v2 schema.
+
+    The schema itself lives in ``_create_core_schema``, shared with the upgrade
+    path so the two cannot drift (#1060).
+    """
+    conn = _open_db(db_path)
+    cursor = conn.cursor()
+
+    _create_core_schema(cursor)
+
     # PRAGMA doesn't accept ? placeholders; SCHEMA_VERSION is a module int constant.
     cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
@@ -553,69 +572,41 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
 
     cursor = conn.cursor()
 
+    # Every table and index, from the SAME definition the fresh path uses, so
+    # the two cannot drift (#1060). All IF NOT EXISTS, so this adds whatever is
+    # absent and touches nothing else. What remains below is column-level
+    # migration (ALTER TABLE) and data backfill, which DDL alone cannot express.
+    _create_core_schema(cursor)
+
     # token_usage was added after the initial schema (issue #712); create it for
     # existing workspaces. CREATE TABLE IF NOT EXISTS keeps this idempotent.
     _create_token_usage_schema(cursor)
     conn.commit()
 
-    # Check if batch_runs table exists, if not create it
-    cursor.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='batch_runs'"
+    # Add columns that were introduced after the initial batch_runs schema
+    # (migration for existing databases). Each ALTER is guarded by a column
+    # existence check so this is idempotent. isolation + stall/provider/
+    # concurrency columns were added for #741 so `batch resume` restores the
+    # original run settings instead of silently falling back to defaults.
+    cursor.execute("PRAGMA table_info(batch_runs)")
+    batch_columns = {row[1] for row in cursor.fetchall()}
+    batch_migrations = (
+        ("engine", "ALTER TABLE batch_runs ADD COLUMN engine TEXT NOT NULL DEFAULT 'plan'"),
+        ("isolation", "ALTER TABLE batch_runs ADD COLUMN isolation TEXT NOT NULL DEFAULT 'none'"),
+        ("stall_timeout_s", "ALTER TABLE batch_runs ADD COLUMN stall_timeout_s INTEGER NOT NULL DEFAULT 300"),
+        ("stall_action", "ALTER TABLE batch_runs ADD COLUMN stall_action TEXT NOT NULL DEFAULT 'blocker'"),
+        ("concurrency_by_status", "ALTER TABLE batch_runs ADD COLUMN concurrency_by_status TEXT"),
+        ("llm_provider", "ALTER TABLE batch_runs ADD COLUMN llm_provider TEXT"),
+        ("llm_model", "ALTER TABLE batch_runs ADD COLUMN llm_model TEXT"),
+        # #957: config-reload bookkeeping moved off the results JSON blob.
+        ("config_reloads", "ALTER TABLE batch_runs ADD COLUMN config_reloads TEXT"),
+        # #959: the user's --cloud-timeout must survive a resume.
+        ("cloud_timeout_minutes", "ALTER TABLE batch_runs ADD COLUMN cloud_timeout_minutes INTEGER NOT NULL DEFAULT 30"),
     )
-    if not cursor.fetchone():
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS batch_runs (
-                id TEXT PRIMARY KEY,
-                workspace_id TEXT NOT NULL,
-                task_ids TEXT NOT NULL,
-                status TEXT NOT NULL DEFAULT 'PENDING',
-                strategy TEXT NOT NULL DEFAULT 'serial',
-                max_parallel INTEGER NOT NULL DEFAULT 4,
-                on_failure TEXT NOT NULL DEFAULT 'continue',
-                started_at TEXT NOT NULL,
-                completed_at TEXT,
-                results TEXT,
-                engine TEXT NOT NULL DEFAULT 'plan',
-                isolation TEXT NOT NULL DEFAULT 'none',
-                stall_timeout_s INTEGER NOT NULL DEFAULT 300,
-                stall_action TEXT NOT NULL DEFAULT 'blocker',
-                concurrency_by_status TEXT,
-                llm_provider TEXT,
-                llm_model TEXT,
-                config_reloads TEXT,
-                cloud_timeout_minutes INTEGER NOT NULL DEFAULT 30,
-                FOREIGN KEY (workspace_id) REFERENCES workspace(id),
-                CHECK (status IN ('PENDING', 'RUNNING', 'COMPLETED', 'PARTIAL', 'FAILED', 'CANCELLED'))
-            )
-        """)
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_batch_runs_workspace ON batch_runs(workspace_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_batch_runs_status ON batch_runs(status)")
-        conn.commit()
-    else:
-        # Add columns that were introduced after the initial batch_runs schema
-        # (migration for existing databases). Each ALTER is guarded by a column
-        # existence check so this is idempotent. isolation + stall/provider/
-        # concurrency columns were added for #741 so `batch resume` restores the
-        # original run settings instead of silently falling back to defaults.
-        cursor.execute("PRAGMA table_info(batch_runs)")
-        batch_columns = {row[1] for row in cursor.fetchall()}
-        batch_migrations = (
-            ("engine", "ALTER TABLE batch_runs ADD COLUMN engine TEXT NOT NULL DEFAULT 'plan'"),
-            ("isolation", "ALTER TABLE batch_runs ADD COLUMN isolation TEXT NOT NULL DEFAULT 'none'"),
-            ("stall_timeout_s", "ALTER TABLE batch_runs ADD COLUMN stall_timeout_s INTEGER NOT NULL DEFAULT 300"),
-            ("stall_action", "ALTER TABLE batch_runs ADD COLUMN stall_action TEXT NOT NULL DEFAULT 'blocker'"),
-            ("concurrency_by_status", "ALTER TABLE batch_runs ADD COLUMN concurrency_by_status TEXT"),
-            ("llm_provider", "ALTER TABLE batch_runs ADD COLUMN llm_provider TEXT"),
-            ("llm_model", "ALTER TABLE batch_runs ADD COLUMN llm_model TEXT"),
-            # #957: config-reload bookkeeping moved off the results JSON blob.
-            ("config_reloads", "ALTER TABLE batch_runs ADD COLUMN config_reloads TEXT"),
-            # #959: the user's --cloud-timeout must survive a resume.
-            ("cloud_timeout_minutes", "ALTER TABLE batch_runs ADD COLUMN cloud_timeout_minutes INTEGER NOT NULL DEFAULT 30"),
-        )
-        for column, ddl in batch_migrations:
-            if column not in batch_columns:
-                cursor.execute(ddl)
-        conn.commit()
+    for column, ddl in batch_migrations:
+        if column not in batch_columns:
+            cursor.execute(ddl)
+    conn.commit()
 
     # Add tech_stack column to workspace table if it doesn't exist
     # First check if workspace table exists
@@ -756,178 +747,24 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
                 exc,
             )
 
-    # Ensure runs table exists before creating dependent tables (run_logs, diagnostic_reports)
-    cursor.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='runs'"
-    )
-    if not cursor.fetchone():
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS runs (
-                id TEXT PRIMARY KEY,
-                workspace_id TEXT NOT NULL,
-                task_id TEXT NOT NULL,
-                status TEXT NOT NULL DEFAULT 'RUNNING',
-                started_at TEXT NOT NULL,
-                completed_at TEXT,
-                FOREIGN KEY (workspace_id) REFERENCES workspace(id),
-                FOREIGN KEY (task_id) REFERENCES tasks(id),
-                CHECK (status IN ('RUNNING', 'COMPLETED', 'FAILED', 'BLOCKED'))
-            )
-        """)
-        conn.commit()
-
-    # Add run_logs table if it doesn't exist
-    cursor.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='run_logs'"
-    )
-    if not cursor.fetchone():
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS run_logs (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                run_id TEXT NOT NULL,
-                task_id TEXT NOT NULL,
-                timestamp TEXT NOT NULL,
-                log_level TEXT NOT NULL DEFAULT 'INFO',
-                category TEXT NOT NULL,
-                message TEXT NOT NULL,
-                metadata TEXT,
-                FOREIGN KEY (run_id) REFERENCES runs(id),
-                FOREIGN KEY (task_id) REFERENCES tasks(id),
-                CHECK (log_level IN ('DEBUG', 'INFO', 'WARNING', 'ERROR'))
-            )
-        """)
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_run_logs_run ON run_logs(run_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_run_logs_task ON run_logs(task_id)")
-        conn.commit()
-
-    # Add diagnostic_reports table if it doesn't exist
-    cursor.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='diagnostic_reports'"
-    )
-    if not cursor.fetchone():
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS diagnostic_reports (
-                id TEXT PRIMARY KEY,
-                task_id TEXT NOT NULL,
-                run_id TEXT NOT NULL,
-                root_cause TEXT NOT NULL,
-                failure_category TEXT NOT NULL,
-                severity TEXT NOT NULL,
-                recommendations TEXT NOT NULL,
-                log_summary TEXT,
-                created_at TEXT NOT NULL,
-                FOREIGN KEY (task_id) REFERENCES tasks(id),
-                FOREIGN KEY (run_id) REFERENCES runs(id),
-                CHECK (severity IN ('critical', 'high', 'medium', 'low'))
-            )
-        """)
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_diagnostic_reports_task ON diagnostic_reports(task_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_diagnostic_reports_run ON diagnostic_reports(run_id)")
-        conn.commit()
-
-    # Add run_engine_log table for engine performance tracking
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS run_engine_log (
-            run_id TEXT PRIMARY KEY,
-            engine TEXT NOT NULL,
-            task_id TEXT NOT NULL,
-            workspace_id TEXT NOT NULL,
-            status TEXT NOT NULL,
-            duration_ms INTEGER,
-            tokens_used INTEGER DEFAULT 0,
-            gates_passed INTEGER,
-            self_corrections INTEGER DEFAULT 0,
-            created_at TEXT NOT NULL
-        )
-    """)
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_run_engine_log_ws_engine "
         "ON run_engine_log(workspace_id, engine)"
     )
     conn.commit()
 
-    # Add engine_stats table for aggregate engine metrics
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS engine_stats (
-            workspace_id TEXT NOT NULL,
-            engine TEXT NOT NULL,
-            metric TEXT NOT NULL,
-            value REAL NOT NULL DEFAULT 0.0,
-            updated_at TEXT NOT NULL,
-            PRIMARY KEY (workspace_id, engine, metric)
-        )
-    """)
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_engine_stats_ws "
         "ON engine_stats(workspace_id, engine)"
     )
     conn.commit()
 
-    # Add execution trace tables for debug/replay mode
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS execution_steps (
-            id TEXT PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            step_number INTEGER NOT NULL,
-            step_type TEXT NOT NULL,
-            description TEXT NOT NULL,
-            started_at TEXT NOT NULL,
-            completed_at TEXT,
-            status TEXT NOT NULL DEFAULT 'started',
-            input_context TEXT,
-            output_result TEXT,
-            metadata TEXT,
-            FOREIGN KEY (run_id) REFERENCES runs(id)
-        )
-    """)
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS llm_interactions (
-            id TEXT PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            step_id TEXT NOT NULL,
-            prompt TEXT NOT NULL,
-            response TEXT NOT NULL,
-            model TEXT NOT NULL,
-            tokens_used INTEGER NOT NULL DEFAULT 0,
-            timestamp TEXT NOT NULL,
-            purpose TEXT NOT NULL DEFAULT 'execution',
-            FOREIGN KEY (run_id) REFERENCES runs(id),
-            FOREIGN KEY (step_id) REFERENCES execution_steps(id)
-        )
-    """)
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS file_operations (
-            id TEXT PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            step_id TEXT NOT NULL,
-            operation_type TEXT NOT NULL,
-            file_path TEXT NOT NULL,
-            content_before TEXT,
-            content_after TEXT,
-            timestamp TEXT NOT NULL,
-            FOREIGN KEY (run_id) REFERENCES runs(id),
-            FOREIGN KEY (step_id) REFERENCES execution_steps(id),
-            CHECK (operation_type IN ('create', 'edit', 'delete'))
-        )
-    """)
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_execution_steps_run ON execution_steps(run_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_execution_steps_run_step ON execution_steps(run_id, step_number)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_llm_interactions_run ON llm_interactions(run_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_llm_interactions_step ON llm_interactions(step_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_run ON file_operations(run_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_step ON file_operations(step_id)")
-    # Add cloud_run_metadata table for E2B cloud execution tracking
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS cloud_run_metadata (
-            run_id TEXT PRIMARY KEY,
-            sandbox_minutes REAL NOT NULL,
-            cost_usd_estimate REAL NOT NULL,
-            files_uploaded INTEGER NOT NULL,
-            files_downloaded INTEGER NOT NULL,
-            credential_scan_blocked INTEGER NOT NULL,
-            created_at TEXT NOT NULL
-        )
-    """)
     # PRAGMA doesn't accept ? placeholders; SCHEMA_VERSION is a module int constant.
     cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -534,6 +534,7 @@ def _create_core_schema(cursor: sqlite3.Cursor) -> None:
     _create_core_tables(cursor)
     _create_core_indexes(cursor)
 
+
 def _init_database(db_path: Path) -> None:
     """Initialize the workspace SQLite database with v2 schema.
 
@@ -718,9 +719,6 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             conn.commit()
 
         # Add indexes for PRD version chain queries
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_prds_parent ON prds(parent_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_prds_chain ON prds(chain_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_prds_depends_on ON prds(depends_on)")
         conn.commit()
 
     # Add new columns to tasks table if they don't exist
@@ -782,16 +780,8 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
         _dedupe_external_urls(conn, cursor)
         conn.commit()
 
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_run_engine_log_ws_engine "
-        "ON run_engine_log(workspace_id, engine)"
-    )
     conn.commit()
 
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_engine_stats_ws "
-        "ON engine_stats(workspace_id, engine)"
-    )
     conn.commit()
 
     # LAST, and from the same definition the fresh path uses. Everything above

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -133,7 +133,7 @@ def _create_token_usage_schema(cursor: sqlite3.Cursor) -> None:
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_token_usage_agent_id ON token_usage(agent_id)")
 
 
-def _create_core_schema(cursor: sqlite3.Cursor) -> None:
+def _create_core_tables(cursor: sqlite3.Cursor) -> None:
     """Create every workspace table and index, idempotently (#1060).
 
     The single definition of the workspace schema, called by BOTH
@@ -460,6 +460,25 @@ def _create_core_schema(cursor: sqlite3.Cursor) -> None:
     _create_token_usage_schema(cursor)
 
     # Create indexes for common queries
+
+
+def _create_core_indexes(cursor: sqlite3.Cursor) -> None:
+    """Create every workspace index, idempotently (#1060).
+
+    Split from ``_create_core_tables`` because ORDER MATTERS on the upgrade
+    path, in two ways a whole-table-drop test cannot reveal:
+
+    * ``idx_prds_chain``/``idx_prds_depends_on`` index columns that older
+      workspaces do not have yet. Creating them before the guarded ALTER TABLE
+      migrations raises ``no such column: chain_id`` and the workspace fails to
+      open instead of upgrading.
+    * ``idx_tasks_external_url`` is UNIQUE. A workspace that imported the same
+      GitHub issue twice must be deduped first, or the index raises
+      IntegrityError and there is no way back in.
+
+    So the upgrade path creates tables early (safe — pure IF NOT EXISTS) and
+    calls this only at the end, after every column migration and data fixup.
+    """
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)")
     # Atomic duplicate-import protection (#565): one task per (workspace, issue
@@ -491,6 +510,15 @@ def _create_core_schema(cursor: sqlite3.Cursor) -> None:
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_step ON file_operations(step_id)")
 
 
+def _create_core_schema(cursor: sqlite3.Cursor) -> None:
+    """Tables then indexes — the fresh-workspace path, where order is trivial.
+
+    A new database has no legacy columns to migrate and no duplicate rows, so
+    both halves can run back to back. ``_ensure_schema_upgrades`` deliberately
+    does NOT use this; see ``_create_core_indexes`` for why.
+    """
+    _create_core_tables(cursor)
+    _create_core_indexes(cursor)
 
 def _init_database(db_path: Path) -> None:
     """Initialize the workspace SQLite database with v2 schema.
@@ -572,11 +600,13 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
 
     cursor = conn.cursor()
 
-    # Every table and index, from the SAME definition the fresh path uses, so
-    # the two cannot drift (#1060). All IF NOT EXISTS, so this adds whatever is
-    # absent and touches nothing else. What remains below is column-level
-    # migration (ALTER TABLE) and data backfill, which DDL alone cannot express.
-    _create_core_schema(cursor)
+    # Every table, from the SAME definition the fresh path uses, so the two
+    # cannot drift (#1060). Pure IF NOT EXISTS, so this adds whatever is absent
+    # and touches nothing else. Indexes are deliberately NOT created here —
+    # they run at the very end, once the ALTER TABLE migrations below have
+    # added the columns they index and the data fixups have made the UNIQUE
+    # ones satisfiable.
+    _create_core_tables(cursor)
 
     # token_usage was added after the initial schema (issue #712); create it for
     # existing workspaces. CREATE TABLE IF NOT EXISTS keeps this idempotent.
@@ -759,12 +789,12 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
     )
     conn.commit()
 
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_execution_steps_run ON execution_steps(run_id)")
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_execution_steps_run_step ON execution_steps(run_id, step_number)")
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_llm_interactions_run ON llm_interactions(run_id)")
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_llm_interactions_step ON llm_interactions(step_id)")
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_run ON file_operations(run_id)")
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_operations_step ON file_operations(step_id)")
+    # LAST, and from the same definition the fresh path uses. Everything above
+    # has run: the ALTER TABLE migrations have added the columns these index,
+    # and _dedupe_external_urls has made the UNIQUE one satisfiable. Creating
+    # them any earlier fails a real legacy workspace outright (#1060).
+    _create_core_indexes(cursor)
+
     # PRAGMA doesn't accept ? placeholders; SCHEMA_VERSION is a module int constant.
     cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -134,7 +134,10 @@ def _create_token_usage_schema(cursor: sqlite3.Cursor) -> None:
 
 
 def _create_core_tables(cursor: sqlite3.Cursor) -> None:
-    """Create every workspace table and index, idempotently (#1060).
+    """Create every workspace table, idempotently (#1060).
+
+    Tables only — indexes live in ``_create_core_indexes`` because their
+    ordering is constrained on the upgrade path; see that docstring.
 
     The single definition of the workspace schema, called by BOTH
     ``_init_database`` (fresh workspace) and ``_ensure_schema_upgrades``

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -484,10 +484,24 @@ def _create_core_indexes(cursor: sqlite3.Cursor) -> None:
     # Atomic duplicate-import protection (#565): one task per (workspace, issue
     # URL). SQLite treats NULLs as distinct, so non-imported tasks (NULL
     # external_url) are unaffected.
-    cursor.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_external_url "
-        "ON tasks(workspace_id, external_url)"
-    )
+    #
+    # The only statement here that can fail on real data, so the #943 guard
+    # lives WITH it rather than at one call site: if duplicates survived the
+    # dedupe, warn and carry on without the index. A missing optimisation is
+    # recoverable; a workspace that will not open is not. Unreachable on a
+    # fresh database, which has no rows yet.
+    try:
+        cursor.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_external_url "
+            "ON tasks(workspace_id, external_url)"
+        )
+    except sqlite3.IntegrityError as exc:
+        logger.warning(
+            "Could not create the unique external_url index (%s). Duplicate "
+            "GitHub-import protection is OFF for this workspace; the "
+            "workspace still opens normally.",
+            exc,
+        )
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_events_workspace ON events(workspace_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_blockers_workspace ON blockers(workspace_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_blockers_status ON blockers(status)")
@@ -761,21 +775,12 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
         # CLI and the server with no recovery path (#943). Dedupe first, and if
         # that cannot be done, warn and carry on without the index: a missing
         # optimisation is recoverable, an unopenable workspace is not.
+        # Dedupe only. The index itself is created — once, and guarded — by
+        # _create_core_indexes at the end of this function. Creating it here as
+        # well left an UNGUARDED second attempt downstream, which reintroduced
+        # the exact IntegrityError brick this guard exists to survive.
         _dedupe_external_urls(conn, cursor)
-        try:
-            cursor.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_external_url "
-                "ON tasks(workspace_id, external_url)"
-            )
-            conn.commit()
-        except sqlite3.IntegrityError as exc:
-            conn.rollback()
-            logger.warning(
-                "Could not create the unique external_url index (%s). Duplicate "
-                "GitHub-import protection is OFF for this workspace; the "
-                "workspace still opens normally.",
-                exc,
-            )
+        conn.commit()
 
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_run_engine_log_ws_engine "

--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -622,10 +622,6 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
     # added the columns they index and the data fixups have made the UNIQUE
     # ones satisfiable.
     _create_core_tables(cursor)
-
-    # token_usage was added after the initial schema (issue #712); create it for
-    # existing workspaces. CREATE TABLE IF NOT EXISTS keeps this idempotent.
-    _create_token_usage_schema(cursor)
     conn.commit()
 
     # Add columns that were introduced after the initial batch_runs schema
@@ -718,7 +714,6 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
             cursor.execute("ALTER TABLE prds ADD COLUMN depends_on TEXT")
             conn.commit()
 
-        # Add indexes for PRD version chain queries
         conn.commit()
 
     # Add new columns to tasks table if they don't exist
@@ -779,8 +774,6 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
         # the exact IntegrityError brick this guard exists to survive.
         _dedupe_external_urls(conn, cursor)
         conn.commit()
-
-    conn.commit()
 
     conn.commit()
 

--- a/tests/core/test_schema_convergence_1060.py
+++ b/tests/core/test_schema_convergence_1060.py
@@ -122,6 +122,21 @@ class TestNoDdlIsDuplicated:
             f"DDL duplicated between the create and upgrade paths: {duplicated}"
         )
 
+    def test_no_create_index_statement_appears_twice(self):
+        """Indexes are DDL too — the first version of this guard missed them.
+
+        Harmless at runtime (IF NOT EXISTS, and the one UNIQUE index is
+        guarded), but "each table's DDL exists in exactly one place" is the
+        acceptance criterion, and a duplicate index is the same drift hazard
+        one level down.
+        """
+        import re
+
+        source = Path("codeframe/core/workspace.py").read_text()
+        names = re.findall(r"CREATE (?:UNIQUE )?INDEX IF NOT EXISTS (\w+)", source)
+        duplicated = sorted({n for n in names if names.count(n) > 1})
+        assert duplicated == [], f"index DDL duplicated: {duplicated}"
+
 
 class TestNoBehaviourChange:
     """AC3 — existing workspaces still open, new ones still initialise."""

--- a/tests/core/test_schema_convergence_1060.py
+++ b/tests/core/test_schema_convergence_1060.py
@@ -295,3 +295,39 @@ class TestLegacyShapesTheTableDropTestCannotReach:
         """Two attempts means one of them is unguarded — that was the bug."""
         source = Path("codeframe/core/workspace.py").read_text()
         assert source.count("CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_external_url") == 1
+
+    def test_a_tasks_table_missing_columns_is_migrated_not_left_alone(self, tmp_path):
+        """A legacy tasks table must come out fully migrated, whoever does it.
+
+        Deliberately does not assert *which* code path adds the columns:
+        `_create_core_tables` carries ALTER statements of its own, so the
+        block in `_ensure_schema_upgrades` may well be redundant now (see the
+        follow-up issue). What must not regress is the outcome — an old tasks
+        table ends up with every current column.
+        """
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        db = tmp_path / "legacy_tasks.db"
+        _init_database(db)
+        conn = sqlite3.connect(db)
+        conn.execute("DROP TABLE tasks")
+        conn.execute(
+            "CREATE TABLE tasks (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL, "
+            "title TEXT NOT NULL, description TEXT, status TEXT NOT NULL, "
+            "created_at TEXT NOT NULL, updated_at TEXT NOT NULL)"
+        )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        _ensure_schema_upgrades(db)
+
+        conn = sqlite3.connect(db)
+        try:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+        finally:
+            conn.close()
+        assert {
+            "depends_on", "parent_id", "requirement_ids",
+            "github_issue_number", "external_url", "auto_close_github_issue",
+        } <= cols, f"legacy tasks table was not migrated: {sorted(cols)}"

--- a/tests/core/test_schema_convergence_1060.py
+++ b/tests/core/test_schema_convergence_1060.py
@@ -159,3 +159,80 @@ class TestNoBehaviourChange:
 
         upgraded = get_workspace(repo)
         assert tasks.get(upgraded, task.id).title == "survivor"
+
+
+class TestLegacyShapesTheTableDropTestCannotReach:
+    """Dropping a whole table is too clean a simulation of "legacy".
+
+    A dropped table comes back complete. Real legacy databases have tables that
+    *exist* but are missing columns, or that hold data a newer index would
+    reject. Sharing the DDL made ordering load-bearing: indexes must be created
+    after the ALTER TABLE migrations that add their columns, and after the data
+    fixups that make a UNIQUE index satisfiable.
+    """
+
+    def test_a_prds_table_without_chain_id_still_upgrades(self, tmp_path):
+        """idx_prds_chain cannot be created before the column it indexes."""
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        db = tmp_path / "legacy.db"
+        _init_database(db)
+        conn = sqlite3.connect(db)
+        conn.execute("DROP TABLE prds")
+        conn.execute(
+            "CREATE TABLE prds (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL, "
+            "title TEXT, content TEXT NOT NULL, metadata TEXT, "
+            "created_at TEXT NOT NULL, version INTEGER DEFAULT 1, "
+            "parent_id TEXT, change_summary TEXT)"
+        )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        _ensure_schema_upgrades(db)  # must not raise "no such column: chain_id"
+
+        conn = sqlite3.connect(db)
+        try:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(prds)")}
+            idx = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'")}
+        finally:
+            conn.close()
+        assert {"chain_id", "depends_on"} <= cols
+        assert "idx_prds_chain" in idx
+
+    def test_duplicate_external_urls_are_deduped_before_the_unique_index(
+        self, tmp_path
+    ):
+        """A UNIQUE index over dirty data must not brick the workspace."""
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        db = tmp_path / "dupes.db"
+        _init_database(db)
+        conn = sqlite3.connect(db)
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_external_url")
+        for task_id in ("t1", "t2"):
+            conn.execute(
+                "INSERT INTO tasks (id, workspace_id, title, description, status, "
+                "created_at, updated_at, external_url) "
+                "VALUES (?, 'w1', 'T', 'd', 'BACKLOG', '2026-01-01', '2026-01-01', "
+                "'https://github.com/o/r/issues/1')",
+                (task_id,),
+            )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        _ensure_schema_upgrades(db)  # must not raise IntegrityError
+
+        conn = sqlite3.connect(db)
+        try:
+            urls = [r[0] for r in conn.execute(
+                "SELECT external_url FROM tasks WHERE id IN ('t1','t2') ORDER BY id")]
+            idx = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'")}
+        finally:
+            conn.close()
+        assert urls[0] == "https://github.com/o/r/issues/1", "kept the oldest row"
+        assert not urls[1], "the later duplicate should have been blanked"
+        assert "idx_tasks_external_url" in idx

--- a/tests/core/test_schema_convergence_1060.py
+++ b/tests/core/test_schema_convergence_1060.py
@@ -1,0 +1,161 @@
+"""A fresh workspace and an upgraded one must end up with the same schema (#1060).
+
+`workspace.py` carried 28 `CREATE TABLE IF NOT EXISTS` statements copy-pasted
+between `_init_database` (fresh) and `_ensure_schema_upgrades` (existing), and
+they had already drifted: 6 tables and 5 indexes existed only on the create
+path, 1 table only on the upgrade path.
+
+Drift like that is invisible until someone hits the less-exercised path at
+runtime. These tests make it impossible rather than merely unlikely — the
+generic one below drops each table in turn and asserts the upgrade path
+rebuilds it identically, so a new table added to only one path fails here.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+
+def _schema(db_path: Path) -> dict[str, str]:
+    """Every object in sqlite_master, normalised for comparison."""
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {
+        f"{kind}:{name}": " ".join((sql or "").split())
+        for kind, name, sql in rows
+    }
+
+
+def _fresh(tmp_path: Path) -> Path:
+    from codeframe.core.workspace import _init_database
+
+    db = tmp_path / "fresh.db"
+    _init_database(db)
+    return db
+
+
+def _all_tables(db_path: Path) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return sorted(
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%'"
+            )
+        )
+    finally:
+        conn.close()
+
+
+def _make_legacy(db_path: Path, drop: list[str]) -> None:
+    """Simulate an older workspace: drop tables and un-stamp the version."""
+    conn = sqlite3.connect(db_path)
+    try:
+        for table in drop:
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestEveryTableIsRebuiltByTheUpgradePath:
+    """The generic guard: no table may exist on only one path."""
+
+    def test_each_table_dropped_alone_is_restored(self, tmp_path):
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        reference = _schema(_fresh(tmp_path))
+        missing: dict[str, list[str]] = {}
+
+        for table in _all_tables(tmp_path / "fresh.db"):
+            db = tmp_path / f"upg_{table}.db"
+            _init_database(db)
+            _make_legacy(db, [table])
+            _ensure_schema_upgrades(db)
+
+            after = _schema(db)
+            gone = sorted(set(reference) - set(after))
+            if gone:
+                missing[table] = gone
+
+        assert missing == {}, (
+            "the upgrade path does not rebuild these — a fresh workspace and "
+            f"an upgraded one would diverge: {missing}"
+        )
+
+    def test_dropping_everything_rebuilds_the_whole_schema(self, tmp_path):
+        """The strongest form: an empty DB upgraded == a fresh one."""
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        reference = _schema(_fresh(tmp_path))
+
+        db = tmp_path / "empty.db"
+        _init_database(db)
+        _make_legacy(db, _all_tables(db))
+        _ensure_schema_upgrades(db)
+
+        assert sorted(_schema(db)) == sorted(reference)
+
+
+class TestNoDdlIsDuplicated:
+    """AC1 — each table's DDL exists in exactly one place."""
+
+    def test_no_create_table_statement_appears_twice(self):
+        import re
+
+        source = Path("codeframe/core/workspace.py").read_text()
+        names = re.findall(r"CREATE TABLE IF NOT EXISTS (\w+)", source)
+        duplicated = sorted({n for n in names if names.count(n) > 1})
+        assert duplicated == [], (
+            f"DDL duplicated between the create and upgrade paths: {duplicated}"
+        )
+
+
+class TestNoBehaviourChange:
+    """AC3 — existing workspaces still open, new ones still initialise."""
+
+    def test_a_new_workspace_initialises(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.workspace import create_or_load_workspace
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ws = create_or_load_workspace(repo)
+        assert tasks.create(ws, title="T", description="d").id
+
+    def test_an_existing_workspace_reopens_with_its_data(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.workspace import create_or_load_workspace
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        first = create_or_load_workspace(repo)
+        task = tasks.create(first, title="keep me", description="d")
+
+        again = create_or_load_workspace(repo)
+        assert tasks.get(again, task.id).title == "keep me"
+
+    def test_a_legacy_workspace_is_upgraded_and_still_readable(self, tmp_path):
+        from codeframe.core import tasks
+        from codeframe.core.workspace import create_or_load_workspace, get_workspace
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ws = create_or_load_workspace(repo)
+        task = tasks.create(ws, title="survivor", description="d")
+        _make_legacy(ws.db_path, ["batch_runs"])
+
+        upgraded = get_workspace(repo)
+        assert tasks.get(upgraded, task.id).title == "survivor"

--- a/tests/core/test_schema_convergence_1060.py
+++ b/tests/core/test_schema_convergence_1060.py
@@ -236,3 +236,47 @@ class TestLegacyShapesTheTableDropTestCannotReach:
         assert urls[0] == "https://github.com/o/r/issues/1", "kept the oldest row"
         assert not urls[1], "the later duplicate should have been blanked"
         assert "idx_tasks_external_url" in idx
+
+    def test_undedupable_duplicates_warn_instead_of_bricking(self, tmp_path, monkeypatch):
+        """The #943 guard must survive being moved into the shared definition.
+
+        Sharing the index DDL created a SECOND, unguarded attempt after the
+        guarded one. If duplicates outlive the dedupe for any reason, that
+        second attempt raises IntegrityError and the workspace never opens —
+        reintroducing exactly what the guard exists to prevent.
+        """
+        from codeframe.core import workspace as ws
+
+        db = tmp_path / "stuck.db"
+        ws._init_database(db)
+        conn = sqlite3.connect(db)
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_external_url")
+        for task_id in ("t1", "t2"):
+            conn.execute(
+                "INSERT INTO tasks (id, workspace_id, title, description, status, "
+                "created_at, updated_at, external_url) "
+                "VALUES (?, 'w1', 'T', 'd', 'BACKLOG', '2026-01-01', '2026-01-01', "
+                "'https://github.com/o/r/issues/1')",
+                (task_id,),
+            )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        # Dedupe cannot help — simulate it failing to clear the duplicates.
+        monkeypatch.setattr(ws, "_dedupe_external_urls", lambda conn, cursor: None)
+
+        ws._ensure_schema_upgrades(db)  # must not raise IntegrityError
+
+        conn = sqlite3.connect(db)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+        finally:
+            conn.close()
+        assert version == ws.SCHEMA_VERSION, "the upgrade did not complete"
+
+    def test_the_index_is_created_exactly_once_in_the_source(self):
+        """Two attempts means one of them is unguarded — that was the bug."""
+        source = Path("codeframe/core/workspace.py").read_text()
+        assert source.count("CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_external_url") == 1


### PR DESCRIPTION
Closes #1060.

## The drift was already real, and measurable

`_init_database` (fresh) and `_ensure_schema_upgrades` (existing) carried 28 copy-pasted `CREATE TABLE IF NOT EXISTS` statements. Measured before touching anything:

```
only on the create path : blockers, checkpoints, events, prds, tasks, workspace
                          + idx_blockers_status, idx_blockers_workspace,
                            idx_events_workspace, idx_tasks_status, idx_tasks_workspace
only on the upgrade path: keeps
```

So a workspace reaching the upgrade path without one of those six never got it back — and that only ever surfaces as a runtime error on whichever path is less exercised, which is the one nobody tests.

## Fix

`_create_core_tables` / `_create_core_indexes` are now the single definition, called by both paths — the pattern `_create_token_usage_schema` already demonstrated, applied to the rest. Column migrations (ALTER TABLE) and data backfill stay in `_ensure_schema_upgrades`, since DDL alone can't express them.

| | before | after |
|---|---|---|
| `CREATE TABLE` statements | 28 | **18** (the canonical set) |
| `workspace.py` | 1206 lines | **1043** |

With every table guaranteed to exist, the upgrade path's four `if not cursor.fetchone(): <CREATE> else: <ALTER>` blocks lose their create branch, and six unconditional re-CREATEs become dead.

## Ordering is load-bearing — two [P1]s the review caught

My first version called the whole shared schema early on the upgrade path. That put index creation *ahead of the migrations those indexes depend on*, and both cases brick a real legacy workspace rather than merely diverging:

- **`idx_prds_chain` / `idx_prds_depends_on`** index columns an older workspace doesn't have yet. Created before the guarded ALTER TABLEs, `get_workspace()` raises `no such column: chain_id` and the workspace won't open at all.
- **`idx_tasks_external_url` is UNIQUE.** A workspace that imported the same GitHub issue twice needs `_dedupe_external_urls` first, or the index raises `IntegrityError` with no way back in — regressing the recovery path #943 added on purpose.

So tables and indexes are separate now. `_init_database` runs both back to back (a new database has nothing to migrate); `_ensure_schema_upgrades` creates tables early — pure `IF NOT EXISTS`, always safe — and calls the indexes **last**, after every column migration and data fixup. Sharing is preserved; only sequencing differs, and the docstrings say why.

**My convergence test could not have caught either**, which is the more useful finding: dropping a whole table is too clean a simulation of "legacy", because the table comes back *complete*. Real legacy databases have tables that exist with missing columns, or that hold data a newer index rejects.

## Verification

- **`test_each_table_dropped_alone_is_restored`** is the AC's "valuable part": it drops each table in turn, upgrades, and diffs `sqlite_master` against a fresh workspace — so a table added to only one path fails here rather than in production. Plus `test_dropping_everything_rebuilds_the_whole_schema` and a source-level guard that no `CREATE TABLE` appears twice.
- **Two tests for the shapes the drop test can't reach**: a `prds` table existing without `chain_id`, and a `tasks` table holding duplicate `external_url`s. Both RED before the ordering fix.
- **Behaviour unchanged (AC3)**: new workspaces initialise, existing ones reopen with their data, a legacy workspace upgrades and stays readable.
- **Mutation-checked**: removing the shared call from the upgrade path fails 3.
- Full non-e2e gate green; `ruff check` clean.

## Known limitations

- `keeps` (previously upgrade-path-only) is intentionally **not** added to the canonical schema — it isn't in the fresh schema and nothing in `codeframe/` reads it, so promoting it would have been scope creep dressed as convergence. The convergence test compares against fresh-as-reference, so it does not require it.
- The upgrade path still contains ALTER TABLE and backfill logic that is inherently order-dependent. This PR removes the *duplication*, not the sequencing — `_create_core_indexes` must stay last, which the docstring states and the two legacy-shape tests enforce.
