### PR TITLE
fix(tasks): decompose the PRD into tasks instead of splitting its bullets (#1115)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2107,6 +2107,15 @@ def tasks_generate(
     except FileNotFoundError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+    except tasks.TaskGenerationError as e:
+        # The core message is surface-neutral because the web UI toasts it too
+        # (#1115 review); the CLI-specific remedy belongs here.
+        console.print(f"[red]Error:[/red] {e}")
+        console.print(
+            "  Retry with [bold]cf tasks generate[/bold], or "
+            "[bold]cf tasks generate --no-llm[/bold] to extract bullets directly."
+        )
+        raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -28,6 +28,109 @@ from codeframe.core.prd import PrdRecord
 logger = logging.getLogger(__name__)
 
 
+class TaskGenerationError(Exception):
+    """LLM task decomposition failed and must not degrade silently (#1115).
+
+    This used to fall back to ``_extract_tasks_simple`` — a markdown bullet
+    splitter — which turned a truncated JSON response into twenty "tasks" made
+    of persona traits and requirement fragments, exiting 0 with a green success
+    message. Everything downstream then operated on non-tasks, and one of them
+    consumed a full agent run before anyone noticed. An error is strictly better.
+    """
+
+
+# Markdown that has no business in a task title: emphasis, list bullets, ATX
+# headings, inline code, and the `**Label:**` prefix the PRD template emits.
+_MD_LABEL_PREFIX_RE = re.compile(r"^\s*\*\*[^*]+:\*\*\s*")
+_MD_LEADING_MARKER_RE = re.compile(r"^\s*(?:[-*+]\s+|#{1,6}\s+|\d+\.\s+)")
+# Underscores are deliberately NOT stripped: task titles name identifiers and
+# files (`create_todo`, `test_tasks.py`) far more often than they use _emphasis_.
+_MD_INLINE_RE = re.compile(r"[*`]{1,3}")
+
+
+# PRD sections that describe context, not work. Bullets under these are pain
+# points, persona traits, user goals and assumptions — every one of them showed
+# up as a "task" in the #1115 report, and none of them is implementable.
+_NON_WORK_SECTION_RE = re.compile(
+    r"^\s*#{1,6}\s*.*\b("
+    r"problem statement|pain point|background|context|motivation|"
+    r"target user|user persona|persona|audience|"
+    r"user goal|goal|objective|success (metric|criteria)|"
+    r"assumption|constraint|out of scope|non-goal|risk|glossary"
+    r")",
+    re.IGNORECASE,
+)
+# The same content also appears under bold pseudo-headings (`**User Goals:**`)
+# in the PRD template, which are not ATX headings at all.
+_NON_WORK_PSEUDO_HEADING_RE = re.compile(
+    r"^\s*\*\*\s*("
+    r"key pain points|pain points|user goals|goals|assumptions|constraints|"
+    r"primary persona|secondary persona|persona|target users|out of scope|non-goals"
+    r")\b[^*]*:?\s*\*\*\s*:?\s*$",
+    re.IGNORECASE,
+)
+# Document scaffolding — a heading naming the document's own structure.
+_STRUCTURAL_HEADING_RE = re.compile(
+    r"\s*(executive summary|summary|overview|introduction|requirements?|"
+    r"functional requirements|technical requirements|specification|scope|"
+    r"appendix|references|table of contents|milestones?|timeline)\s*",
+    re.IGNORECASE,
+)
+_ATX_HEADING_RE = re.compile(r"^\s*#{1,6}\s+")
+_BOLD_PSEUDO_HEADING_RE = re.compile(r"^\s*\*\*[^*]+\*\*\s*:?\s*$")
+
+
+def _strip_non_work_sections(prd_content: str) -> str:
+    """Drop the PRD sections that describe context rather than work (#1115).
+
+    Used by the ``--no-llm`` extractor, which is a bullet splitter and cannot
+    tell a persona trait from a requirement on its own. A section stays skipped
+    until a heading of the same or higher level ends it.
+    """
+    kept: list[str] = []
+    skipping = False
+    skip_depth = 0
+
+    for line in prd_content.splitlines():
+        atx = _ATX_HEADING_RE.match(line)
+        if atx:
+            depth = len(line.strip()) - len(line.strip().lstrip("#"))
+            if _NON_WORK_SECTION_RE.match(line):
+                skipping, skip_depth = True, depth
+                continue
+            # A heading at the same or higher level closes the skipped section.
+            if skipping and depth <= skip_depth:
+                skipping = False
+        elif _BOLD_PSEUDO_HEADING_RE.match(line):
+            # Pseudo-headings only nest inside the current section, so any of
+            # them ends a pseudo-heading skip but never an ATX one.
+            if _NON_WORK_PSEUDO_HEADING_RE.match(line):
+                if not skipping:
+                    skipping, skip_depth = True, 99
+                continue
+            if skipping and skip_depth == 99:
+                skipping = False
+
+        if not skipping:
+            kept.append(line)
+
+    return "\n".join(kept)
+
+
+def _clean_task_title(title: str) -> str:
+    """Strip markdown so a title reads as a task, not as a slice of the PRD.
+
+    A literal ``**`` in a task title is proof the text was cut out of the source
+    document rather than composed (#1115), so this runs on both the LLM path and
+    the ``--no-llm`` extractor.
+    """
+    cleaned = str(title)
+    cleaned = _MD_LEADING_MARKER_RE.sub("", cleaned)
+    cleaned = _MD_LABEL_PREFIX_RE.sub("", cleaned)
+    cleaned = _MD_INLINE_RE.sub("", cleaned)
+    return cleaned.strip()
+
+
 def _utc_now() -> datetime:
     """Get current UTC time as timezone-aware datetime."""
     return datetime.now(timezone.utc)
@@ -1074,20 +1177,13 @@ def generate_from_prd(
         List of created Tasks
     """
     if use_llm:
-        try:
-            tasks_data = _generate_tasks_with_llm(
-                prd.content, provider, repo_path=workspace.repo_path
-            )
-        except json.JSONDecodeError as e:
-            # Invalid JSON from LLM response — fall back to simple extraction
-            logger.warning(f"LLM generation failed ({e}), using simple extraction")
-            tasks_data = _extract_tasks_simple(prd.content)
-        except ValueError:
-            raise  # Config errors (missing API key) should fail loudly
-        except Exception as e:
-            # Fall back to simple extraction
-            logger.warning(f"LLM generation failed ({e}), using simple extraction")
-            tasks_data = _extract_tasks_simple(prd.content)
+        # No silent fallback to _extract_tasks_simple (#1115). It is a markdown
+        # bullet splitter; degrading into it turns a failed decomposition into
+        # twenty unimplementable "tasks" and a green success message. `--no-llm`
+        # is the explicit way to ask for bullet extraction.
+        tasks_data = _generate_tasks_with_llm(
+            prd.content, provider, repo_path=workspace.repo_path
+        )
     else:
         tasks_data = _extract_tasks_simple(prd.content)
 
@@ -1106,13 +1202,16 @@ def generate_from_prd(
         )
         created_tasks.append(task)
 
-    # Resolve title-based dependencies to task IDs
+    # Resolve title-based dependencies to task IDs. The refreshed Task from
+    # update_depends_on replaces the stale one: it was being discarded, so
+    # generate_from_prd returned tasks whose depends_on was empty even though
+    # the row on disk had them (#1115).
     title_to_id = {t.title: t.id for t in created_tasks}
-    for task_data, task in zip(tasks_data, created_tasks):
+    for i, (task_data, task) in enumerate(zip(tasks_data, created_tasks)):
         dep_titles = task_data.get("depends_on_titles", [])
         dep_ids = [title_to_id[t] for t in dep_titles if t in title_to_id]
         if dep_ids:
-            update_depends_on(workspace, task.id, dep_ids)
+            created_tasks[i] = update_depends_on(workspace, task.id, dep_ids)
 
     return created_tasks
 
@@ -1140,12 +1239,31 @@ def _generate_tasks_with_llm(
 
         provider = create_provider(resolve_llm_settings(repo_path))
 
-    prompt = f"""Analyze the following PRD and generate a list of actionable development tasks.
+    prompt = f"""Decompose the following PRD into atomic, actionable development tasks.
+
+A task is a unit of engineering work. It names something concrete that gets
+built: a module, a model, an endpoint, a migration, a test suite, a config file.
+
+DO NOT emit tasks for PRD content that is not work. In particular, never turn
+these into tasks:
+- problem statements and pain points (they describe why the project exists)
+- user personas and persona traits (they describe who the user is)
+- user goals and success metrics (they describe outcomes, not work)
+- assumptions and constraints
+
+Every title MUST:
+- start with an imperative verb (Define, Create, Implement, Add, Configure, Wire)
+- name the concrete artifact ("Implement POST /todos", not "Fast todo creation")
+- be plain text under 80 characters — no markdown, no `**`, no leading `-` or `#`
 
 For each task, provide:
-1. "title": Clear, specific title (under 80 characters)
-2. "description": What needs to be done
-3. "depends_on_titles": List of other task titles this depends on (empty list if none)
+1. "title": as above
+2. "description": what needs to be done, including relevant acceptance detail
+3. "depends_on_titles": titles of tasks that must land first — copied EXACTLY as
+   written in their own "title" field. Populate this: data models come before the
+   logic that uses them, that logic comes before the endpoints that expose it,
+   and tests come after the thing they test. An empty graph means the
+   decomposition is wrong.
 4. "complexity": Complexity score 1-5 (1=trivial, 5=very complex)
 5. "estimated_hours": Estimated hours to complete (float)
 6. "uncertainty": "low", "medium", or "high"
@@ -1161,7 +1279,10 @@ PRD:
     response = provider.complete(
         messages=[{"role": "user", "content": prompt}],
         purpose=Purpose.GENERATION,
-        max_tokens=2000,
+        # 2000 truncated a 20-task array mid-object and the parse failure was
+        # the whole of #1115. A full decomposition with descriptions and file
+        # lists runs well past that; leave real headroom.
+        max_tokens=16000,
     )
 
     # Extract JSON from response
@@ -1169,10 +1290,29 @@ PRD:
 
     # Try to find JSON array in response
     json_match = re.search(r"\[[\s\S]*\]", response_text)
-    if json_match:
-        tasks_raw = json.loads(json_match.group())
-    else:
-        tasks_raw = json.loads(response_text)
+    try:
+        tasks_raw = json.loads(json_match.group() if json_match else response_text)
+    except json.JSONDecodeError as e:
+        # Distinguish "the model wrote prose" from "the response ran out of
+        # tokens" — they need different things from the user (#1115).
+        truncated = not response_text.endswith("]")
+        detail = (
+            "the response was truncated before the JSON array closed"
+            if truncated
+            else f"the response was not valid JSON ({e})"
+        )
+        raise TaskGenerationError(
+            f"Task generation failed: {detail}. "
+            "Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm` "
+            "to fall back to plain bullet extraction from the PRD."
+        ) from e
+
+    if not isinstance(tasks_raw, list):
+        raise TaskGenerationError(
+            "Task generation failed: the model did not return a JSON array of tasks. "
+            "Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm` "
+            "to fall back to plain bullet extraction from the PRD."
+        )
 
     # Validate and extract rich fields
     validated = []
@@ -1198,14 +1338,35 @@ PRD:
         if files:
             desc += "\n\nFiles to modify: " + ", ".join(str(f) for f in files)
 
+        title = _clean_task_title(str(task["title"]))[:200]
+        if not title:
+            continue
+
+        # Dependency titles are cleaned the same way, or a model that echoes a
+        # markdown-y title back would fail to match and silently drop the edge.
+        dep_titles = [
+            cleaned
+            for cleaned in (
+                _clean_task_title(str(d)) for d in task.get("depends_on_titles", []) or []
+            )
+            if cleaned
+        ]
+
         validated.append({
-            "title": str(task["title"])[:200],
+            "title": title,
             "description": desc,
-            "depends_on_titles": task.get("depends_on_titles", []),
+            "depends_on_titles": dep_titles,
             "complexity": complexity,
             "estimated_hours": estimated_hours,
             "uncertainty": uncertainty,
         })
+
+    if not validated:
+        raise TaskGenerationError(
+            "Task generation failed: the model returned no usable tasks. "
+            "Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm` "
+            "to fall back to plain bullet extraction from the PRD."
+        )
 
     return validated
 
@@ -1223,6 +1384,9 @@ def _extract_tasks_simple(prd_content: str) -> list[dict]:
     """
     tasks = []
 
+    # Persona traits, pain points and user goals are not work (#1115).
+    prd_content = _strip_non_work_sections(prd_content)
+
     # Find bullet points and numbered items
     patterns = [
         r"^[-*]\s+(.+)$",  # Bullet points
@@ -1233,7 +1397,14 @@ def _extract_tasks_simple(prd_content: str) -> list[dict]:
     for pattern in patterns:
         matches = re.findall(pattern, prd_content, re.MULTILINE)
         for match in matches:
-            title = match.strip()
+            # Strip markdown here too — `**Requirement:** ...` in a title is the
+            # #1115 tell that text was sliced out of the PRD, and --no-llm users
+            # deserve better than that even though this path is a crude split.
+            title = _clean_task_title(match)
+            # Structural headings survive the section filter (their *children*
+            # are real work) but are not themselves tasks.
+            if _STRUCTURAL_HEADING_RE.fullmatch(title):
+                continue
             # Skip very short items or ones that look like headers
             if len(title) > 10 and not title.endswith(":"):
                 tasks.append({

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -51,22 +51,29 @@ _MD_INLINE_RE = re.compile(r"[*`]{1,3}")
 # PRD sections that describe context, not work. Bullets under these are pain
 # points, persona traits, user goals and assumptions — every one of them showed
 # up as a "task" in the #1115 report, and none of them is implementable.
+# The heading must *be* one of these, not merely contain one. `## Goal Tracking`
+# is a feature section whose bullets are real work; dropping it because it says
+# "goal" silently loses tasks, which is a worse failure than letting a persona
+# bullet through. Optional leading numbering and trailing punctuation only.
 _NON_WORK_SECTION_RE = re.compile(
-    r"^\s*#{1,6}\s*.*\b("
-    r"problem statement|pain point|background|context|motivation|"
-    r"target user|user persona|persona|audience|"
-    r"user goal|goal|objective|success (metric|criteria)|"
-    r"assumption|constraint|out of scope|non-goal|risk|glossary"
-    r")",
+    r"^\s*#{1,6}\s*(?:[\d.]+\s+)?("
+    r"problem statements?|pain points?|key pain points?|background|context|motivation|"
+    r"target users?|user personas?|personas?|audience|"
+    r"user goals?|goals?|objectives?|success metrics?|success criteria|"
+    r"assumptions?|constraints?|out of scope|non-goals?|risks?|glossary"
+    r")\s*:?\s*$",
     re.IGNORECASE,
 )
 # The same content also appears under bold pseudo-headings (`**User Goals:**`)
 # in the PRD template, which are not ATX headings at all.
+# Same rule as the ATX case: the term must be the whole pseudo-heading, except
+# that a colon may introduce a qualifier (`**Primary Persona: The Developer**`).
+# So `**Goal Tracking:**` — a feature — does not match, but `**User Goals:**` does.
 _NON_WORK_PSEUDO_HEADING_RE = re.compile(
     r"^\s*\*\*\s*("
-    r"key pain points|pain points|user goals|goals|assumptions|constraints|"
-    r"primary persona|secondary persona|persona|target users|out of scope|non-goals"
-    r")\b[^*]*:?\s*\*\*\s*:?\s*$",
+    r"key pain points?|pain points?|user goals?|goals?|assumptions?|constraints?|"
+    r"primary personas?|secondary personas?|personas?|target users?|out of scope|non-goals?"
+    r")\s*(?::[^*]*)?\*\*\s*:?\s*$",
     re.IGNORECASE,
 )
 # Document scaffolding — a heading naming the document's own structure.

--- a/codeframe/core/tasks.py
+++ b/codeframe/core/tasks.py
@@ -28,6 +28,15 @@ from codeframe.core.prd import PrdRecord
 logger = logging.getLogger(__name__)
 
 
+#: Surface-neutral remedy. This message is shown by the CLI *and* toasted by the
+#: web UI via the 502 from discovery_v2, so it must not name a CLI command — the
+#: CLI adds its own `--no-llm` hint on top (#1115 review).
+_RETRY_HINT = (
+    "Retry task generation, or generate without the LLM to fall back to plain "
+    "bullet extraction from the PRD."
+)
+
+
 class TaskGenerationError(Exception):
     """LLM task decomposition failed and must not degrade silently (#1115).
 
@@ -1170,8 +1179,9 @@ def generate_from_prd(
 ) -> list[Task]:
     """Generate tasks from a PRD.
 
-    Uses LLM to decompose the PRD into actionable tasks.
-    Falls back to simple extraction if LLM is unavailable.
+    Uses an LLM to decompose the PRD into actionable tasks. There is no silent
+    fallback: if the LLM path fails, TaskGenerationError is raised (#1115).
+    ``use_llm=False`` is the explicit opt-in to crude bullet extraction.
 
     Args:
         workspace: Target workspace
@@ -1309,16 +1319,13 @@ PRD:
             else f"the response was not valid JSON ({e})"
         )
         raise TaskGenerationError(
-            f"Task generation failed: {detail}. "
-            "Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm` "
-            "to fall back to plain bullet extraction from the PRD."
+            f"Task generation failed: {detail}. " + _RETRY_HINT
         ) from e
 
     if not isinstance(tasks_raw, list):
         raise TaskGenerationError(
-            "Task generation failed: the model did not return a JSON array of tasks. "
-            "Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm` "
-            "to fall back to plain bullet extraction from the PRD."
+            "Task generation failed: the model did not return a JSON array of "
+            "tasks. " + _RETRY_HINT
         )
 
     # Validate and extract rich fields
@@ -1371,8 +1378,7 @@ PRD:
     if not validated:
         raise TaskGenerationError(
             "Task generation failed: the model returned no usable tasks. "
-            "Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm` "
-            "to fall back to plain bullet extraction from the PRD."
+            + _RETRY_HINT
         )
 
     return validated

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
 from codeframe.core import prd_discovery, prd, tasks
+from codeframe.core.tasks import TaskGenerationError
 from codeframe.core.prd_discovery import (
     DiscoveryError,
     NoApiKeyError,
@@ -450,6 +451,13 @@ async def generate_tasks_from_prd(
         # it into a 500 "task generation failed", hiding both the reason and
         # the registered 400 handler.
         raise
+    except TaskGenerationError as e:
+        # The model returned something unusable — an upstream failure, not a bug
+        # here, so 502 rather than a generic 500 (#1115). Before, this path
+        # silently degraded to bullet extraction and returned 200 with a list of
+        # unimplementable "tasks"; the caller could not tell it had failed.
+        logger.warning(f"Task generation failed: {e}")
+        raise HTTPException(status_code=502, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to generate tasks: {e}", exc_info=True)
         raise HTTPException(

--- a/tests/cli/test_v2_cli_integration.py
+++ b/tests/cli/test_v2_cli_integration.py
@@ -840,18 +840,33 @@ class TestAITaskGeneration:
         assert "generated" in result.output.lower()
         assert provider.call_count >= 1
 
-    def test_generate_llm_returns_invalid_json_falls_back(
+    def test_generate_llm_returns_invalid_json_fails_loudly(
         self, workspace_with_prd, mock_llm
     ):
-        """When LLM returns garbage, generate_from_prd falls back to simple extraction."""
+        """When the LLM returns garbage, generation fails instead of degrading (#1115).
+
+        This test previously asserted the opposite — that the command exits 0 via
+        fallback extraction. That fallback is a markdown bullet splitter, and in
+        the field it turned a truncated response into twenty "tasks" made of
+        persona traits, with a green success message on top. `--no-llm` is now
+        the only way to ask for bullet extraction.
+        """
         mock_llm(["This is not valid JSON at all."])
 
         result = runner.invoke(
             app,
             ["tasks", "generate", "-w", str(workspace_with_prd)],
         )
-        # Should still succeed via fallback extraction
-        assert result.exit_code == 0, f"fallback failed: {result.output}"
+        assert result.exit_code != 0, f"should not have succeeded: {result.output}"
+        assert "--no-llm" in result.output
+
+    def test_generate_no_llm_still_extracts(self, workspace_with_prd):
+        """The escape hatch the failure message points at must actually work."""
+        result = runner.invoke(
+            app,
+            ["tasks", "generate", "--no-llm", "-w", str(workspace_with_prd)],
+        )
+        assert result.exit_code == 0, result.output
         assert "generated" in result.output.lower()
 
 

--- a/tests/core/test_task_decomposition_1115.py
+++ b/tests/core/test_task_decomposition_1115.py
@@ -183,7 +183,19 @@ class TestTheFallbackIsLoud:
     def test_the_error_tells_the_user_what_to_do(self):
         with pytest.raises(TaskGenerationError) as exc:
             _generate_tasks_with_llm(FIXTURE_PRD, provider=_provider_returning("not json"))
-        assert "--no-llm" in str(exc.value)
+        message = str(exc.value)
+        assert "Retry task generation" in message
+        assert "without the LLM" in message
+
+    def test_the_core_message_names_no_cli_command(self):
+        """The web UI toasts this via the 502, where `cf ...` is useless advice.
+
+        Raised in PR review. The CLI adds its own `--no-llm` line on top — see
+        tests/cli/test_v2_cli_integration.py::test_generate_llm_returns_invalid_json_fails_loudly.
+        """
+        with pytest.raises(TaskGenerationError) as exc:
+            _generate_tasks_with_llm(FIXTURE_PRD, provider=_provider_returning("not json"))
+        assert "cf tasks generate" not in str(exc.value)
 
     def test_generate_from_prd_does_not_swallow_it(self, tmp_path):
         ws, record = _workspace_with_prd(tmp_path)

--- a/tests/core/test_task_decomposition_1115.py
+++ b/tests/core/test_task_decomposition_1115.py
@@ -1,0 +1,279 @@
+"""#1115 — `cf tasks generate` emitted PRD prose verbatim instead of tasks.
+
+The cold-start transcript names the mechanism exactly:
+
+    LLM generation failed (Expecting ',' delimiter: line 179 column 6 (char 6820)),
+    using simple extraction
+
+`max_tokens=2000` truncated the JSON array mid-array, the parse blew up, and the
+LLM path fell back to a markdown bullet splitter — silently, still exiting 0 with
+a green "Generated 20 tasks". So the user got persona traits and `**Requirement:**`
+fragments as "tasks", and every downstream stage operated on non-tasks.
+
+Three things are pinned here: the fallback is no longer silent, titles are never
+raw markdown, and the budget is big enough for a real task list.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeframe.core import prd, tasks, workspace
+from codeframe.core.tasks import (
+    TaskGenerationError,
+    _clean_task_title,
+    _extract_tasks_simple,
+    _generate_tasks_with_llm,
+)
+
+pytestmark = pytest.mark.v2
+
+
+# The PRD from the cold-start report, trimmed to the sections that produced the
+# bogus tasks: problem statement, persona traits, user goals, requirement bullets.
+FIXTURE_PRD = """# Self-Hosted Todo Management REST API
+
+## Executive Summary
+
+A lightweight, self-hosted REST API for managing personal todos.
+
+## Problem Statement
+
+**Key Pain Points:**
+- Todos scattered across different notes and systems make it difficult to maintain a complete view
+- Existing SaaS tools add unwanted subscriptions and external dependencies
+- No simple, self-hostable solution that developers can deploy and control themselves
+- Lack of focus when completed items clutter active task lists
+
+## Target Users
+
+**Primary Persona: The Self-Hosting Developer**
+- Comfortable with REST APIs and command-line tools
+- Prefers self-hosted solutions over SaaS subscriptions
+- Works on multiple projects simultaneously
+- Values simplicity and performance over feature bloat
+
+**User Goals:**
+- Centralize task management in a single, reliable system
+- Maintain control over data and hosting infrastructure
+
+**Assumptions:**
+- Has access to a laptop or small VPS for hosting
+- Comfortable deploying Python applications
+
+## Requirements
+
+### Create Todo
+- **Requirement:** Fast, lightweight endpoint to create new todos
+- **Fields:** Description (required), priority (optional), created timestamp
+- **Performance:** Sub-50ms response time for single todo creation
+- **Validation:** Description must be non-empty, max 500 characters
+"""
+
+
+def _workspace_with_prd(tmp_path):
+    """A real workspace holding FIXTURE_PRD — no mocking below the LLM boundary."""
+    ws = workspace.create_or_load_workspace(tmp_path)
+    return ws, prd.store(ws, FIXTURE_PRD, title="Self-Hosted Todo Management REST API")
+
+
+def _provider_returning(payload: str) -> MagicMock:
+    provider = MagicMock()
+    provider.complete.return_value = MagicMock(content=payload)
+    return provider
+
+
+class TestTitlesAreNeverRawMarkdown:
+    """AC: no task title contains raw markdown markers (`**`, leading `-`, `#`)."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("**Requirement:** Fast, lightweight endpoint", "Fast, lightweight endpoint"),
+            ("**Fields:** Description (required)", "Description (required)"),
+            ("- Implement POST /todos", "Implement POST /todos"),
+            ("## Create the Todo model", "Create the Todo model"),
+            ("*Add pytest fixtures*", "Add pytest fixtures"),
+            ("`cf init` wiring", "cf init wiring"),
+            ("Implement POST /todos", "Implement POST /todos"),
+        ],
+    )
+    def test_markdown_is_stripped(self, raw, expected):
+        assert _clean_task_title(raw) == expected
+
+    def test_non_work_sections_never_become_tasks(self):
+        """AC: persona traits, user goals and problem statements are never tasks.
+
+        This holds on the --no-llm path too, because the new error message
+        actively points users there — it must not hand back PRD prose.
+        """
+        titles = [t["title"] for t in _extract_tasks_simple(FIXTURE_PRD)]
+        for prose in (
+            "Todos scattered across different notes",  # pain point
+            "Comfortable with REST APIs and command-line tools",  # persona trait
+            "Centralize task management in a single, reliable system",  # user goal
+            "Has access to a laptop or small VPS for hosting",  # assumption
+        ):
+            assert not any(prose in t for t in titles), f"{prose!r} is not a task"
+
+        # ...while the actual requirements survive.
+        assert any("endpoint to create new todos" in t for t in titles)
+
+    def test_the_simple_extractor_emits_no_markdown_markers(self):
+        for task in _extract_tasks_simple(FIXTURE_PRD):
+            assert "**" not in task["title"]
+            assert not task["title"].startswith(("-", "#", "*"))
+
+    def test_llm_titles_are_cleaned_too(self):
+        payload = json.dumps([{"title": "**Requirement:** Build the API", "description": "x"}])
+        result = _generate_tasks_with_llm(FIXTURE_PRD, provider=_provider_returning(payload))
+        assert result[0]["title"] == "Build the API"
+
+
+class TestTheFallbackIsLoud:
+    """AC: if the LLM path silently falls back to a text splitter, that must be loud.
+
+    It is now not a fallback at all. Silently emitting 20 unimplementable items
+    that exit 0 is worse than an error — one of them consumed a whole agent run.
+    `--no-llm` remains the explicit way to ask for bullet extraction.
+    """
+
+    def test_truncated_json_raises_instead_of_degrading(self):
+        # Exactly the 0.9.x failure: a JSON array cut off mid-object.
+        truncated = '[{"title": "Define the Todo model", "description": "x"}, {"title": "Imple'
+        with pytest.raises(TaskGenerationError) as exc:
+            _generate_tasks_with_llm(FIXTURE_PRD, provider=_provider_returning(truncated))
+        assert "truncated" in str(exc.value).lower()
+
+    def test_the_error_tells_the_user_what_to_do(self):
+        with pytest.raises(TaskGenerationError) as exc:
+            _generate_tasks_with_llm(FIXTURE_PRD, provider=_provider_returning("not json"))
+        assert "--no-llm" in str(exc.value)
+
+    def test_generate_from_prd_does_not_swallow_it(self, tmp_path):
+        ws, record = _workspace_with_prd(tmp_path)
+        with pytest.raises(TaskGenerationError):
+            tasks.generate_from_prd(
+                ws, record, use_llm=True, provider=_provider_returning("garbage")
+            )
+
+    def test_no_llm_still_uses_the_extractor_without_raising(self, tmp_path):
+        ws, record = _workspace_with_prd(tmp_path)
+        created = tasks.generate_from_prd(ws, record, use_llm=False)
+        assert created, "--no-llm is an explicit opt-in and must keep working"
+
+
+class TestTheBudgetFitsARealTaskList:
+    """The truncation was a budget bug, not a model bug."""
+
+    def test_max_tokens_is_large_enough_for_a_full_array(self):
+        provider = _provider_returning(json.dumps([{"title": "Define the Todo model"}]))
+        _generate_tasks_with_llm(FIXTURE_PRD, provider=provider)
+        max_tokens = provider.complete.call_args.kwargs["max_tokens"]
+        # The real run truncated at ~6820 chars (~1900 tokens) partway through
+        # a 20-task array. Anything at or below that repeats the bug.
+        assert max_tokens >= 8000
+
+
+class TestThePromptAsksForTasks:
+    """AC: persona traits, user goals and problem statements must never become tasks."""
+
+    def _prompt(self) -> str:
+        provider = _provider_returning(json.dumps([{"title": "Define the Todo model"}]))
+        _generate_tasks_with_llm(FIXTURE_PRD, provider=provider)
+        return provider.complete.call_args.kwargs["messages"][0]["content"].lower()
+
+    def test_it_excludes_the_prd_sections_that_are_not_work(self):
+        prompt = self._prompt()
+        for term in ("persona", "user goal", "problem statement"):
+            assert term in prompt, f"prompt must tell the model to skip {term}s"
+
+    def test_it_demands_verb_first_concrete_titles(self):
+        prompt = self._prompt()
+        assert "verb" in prompt
+        assert "depends_on_titles" in prompt
+
+
+class TestDependenciesArePopulated:
+    """AC: dependencies are populated for a PRD with obvious ordering."""
+
+    def test_title_dependencies_resolve_to_ids(self, tmp_path):
+        payload = json.dumps([
+            {"title": "Define the Todo SQLAlchemy model", "depends_on_titles": []},
+            {
+                "title": "Implement the todo CRUD layer",
+                "depends_on_titles": ["Define the Todo SQLAlchemy model"],
+            },
+            {
+                "title": "Implement POST /todos",
+                "depends_on_titles": ["Implement the todo CRUD layer"],
+            },
+        ])
+        ws, record = _workspace_with_prd(tmp_path)
+        created = tasks.generate_from_prd(
+            ws, record, use_llm=True, provider=_provider_returning(payload)
+        )
+
+        by_title = {t.title: t for t in created}
+        model = by_title["Define the Todo SQLAlchemy model"]
+        crud = by_title["Implement the todo CRUD layer"]
+        endpoint = by_title["Implement POST /todos"]
+
+        assert model.depends_on == []
+        assert crud.depends_on == [model.id]
+        assert endpoint.depends_on == [crud.id]
+
+    def test_dependency_titles_are_matched_after_cleaning(self, tmp_path):
+        """A model that echoes a markdown-y title in depends_on_titles must still link."""
+        payload = json.dumps([
+            {"title": "**Define the Todo model**", "depends_on_titles": []},
+            {"title": "Implement POST /todos", "depends_on_titles": ["**Define the Todo model**"]},
+        ])
+        ws, record = _workspace_with_prd(tmp_path)
+        created = tasks.generate_from_prd(
+            ws, record, use_llm=True, provider=_provider_returning(payload)
+        )
+        model, endpoint = created
+        assert model.title == "Define the Todo model"
+        assert endpoint.depends_on == [model.id]
+
+
+class TestTaskShapeOnTheFixturePrd:
+    """AC: a test asserts task-shape — no `**` in titles, every title starts with a verb."""
+
+    # A plausible decomposition of FIXTURE_PRD, as the fixed prompt should yield.
+    REALISTIC = [
+        {"title": "Define the Todo SQLAlchemy model", "depends_on_titles": []},
+        {"title": "Create the SQLite database session module", "depends_on_titles": []},
+        {
+            "title": "Implement the todo CRUD layer",
+            "depends_on_titles": ["Define the Todo SQLAlchemy model"],
+        },
+        {
+            "title": "Implement POST /todos with validation",
+            "depends_on_titles": ["Implement the todo CRUD layer"],
+        },
+        {
+            "title": "Add pytest fixtures for the test database",
+            "depends_on_titles": ["Create the SQLite database session module"],
+        },
+    ]
+
+    def test_generated_tasks_have_task_shape(self, tmp_path):
+        ws, record = _workspace_with_prd(tmp_path)
+        created = tasks.generate_from_prd(
+            ws, record, use_llm=True, provider=_provider_returning(json.dumps(self.REALISTIC))
+        )
+
+        assert len(created) == len(self.REALISTIC)
+        for task in created:
+            assert "**" not in task.title
+            assert not task.title.startswith(("-", "#", "*"))
+            first_word = task.title.split()[0].lower()
+            assert first_word in {
+                "define", "create", "implement", "add", "build", "write",
+                "configure", "set", "wire", "expose", "validate",
+            }, f"{task.title!r} does not start with a verb"
+
+        assert any(t.depends_on for t in created), "ordering must produce dependencies"

--- a/tests/core/test_task_decomposition_1115.py
+++ b/tests/core/test_task_decomposition_1115.py
@@ -120,6 +120,40 @@ class TestTitlesAreNeverRawMarkdown:
         # ...while the actual requirements survive.
         assert any("endpoint to create new todos" in t for t in titles)
 
+    def test_a_feature_section_is_not_dropped_for_naming_a_goal(self):
+        """The section filter must not eat real work (found in third-party review).
+
+        `## Goal Tracking` is a feature, not the PRD's "User Goals" section.
+        Substring matching on "goal" silently dropped every task under it —
+        losing implementable work is worse than letting a persona bullet through.
+        """
+        prd = (
+            "# App\n\n"
+            "## Goal Tracking\n\n"
+            "- Implement goal CRUD API endpoints\n"
+            "- Add goal progress calculation\n\n"
+            "## User Goals\n\n"
+            "- Centralize everything in one place\n"
+        )
+        titles = [t["title"] for t in _extract_tasks_simple(prd)]
+        assert "Implement goal CRUD API endpoints" in titles
+        assert "Add goal progress calculation" in titles
+        assert "Centralize everything in one place" not in titles
+
+    def test_a_bold_feature_pseudo_heading_is_not_dropped_either(self):
+        """`**Goal Tracking:**` is a feature; `**User Goals:**` is not."""
+        prd = (
+            "# App\n\n"
+            "## Features\n\n"
+            "**Goal Tracking:**\n"
+            "- Implement goal CRUD API endpoints\n\n"
+            "**Primary Persona: The Self-Hosting Developer**\n"
+            "- Comfortable with REST APIs\n"
+        )
+        titles = [t["title"] for t in _extract_tasks_simple(prd)]
+        assert "Implement goal CRUD API endpoints" in titles
+        assert "Comfortable with REST APIs" not in titles
+
     def test_the_simple_extractor_emits_no_markdown_markers(self):
         for task in _extract_tasks_simple(FIXTURE_PRD):
             assert "**" not in task["title"]

--- a/tests/ui/test_discovery_generate_tasks.py
+++ b/tests/ui/test_discovery_generate_tasks.py
@@ -80,3 +80,46 @@ class TestGenerateTasksProviderResolution:
             )
         assert response.status_code == 200, response.text
         mock_create.assert_not_called()
+
+
+class TestUnusableLLMOutputIsAnUpstreamFailure:
+    """#1115: the endpoint must report a failed decomposition, not a 200 or a 500.
+
+    Before, a truncated/garbage response degraded silently to bullet extraction
+    and returned 200 with a list of unimplementable "tasks" — the caller could
+    not tell it had failed. TaskGenerationError now maps to 502, matching how the
+    repo already remaps upstream GitHub failures.
+    """
+
+    def _post_with_llm_returning(self, test_client, monkeypatch, payload):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "ollama")
+        provider = MagicMock()
+        provider.complete.return_value = MagicMock(content=payload)
+        with patch(
+            "codeframe.core.llm_resolution.create_provider", return_value=provider
+        ):
+            return test_client.post("/api/v2/discovery/generate-tasks")
+
+    def test_truncated_json_returns_502(self, test_client, monkeypatch):
+        truncated = '[{"title": "Define the model", "description": "x"}, {"title": "Imple'
+        response = self._post_with_llm_returning(test_client, monkeypatch, truncated)
+
+        assert response.status_code == 502, response.text
+        assert "truncated" in response.json()["detail"].lower()
+
+    def test_garbage_returns_502_not_200(self, test_client, monkeypatch):
+        response = self._post_with_llm_returning(
+            test_client, monkeypatch, "I'm afraid I can't do that"
+        )
+
+        assert response.status_code == 502, response.text
+        assert response.json()["detail"].startswith("Task generation failed")
+
+    def test_the_detail_does_not_tell_a_web_user_to_run_a_cli_command(
+        self, test_client, monkeypatch
+    ):
+        """This detail is toasted verbatim by /prd — `cf tasks generate` is useless there."""
+        response = self._post_with_llm_returning(test_client, monkeypatch, "nonsense")
+
+        assert "cf tasks generate" not in response.json()["detail"]


### PR DESCRIPTION
Closes #1115.

## Root cause — it is in the issue's own transcript

```
LLM generation failed (Expecting ',' delimiter: line 179 column 6 (char 6820)),
using simple extraction
```

So the LLM path **was** taken. `max_tokens=2000` truncated the JSON array
mid-object at ~6820 chars, the parse blew up, and the code fell back to
`_extract_tasks_simple` — a markdown bullet splitter — then printed
"Generated 20 tasks" in green and exited 0.

Every symptom in the report follows from those two facts. The persona traits,
the pain points, the `**Requirement:**` markers still in the titles, the empty
`Deps` column — that is what a bullet splitter produces from a PRD.

## Changes

**The budget.** `max_tokens` 2000 → 16000. A real decomposition with
descriptions and file lists does not fit in 2000. This alone was the bug.

**No more silent fallback.** A parse failure, a non-array response, or an empty
result now raises `TaskGenerationError` with a message that distinguishes
truncation from malformed output and names `--no-llm`. Producing twenty
unimplementable items and exiting 0 is worse than an error — one of those items
went on to consume a full agent run.

**The prompt** now says what a task is, names the PRD sections that are *not*
work (problem statements, personas, user goals, assumptions), requires
verb-first concrete titles, and explains what a dependency edge means.

**Titles** are stripped of markdown on both paths. Underscores are deliberately
left alone — titles name identifiers (`create_todo`, `test_tasks.py`) far more
often than they use `_emphasis_`. Dependency titles get the same cleaning, so a
model echoing a markdown-y title back still resolves the edge.

**Two bugs found on the way:**

- `generate_from_prd` discarded the refreshed `Task` returned by
  `update_depends_on`, so it returned tasks whose `depends_on` was empty even
  though the row on disk had them.
- The web caller (`discovery_v2`) would have turned this into a generic 500; it
  now maps to **502**, matching the repo's existing upstream-failure convention.

**`--no-llm`** skips non-work sections and structural headings, because the new
failure message actively points users at it and it shouldn't hand back prose.

## Evidence — live, on the report's own PRD

`cf tasks generate` now produces:

```
  1. Define Todo data model with SQLAlchemy ORM
  2. Create SQLite database initialization and migrations
  3. Define Pydantic schemas for todo requests and responses
  4. Implement POST /todos endpoint for creating todos
  5. Implement PATCH /todos/{id} endpoint for updating todo status
  6. Implement GET /todos endpoint with completion status filtering
  7. Create test suite for POST /todos endpoint
  ...
```

with a real dependency graph — models → migrations/CRUD → endpoints → tests:

```
│ d15a387a │  0  │       -        │ Define Todo data model with SQLAlchemy ORM
│ 5ef73f95 │  1  │     d15a38     │ Create SQLite database initialization...
│ 19d04138 │  3  │    3 tasks     │ Implement POST /todos endpoint...
│ fb8d4d3d │  6  │     19d041     │ Create test suite for POST /todos endpoint
│ 906b79d8 │ 10  │ 02d1d2, 5ef73f │ Wire database session dependency...
```

Reproducing the original failure by temporarily restoring the small budget gives
the loud version instead of silent garbage:

```
Error: Task generation failed: the response was truncated before the JSON array
closed. Re-run `cf tasks generate` to retry, or use `cf tasks generate --no-llm`
to fall back to plain bullet extraction from the PRD.
```

22 new tests. Full suite: **6240 passed, 49 skipped**.

## Acceptance criteria

- [x] Tasks name concrete units of work, not PRD prose
- [x] No raw markdown markers in titles
- [x] Persona traits, user goals, problem statements never become tasks — on both paths
- [x] Dependencies populated for a PRD with obvious ordering
- [x] A test asserts task-shape on a fixture PRD (no `**`, verb-first)
- [x] Confirmed the LLM path *is* taken; the fallback is now loud

## Review finding, fixed

Third-party review (codex) caught a regression in my own fix: the non-work
section filter matched terms *anywhere* in a heading, so `## Goal Tracking` — a
feature whose bullets are real work — was classified as the PRD's "User Goals"
section and every task under it was silently dropped. Confirmed by reproduction,
then both regexes tightened to require the term to *be* the heading. The bold
form keeps a colon escape (`**Primary Persona: The Developer**`, which is how
the PRD template writes personas) but `**Goal Tracking:**` no longer matches.
Two regression tests added.

## Known limitations

- `--no-llm` is still a bullet splitter: its titles are requirement text, not
  verb-first tasks, and it infers no dependencies. It is an explicit opt-in and
  the error message describes it as such. Making it a real decomposer is not
  possible without an LLM.
- `test_generate_llm_returns_invalid_json_falls_back` asserted the old
  behaviour and is rewritten to assert the new contract. The escape hatch it
  points at is now covered by its own test.
