### PR TITLE
ci: lint the workflow files so an uncompilable one cannot ship (#1122)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,37 @@ jobs:
         run: npm run lint
 
   # ============================================
+  # Workflow Lint — a workflow that will not compile ships silently (#1122)
+  # ============================================
+  # An uncompilable workflow does not fail like a normal job: the run has zero
+  # jobs and no logs, `gh run view --log-failed` says "log not found", and it
+  # ignores its own trigger filters. deploy.yml failed that way on every push to
+  # main for a week and read as background noise. actionlint catches it in under
+  # a second. Deliberately NOT paths-filtered: a skipped required check is the
+  # same silence this job exists to remove.
+  workflow-lint:
+    name: Workflow Lint (actionlint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Pinned release + checksum rather than a floating action: this job's
+      # whole job is to stop unverifiable CI config from landing.
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.7"
+          ACTIONLINT_SHA256: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+        run: |
+          set -euo pipefail
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
+  # ============================================
   # Static Analysis - Check for Hardcoded URLs
   # ============================================
   check-hardcoded-urls:
@@ -548,7 +579,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [backend-tests, frontend-tests, code-quality, check-hardcoded-urls, e2e-browser-smoke]
+    needs: [backend-tests, frontend-tests, code-quality, check-hardcoded-urls, e2e-browser-smoke, workflow-lint]
     if: always()
 
     steps:
@@ -559,6 +590,7 @@ jobs:
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Code Quality | ${{ needs.code-quality.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow Lint | ${{ needs.workflow-lint.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Hardcoded URLs | ${{ needs.check-hardcoded-urls.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Backend Tests | ${{ needs.backend-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Frontend Tests | ${{ needs.frontend-tests.result }} |" >> $GITHUB_STEP_SUMMARY
@@ -568,6 +600,7 @@ jobs:
           # (failure / cancelled / timed_out) as a gate failure, not just
           # "failure". Other jobs keep the file's existing "failure"-only check.
           if [ "${{ needs.code-quality.result }}" == "failure" ] || \
+             [ "${{ needs.workflow-lint.result }}" == "failure" ] || \
              [ "${{ needs.check-hardcoded-urls.result }}" == "failure" ] || \
              [ "${{ needs.backend-tests.result }}" == "failure" ] || \
              [ "${{ needs.e2e-browser-smoke.result }}" == "failure" ] || \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,14 @@ jobs:
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
           tar -xzf actionlint.tar.gz actionlint
-          ./actionlint -color
+          # -shellcheck= disables actionlint's shellcheck integration. This gate
+          # is about workflows GitHub cannot COMPILE (#1122) — the failure mode
+          # that produces a run with zero jobs and no logs. shellcheck reports 44
+          # pre-existing style/info findings in existing `run:` blocks, almost
+          # all in deploy.yml; turning that on here would either block this fix
+          # or force blind quoting changes to the deploy path that cannot be
+          # tested from a PR. Tracked separately in #1130.
+          ./actionlint -color -shellcheck=
 
   # ============================================
   # Static Analysis - Check for Hardcoded URLs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,7 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
 - Don't update task status from `agent.py` — let `runtime.py` handle transitions
 - Don't skip web UI testing when verifying features that have a web surface
 - **Don't leave a CI gate disabled when its feature area becomes active.** Re-enable `DISABLED:` / `# COMMENTED OUT:` jobs before the first PR in that area. Verify `frontend-tests` is wired into `test-summary`.
+- **A CI run that fails with ZERO jobs and no logs means the workflow file will not compile** (#1122). `gh run view --log-failed` returns `log not found`, the jobs API is empty, and the run ignores its own trigger filters — so it looks like an unrelated trigger bug rather than an outage. YAML validity is not enough: `yaml.safe_load()` parses these files fine; it is GitHub's expression pass that rejects them. Run `actionlint .github/workflows/*.yml` first — the `workflow-lint` job in `test.yml` now enforces this on every PR, but it is the first thing to run locally when a workflow misbehaves. This shipped twice undetected: `deploy.yml` (staging down for a week, an empty `${{ }}` inside a `run:` block) and `claude-review` (#1011).
 
 ---
 

--- a/tests/test_workflow_lint_wiring_1122.py
+++ b/tests/test_workflow_lint_wiring_1122.py
@@ -1,0 +1,74 @@
+"""#1122 — the workflow-lint gate must stay wired in.
+
+An uncompilable workflow produces a run with zero jobs and no logs, so it reads
+as background noise rather than an outage. `deploy.yml` failed that way on every
+push to main for a week, and `claude-review` (#1011) before it.
+
+The `workflow-lint` job closes that hole, but only while it is actually reachable
+and actually gates the summary — the CLAUDE.md rule about disabled gates exists
+because that wiring has been quietly lost before. These tests pin it.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(TEST_WORKFLOW.read_text())
+
+
+def test_the_workflow_lint_job_exists(workflow):
+    assert "workflow-lint" in workflow["jobs"]
+
+
+def test_it_is_a_dependency_of_test_summary(workflow):
+    """Otherwise it can pass/fail without affecting the merge gate."""
+    assert "workflow-lint" in workflow["jobs"]["test-summary"]["needs"]
+
+
+def test_test_summary_actually_fails_on_it(workflow):
+    """Being in `needs` is not enough — the summary's own check must name it.
+
+    `if: always()` means test-summary runs regardless, so the exit-1 branch is
+    what makes the gate real.
+    """
+    steps = workflow["jobs"]["test-summary"]["steps"]
+    script = "\n".join(s.get("run", "") for s in steps)
+    # Must be the exit-1 condition, not merely the summary table row — the table
+    # also interpolates the result, so a looser check passes while the gate is
+    # gone. (Caught by deliberately removing the condition and re-running.)
+    assert '[ "${{ needs.workflow-lint.result }}" == "failure" ]' in script
+
+
+def test_it_is_not_paths_filtered(workflow):
+    """A skipped required check is the same silence this job removes.
+
+    actionlint takes about a second, so running it on every PR costs nothing
+    and avoids a gate that reports "skipped" exactly when a workflow changed.
+    """
+    job = workflow["jobs"]["workflow-lint"]
+    assert "if" not in job, "workflow-lint must not be conditionally skipped"
+
+
+def test_actionlint_is_pinned_with_a_checksum():
+    """This job's purpose is stopping unverifiable CI config from landing."""
+    raw = TEST_WORKFLOW.read_text()
+    assert "ACTIONLINT_VERSION" in raw
+    assert "ACTIONLINT_SHA256" in raw
+    assert "sha256sum -c -" in raw
+
+
+def test_every_workflow_file_still_parses():
+    """A cheap local backstop; actionlint in CI is the real check."""
+    for path in sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml")):
+        data = yaml.safe_load(path.read_text())
+        assert isinstance(data, dict), f"{path.name} did not parse to a mapping"
+        assert "jobs" in data, f"{path.name} declares no jobs"

--- a/tests/test_workflow_lint_wiring_1122.py
+++ b/tests/test_workflow_lint_wiring_1122.py
@@ -72,3 +72,29 @@ def test_every_workflow_file_still_parses():
         data = yaml.safe_load(path.read_text())
         assert isinstance(data, dict), f"{path.name} did not parse to a mapping"
         assert "jobs" in data, f"{path.name} declares no jobs"
+
+
+def test_the_shellcheck_suppression_is_documented_and_tracked():
+    """`-shellcheck=` is a deliberate scope limit, not a silent one (#1130).
+
+    actionlint runs shellcheck whenever it is on PATH — which it is on GitHub
+    runners but often not locally, so this class of check disappears without
+    warning depending on where you run it. If the suppression is ever removed,
+    this test should be deleted along with it; if it stays, it stays explained.
+    """
+    raw = TEST_WORKFLOW.read_text()
+    assert "-shellcheck=" in raw
+    assert "#1130" in raw, "the suppression must point at its follow-up issue"
+
+
+def test_workflow_compilability_is_still_checked():
+    """The suppression must not have disabled the thing the job exists for."""
+    invocation = next(
+        line for line in TEST_WORKFLOW.read_text().splitlines()
+        if "./actionlint" in line
+    )
+    # -shellcheck= narrows the checks; it must not be paired with anything that
+    # would also drop the expression/syntax pass. (Scoped to the invocation
+    # line — `paths-ignore` appears elsewhere in this file.)
+    assert "-ignore" not in invocation
+    assert "-shellcheck=" in invocation


### PR DESCRIPTION
Closes #1122.

## Why this class of bug is invisible

An uncompilable workflow does not fail like a normal job. The run has **zero
jobs and no logs**, `gh run view --log-failed` returns `log not found`, and the
invalid run **ignores its own trigger filters** — so it surfaces on branches the
workflow should never touch and reads as an unrelated trigger bug rather than an
outage. `deploy.yml` failed that way on every push to `main` for a week; nobody
noticed staging had stopped deploying. `claude-review` (#1011) was the same shape.

YAML validity does not catch it: `yaml.safe_load()` parses these files fine. It
is GitHub's expression pass that rejects them.

## Changes

**`workflow-lint` job** — runs `actionlint` on every PR.

Deliberately **not** paths-filtered. A required check that reports "skipped"
exactly when a workflow changed is the same silence this job exists to remove,
and actionlint takes about a second.

**Wired into `test-summary` twice** — into `needs`, and into the exit-1
condition. Being in `needs` alone is not a gate: `test-summary` runs under
`if: always()`, so the failure branch is what makes it real. This is the
CLAUDE.md rule about gates that quietly stop gating.

**actionlint is a pinned release verified by sha256**, not a floating action —
this job's whole purpose is stopping unverifiable CI config from landing, so it
should not itself pull an unpinned artifact.

**`CLAUDE.md`** records the diagnostic, since the symptom is the hard part: zero
jobs and no logs means the file will not compile; run `actionlint` first.

## Evidence — verified against the actual regression

`actionlint` on `deploy.yml` as it stood at `a0a69636`:

```
.github/workflows/deploy.yml:570:135: unexpected end of input while parsing
variable access, function call, null, bool, int, float or string.
expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
exit=1
```

That is the empty `${{ }}` that caused the week-long outage — found in under a
second. Current `main` is clean under the checks this job enforces
(`actionlint -shellcheck=`, `exit=0`), including this PR's own additions.

### Correction: the first version of this PR failed its own job

My initial local verification was invalid. `actionlint` runs `shellcheck` over
every `run:` block **whenever shellcheck is on PATH** — it is on GitHub runners,
it was not on my machine, so that entire check class silently vanished locally
and the run looked clean. The job failed on its first CI run.

Reproduced after installing shellcheck locally:

```
actionlint              # 44 findings — every one of them [shellcheck]
actionlint -shellcheck= # clean
```

**Zero non-shellcheck findings**: the workflows compile. The job therefore runs
`-shellcheck=`, which keeps exactly the failure mode #1122 is about, and the 44
shell findings are tracked in **#1130 (P2.34)** rather than fixed here — they are
pre-existing, almost all in `deploy.yml`, and quoting changes in the deploy path
cannot be validated from a PR. Deploying is the only way to know an SSH heredoc
still behaves, and changing it blind is how the original outage happened.

Two tests pin that the suppression stays documented and stays narrow, so it
cannot quietly become permanent.

## The wiring tests are verified non-tautological

`tests/test_workflow_lint_wiring_1122.py` pins that the job exists, is in
`needs`, is in the exit-1 condition, is not conditionally skipped, and is
checksum-pinned.

I removed each half in turn to confirm they actually fail. That caught a weak
test of my own: `test_test_summary_actually_fails_on_it` originally searched for
`needs.workflow-lint.result` anywhere in the script, which **passed with the gate
removed** because the summary *table row* also interpolates that value. It now
asserts the exact exit-1 condition.

## Acceptance criteria

- [x] A CI job runs `actionlint` over `.github/workflows/*.yml` and fails on findings
- [x] Wired into `test-summary` so it cannot be skipped silently
- [x] Runs on PRs that change workflow files (runs on all PRs, a superset)
- [x] Verified against `a0a69636` — reproduced the exact finding
- [x] Note in `CLAUDE.md`: zero jobs + no logs means it will not compile

## Not done here — deliberately

The issue's "worth considering in the same change" item — **notifying when a
valid workflow starts failing on `main`** — is not in this PR. Linting stops a
broken workflow from landing; it does nothing for a workflow that compiles and
then fails, which is the other half of why staging was down for a week. That
needs a decision about where notifications go (the #560 webhook plumbing exists,
but pointing it at CI failures is a new policy, not a refactor). The issue itself
offers to split it out, so I have: say the word and I will file it as its own
P-numbered issue rather than guessing at the routing.
