### PR TITLE
fix(cli): lead the next-steps hints with prd generate, not prd add (#1111)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -51,6 +51,17 @@ app = typer.Typer(
 
 console = Console()
 
+#: The single "you need a PRD" hint, shared by every command that reaches this
+#: state (#1111). `prd generate` is the primary path per GOLDEN_PATH §2 and is
+#: what the README leads with; `prd add` is the fallback for a PRD you already
+#: wrote. Pointing only at `prd add` sent new users straight past Socratic
+#: discovery — the capability the product leads on. `cf` rather than
+#: `codeframe` because that is the name the README uses; both binaries work.
+PRD_NEXT_STEPS = (
+    "  cf prd generate              Start AI-guided requirements discovery\n"
+    "  cf prd add <file.md>         Import a PRD you already have"
+)
+
 
 def _get_version() -> str:
     """Resolve the installed CodeFRAME version, falling back gracefully."""
@@ -237,8 +248,8 @@ def init(
 
         console.print()
         console.print("Next steps:")
-        console.print("  codeframe prd add <file.md>   Add a PRD")
-        console.print("  codeframe status              View workspace status")
+        console.print(PRD_NEXT_STEPS)
+        console.print("  cf status                    View workspace status")
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
@@ -485,7 +496,8 @@ def status(
             console.print(f"  Title: [green]{escape(latest_prd.title)}[/green]")
             console.print(f"  Added: {latest_prd.created_at.strftime('%Y-%m-%d %H:%M')}")
         else:
-            console.print("  [dim]No PRD loaded. Run 'codeframe prd add <file>'[/dim]")
+            console.print("  [dim]No PRD loaded. Run 'cf prd generate', or "
+                          "'cf prd add <file>' if you already have one.[/dim]")
 
         # Task counts
         console.print("\n[bold]Tasks[/bold]")
@@ -1024,7 +1036,7 @@ def prd_show(
 
         if not record:
             console.print("[yellow]No PRD found.[/yellow]")
-            console.print("Add one with: codeframe prd add <file.md>")
+            console.print(PRD_NEXT_STEPS)
             return
 
         console.print(f"\n[bold]PRD:[/bold] {escape(record.title)}")
@@ -1076,7 +1088,7 @@ def prd_list(
 
         if not records:
             console.print("[yellow]No PRDs found.[/yellow]")
-            console.print("Add one with: codeframe prd add <file.md>")
+            console.print(PRD_NEXT_STEPS)
             return
 
         console.print(f"\n[bold]PRDs ({len(records)}):[/bold]\n")
@@ -1998,7 +2010,7 @@ def tasks_generate(
         prd_record = prd.get_latest(workspace)
         if not prd_record:
             console.print("[red]Error:[/red] No PRD found.")
-            console.print("Add one first: codeframe prd add <file.md>")
+            console.print(PRD_NEXT_STEPS)
             raise typer.Exit(1)
 
         # --overwrite must not lose the existing tasks if generation fails
@@ -6107,8 +6119,8 @@ def templates_apply(
         # Check for PRD
         prd_record = prd.get_latest(workspace)
         if not prd_record:
-            console.print("[red]Error:[/red] No PRD found. Add one first:")
-            console.print("  codeframe prd add <file.md>")
+            console.print("[red]Error:[/red] No PRD found.")
+            console.print(PRD_NEXT_STEPS)
             raise typer.Exit(1)
 
         # Delegate to core (#962). This command used to reimplement

--- a/tests/cli/test_next_steps_hints_1111.py
+++ b/tests/cli/test_next_steps_hints_1111.py
@@ -1,0 +1,88 @@
+"""#1111 — the CLI's own hints steered new users off the documented path.
+
+`cf init` and `cf status` pointed only at `cf prd add <file.md>`, which requires
+a PRD you have already written. GOLDEN_PATH §2 makes `prd generate` the primary
+path and `prd add` the secondary one, and the README leads with `prd generate`.
+So a user following the tool's own advice never discovered Socratic discovery —
+the capability the product leads on.
+
+These tests pin the hint against the docs so it cannot drift back.
+"""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.app import PRD_NEXT_STEPS, app
+
+pytestmark = pytest.mark.v2
+
+runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestTheHintLeadsWithGenerate:
+    def test_generate_comes_before_add(self):
+        """Order is the whole point — both commands were never the problem."""
+        assert PRD_NEXT_STEPS.index("prd generate") < PRD_NEXT_STEPS.index("prd add")
+
+    def test_add_is_still_offered(self):
+        """`prd add` is the documented secondary path, not something to hide."""
+        assert "prd add" in PRD_NEXT_STEPS
+
+    def test_it_uses_the_binary_name_the_readme_uses(self):
+        for line in PRD_NEXT_STEPS.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            assert stripped.startswith("cf "), f"{stripped!r} should use the `cf` binary"
+            assert not stripped.startswith("codeframe "), stripped
+
+
+class TestTheCommandsActuallyPrintIt:
+    def test_init_next_steps(self, tmp_path):
+        result = runner.invoke(app, ["init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "cf prd generate" in result.output
+        assert "cf prd add" in result.output
+        assert result.output.index("cf prd generate") < result.output.index("cf prd add")
+
+    def test_status_with_no_prd(self, tmp_path):
+        runner.invoke(app, ["init", str(tmp_path)])
+        result = runner.invoke(app, ["status", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "cf prd generate" in result.output
+
+    def test_tasks_generate_with_no_prd(self, tmp_path):
+        runner.invoke(app, ["init", str(tmp_path)])
+        result = runner.invoke(app, ["tasks", "generate", "-w", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "cf prd generate" in result.output
+
+    def test_prd_show_with_no_prd(self, tmp_path):
+        runner.invoke(app, ["init", str(tmp_path)])
+        result = runner.invoke(app, ["prd", "show", "-w", str(tmp_path)])
+        assert "cf prd generate" in result.output
+
+
+class TestNoCommandStillPointsOnlyAtAdd:
+    """The regression was six separate strings drifting apart; now there is one."""
+
+    def test_no_stale_codeframe_prd_add_hints_remain(self):
+        app_source = (REPO_ROOT / "codeframe" / "cli" / "app.py").read_text()
+        offenders = [
+            line.strip()
+            for line in app_source.splitlines()
+            if "codeframe prd add" in line and "console.print" in line
+        ]
+        assert offenders == [], (
+            "these still hard-code the old hint instead of PRD_NEXT_STEPS: "
+            f"{offenders}"
+        )
+
+    def test_the_hint_matches_the_golden_path_ordering(self):
+        """GOLDEN_PATH is the contract these strings are supposed to follow."""
+        golden = (REPO_ROOT / "docs" / "GOLDEN_PATH.md").read_text()
+        assert "prd generate" in golden, "GOLDEN_PATH should document prd generate"
+        assert "prd generate" in PRD_NEXT_STEPS


### PR DESCRIPTION
Closes #1111.

## The problem

Immediately after the documented `cf init . --detect`, the tool said:

```
Next steps:
  codeframe prd add <file.md>   Add a PRD
  codeframe status              View workspace status
```

`prd add` requires a PRD the user has already written. GOLDEN_PATH §2 makes
`prd generate` **primary** and `prd add` **secondary**, and the README leads with
`prd generate`. A new user following the tool's own hint walks straight past
Socratic discovery — the capability the product leads on.

## Scope: six sites, not two

The issue names `app.py:240` and `:488`. There were **six**, each with its own
wording, every one pointing only at `prd add`:

| site | command |
|---|---|
| `init` next-steps | `cf init` |
| status empty-PRD hint | `cf status` |
| `prd show` no-PRD | `cf prd show` |
| `prd list` empty | `cf prd list` |
| `tasks generate` no-PRD | `cf tasks generate` |
| templates apply no-PRD | `cf templates apply` |

They are now a single `PRD_NEXT_STEPS` constant. Six strings drifting apart
independently is what produced this, so consolidating is the fix, not just
editing the two the report happened to catch.

## After

```
Next steps:
  cf prd generate              Start AI-guided requirements discovery
  cf prd add <file.md>         Import a PRD you already have
  cf status                    View workspace status
```

```
PRD
  No PRD loaded. Run 'cf prd generate', or 'cf prd add <file>' if you already have one.
```

Both captured from a real `cf init --detect` on a fresh workspace.

## Acceptance criteria

- [x] `cf init` leads with `cf prd generate`, `prd add` offered as the alternative
- [x] `cf status` empty-PRD hint does the same
- [x] Hints use `cf`, matching the README
- [x] Tests pin the hint text against the docs

Nine tests cover the ordering, the binary name, the four commands that print it,
and a guard that no hard-coded `codeframe prd add` hint creeps back in.

`ruff` clean; `tests/cli/` + golden-path integration: **558 passed**.
