### PR TITLE
fix(api): an empty workspace is not a missing one, and /review/task validates its id (#1066)

### DIFF
--- a/codeframe/core/review.py
+++ b/codeframe/core/review.py
@@ -20,6 +20,10 @@ from codeframe.lib.quality.owasp_patterns import OWASPPatterns
 logger = logging.getLogger(__name__)
 
 
+class TaskNotFoundError(Exception):
+    """`review_task` was given an id no task in this workspace has (#1066)."""
+
+
 # ============================================================================
 # Data Classes
 # ============================================================================
@@ -340,6 +344,14 @@ def review_task(
     Returns:
         ReviewResult with findings and overall score
     """
+    # The id used to be a log line and nothing else (#1066), so this endpoint
+    # presented as task-scoped and was not: a stale, wrong or invented id got a
+    # confident 200 scoring whatever files_modified the caller also sent.
+    from codeframe.core import tasks as _tasks
+
+    if _tasks.get(workspace, task_id) is None:
+        raise TaskNotFoundError(f"Task not found: {task_id}")
+
     logger.info(f"Starting review for task {task_id} ({len(files_modified)} files)")
     return review_files(workspace, files_modified)
 

--- a/codeframe/core/schedule.py
+++ b/codeframe/core/schedule.py
@@ -92,13 +92,16 @@ def get_schedule(
     Returns:
         ScheduleResult with task assignments
 
-    Raises:
-        ValueError: If no tasks found in workspace
+    An empty workspace yields an empty result rather than an error (#1066).
     """
     # Load tasks from workspace
     task_list = tasks.list_tasks(workspace, limit=1000)
     if not task_list:
-        raise ValueError("No tasks found in workspace")
+        # An empty workspace has an empty schedule, not a missing one (#1066).
+        # Raising here made the router answer 404, so a client could not tell
+        # "this workspace does not exist" from "you have not created any tasks
+        # yet" — and the latter is the first state every client meets.
+        return ScheduleResult(task_assignments=[], total_duration=0.0, agents_used=0)
 
     # Build ID mapping (v2 string UUID -> v1 integer)
     # We use task index as the integer ID
@@ -196,8 +199,7 @@ def predict_completion(
     Returns:
         CompletionPrediction with predicted date and confidence interval
 
-    Raises:
-        ValueError: If no tasks found in workspace
+    An empty workspace yields an empty result rather than an error (#1066).
     """
     if start_date is None:
         start_date = _utc_now()
@@ -205,7 +207,16 @@ def predict_completion(
     # Load tasks
     task_list = tasks.list_tasks(workspace, limit=1000)
     if not task_list:
-        raise ValueError("No tasks found in workspace")
+        # Nothing outstanding, so the project is "finished" as of now (#1066).
+        # completed_percentage is 100 rather than 0 because 0 remaining hours
+        # with 0% complete is self-contradictory; there is simply no work.
+        return CompletionPrediction(
+            predicted_date=start_date,
+            confidence_early=start_date,
+            confidence_late=start_date,
+            remaining_hours=0.0,
+            completed_percentage=100.0,
+        )
 
     # Build ID mapping
     uuid_to_int: dict[str, int] = {}
@@ -292,13 +303,13 @@ def get_bottlenecks(workspace: Workspace) -> list[BottleneckInfo]:
     Returns:
         List of BottleneckInfo objects
 
-    Raises:
-        ValueError: If no tasks found in workspace
+    An empty workspace yields an empty result rather than an error (#1066).
     """
     # Load tasks
     task_list = tasks.list_tasks(workspace, limit=1000)
     if not task_list:
-        raise ValueError("No tasks found in workspace")
+        # No tasks means no bottlenecks (#1066), not a missing resource.
+        return []
 
     # Build ID mapping
     uuid_to_int: dict[str, int] = {}

--- a/codeframe/ui/routers/review_v2.py
+++ b/codeframe/ui/routers/review_v2.py
@@ -208,6 +208,11 @@ async def review_task(
             summary=result.summary,
         )
 
+    except review.TaskNotFoundError as e:
+        # The endpoint is task-scoped; an id no task has is a 404, not a 200
+        # scoring whatever files the caller happened to send (#1066).
+        # Plain-string detail, matching this router's existing convention.
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to review task: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/core/test_review.py
+++ b/tests/core/test_review.py
@@ -8,12 +8,12 @@ We patch the three analyzers so tests are deterministic and never shell out to
 Issue #654 (P6.8.1): test coverage hardening for untested core modules.
 """
 
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from codeframe.core import review as review_mod
+from codeframe.core import tasks
 from codeframe.core.review import (
     ReviewFinding,
     ReviewResult,
@@ -23,7 +23,7 @@ from codeframe.core.review import (
     review_task,
     get_review_summary,
 )
-from codeframe.core.workspace import Workspace
+from codeframe.core.workspace import Workspace, create_or_load_workspace
 from codeframe.lib.quality.complexity_analyzer import ComplexityAnalyzer
 from codeframe.lib.quality.security_scanner import SecurityScanner
 from codeframe.lib.quality.owasp_patterns import OWASPPatterns
@@ -46,14 +46,12 @@ class _Finding:
 
 @pytest.fixture
 def workspace(tmp_path) -> Workspace:
+    # A real, initialised workspace rather than a hand-built dataclass: since
+    # #1066 review_task looks the task up, which needs the database. The
+    # session-template conftest makes this ~0.1ms (#979).
     repo = tmp_path / "repo"
     repo.mkdir()
-    return Workspace(
-        id="ws-test",
-        repo_path=repo,
-        state_dir=repo / ".codeframe",
-        created_at=datetime.now(timezone.utc),
-    )
+    return create_or_load_workspace(repo)
 
 
 @pytest.fixture(autouse=True)
@@ -217,11 +215,34 @@ class TestReviewTask:
             return ReviewResult("approved", 100.0, [], "ok")
 
         monkeypatch.setattr(review_mod, "review_files", fake_review_files)
-        result = review_task(workspace, task_id="T-1", files_modified=["a.py"])
+        # A real task: review_task validates the id since #1066, so the old
+        # placeholder "T-1" would now raise before delegating.
+        task = tasks.create(workspace, title="review me", description="")
+        result = review_task(workspace, task_id=task.id, files_modified=["a.py"])
 
         assert result.status == "approved"
         assert captured["ws"] is workspace
         assert captured["files"] == ["a.py"]
+
+    def test_an_unknown_task_id_is_rejected(self, workspace):
+        """#1066: the id used to be a log line, so any id got a confident pass."""
+        with pytest.raises(review_mod.TaskNotFoundError) as exc:
+            review_task(workspace, task_id="no-such-task", files_modified=["a.py"])
+        assert "no-such-task" in str(exc.value)
+
+    def test_the_task_is_checked_before_any_file_is_touched(
+        self, workspace, monkeypatch
+    ):
+        """Validation must come first, or an unknown id still reaches the files."""
+        called = []
+        monkeypatch.setattr(
+            review_mod, "review_files", lambda ws, files: called.append(files)
+        )
+
+        with pytest.raises(review_mod.TaskNotFoundError):
+            review_task(workspace, task_id="nope", files_modified=["a.py"])
+
+        assert called == []
 
 
 class TestWorkspaceContainment:
@@ -353,8 +374,13 @@ class TestWorkspaceContainment:
         self, workspace, outsider, analyzed
     ):
         """review_task delegates to review_files, so it inherits the guard —
-        pinned because the issue names it as a shared code path."""
-        review_task(workspace, task_id="T-1", files_modified=[str(outsider)])
+        pinned because the issue names it as a shared code path.
+
+        A real task id: since #1066 an unknown one is rejected before the guard
+        is reached, which would leave this passing while testing nothing.
+        """
+        task = tasks.create(workspace, title="review me", description="")
+        review_task(workspace, task_id=task.id, files_modified=[str(outsider)])
 
         assert analyzed == [], f"analyzer was handed {analyzed}"
 

--- a/tests/ui/test_review_v2_path_containment.py
+++ b/tests/ui/test_review_v2_path_containment.py
@@ -140,25 +140,52 @@ class TestReviewFilesEndpoint:
 
 
 class TestReviewTaskEndpoint:
-    """The issue names review_task as sharing the vulnerable code path."""
+    """The issue names review_task as sharing the vulnerable code path.
 
-    def test_parent_traversal_is_rejected(self, client, outsider, analyzed):
+    These use a REAL task id. `review_task` validates it since #1066, so a
+    placeholder now 404s before the path guard is ever reached — which would
+    leave these passing while testing nothing about containment.
+    """
+
+    @pytest.fixture
+    def real_task_id(self, test_workspace) -> str:
+        from codeframe.core import tasks
+
+        return tasks.create(
+            test_workspace, title="review me", description=""
+        ).id
+
+    def test_parent_traversal_is_rejected(
+        self, client, outsider, analyzed, real_task_id
+    ):
         resp = client.post(
             "/api/v2/review/task",
-            json={"task_id": "T-1", "files_modified": ["../secrets.py"]},
+            json={"task_id": real_task_id, "files_modified": ["../secrets.py"]},
         )
 
         assert resp.status_code == 200, resp.text
         assert analyzed == [], f"analyzer opened {analyzed}"
 
-    def test_absolute_path_is_rejected(self, client, outsider, analyzed):
+    def test_absolute_path_is_rejected(self, client, outsider, analyzed, real_task_id):
         resp = client.post(
             "/api/v2/review/task",
             json={
-                "task_id": "T-1",
+                "task_id": real_task_id,
                 "files_modified": [str(outsider)],
             },
         )
 
         assert resp.status_code == 200, resp.text
+        assert analyzed == [], f"analyzer opened {analyzed}"
+
+    def test_an_unknown_task_is_rejected_before_any_file_is_opened(
+        self, client, outsider, analyzed
+    ):
+        """The new gate must not weaken containment — it runs ahead of it."""
+        resp = client.post(
+            "/api/v2/review/task",
+            json={"task_id": "no-such-task", "files_modified": [str(outsider)]},
+        )
+
+        assert resp.status_code == 404, resp.text
         assert analyzed == [], f"analyzer opened {analyzed}"

--- a/tests/ui/test_schedule_empty_workspace_1066.py
+++ b/tests/ui/test_schedule_empty_workspace_1066.py
@@ -1,0 +1,96 @@
+"""#1066 — an empty workspace is not a missing one.
+
+All three schedule endpoints mapped `ValueError("No tasks found in workspace")`
+to 404, so a brand-new workspace — the first state every client meets — got
+"not found" for a schedule that is simply empty. A client could not tell that
+apart from asking for a workspace that does not exist without string-matching
+the detail.
+
+`core/schedule.py` is consumed only by this router (the CLI uses a different
+scheduler), so the fix is in core: an empty workspace yields an empty result.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core import schedule, tasks
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    return create_or_load_workspace(tmp_path)
+
+
+@pytest.fixture
+def client(workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import schedule_v2
+
+    app = FastAPI()
+    app.include_router(schedule_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: workspace
+    return TestClient(app)
+
+
+class TestTheCoreReturnsEmptyResults:
+    """Fixed in core so every surface benefits, not just this router."""
+
+    def test_schedule_is_empty_not_an_error(self, workspace):
+        result = schedule.get_schedule(workspace)
+        assert result.task_assignments == []
+        assert result.total_duration == 0.0
+        assert result.agents_used == 0
+
+    def test_bottlenecks_are_empty_not_an_error(self, workspace):
+        assert schedule.get_bottlenecks(workspace) == []
+
+    def test_prediction_reports_nothing_outstanding(self, workspace):
+        result = schedule.predict_completion(workspace)
+        assert result.remaining_hours == 0.0
+        # 100, not 0: zero remaining hours at 0% complete is self-contradictory.
+        assert result.completed_percentage == 100.0
+
+    def test_no_value_error_is_raised_for_an_empty_workspace(self, workspace):
+        """The old contract; pinned so it cannot come back by accident."""
+        for call in (
+            schedule.get_schedule,
+            schedule.get_bottlenecks,
+            schedule.predict_completion,
+        ):
+            call(workspace)  # must not raise
+
+
+class TestAllThreeEndpointsAgree:
+    """AC: predict and bottlenecks checked for the same over-broad mapping."""
+
+    @pytest.mark.parametrize(
+        "path", ["/api/v2/schedule", "/api/v2/schedule/predict", "/api/v2/schedule/bottlenecks"]
+    )
+    def test_an_empty_workspace_is_not_a_404(self, client, path):
+        res = client.get(path)
+        assert res.status_code == 200, res.text
+
+    def test_the_empty_schedule_has_no_assignments(self, client):
+        body = client.get("/api/v2/schedule").json()
+        assert body["task_assignments"] == []
+
+    def test_the_empty_bottlenecks_list_is_empty(self, client):
+        assert client.get("/api/v2/schedule/bottlenecks").json() == []
+
+
+class TestAPopulatedWorkspaceStillWorks:
+    """The empty case must not have been special-cased into breaking the real one."""
+
+    def test_tasks_are_scheduled(self, client, workspace):
+        for i in range(3):
+            tasks.create(workspace, title=f"t{i}", description="", estimated_hours=2.0)
+
+        res = client.get("/api/v2/schedule")
+
+        assert res.status_code == 200, res.text
+        assert len(res.json()["task_assignments"]) == 3
+        assert res.json()["total_duration"] > 0

--- a/tests/ui/test_v2_untested_routers_947.py
+++ b/tests/ui/test_v2_untested_routers_947.py
@@ -403,12 +403,12 @@ class TestReviewFiles:
         assert summary["overall_score"] == full["overall_score"]
         assert summary["total_findings"] == len(full["findings"])
 
-    def test_an_unknown_task_id_is_accepted_silently(self, client, repo):
-        """Documenting, not endorsing. `review.review_task` uses `task_id` for a
-        log line and nothing else — it never loads the task — so the endpoint
-        looks task-scoped and is not. A caller passing a stale or wrong id gets
-        a confident 200 about whatever files it also sent. Filed separately
-        rather than changed under a test-only issue."""
+    def test_an_unknown_task_id_is_a_404(self, client, repo):
+        """The endpoint is task-scoped, so an id no task has is a 404 (#1066).
+
+        It used to use `task_id` for a log line and nothing else, so a stale or
+        invented id got a confident 200 scoring whatever files were also sent.
+        """
         (repo / "sample.py").write_text("x = 1\n")
 
         res = client.post(
@@ -416,7 +416,21 @@ class TestReviewFiles:
             json={"task_id": "no-such-task", "files_modified": ["sample.py"]},
         )
 
+        assert res.status_code == 404, res.text
+        assert "no-such-task" in res.json()["detail"]
+
+    def test_a_real_task_id_still_reviews(self, client, repo, workspace):
+        """The validation must not break the endpoint's actual job."""
+        (repo / "sample.py").write_text("x = 1\n")
+        task = tasks.create(workspace, title="real", description="")
+
+        res = client.post(
+            "/api/v2/review/task",
+            json={"task_id": task.id, "files_modified": ["sample.py"]},
+        )
+
         assert res.status_code == 200, res.text
+        assert "overall_score" in res.json()
 
     def test_review_task_requires_the_file_list(self, client):
         """files_modified is required with min_length=1, so the endpoint cannot
@@ -490,17 +504,20 @@ class TestReviewDiffAndPatch:
 
 
 class TestSchedule:
-    def test_an_empty_workspace_is_a_404(self, client):
-        """Documenting, not endorsing. `schedule.get_schedule` raises
-        ValueError("No tasks found in workspace") and the handler maps every
-        ValueError to 404 — so a brand-new workspace gets "Schedule not found"
-        for what is really an empty, perfectly valid schedule. Pinned here so
-        the behaviour is at least known; filed separately rather than changed
-        under a test-only issue."""
+    def test_an_empty_workspace_has_an_empty_schedule(self, client):
+        """An empty workspace's schedule is empty, not missing (#1066).
+
+        This used to be a 404 "Schedule not found", so a client could not tell
+        a nonexistent workspace from one with no tasks yet — the first state
+        every client meets.
+        """
         res = client.get("/api/v2/schedule")
 
-        assert res.status_code == 404
-        assert res.json()["detail"]["code"] == "NOT_FOUND"
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["task_assignments"] == []
+        assert body["total_duration"] == 0
+        assert body["agents_used"] == 0
 
     def test_tasks_are_assigned(self, client, workspace):
         for i in range(3):


### PR DESCRIPTION
Closes #1066.

## 1. An empty workspace is not a missing one

All three schedule endpoints mapped `ValueError("No tasks found in workspace")`
to 404, so a brand-new workspace — the first state every client meets — got
"Schedule not found" for a schedule that is merely **empty**, indistinguishable
from asking for a workspace that does not exist without string-matching `detail`.

**Fixed in core, not the router.** I checked first that `core/schedule.py` has no
other consumer (the CLI uses a different scheduler), so this is safe and means a
future surface inherits the right behaviour:

| function | empty workspace now returns |
|---|---|
| `get_schedule` | empty `ScheduleResult` (no assignments, 0 duration, 0 agents) |
| `get_bottlenecks` | `[]` |
| `predict_completion` | nothing outstanding |

One judgment call: `predict_completion` reports `completed_percentage=100.0`, not
`0.0`. Zero remaining hours at 0% complete is self-contradictory; "there is no
outstanding work" is the honest reading. Commented in the code and asserted, so
it is easy to overrule.

## 2. `/review/task` never looked at `task_id`

The id was a log line and nothing else, so a stale, wrong or invented id got a
confident `200` scoring whatever `files_modified` came with it. `review_task`
now looks the task up and raises `TaskNotFoundError`; the router maps it to 404.

**Validated rather than deleted** — the AC allowed either. Deleting is a
breaking API change and the endpoint's name is a reasonable contract; making it
honest is the smaller move. Say the word if you would rather it go.

## The part worth reading: two security tests broke

Four existing tests used a placeholder `task_id="T-1"`. **Two of them are path-containment tests** — they assert that `../secrets.py` and absolute paths are rejected. With validation added, those requests 404 *before* the path guard is reached, so they would have **kept passing while testing nothing about containment**.

They now use real task ids. I also added a test asserting the new gate runs
*before* any file is opened:

```python
assert resp.status_code == 404
assert analyzed == [], f"analyzer opened {analyzed}"
```

That matters because `analyzed == []` was quietly doing double duty: it used to
mean "the guard blocked the file", and after this change it could also mean "we
never got that far". The ordering is now pinned rather than assumed.

Found by running the full suite before pushing — a targeted run of the schedule
and review tests would have missed all four.

## A behaviour change worth naming

`review_task` now touches the database, where it was previously pure. That
surfaced in `tests/core/test_review.py`, whose `workspace` fixture hand-built a
`Workspace` dataclass with no DB. It now builds a real one — more faithful, and
~0.1ms under the #979 session template. In production a `Workspace` always has a
database, so this is not a new failure mode there.

## Acceptance criteria

- [x] Empty workspace gets 200 with empty `task_assignments`; a bad workspace still errors
- [x] `/predict` and `/bottlenecks` checked for the same over-broad mapping — both fixed
- [x] `/review/task` validates `task_id` (404 when absent)
- [x] Both "documenting, not endorsing" tests updated and their comments removed

10 new tests for the schedule behaviour, plus the updated pins. `ruff` clean.
Full suite: **6421 passed, 49 skipped**.
