### PR TITLE
fix(release): declare the staging environment so the model guard can see its key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ jobs:
   build:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
+    # ANTHROPIC_API_KEY lives in the `staging` environment, and GitHub only
+    # exposes environment secrets to jobs that declare that environment. The
+    # model-default guard below sets MODEL_GUARD_REQUIRE_LIVE=1, so without
+    # this the secret resolves empty and every release fails by design.
+    # Same convention as lifecycle.yml and engine-smoke.yml, which is where
+    # this key already lives for CI.
+    environment: staging
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/tests/test_workflow_lint_wiring_1122.py
+++ b/tests/test_workflow_lint_wiring_1122.py
@@ -98,3 +98,70 @@ def test_workflow_compilability_is_still_checked():
     # line — `paths-ignore` appears elsewhere in this file.)
     assert "-ignore" not in invocation
     assert "-shellcheck=" in invocation
+
+
+class TestEnvironmentSecretsAreReachable:
+    """A job using an environment secret must declare that environment.
+
+    GitHub exposes environment secrets ONLY to jobs with a matching
+    `environment:` key. A job that references one without declaring it gets an
+    empty string — silently, with no warning from actionlint, which cannot know
+    where a secret lives.
+
+    That is not hypothetical: release.yml's build job referenced
+    ANTHROPIC_API_KEY without declaring `environment: staging`, so the
+    model-default guard's MODEL_GUARD_REQUIRE_LIVE=1 would have failed every
+    release. Caught by inspecting the repo's actual secrets, not by CI.
+    """
+
+    #: Secrets that live in an environment rather than at repo level. Keeping
+    #: the list here means adding one to a job without its environment fails.
+    ENVIRONMENT_SECRETS = {"ANTHROPIC_API_KEY": "staging"}
+
+    #: (workflow, job) pairs knowingly referencing a secret their environment
+    #: does not supply. Exempted with a pointer, not silenced: the `production`
+    #: environment holds zero secrets, so deploy-production cannot work at all —
+    #: tracked in #1143, which is an operator decision (populate it, or delete
+    #: the job), not something a code change can fix.
+    KNOWN_GAPS = {("deploy.yml", "deploy-production")}
+
+    def _jobs(self, path: Path) -> dict:
+        return (yaml.safe_load(path.read_text()) or {}).get("jobs", {}) or {}
+
+    def test_every_job_using_an_environment_secret_declares_it(self):
+        offenders: list[str] = []
+
+        for path in sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml")):
+            raw_jobs = self._jobs(path)
+            for job_name, job in raw_jobs.items():
+                if not isinstance(job, dict):
+                    continue
+                body = yaml.safe_dump(job)
+                for secret, environment in self.ENVIRONMENT_SECRETS.items():
+                    if f"secrets.{secret}" not in body:
+                        continue
+                    declared = job.get("environment")
+                    if isinstance(declared, dict):
+                        declared = declared.get("name")
+                    if (path.name, job_name) in self.KNOWN_GAPS:
+                        continue
+                    if declared != environment:
+                        offenders.append(
+                            f"{path.name}:{job_name} uses secrets.{secret} but "
+                            f"declares environment={declared!r}, not {environment!r}"
+                        )
+
+        assert offenders == [], (
+            "these jobs will receive an empty secret at runtime:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_the_release_build_job_can_see_the_key_it_requires(self):
+        """Specific to the guard: it sets MODEL_GUARD_REQUIRE_LIVE, so an empty
+        secret is a hard failure rather than a skipped check."""
+        release = REPO_ROOT / ".github" / "workflows" / "release.yml"
+        build = self._jobs(release)["build"]
+
+        raw = yaml.safe_dump(build)
+        assert "MODEL_GUARD_REQUIRE_LIVE" in raw
+        assert build.get("environment") == "staging"


### PR DESCRIPTION
## What happened

The `v0.9.2` release failed at the model-default guard. Cause: a one-line
omission in my #1112 change.

`ANTHROPIC_API_KEY` lives in the **`staging`** GitHub environment. Environment
secrets reach only jobs that declare that environment, and `release.yml`'s
`build` job declared none — so it resolved empty, `MODEL_GUARD_REQUIRE_LIVE=1`
tripped, and the build refused.

`lifecycle.yml:33` and `engine-smoke.yml:122` both already do
`environment: staging` for this exact key. I did not follow the existing
convention.

**The guard behaved correctly.** `publish-pypi` and `github-release` were
skipped, nothing reached PyPI (still 0.9.1). It refused to publish unverified —
just for the wrong reason.

## The scanner, and what it found

`actionlint` cannot catch this: it has no way to know which environment a secret
lives in. So this adds a test asserting that any job referencing an
environment-scoped secret declares that environment. Verified non-tautological —
removing the fix fails both new tests.

It immediately found a **second, pre-existing defect**: the `production`
environment holds **zero** secrets, while `deploy.yml`'s `deploy-production`
references ten (`SSH_KEY`, `USER`, `PROJECT_PATH`, `AUTH_SECRET`,
`ANTHROPIC_API_KEY`, …).

```
$ gh api repos/frankbria/codeframe/environments/production/secrets --jq .total_count
0
$ gh api repos/frankbria/codeframe/environments/staging/secrets --jq .total_count
20
```

That deploy path has never worked. It fails on SSH auth rather than deploying
something broken — but with the SSH secrets alone populated it would write a
remote `.env` containing an empty `AUTH_SECRET`, the JWT signing key. Filed as
**#1143** (operator decision: populate, delete, or guard) and exempted here with
a pointer, not silenced.

## After this merges

The tag needs moving to a commit that contains the fix — `v0.9.2` currently
points at `60c06c5f`, which does not.