### PR TITLE
fix(deploy): point the staging deployment URL at the host that actually serves it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,11 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
     environment:
       name: staging
-      url: https://dev.codeframeapp.com
+      # dev.codeframeapp.com has DNS to this box but no nginx site and no
+      # certificate, so the shared VPS serves another project's cert and TLS
+      # fails. The GitHub deployment link therefore looked like staging was
+      # down when it was serving fine. dev.codeframe.sh is the real host.
+      url: https://dev.codeframe.sh
 
     steps:
       - name: Checkout code

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,6 +24,12 @@ ever travel over HTTPS/WSS between the browser and Caddy. Plaintext
    sudo systemctl reload caddy
    ```
    Caddy provisions and renews the Let's Encrypt certificate automatically.
+> **Staging lives at <https://dev.codeframe.sh>.** It runs behind nginx on a
+> shared VPS (`/etc/nginx/sites-available/dev.codeframe.sh.conf`), with the
+> backend on 14200 and the frontend on 14100 under pm2. `dev.codeframeapp.com`
+> is an older domain that was never finished — it resolves to the same box but
+> has no site block and no certificate.
+
 3. Set the public origins in `.env.staging` / `.env.production`:
    ```
    NEXT_PUBLIC_API_URL=https://your-domain

--- a/legacydocs/nginx-setup-complete.md
+++ b/legacydocs/nginx-setup-complete.md
@@ -1,3 +1,10 @@
+> **SUPERSEDED — do not follow.** This documents `dev.codeframeapp.com` on
+> `47.88.89.175`. Both are dead: the box was rebuilt at `195.35.14.177` on
+> 2026-07-01 and staging is now **<https://dev.codeframe.sh>**, configured at
+> `/etc/nginx/sites-available/dev.codeframe.sh.conf`. `dev.codeframeapp.com`
+> still resolves to the new box but has no site block and no certificate, so it
+> fails TLS. Kept for history only; see `deploy/README.md`.
+
 # Nginx & SSL Configuration Complete
 
 **Date**: 2025-10-25


### PR DESCRIPTION
Found while verifying the staging deploy after v0.9.2.

## The problem

`deploy.yml`'s `environment.url` pointed at `https://dev.codeframeapp.com`. That
name resolves to the staging box but has **no nginx site block and no
certificate**, so the shared VPS answers with another project's cert
(`dev.autoauthor.app`) and TLS fails:

```
curl: (60) SSL: no alternative certificate subject name matches
      target host name 'dev.codeframeapp.com'
```

So the GitHub deployment link looked like staging was down, while it was serving
fine at **https://dev.codeframe.sh**.

## Verified on the box, not inferred

```
pm2:    codeframe-staging-backend   online   40m
        codeframe-staging-frontend  online   40m
proxy:  nginx active, caddy inactive
sites:  dev.codeframe.sh.conf        ← exists
        dev.codeframeapp.com         ← no site block at all
```

And the live endpoint reports the commit that was just merged:

```json
{"status":"healthy","commit":"d78281c","deployed_at":"2026-08-11T01:46:43Z"}
```

`/api/v2/settings/keys` returns 401, so auth enforcement is working too.

## Changes

- **`deploy.yml`** — `url: https://dev.codeframe.sh`, with the reason recorded so
  the next person does not re-derive it
- **`deploy/README.md`** — states where staging is and how it is served. The
  working URL appeared **nowhere** in the repository; only the wrong one did
- **`legacydocs/nginx-setup-complete.md`** — `SUPERSEDED` banner. It documents
  the dead domain *and* a dead IP (`47.88.89.175`, replaced by `195.35.14.177` in
  the 2026-07-01 rebuild), so following it wastes real time

Docs and one workflow field only — no application code. `actionlint` clean, full
suite **6443 passed, 49 skipped**.