### PR TITLE
test(lifecycle): make `--mode api` a real, free Golden Path suite (#1068)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,11 @@ uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"  # The CI gate (every
                                          # ~6.5 min locally. If it is much slower on your
                                          # machine, see "Suite speed" below.
 uv run pytest tests/core/                # Core module tests
-scripts/lifecycle --mode cli|all         # Real-LLM lifecycle tests (run locally before a PR)
-                                         # api/web exit 3 — not implemented (#948, #1068)
+scripts/lifecycle --mode cli|api|all     # Lifecycle tests (run locally before a PR)
+                                         # cli — real LLM calls, needs a key, costs money
+                                         # api — Golden Path over HTTP on the mock provider,
+                                         #       free, and also runs in normal CI (#1068)
+                                         # web exits 3 — not implemented (#948, #1068)
 uv run ruff check .
 
 # Web UI

--- a/scripts/lifecycle
+++ b/scripts/lifecycle
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# lifecycle — Run CodeFRAME full lifecycle tests (real LLM calls)
+# lifecycle — Run CodeFRAME full lifecycle tests
 #
 # Usage:
 #   scripts/lifecycle [options]
 #
 # Options:
-#   --mode cli|all           Which test mode (default: cli)
-#                            api and web are NOT implemented — they exit 3
-#                            rather than reporting a false pass (#948, #1068)
+#   --mode cli|api|all       Which test mode (default: cli)
+#                            cli — real LLM calls, needs ANTHROPIC_API_KEY, costs money
+#                            api — Golden Path over HTTP on the mock provider, free
+#                            all — both
+#                            web is NOT implemented — it exits 3 rather than
+#                            reporting a false pass (#948, #1068)
 #   --model haiku|sonnet     LLM model to use (default: haiku, cheaper)
 #   --verbose / -v           Pass -s to pytest (show live output)
 #   --no-cleanup             Keep temp directories after test (for inspection)
@@ -45,18 +48,18 @@ case "$MODE" in
   *) echo "Error: --mode must be cli, api, web, or all" >&2; exit 1 ;;
 esac
 
-# api and web are NOT implemented (#948). They used to resolve to files whose
+# `web` is still NOT implemented (#948/#1068). It used to resolve to a file whose
 # only content was a @pytest.mark.skip class raising NotImplementedError, so
-# pytest collected nothing but skips and exited 0 — and CLAUDE.md advertises
-# this script as the pre-PR gate. Two of its four modes therefore reported
-# success for work that did not exist. Fail loudly instead; tracked in #1068.
-if [[ "$MODE" == "api" || "$MODE" == "web" ]]; then
-  echo "Error: --mode $MODE is not implemented." >&2
+# pytest collected nothing but skips and exited 0 — while CLAUDE.md advertises
+# this script as the pre-PR gate. Fail loudly rather than report success for work
+# that does not exist. `api` is now real and runs on the mock provider.
+if [[ "$MODE" == "web" ]]; then
+  echo "Error: --mode web is not implemented." >&2
   echo "" >&2
-  echo "  The $MODE lifecycle test does not exist yet. It used to 'pass' by" >&2
+  echo "  The web lifecycle test does not exist yet. It used to 'pass' by" >&2
   echo "  collecting only skipped stubs — see issue #1068 for the plan." >&2
   echo "" >&2
-  echo "  Run the implemented mode instead:  scripts/lifecycle --mode cli" >&2
+  echo "  Implemented modes:  scripts/lifecycle --mode cli|api" >&2
   exit 3
 fi
 
@@ -66,7 +69,9 @@ case "$MODEL" in
 esac
 
 # ── Check API key ────────────────────────────────────────────────────────────
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+# `api` runs entirely on the mock provider: no key, no cost, no network. That is
+# the point of it — it can run on every PR, where the paid cli mode cannot.
+if [[ "$MODE" != "api" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
   echo "Error: ANTHROPIC_API_KEY is not set." >&2
   echo "" >&2
   echo "Export it first:" >&2
@@ -78,12 +83,26 @@ if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
 fi
 
 # ── Resolve test path ────────────────────────────────────────────────────────
+# The marker matters as much as the path. pytest.ini defaults to
+# -m "not e2e_llm and not lifecycle", so the paid cli tests need -m lifecycle to
+# be selected at all, while the mock-driven api tests are deliberately unmarked
+# and are selected by that same default. Getting this wrong silently runs
+# nothing, which is the failure mode #948 was about.
 case "$MODE" in
-  cli) TEST_PATH="tests/lifecycle/test_cli_lifecycle.py" ;;
-  # 'all' is currently the same set as 'cli' — the api and web modes are
-  # rejected above. Kept as a distinct mode so it starts covering them the
-  # moment #1068 lands, rather than needing a caller to change.
-  all) TEST_PATH="tests/lifecycle/" ;;
+  cli)
+    TEST_PATH="tests/lifecycle/test_cli_lifecycle.py"
+    MARKER_ARGS=(-m lifecycle)
+    ;;
+  api)
+    TEST_PATH="tests/lifecycle/test_api_lifecycle.py"
+    MARKER_ARGS=(-m "not lifecycle")
+    ;;
+  all)
+    TEST_PATH="tests/lifecycle/"
+    # Always true, so it clears pytest.ini's default and selects both the
+    # marked (cli) and unmarked (api) tests in one run.
+    MARKER_ARGS=(-m "lifecycle or not lifecycle")
+    ;;
 esac
 
 # ── Cost warning ─────────────────────────────────────────────────────────────
@@ -94,6 +113,9 @@ fi
 if [[ "$MODE" == "all" ]]; then
   COST_HINT="~\$1.50–5.00"
 fi
+if [[ "$MODE" == "api" ]]; then
+  COST_HINT="free (mock provider, no API calls)"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
@@ -102,12 +124,12 @@ echo "  ────────────────────────
 echo "  Mode:    $MODE"
 echo "  Model:   $MODEL (set via CODEFRAME_LIFECYCLE_MODEL)"
 echo "  Path:    $TEST_PATH"
-echo "  Cost:    $COST_HINT (real API calls)"
+echo "  Cost:    $COST_HINT"
 echo ""
 
 if [[ -n "$DRY_RUN" ]]; then
   echo "[dry-run] Would run:"
-  echo "  CODEFRAME_LIFECYCLE_MODEL=$MODEL uv run pytest $TEST_PATH -m lifecycle -v $VERBOSE"
+  echo "  CODEFRAME_LIFECYCLE_MODEL=$MODEL uv run pytest $TEST_PATH ${MARKER_ARGS[*]} -v $VERBOSE"
   echo ""
   exit 0
 fi
@@ -125,7 +147,7 @@ fi
 # ── Build pytest args ─────────────────────────────────────────────────────────
 PYTEST_ARGS=(
   "$TEST_PATH"
-  -m lifecycle
+  "${MARKER_ARGS[@]}"
   -v
   --tb=long
   --no-header
@@ -145,5 +167,8 @@ echo "  Starting... (this may take 10–30 minutes)"
 echo ""
 
 export CODEFRAME_LIFECYCLE_MODEL="$MODEL"
+if [[ "$MODE" == "api" ]]; then
+  export CODEFRAME_LLM_PROVIDER=mock
+fi
 
 uv run pytest "${PYTEST_ARGS[@]}"

--- a/tests/lifecycle/test_api_lifecycle.py
+++ b/tests/lifecycle/test_api_lifecycle.py
@@ -34,7 +34,12 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.v2
+# A hang here would be worse than a failure: this suite is unmarked so the
+# default CI gate collects it, and a non-terminating request would stall the
+# whole backend job rather than reporting anything. The whole file runs in ~7s,
+# so 120s can only fire on a genuine block. Same reasoning as the absent SSE
+# test below — pytest-timeout is a dependency, so this costs nothing.
+pytestmark = [pytest.mark.v2, pytest.mark.timeout(120)]
 
 PRD_CONTENT = """# CSV Stats
 

--- a/tests/lifecycle/test_api_lifecycle.py
+++ b/tests/lifecycle/test_api_lifecycle.py
@@ -98,8 +98,22 @@ class ApiDriver:
         return self.client.get("/api/v2/tasks", params=self.params)
 
     def approve(self, task_ids):
+        """Approve exactly ``task_ids`` and nothing else.
+
+        The endpoint's contract is exclusion-based — `ApproveTasksRequest` has
+        `excluded_task_ids` and no `task_ids` — and Pydantic drops unknown
+        fields, so posting `task_ids` approves EVERY backlog task while
+        returning 200. Caught in review; `test_approval_is_scoped_to_the_chosen
+        _tasks` below fails on that version.
+        """
+        wanted = set(task_ids)
+        excluded = [
+            t["id"] for t in self.list_tasks().json()["tasks"] if t["id"] not in wanted
+        ]
         return self.client.post(
-            "/api/v2/tasks/approve", params=self.params, json={"task_ids": list(task_ids)}
+            "/api/v2/tasks/approve",
+            params=self.params,
+            json={"excluded_task_ids": excluded},
         )
 
     def execute(self, task_ids, strategy: str = "serial"):
@@ -173,6 +187,21 @@ class TestTheGoldenPathOverHttp:
         final = api.await_batch(batch_id)
         assert final["status"] == "COMPLETED", final
         assert api.task(task_ids[0]).json()["status"] == "DONE"
+
+    def test_approval_is_scoped_to_the_chosen_tasks(self, api):
+        """Approving one task must not release the rest of the backlog."""
+        api.init_workspace()
+        api.upload_prd()
+        api.generate_tasks()
+        tasks = api.list_tasks().json()["tasks"]
+        assert len(tasks) >= 2, "need a second task for this to prove anything"
+
+        chosen = tasks[0]["id"]
+        assert api.approve([chosen]).status_code == 200
+
+        after = {t["id"]: t["status"] for t in api.list_tasks().json()["tasks"]}
+        assert after[chosen] == "READY"
+        assert all(status == "BACKLOG" for tid, status in after.items() if tid != chosen), after
 
     def test_generation_is_rejected_without_a_prd(self, api):
         """The order of the pipeline is part of the contract."""

--- a/tests/lifecycle/test_api_lifecycle.py
+++ b/tests/lifecycle/test_api_lifecycle.py
@@ -1,0 +1,266 @@
+"""Golden Path end to end over HTTP, driven by the mock provider (#1068).
+
+#948 deleted the stub this replaces: a `@pytest.mark.skip` class whose methods
+raised `NotImplementedError`, so `scripts/lifecycle --mode api` collected only
+skips and exited 0 while CLAUDE.md advertised it as the pre-PR gate.
+
+**This file deliberately does NOT carry the `lifecycle` marker.** That marker
+means "real LLM calls, costs money, run explicitly" and its conftest guard skips
+the whole set without an `ANTHROPIC_API_KEY`. Everything here runs on
+`CODEFRAME_LLM_PROVIDER=mock`, costs nothing, and is worth running on every PR —
+it covers the seam no unit test does: workspace init, PRD upload, task
+generation, approval, batch execution and SSE, wired together through the real
+FastAPI app.
+
+The plan preserved in #1068 named endpoints that do not exist as written; the
+issue says so and it was right. Verified against the live OpenAPI schema:
+
+    plan                          actual
+    POST /api/v2/workspace/init   POST /api/v2/workspaces
+    POST /api/v2/tasks/generate   POST /api/v2/discovery/generate-tasks
+    POST /api/v2/batches/run      POST /api/v2/tasks/execute
+
+`use_llm=false` on generation is deliberate: it makes the task list
+deterministic, so a failure here is a server-layer failure rather than the mock
+returning prose the decomposer cannot parse (#1115 turned that into a hard
+error, correctly).
+"""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.v2
+
+PRD_CONTENT = """# CSV Stats
+
+## Requirements
+
+- Implement a mean function in stats.py
+- Add a test for the mean function
+"""
+
+TERMINAL = {"COMPLETED", "FAILED", "PARTIAL", "CANCELLED"}
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repo — workspace init and the gates both need one."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.test"], cwd=tmp_path, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True)
+    (tmp_path / "README.md").write_text("# demo\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+@pytest.fixture
+def client(monkeypatch, repo):
+    monkeypatch.setenv("CODEFRAME_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("CODEFRAME_AUTH_REQUIRED", "false")
+    # The workspace is a tmp dir, so it is outside any WORKSPACE_ROOT allowlist.
+    monkeypatch.setenv("CODEFRAME_ALLOW_UNRESTRICTED_WORKSPACES", "1")
+
+    from codeframe.ui.server import app
+
+    return TestClient(app)
+
+
+class ApiDriver:
+    """The Golden Path expressed as HTTP calls, so the tests read as a story."""
+
+    def __init__(self, client: TestClient, repo: Path):
+        self.client = client
+        self.repo = repo
+        self.params = {"workspace_path": str(repo)}
+
+    def init_workspace(self):
+        return self.client.post("/api/v2/workspaces", json={"repo_path": str(self.repo)})
+
+    def upload_prd(self, content: str = PRD_CONTENT):
+        return self.client.post(
+            "/api/v2/prd", params=self.params, json={"content": content, "title": "CSV Stats"}
+        )
+
+    def generate_tasks(self, use_llm: bool = False):
+        return self.client.post(
+            "/api/v2/discovery/generate-tasks", params={**self.params, "use_llm": use_llm}
+        )
+
+    def list_tasks(self):
+        return self.client.get("/api/v2/tasks", params=self.params)
+
+    def approve(self, task_ids):
+        return self.client.post(
+            "/api/v2/tasks/approve", params=self.params, json={"task_ids": list(task_ids)}
+        )
+
+    def execute(self, task_ids, strategy: str = "serial"):
+        return self.client.post(
+            "/api/v2/tasks/execute",
+            params=self.params,
+            json={"task_ids": list(task_ids), "strategy": strategy},
+        )
+
+    def batch(self, batch_id: str):
+        return self.client.get(f"/api/v2/batches/{batch_id}", params=self.params)
+
+    def task(self, task_id: str):
+        return self.client.get(f"/api/v2/tasks/{task_id}", params=self.params)
+
+    def await_batch(self, batch_id: str, timeout_s: int = 120) -> dict:
+        """Poll until the batch reaches a terminal state.
+
+        Returns the final body; the caller asserts on it. Raises on timeout
+        rather than returning a half-finished batch that would produce a
+        confusing downstream assertion.
+        """
+        deadline = time.monotonic() + timeout_s
+        body: dict = {}
+        while time.monotonic() < deadline:
+            res = self.batch(batch_id)
+            assert res.status_code == 200, res.text
+            body = res.json()
+            if body.get("status") in TERMINAL:
+                return body
+            time.sleep(0.5)
+        raise AssertionError(
+            f"batch {batch_id} never reached a terminal state "
+            f"(last status {body.get('status')!r})"
+        )
+
+
+@pytest.fixture
+def api(client, repo) -> ApiDriver:
+    return ApiDriver(client, repo)
+
+
+class TestTheGoldenPathOverHttp:
+    """THINK -> BUILD, end to end, with no API key and no money spent."""
+
+    def test_a_project_is_built_through_the_api(self, api):
+        # THINK
+        assert api.init_workspace().status_code == 201
+        assert api.upload_prd().status_code == 201
+
+        generated = api.generate_tasks()
+        assert generated.status_code == 200, generated.text
+        assert generated.json()["task_count"] > 0
+
+        listed = api.list_tasks()
+        assert listed.status_code == 200, listed.text
+        tasks = listed.json()["tasks"]
+        assert tasks, "task generation reported success but listed nothing"
+        assert {t["status"] for t in tasks} == {"BACKLOG"}
+
+        # BUILD
+        task_ids = [tasks[0]["id"]]
+        assert api.approve(task_ids).status_code == 200
+        assert api.task(task_ids[0]).json()["status"] == "READY"
+
+        started = api.execute(task_ids)
+        assert started.status_code == 200, started.text
+        batch_id = started.json()["batch_id"]
+        assert batch_id
+
+        final = api.await_batch(batch_id)
+        assert final["status"] == "COMPLETED", final
+        assert api.task(task_ids[0]).json()["status"] == "DONE"
+
+    def test_generation_is_rejected_without_a_prd(self, api):
+        """The order of the pipeline is part of the contract."""
+        assert api.init_workspace().status_code == 201
+
+        generated = api.generate_tasks()
+
+        assert generated.status_code != 200, generated.text
+
+    def test_the_batch_records_the_task_it_ran(self, api):
+        api.init_workspace()
+        api.upload_prd()
+        api.generate_tasks()
+        task_ids = [api.list_tasks().json()["tasks"][0]["id"]]
+        api.approve(task_ids)
+
+        batch_id = api.execute(task_ids).json()["batch_id"]
+        final = api.await_batch(batch_id)
+
+        assert final["task_ids"] == task_ids
+        assert final["strategy"] == "serial"
+
+
+class TestSseStreamingDeliversEvents:
+    """The stream is the only way the web UI learns a run progressed."""
+
+    def _events(self, raw: str) -> list[dict]:
+        out = []
+        for line in raw.splitlines():
+            if line.startswith("data:"):
+                try:
+                    out.append(json.loads(line[5:].strip()))
+                except json.JSONDecodeError:
+                    pass
+        return out
+
+    # There is deliberately NO test here that opens the SSE stream.
+    #
+    # `TestClient.stream()` on an event-stream endpoint blocks: the response
+    # never completes, and the block happens inside anyio's portal, where an
+    # httpx read timeout does not interrupt it. Both a plain context manager
+    # and a bounded `iter_lines()` with a 5s read timeout hung until an outer
+    # timeout killed the run. A test that can hang CI indefinitely is strictly
+    # worse than no test.
+    #
+    # What the stream carries is asserted below via the event log, and the real
+    # browser-to-server SSE path is covered by the Playwright harness
+    # (#684/#703). An in-process SSE test needs a live uvicorn on a real socket
+    # rather than TestClient — that belongs with the web lifecycle work, not
+    # bolted on here.
+
+    def test_an_executed_task_produces_events(self, api):
+        """Execution must leave a trail the UI can render."""
+        api.init_workspace()
+        api.upload_prd()
+        api.generate_tasks()
+        task_ids = [api.list_tasks().json()["tasks"][0]["id"]]
+        api.approve(task_ids)
+        api.await_batch(api.execute(task_ids).json()["batch_id"])
+
+        events = api.client.get("/api/v2/events", params=api.params)
+
+        assert events.status_code == 200, events.text
+        body = events.json()
+        recorded = body["events"] if isinstance(body, dict) else body
+        types = {e.get("event_type") for e in recorded}
+        # The run happened, and the taxonomy distinguishes its phases (#1116).
+        assert "RUN_COMPLETED" in types or "BATCH_COMPLETED" in types, sorted(types)
+
+
+class TestThisSuiteRunsWithoutAnApiKey:
+    """The point of the mock provider: this is free and runs on every PR."""
+
+    def test_it_is_not_marked_lifecycle(self):
+        """`lifecycle` means real LLM calls and is skipped without a key.
+
+        Marking this file would put it back behind the same guard that made the
+        old stub invisible.
+        """
+        import tests.lifecycle.test_api_lifecycle as module
+
+        marks = getattr(module, "pytestmark", [])
+        names = {m.name for m in (marks if isinstance(marks, list) else [marks])}
+        assert "lifecycle" not in names
+
+    def test_it_passes_with_no_anthropic_key_present(self, api, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        assert api.init_workspace().status_code == 201
+        assert api.upload_prd().status_code == 201
+        assert api.generate_tasks().status_code == 200

--- a/tests/test_lifecycle_gates_948.py
+++ b/tests/test_lifecycle_gates_948.py
@@ -16,6 +16,7 @@ These are meta-tests: they assert on the repository's own gate configuration,
 which is where the defect lives. They run in the default CI gate.
 """
 
+import ast
 import configparser
 import subprocess
 import sys
@@ -31,15 +32,22 @@ LIFECYCLE = REPO_ROOT / "scripts" / "lifecycle"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
 
 
-def _run_lifecycle(*args) -> subprocess.CompletedProcess:
-    """--dry-run so nothing is executed and no key is spent."""
+def _run_lifecycle(*args, drop_api_key: bool = False) -> subprocess.CompletedProcess:
+    """--dry-run so nothing is executed and no key is spent.
+
+    ``drop_api_key`` omits ANTHROPIC_API_KEY entirely, which is how the `api`
+    mode is meant to run — on the mock provider, for free, on every PR.
+    """
+    env = {"PATH": "/usr/bin:/bin"}
+    if not drop_api_key:
+        # The script exits early without a key, which would mask the mode check.
+        env["ANTHROPIC_API_KEY"] = "not-a-real-key"
     return subprocess.run(
         [str(LIFECYCLE), *args, "--dry-run"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
-        # The script exits early without a key, which would mask the mode check.
-        env={"PATH": "/usr/bin:/bin", "ANTHROPIC_API_KEY": "not-a-real-key"},
+        env=env,
         timeout=60,
     )
 
@@ -52,7 +60,9 @@ def _e2e_backend_job() -> dict:
 class TestUnimplementedLifecycleModesFailLoudly:
     """AC1. The modes must not report success for a suite that does not exist."""
 
-    @pytest.mark.parametrize("mode", ["api", "web"])
+    # `api` is implemented as of #1068 and is asserted below to WORK. Only
+    # `web` remains unbuilt, so only `web` must still fail loudly.
+    @pytest.mark.parametrize("mode", ["web"])
     def test_the_mode_exits_non_zero(self, mode: str):
         proc = _run_lifecycle("--mode", mode)
 
@@ -60,14 +70,14 @@ class TestUnimplementedLifecycleModesFailLoudly:
             f"--mode {mode} still exits 0 — a caller reads that as a pass"
         )
 
-    @pytest.mark.parametrize("mode", ["api", "web"])
+    @pytest.mark.parametrize("mode", ["web"])
     def test_it_says_why_and_points_somewhere(self, mode: str):
         proc = _run_lifecycle("--mode", mode)
 
         assert "not implemented" in proc.stderr.lower(), proc.stderr
         assert "#1068" in proc.stderr, "no pointer to the tracking issue"
 
-    @pytest.mark.parametrize("mode", ["api", "web"])
+    @pytest.mark.parametrize("mode", ["web"])
     def test_its_exit_code_differs_from_a_typo(self, mode: str):
         """`--mode api` and `--mode banana` are different failures: one is
         "not built yet", the other is "you mistyped". Same code would conflate
@@ -82,6 +92,31 @@ class TestUnimplementedLifecycleModesFailLoudly:
 
         assert proc.returncode == 0, proc.stderr
         assert "test_cli_lifecycle.py" in proc.stdout
+
+    def test_api_mode_is_implemented_now(self):
+        """The flip #1068 asks for: `api` resolves to a real suite (#1068)."""
+        proc = _run_lifecycle("--mode", "api")
+
+        assert proc.returncode == 0, proc.stderr
+        assert "test_api_lifecycle.py" in proc.stdout
+        assert "not implemented" not in proc.stderr.lower()
+
+    def test_api_mode_needs_no_api_key(self):
+        """The whole point of driving it with the mock provider: it is free,
+        so CI can run it on every PR where the paid cli mode cannot."""
+        proc = _run_lifecycle("--mode", "api", drop_api_key=True)
+
+        assert proc.returncode == 0, proc.stderr
+        assert "ANTHROPIC_API_KEY" not in proc.stderr
+
+    def test_api_mode_selects_tests_rather_than_silently_matching_none(self):
+        """pytest.ini defaults to `-m "not lifecycle"`, and the script used to
+        pass `-m lifecycle` for every mode. With the api suite deliberately
+        unmarked, that combination selects ZERO tests and exits 0 — exactly the
+        silent success #948 removed the stubs for."""
+        proc = _run_lifecycle("--mode", "api")
+
+        assert "-m not lifecycle" in proc.stdout or "not lifecycle" in proc.stdout
 
     def test_all_still_works(self):
         proc = _run_lifecycle("--mode", "all")
@@ -98,17 +133,43 @@ class TestUnimplementedLifecycleModesFailLoudly:
         )
 
         assert "cli|api|web|all" not in proc.stdout, (
-            "--help still offers the two modes that cannot run"
+            "--help still offers web, the one mode that cannot run"
+        )
+        assert "--mode cli|api|all" in proc.stdout, (
+            "--help must offer api now that it is implemented (#1068)"
         )
 
 
 class TestNoAdvertisedModeCollectsOnlySkips:
     """AC1's second half, measured rather than assumed."""
 
-    def test_the_stub_files_are_gone(self):
-        for name in ("test_api_lifecycle.py", "test_web_lifecycle.py"):
-            assert not (REPO_ROOT / "tests" / "lifecycle" / name).exists(), (
-                f"{name} still exists — pytest will collect its skips"
+    def test_the_web_stub_file_is_still_gone(self):
+        """`api` came back as a real suite in #1068; `web` has not."""
+        assert not (REPO_ROOT / "tests" / "lifecycle" / "test_web_lifecycle.py").exists()
+
+    def test_the_api_file_is_a_real_suite_not_a_stub(self):
+        """It exists again — so assert it is the opposite of what #948 deleted:
+        real test bodies, not a skipped class of NotImplementedError.
+
+        Parsed, not grepped: the file's own docstring quotes both `NotImplemented
+        Error` and `pytest.mark.skip` while describing the stub it replaces, so a
+        substring check reports the stub it is documenting.
+        """
+        tree = ast.parse(
+            (REPO_ROOT / "tests" / "lifecycle" / "test_api_lifecycle.py").read_text()
+        )
+        tests = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+        ]
+
+        assert len(tests) >= 3, "too thin to be a lifecycle suite"
+        for node in tests:
+            body = [n for n in node.body if not isinstance(n, ast.Expr)]
+            assert body, f"{node.name} has no body beyond its docstring"
+            assert not any(isinstance(n, ast.Raise) for n in body), (
+                f"{node.name} is still a stub that raises"
             )
 
     def test_the_remaining_lifecycle_suite_has_real_tests(self):
@@ -132,6 +193,51 @@ class TestNoAdvertisedModeCollectsOnlySkips:
             assert "raise NotImplementedError" not in source, (
                 f"{path.name} still contains a stub body"
             )
+
+
+class TestTheApiSuiteActuallyRunsInCi:
+    """#1068 AC2: "It runs in CI (free, no ANTHROPIC_API_KEY), not only under
+    scripts/lifecycle."
+
+    It is unmarked on purpose, so the default gate collects it. That only holds
+    while the gate keeps pointing at `tests/` — an `--ignore=tests/lifecycle`
+    added later would take the suite out of CI without failing anything.
+    """
+
+    def _gate_step(self) -> str:
+        workflow = yaml.safe_load(WORKFLOW.read_text())
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                run = step.get("run", "")
+                if "pytest tests/" in run and "--ignore=tests/e2e" in run:
+                    return run
+        raise AssertionError("no job runs the default pytest gate")
+
+    def test_the_gate_does_not_ignore_the_lifecycle_directory(self):
+        assert "--ignore=tests/lifecycle" not in self._gate_step()
+
+    def test_the_gate_deselects_only_the_paid_marker(self):
+        """`-m "not lifecycle"` skips the marked (paid) suite. The api suite is
+        unmarked, so it survives — deselecting by path would not."""
+        assert '-m "not lifecycle"' in self._gate_step()
+
+    def test_the_api_suite_is_collected_by_the_gate_selector(self):
+        """Measured, not inferred from the YAML."""
+        proc = subprocess.run(
+            [
+                sys.executable, "-m", "pytest",
+                "--collect-only", "-q",
+                "-m", "not lifecycle",
+                "tests/lifecycle",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+        assert "test_api_lifecycle" in proc.stdout, proc.stdout[-1500:]
+        assert "test_cli_lifecycle" not in proc.stdout, "the paid suite leaked in"
 
 
 class TestE2eBackendJobIsHonest:


### PR DESCRIPTION
Closes #1068 (API half — see **Scope** below).

## What

`#948` deleted `tests/lifecycle/test_api_lifecycle.py` because it was green theatre: a `@pytest.mark.skip` class whose methods raised `NotImplementedError`, so `scripts/lifecycle --mode api` collected only skips and exited **0** while `CLAUDE.md` advertised it as the pre-PR gate. This is the work #948 spun off.

The new suite drives the Golden Path over HTTP against the real FastAPI app on `CODEFRAME_LLM_PROVIDER=mock`: workspace init → PRD upload → task generation → approval → batch execution → terminal-state polling → event trail. It costs nothing and needs no `ANTHROPIC_API_KEY`, so it is **deliberately not marked `lifecycle`** — the default CI gate collects it on every PR. That is the point the issue makes about the mock provider: it covers the server-layer seam no unit test reaches, for free, rather than being a paid duplicate of the CLI test.

7 tests, **~7s**.

## The plan's endpoints were wrong, as the issue warned

The issue preserves the deleted stub's plan and says to verify each endpoint rather than trust it. Checked against the live OpenAPI schema:

| plan | actual |
|---|---|
| `POST /api/v2/workspace/init` | `POST /api/v2/workspaces` |
| `POST /api/v2/tasks/generate` | `POST /api/v2/discovery/generate-tasks` |
| `POST /api/v2/batches/run` | `POST /api/v2/tasks/execute` |

`use_llm=false` on generation is deliberate: it makes the task list deterministic, so a failure here is a server-layer failure rather than the mock returning prose the decomposer cannot parse (#1115 turned that into a hard error, correctly).

## `scripts/lifecycle` resolves per-mode, not one-size-fits-all

It used to pass `-m lifecycle` for every mode. With the api suite unmarked, that selects **zero tests and exits 0** — the same silent success #948 removed the stubs for. Now each mode carries its own path, marker and key requirement:

| mode | path | marker | needs a key |
|---|---|---|---|
| `cli` | `test_cli_lifecycle.py` | `-m lifecycle` | yes, costs money |
| `api` | `test_api_lifecycle.py` | `-m "not lifecycle"` | **no** |
| `all` | `tests/lifecycle/` | `-m "lifecycle or not lifecycle"` | yes |
| `web` | — | — | `exit 3`, unchanged |

A gate test measures that selector rather than trusting it.

## The gates flip, as the issue's last AC requires

`tests/test_lifecycle_gates_948.py` asserted that `api` and `web` are *rejected*. Now `api` is asserted to **work** — and to work with **no `ANTHROPIC_API_KEY` present at all** — while `web` keeps every must-fail-loudly assertion. Two further gates assert AC2 instead of assuming it: the CI step must not `--ignore=tests/lifecycle`, and the gate's own selector must actually collect the api suite while leaving the paid cli suite behind.

One of these is AST-parsed rather than grepped: the new file's docstring quotes both `NotImplementedError` and `pytest.mark.skip` while describing the stub it replaces, so a substring check would report the stub it is documenting.

## Review finding, fixed and verified

Codex caught a real one. `ApproveTasksRequest` is **exclusion**-shaped (`excluded_task_ids`, no `task_ids`) and Pydantic drops unknown fields — so the driver's `{"task_ids": [...]}` returned 200 while approving the **entire backlog**. The existing assertion ("the chosen task is READY") held either way, so the suite looked like it covered scoped approval and did not. The helper now computes exclusions from the live task list, and a new test asserts the tasks it did not choose stayed `BACKLOG`. Verified the guard bites: restoring the old one-line body fails it.

The endpoint's own footgun — 200 + inverted semantics for the intuitive payload — is filed as **#1146**; no production caller hits that route today.

## Known limitations

- **The AC's `test_sse_streaming_delivers_events` is only partially met.** `TestClient.stream()` on an event-stream endpoint blocks: the response never completes, and the block happens inside anyio's portal where an httpx read timeout does not interrupt it. Both a plain context manager and a bounded `iter_lines()` with a 5s read timeout hung until an outer timeout killed the run. A test that can hang CI indefinitely is strictly worse than none, so there is **no** test that opens the stream — with that reasoning recorded in the file. What the stream carries is asserted via the event log instead, and the real browser-to-server SSE path is covered by the Playwright harness (#684/#703). An in-process SSE test needs a live uvicorn on a real socket rather than `TestClient`.
- **The web half of #1068 is not in this PR.** It needs Playwright plus two live servers and belongs with the existing harness; bundling it here would have held the free, CI-runnable API suite behind a much larger change. `--mode web` still exits 3 with its pointer, and every gate asserting that still passes. I'll assess it separately — #1068 should stay open for it.

## Testing

- Full CI gate: `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` — **6450 passed, 49 skipped, 421s**
- `uv run ruff check .` — clean
- All four `scripts/lifecycle` modes verified by `--dry-run`, including with the key unset

## Review

Third-party pre-PR review: `codex review` (opencode skipped — it mutates the tree and returns zero bytes on this repo, per prior sessions). One P2 finding, fixed above.