### PR TITLE
feat(proof): report why a proof run produced no results (#1138)

### DIFF
--- a/codeframe/cli/proof_commands.py
+++ b/codeframe/cli/proof_commands.py
@@ -160,8 +160,8 @@ def run(
         codeframe proof run --gate unit
     """
     from codeframe.core.workspace import get_workspace
-    from codeframe.core.proof.models import Gate, GateOutcome
-    from codeframe.core.proof.runner import run_proof
+    from codeframe.core.proof.models import PROOF_CONFIG_FILENAME, Gate, GateOutcome
+    from codeframe.core.proof.runner import EmptyReason, run_proof_with_diagnostics
 
     workspace_path = repo_path or Path.cwd()
     try:
@@ -182,115 +182,76 @@ def run(
     mode = "full" if full else "scope-filtered"
     console.print(f"[dim]Running proof obligations ({mode})...[/dim]")
 
-    results = run_proof(workspace, full=full, gate_filter=gate_filter)
+    results, diagnostics = run_proof_with_diagnostics(
+        workspace, full=full, gate_filter=gate_filter
+    )
 
     if not results:
-        # `run_proof` returning {} has three causes and they need different
-        # answers. Two review rounds went by patching one branch at a time and
-        # getting the reason wrong each time, so this asks the runner's own
-        # selector instead of inferring it from the mode:
-        #
-        #   ledger empty        -> nothing to verify at all (the #1118 case)
-        #   nothing runnable    -> requirements exist but all SATISFIED/WAIVED
-        #                          for this mode; scope was never consulted,
-        #                          because run_proof short-circuits first
-        #   nothing in scope    -> runnable requirements existed and the scope
-        #                          filter excluded every one
-        from codeframe.core.proof import ledger as _ledger
-        from codeframe.core.proof.models import ReqStatus
-        from codeframe.core.proof.runner import _requirements_for_run
+        # The runner now reports WHY (#1138). Before that, this block inferred
+        # the cause from the mode and the ledger, and four consecutive review
+        # rounds on #1137 caught it asserting a reason that was wrong — each
+        # time about a different one of the six causes. It ended up listing
+        # candidates instead, which was honest but useless. The runner is the
+        # only thing that knows, so ask it.
+        reason = diagnostics.reason
 
-        try:
-            all_reqs = _ledger.list_requirements(workspace)
-            # Same selector the runner uses, so this cannot drift from it.
-            runnable = _requirements_for_run(workspace, full=full)
-        except Exception:
-            # A ledger we cannot read is not evidence of an empty one; fall
-            # through to the unverified case rather than inventing a reason.
-            all_reqs, runnable = [], []
-
-        if runnable:
-            # Four review rounds went by asserting a specific reason here and
-            # being wrong each time. The CLI genuinely cannot tell them apart:
-            # run_proof returns only results, and discards the scope_skipped
-            # list it computes internally (runner.py:334/435). With a non-empty
-            # runnable set an empty result can mean the scope filter excluded
-            # everything, --gate excluded every obligation, enabled_gates config
-            # did, or a requirement simply has none.
+        if reason is EmptyReason.NO_REQUIREMENTS:
+            # An empty ledger is not a pass (#1118). Exiting 0 here is what let
+            # the quickstart's PROVE step read as "PROOF9 gates passed" when
+            # nothing had been checked — and every new workspace is in exactly
+            # this state.
             #
-            # So state what is known and list the candidates, rather than
-            # asserting one and sending the user somewhere useless. #1138 tracks
-            # having the runner report the reason so this can be precise.
+            # Exit 2 rather than 1: this is not a failure either, and a script
+            # needs to tell "the gate failed" from "the gate had nothing to
+            # check". CI treats any non-zero as a stop, which is the point.
+            console.print("[yellow]Nothing was verified.[/yellow]")
             console.print(
-                f"[yellow]Nothing was verified.[/yellow] "
-                f"{len(runnable)} requirement(s) were eligible for this run, "
-                f"but no obligations ran."
+                "There are no proof obligations in this workspace, so this run "
+                "checked nothing — it is not a pass."
             )
-            reasons = []
-            if not full:
-                # --full provably ignores scope (runner.py:339), so listing it
-                # there would put an impossible cause in the candidate list.
-                reasons.append("none of them cover the changed files")
-            if gate_filter is not None:
-                reasons.append(f"--gate {gate_filter.value} excluded their obligations")
-            reasons.append("their obligations are disabled in proof_config.json")
-            reasons.append("they have no obligations defined")
-            console.print("Possible reasons: " + "; ".join(reasons) + ".")
-            if not full:
-                console.print(
-                    "Try [bold]cf proof run --full[/bold] to ignore scope, or "
-                    "[bold]cf proof status[/bold] for the ledger."
-                )
-            else:
-                console.print("See [bold]cf proof status[/bold] for the ledger.")
-            return
+            console.print(
+                "\nCapture your first requirement with:\n"
+                "  [bold]cf proof capture[/bold]"
+            )
+            if allow_empty:
+                console.print("\n[dim]--allow-empty: exiting 0 anyway.[/dim]")
+                return
+            raise typer.Exit(2)
 
-        if all_reqs:
-            # This one IS knowable: the runnable set is empty while the ledger
-            # is not, so every requirement was excluded by its status. WAIVED is
-            # excluded from both modes; SATISFIED only from a scoped run.
-            satisfied = sum(1 for r in all_reqs if r.status == ReqStatus.SATISFIED)
-            waived = sum(1 for r in all_reqs if r.status == ReqStatus.WAIVED)
-            detail = ", ".join(
-                part
-                for part in (
-                    f"{satisfied} satisfied" if satisfied else "",
-                    f"{waived} waived" if waived else "",
-                )
-                if part
-            )
-            console.print(
-                f"[yellow]Nothing was verified.[/yellow] "
-                f"{len(all_reqs)} requirement(s) exist, but none are runnable"
-                + (f" ({detail})." if detail else ".")
-            )
-            console.print(
+        console.print(
+            f"[yellow]Nothing was verified.[/yellow] {diagnostics.describe()}."
+        )
+
+        hints = {
+            EmptyReason.EXCLUDED_BY_STATUS: (
                 "A waiver is an accepted risk that no run re-checks; "
-                "[bold]cf proof run --full[/bold] also re-verifies satisfied "
-                "ones. See [bold]cf proof status[/bold] for the ledger."
-            )
-            return
-
-        # An empty ledger is not a pass (#1118). Exiting 0 here is what let the
-        # quickstart's PROVE step read as "PROOF9 gates passed" when nothing had
-        # been checked — and every new workspace is in exactly this state.
-        #
-        # Exit 2 rather than 1: this is not a failure either, and a script needs
-        # to tell "the gate failed" from "the gate had nothing to check". CI
-        # treats any non-zero as a stop, which is the point.
-        console.print("[yellow]Nothing was verified.[/yellow]")
-        console.print(
-            "There are no proof obligations in this workspace, so this run "
-            "checked nothing — it is not a pass."
-        )
-        console.print(
-            "\nCapture your first requirement with:\n"
-            "  [bold]cf proof capture[/bold]"
-        )
-        if allow_empty:
-            console.print("\n[dim]--allow-empty: exiting 0 anyway.[/dim]")
-            return
-        raise typer.Exit(2)
+                "[bold]cf proof run --full[/bold] also re-verifies satisfied ones."
+            ),
+            EmptyReason.EXCLUDED_BY_SCOPE: (
+                "[bold]cf proof run --full[/bold] ignores scope entirely."
+            ),
+            EmptyReason.EXCLUDED_BY_GATE_FILTER: (
+                "Drop [bold]--gate[/bold] to run every obligation."
+            ),
+            EmptyReason.EXCLUDED_BY_CONFIG: (
+                "Check [bold]enabled_gates[/bold] in "
+                f"[bold].codeframe/{PROOF_CONFIG_FILENAME}[/bold]."
+            ),
+            EmptyReason.EXCLUDED_BY_FILTER_COMBINATION: (
+                "Drop [bold]--gate[/bold], or add that gate to "
+                f"[bold]enabled_gates[/bold] in [bold].codeframe/{PROOF_CONFIG_FILENAME}"
+                "[/bold] — each filter alone leaves work to do, but they do not "
+                "overlap."
+            ),
+            EmptyReason.NO_OBLIGATIONS: (
+                "Add obligations to those requirements, or they can never be "
+                "satisfied."
+            ),
+        }
+        if reason in hints:
+            console.print(hints[reason])
+        console.print("See [bold]cf proof status[/bold] for the ledger.")
+        return
 
     # Display results
     table = Table(title="Proof Results")

--- a/codeframe/core/proof/runner.py
+++ b/codeframe/core/proof/runner.py
@@ -8,7 +8,9 @@ and attaches evidence artifacts.
 import json
 import logging
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Optional, Sequence
 
 from codeframe.core.proof import ledger
@@ -25,6 +27,141 @@ from codeframe.core.proof.scope import get_changed_scope, intersects
 from codeframe.core.workspace import Workspace
 
 logger = logging.getLogger(__name__)
+
+
+class EmptyReason(str, Enum):
+    """Why a proof run produced no results (#1138).
+
+    ``run_proof`` used to return only ``dict[req_id, [(gate, outcome)]]``, and
+    an empty dict has six different causes. The reasons were computed inside the
+    runner and then thrown away, so ``cf proof run`` had to guess — four
+    consecutive review rounds on #1137 caught a guess that was confidently
+    wrong, each time about a different one of these.
+    """
+
+    #: Results were produced; there is nothing to explain.
+    NOT_EMPTY = "not_empty"
+    #: The ledger holds no requirements at all.
+    NO_REQUIREMENTS = "no_requirements"
+    #: Requirements exist but none were eligible: WAIVED always, and SATISFIED
+    #: unless the run is --full.
+    EXCLUDED_BY_STATUS = "excluded_by_status"
+    #: Every eligible requirement was out of scope for the current changes.
+    EXCLUDED_BY_SCOPE = "excluded_by_scope"
+    #: --gate excluded every obligation of every in-scope requirement.
+    EXCLUDED_BY_GATE_FILTER = "excluded_by_gate_filter"
+    #: proof_config.json's enabled_gates did the same.
+    EXCLUDED_BY_CONFIG = "excluded_by_config"
+    #: Neither filter excluded everything on its own, but their intersection is
+    #: empty — e.g. obligations {unit, sec} with --gate unit and
+    #: enabled_gates ["sec"]. Blaming either alone would send the user to fix
+    #: something that is not, by itself, the problem.
+    EXCLUDED_BY_FILTER_COMBINATION = "excluded_by_filter_combination"
+    #: In-scope requirements exist but define no obligations to run.
+    NO_OBLIGATIONS = "no_obligations"
+    #: More than one of the above applies, so naming one would be a lie.
+    MIXED = "mixed"
+
+
+@dataclass
+class ProofRunDiagnostics:
+    """What the runner decided, alongside what it produced.
+
+    Counts rather than a single verdict: with three requirements dropped for
+    three different reasons, any single reason is wrong. ``reason`` collapses
+    them only when the collapse is honest.
+    """
+
+    total_requirements: int = 0
+    considered: int = 0
+    evaluated: int = 0
+    scope_skipped: list[str] = field(default_factory=list)
+    gate_filtered: list[str] = field(default_factory=list)
+    config_filtered: list[str] = field(default_factory=list)
+    filter_combination: list[str] = field(default_factory=list)
+    no_obligations: list[str] = field(default_factory=list)
+
+    @property
+    def reason(self) -> EmptyReason:
+        if self.evaluated:
+            return EmptyReason.NOT_EMPTY
+        if not self.total_requirements:
+            return EmptyReason.NO_REQUIREMENTS
+        if not self.considered:
+            return EmptyReason.EXCLUDED_BY_STATUS
+
+        buckets = {
+            EmptyReason.EXCLUDED_BY_SCOPE: self.scope_skipped,
+            EmptyReason.NO_OBLIGATIONS: self.no_obligations,
+            EmptyReason.EXCLUDED_BY_GATE_FILTER: self.gate_filtered,
+            EmptyReason.EXCLUDED_BY_CONFIG: self.config_filtered,
+            EmptyReason.EXCLUDED_BY_FILTER_COMBINATION: self.filter_combination,
+        }
+        non_empty = [name for name, ids in buckets.items() if ids]
+        if len(non_empty) == 1:
+            return non_empty[0]
+        if non_empty:
+            return EmptyReason.MIXED
+        # Considered requirements, none evaluated, and no bucket claims them —
+        # a path this code does not know about. Say so rather than picking one.
+        return EmptyReason.MIXED
+
+    def describe(self) -> str:
+        """One sentence a CLI or API can show verbatim."""
+        return _REASON_TEXT[self.reason](self)
+
+
+def _describe_mixed(d: "ProofRunDiagnostics") -> str:
+    parts = []
+    if d.scope_skipped:
+        parts.append(f"{len(d.scope_skipped)} out of scope for the current changes")
+    if d.no_obligations:
+        parts.append(f"{len(d.no_obligations)} with no obligations defined")
+    if d.gate_filtered:
+        parts.append(f"{len(d.gate_filtered)} excluded by the --gate filter")
+    if d.config_filtered:
+        parts.append(f"{len(d.config_filtered)} excluded by enabled_gates in proof_config.json")
+    if d.filter_combination:
+        parts.append(
+            f"{len(d.filter_combination)} excluded by --gate and enabled_gates together"
+        )
+    if not parts:
+        return (
+            f"{d.considered} requirement(s) were considered and none produced a "
+            "result, for a reason this runner does not classify"
+        )
+    return "nothing ran: " + ", ".join(parts)
+
+
+_REASON_TEXT = {
+    EmptyReason.NOT_EMPTY: lambda d: f"{d.evaluated} requirement(s) verified",
+    EmptyReason.NO_REQUIREMENTS: lambda d: "the requirement ledger is empty",
+    EmptyReason.EXCLUDED_BY_STATUS: lambda d: (
+        f"all {d.total_requirements} requirement(s) are waived, or satisfied on a "
+        "scoped run — re-run with --full to include satisfied ones"
+    ),
+    EmptyReason.EXCLUDED_BY_SCOPE: lambda d: (
+        f"all {len(d.scope_skipped)} open requirement(s) are out of scope for the "
+        "current changes — re-run with --full to include them"
+    ),
+    EmptyReason.EXCLUDED_BY_GATE_FILTER: lambda d: (
+        f"the --gate filter excluded every obligation of all "
+        f"{len(d.gate_filtered)} in-scope requirement(s)"
+    ),
+    EmptyReason.EXCLUDED_BY_CONFIG: lambda d: (
+        f"enabled_gates in proof_config.json excluded every obligation of all "
+        f"{len(d.config_filtered)} in-scope requirement(s)"
+    ),
+    EmptyReason.EXCLUDED_BY_FILTER_COMBINATION: lambda d: (
+        f"--gate and enabled_gates in proof_config.json do not overlap, so no "
+        f"obligation of the {len(d.filter_combination)} in-scope requirement(s) "
+        "could run — each filter alone would have left something to do"
+    ),
+    EmptyReason.NO_OBLIGATIONS: lambda d: (
+        f"all {len(d.no_obligations)} in-scope requirement(s) define no obligations"
+    ),
+    EmptyReason.MIXED: _describe_mixed,
+}
 
 
 def _new_run_id() -> str:
@@ -273,6 +410,24 @@ def run_proof(
 ) -> dict[str, list[tuple[Gate, GateOutcome]]]:
     """Execute proof obligations and collect evidence.
 
+    The results only. Callers that need to explain an EMPTY result — every
+    caller that shows a human anything — want :func:`run_proof_with_diagnostics`
+    instead (#1138). Kept because ~60 call sites do not care.
+    """
+    return run_proof_with_diagnostics(
+        workspace, full=full, gate_filter=gate_filter, run_id=run_id
+    )[0]
+
+
+def run_proof_with_diagnostics(
+    workspace: Workspace,
+    *,
+    full: bool = False,
+    gate_filter: Optional[Gate] = None,
+    run_id: Optional[str] = None,
+) -> tuple[dict[str, list[tuple[Gate, GateOutcome]]], ProofRunDiagnostics]:
+    """Execute proof obligations and collect evidence, with the reasoning.
+
     Args:
         workspace: Target workspace
         full: If True, run ALL obligations regardless of scope
@@ -280,7 +435,8 @@ def run_proof(
         run_id: Unique run identifier (auto-generated if not provided)
 
     Returns:
-        Dict mapping req_id → list of (Gate, GateOutcome) tuples
+        ``(results, diagnostics)`` — results maps req_id → [(Gate, GateOutcome)],
+        and diagnostics explains anything the results do not (#1138).
     """
     if not run_id:
         run_id = _new_run_id()
@@ -297,6 +453,12 @@ def run_proof(
 
     # Get all open requirements
     reqs = _requirements_for_run(workspace, full=full)
+    # The ledger total is what separates "no requirements exist" from "none were
+    # eligible" — _requirements_for_run returns [] for both.
+    diagnostics = ProofRunDiagnostics(
+        total_requirements=len(ledger.list_requirements(workspace)),
+        considered=len(reqs),
+    )
     if not reqs:
         completed_at = datetime.now(timezone.utc)
         ledger.save_run(
@@ -311,7 +473,7 @@ def run_proof(
                 duration_ms=int((completed_at - started_at).total_seconds() * 1000),
             ),
         )
-        return {}
+        return {}, diagnostics
 
     # Warn loudly when config disables every gate — a "vacuous pass" is
     # easy to overlook: nothing runs, overall_passed=True, no evidence.
@@ -340,6 +502,9 @@ def run_proof(
             if not intersects(req.scope, changed_scope):
                 scope_skipped.append(req.id)
                 continue
+
+        if not req.obligations:
+            diagnostics.no_obligations.append(req.id)
 
         req_results: list[tuple[Gate, GateOutcome]] = []
 
@@ -376,6 +541,29 @@ def run_proof(
             # Update obligation status
             obl.status = _OUTCOME_TO_OBLIGATION_STATUS[outcome]
             req_results.append((obl.gate, outcome))
+
+        if not req_results and req.obligations:
+            # Every obligation was filtered out. Attribute it to the filter that
+            # did it ALONE, so the hint points somewhere that helps.
+            survives_gate = [
+                o for o in req.obligations
+                if gate_filter is None or o.gate == gate_filter
+            ]
+            survives_config = [
+                o for o in req.obligations
+                if enabled_gates is None or o.gate in enabled_gates
+            ]
+            if not survives_gate:
+                # --gate is the user's explicit flag, so it is named first when
+                # it is sufficient on its own.
+                diagnostics.gate_filtered.append(req.id)
+            elif not survives_config:
+                diagnostics.config_filtered.append(req.id)
+            else:
+                # Each filter leaves something; their intersection does not.
+                # Neither is "the" cause, and blaming one sends the user to fix
+                # something that is not by itself the problem (review finding).
+                diagnostics.filter_combination.append(req.id)
 
         if req_results:
             results[req.id] = req_results
@@ -434,4 +622,10 @@ def run_proof(
 
     _report_scope_skipped(run_id, scope_skipped)
 
-    return results
+    diagnostics.scope_skipped = scope_skipped
+    diagnostics.evaluated = len(results)
+
+    if not results:
+        logger.info("Proof run %s produced no results: %s", run_id, diagnostics.describe())
+
+    return results, diagnostics

--- a/tests/cli/test_proof_empty_ledger_1118.py
+++ b/tests/cli/test_proof_empty_ledger_1118.py
@@ -128,14 +128,26 @@ class TestAScopeFilteredRunIsNotAnEmptyLedger:
         assert result.exit_code == 0, result.output
 
     def _run_with_nothing_in_scope(self, workspace_dir: Path):
-        """`run_proof` returns {} because the scope filter skipped everything.
+        """The runner returns ({}, scope-skipped) — everything was out of scope.
 
         Patched rather than staged through git: with no working-tree changes the
         detector fails closed and runs every requirement, so the real filter
         cannot produce this state here. The ambiguity under test is in how the
         CLI reports an empty result, not in scope detection.
+
+        Patches `run_proof_with_diagnostics`, which is what the CLI calls since
+        #1138. Patching the old `run_proof` here did not fail loudly — the real
+        run just went ahead and these tests started asserting on a live result.
         """
-        with patch("codeframe.core.proof.runner.run_proof", return_value={}):
+        from codeframe.core.proof.runner import ProofRunDiagnostics
+
+        diagnostics = ProofRunDiagnostics(
+            total_requirements=1, considered=1, scope_skipped=["REQ-0001"]
+        )
+        with patch(
+            "codeframe.core.proof.runner.run_proof_with_diagnostics",
+            return_value=({}, diagnostics),
+        ):
             return runner.invoke(app, ["proof", "run", "-w", str(workspace_dir)])
 
     def test_it_does_not_claim_the_ledger_is_empty(self, workspace_dir):
@@ -171,24 +183,34 @@ class TestAScopeFilteredRunIsNotAnEmptyLedger:
         assert result.exit_code == 2
 
     def test_full_mode_does_not_offer_full_as_the_remedy(self, workspace_dir):
-        """--full never consults scope, so re-running it changes nothing."""
+        """--full never consults scope, so re-running it changes nothing.
+
+        No patch needed since #1138: `--gate perf` genuinely excludes every
+        obligation of a captured requirement, so this is a real empty run whose
+        real reason is the gate filter.
+        """
         self._capture_req(workspace_dir, "src/auth/login.py")
-        with patch("codeframe.core.proof.runner.run_proof", return_value={}):
-            result = runner.invoke(
-                app, ["proof", "run", "-w", str(workspace_dir), "--full"]
-            )
+
+        result = runner.invoke(
+            app, ["proof", "run", "-w", str(workspace_dir), "--full", "--gate", "perf"]
+        )
+
         assert result.exit_code == 0, result.output
         assert "--full" not in _flat(result.output)
 
 
-class TestTheReasonIsDerivedNotGuessed:
-    """Third review finding, and the reason the first two kept recurring.
+class TestTheReasonIsNamedNotGuessed:
+    """#1138 finished what #1137's four review rounds kept failing at.
 
-    `run_proof` returning {} has three causes. Inferring which one from the
-    --full flag was wrong twice: it short-circuits when the runnable set is
-    empty, *before* scope detection, so an all-SATISFIED (scoped) or all-WAIVED
-    ledger never had its scope evaluated at all. The reason now comes from the
-    runner's own `_requirements_for_run`, so the CLI cannot drift from it.
+    `run_proof` returning {} has six causes, and the CLI could not tell them
+    apart because the runner computed the reasons and threw them away. It ended
+    up listing candidates — honest, and useless. `run_proof_with_diagnostics`
+    now returns the reason, so every case below asserts the ACTUAL cause is
+    named and the wrong ones are absent.
+
+    Almost none of these need a patch any more: a waived ledger, a gate filter
+    that matches nothing, and a requirement with no obligations are all states
+    the CLI can be driven into for real.
     """
 
     def _capture(self, workspace_dir: Path) -> None:
@@ -227,68 +249,67 @@ class TestTheReasonIsDerivedNotGuessed:
 
         result = runner.invoke(app, ["proof", "run", "-w", str(workspace_dir)])
 
+        flat = _flat(result.output)
         assert result.exit_code == 0, result.output
-        assert "changed files" not in _flat(result.output), (
+        assert "changed files" not in flat and "out of scope" not in flat, (
             "scope was never evaluated — the requirement was excluded by status"
         )
-        assert "none are runnable" in _flat(result.output)
-        assert "waived" in result.output
+        assert "waived" in flat
 
-    def test_it_offers_scope_as_a_candidate_not_a_verdict(self, workspace_dir):
-        """With an eligible requirement the cause is genuinely ambiguous.
-
-        Scope, --gate, disabled gates in proof_config.json, or a requirement
-        with no obligations all produce {} here, and run_proof does not report
-        which. Asserting one was wrong four review rounds running.
-        """
+    def test_the_gate_filter_is_named_as_the_reason_not_a_candidate(self, workspace_dir):
+        """A real run: `--gate perf` excludes every obligation capture created."""
         self._capture(workspace_dir)
 
-        with patch("codeframe.core.proof.runner.run_proof", return_value={}):
+        result = runner.invoke(
+            app, ["proof", "run", "-w", str(workspace_dir), "--gate", "perf"]
+        )
+
+        flat = _flat(result.output)
+        assert result.exit_code == 0, result.output
+        assert "--gate" in flat
+        assert "Possible reasons" not in flat, "the cause is known now, not guessed"
+        assert "out of scope" not in flat, "scope was not what excluded them"
+
+    def test_scope_is_named_when_scope_is_the_reason(self, workspace_dir):
+        """Still patched: with no working-tree changes the detector fails closed
+        and runs everything, so the real filter cannot produce this state."""
+        from codeframe.core.proof.runner import ProofRunDiagnostics
+
+        self._capture(workspace_dir)
+        diagnostics = ProofRunDiagnostics(
+            total_requirements=1, considered=1, scope_skipped=[self._req_id(workspace_dir)]
+        )
+
+        with patch(
+            "codeframe.core.proof.runner.run_proof_with_diagnostics",
+            return_value=({}, diagnostics),
+        ):
             result = runner.invoke(app, ["proof", "run", "-w", str(workspace_dir)])
 
         flat = _flat(result.output)
         assert result.exit_code == 0, result.output
-        assert "Possible reasons" in flat, "it must not assert a single cause"
-        assert "changed files" in flat, "scope is still one of the candidates"
-
-    def test_the_gate_filter_is_named_when_one_was_used(self, workspace_dir):
-        """`--gate unit` excluding every obligation is one of the causes."""
-        self._capture(workspace_dir)
-
-        with patch("codeframe.core.proof.runner.run_proof", return_value={}):
-            result = runner.invoke(
-                app, ["proof", "run", "-w", str(workspace_dir), "--gate", "unit"]
-            )
-
-        flat = _flat(result.output)
-        assert result.exit_code == 0, result.output
-        assert "--gate unit" in flat
+        assert "out of scope" in flat
+        assert "--full" in flat, "point at the way to check them anyway"
+        assert "--gate" not in flat, "no gate filter was used; it cannot be the cause"
 
     def test_an_empty_ledger_is_still_the_vacuous_pass_case(self, workspace_dir):
         result = runner.invoke(app, ["proof", "run", "-w", str(workspace_dir)])
         assert result.exit_code == 2
         assert "cf proof capture" in result.output
 
-    def test_full_mode_omits_scope_from_the_candidates(self, workspace_dir):
-        """--full provably ignores scope, so listing it is an impossible cause."""
+    def test_no_wrong_remedy_is_offered_when_no_gate_was_passed(self, workspace_dir):
+        """Only the actual cause is named, so --gate must not appear."""
+        from codeframe.core.proof.runner import ProofRunDiagnostics
+
         self._capture(workspace_dir)
+        diagnostics = ProofRunDiagnostics(
+            total_requirements=1, considered=1, scope_skipped=["REQ-0001"]
+        )
 
-        with patch("codeframe.core.proof.runner.run_proof", return_value={}):
-            result = runner.invoke(
-                app,
-                ["proof", "run", "-w", str(workspace_dir), "--full", "--gate", "unit"],
-            )
-
-        flat = _flat(result.output)
-        assert result.exit_code == 0, result.output
-        assert "changed files" not in flat, "scope cannot be the reason under --full"
-        assert "--gate unit" in flat, "the real candidate is still named"
-
-    def test_the_gate_candidate_is_omitted_when_no_gate_was_passed(self, workspace_dir):
-        """Only list causes that could actually apply to this invocation."""
-        self._capture(workspace_dir)
-
-        with patch("codeframe.core.proof.runner.run_proof", return_value={}):
+        with patch(
+            "codeframe.core.proof.runner.run_proof_with_diagnostics",
+            return_value=({}, diagnostics),
+        ):
             result = runner.invoke(app, ["proof", "run", "-w", str(workspace_dir)])
 
         assert "--gate" not in _flat(result.output)

--- a/tests/core/test_proof_run_diagnostics_1138.py
+++ b/tests/core/test_proof_run_diagnostics_1138.py
@@ -1,0 +1,289 @@
+"""#1138 — run_proof reports why it produced no results.
+
+`run_proof` returned `dict[req_id, [(gate, outcome)]]` and nothing else. An
+empty dict has six causes, all computed inside the runner and then discarded —
+`scope_skipped` got as far as a log line. So `cf proof run` had to guess, and
+four consecutive review rounds on #1137 caught it guessing wrong, each time
+about a different cause.
+
+One test per reason, as the issue asks. Where a state can be produced for real
+it is; only the scope filter is patched, because with no working-tree changes
+the detector fails closed and evaluates everything, so a genuinely empty scope
+cannot be staged here.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from codeframe.core.proof import ledger
+from codeframe.core.proof.capture import capture_requirement
+from codeframe.core.proof.models import (
+    PROOF_CONFIG_FILENAME,
+    Gate,
+    Severity,
+    Source,
+    Waiver,
+)
+from codeframe.core.proof.runner import (
+    EmptyReason,
+    ProofRunDiagnostics,
+    run_proof,
+    run_proof_with_diagnostics,
+)
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    return create_or_load_workspace(tmp_path)
+
+
+def _capture(workspace, where: str = "src/auth/login.py"):
+    req, _ = capture_requirement(
+        workspace,
+        title="Login must not 500",
+        description="Expected 200, got 500 on POST /login",
+        where=where,
+        severity=Severity.HIGH,
+        source=Source.PRODUCTION,
+    )
+    return req
+
+
+class TestEachReasonIsReported:
+    def test_an_empty_ledger(self, workspace):
+        results, diagnostics = run_proof_with_diagnostics(workspace)
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.NO_REQUIREMENTS
+        assert diagnostics.total_requirements == 0
+
+    def test_excluded_by_status(self, workspace):
+        """WAIVED is excluded from every run — an accepted risk is not re-checked."""
+        req = _capture(workspace)
+        ledger.waive_requirement(
+            workspace, req.id, Waiver(reason="accepted risk", approved_by="test")
+        )
+
+        results, diagnostics = run_proof_with_diagnostics(workspace)
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_STATUS
+        # The distinguishing pair: requirements exist, none were eligible.
+        assert diagnostics.total_requirements == 1
+        assert diagnostics.considered == 0
+
+    def test_excluded_by_scope(self, workspace, monkeypatch):
+        req = _capture(workspace)
+        # An empty changed-scope that is not None: detection succeeded and found
+        # nothing relevant. None means "failed to detect" and runs everything.
+        monkeypatch.setattr(
+            "codeframe.core.proof.runner.intersects", lambda scope, changed: False
+        )
+        monkeypatch.setattr(
+            "codeframe.core.proof.runner.get_changed_scope", lambda ws: object()
+        )
+
+        results, diagnostics = run_proof_with_diagnostics(workspace)
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_SCOPE
+        assert diagnostics.scope_skipped == [req.id]
+
+    def test_excluded_by_gate_filter(self, workspace):
+        """`--gate perf` against a requirement whose obligations are elsewhere."""
+        req = _capture(workspace)
+        assert Gate.PERF not in {o.gate for o in req.obligations}, (
+            "pick a gate the captured requirement genuinely lacks"
+        )
+
+        results, diagnostics = run_proof_with_diagnostics(
+            workspace, full=True, gate_filter=Gate.PERF
+        )
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_GATE_FILTER
+        assert diagnostics.gate_filtered == [req.id]
+
+    def test_excluded_by_config(self, workspace):
+        """enabled_gates in proof_config.json, not the CLI flag."""
+        req = _capture(workspace)
+        config = workspace.state_dir / PROOF_CONFIG_FILENAME
+        config.write_text('{"enabled_gates": ["perf"], "strictness": "strict"}')
+
+        results, diagnostics = run_proof_with_diagnostics(workspace, full=True)
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_CONFIG
+        assert diagnostics.config_filtered == [req.id]
+
+    def test_no_obligations_defined(self, workspace):
+        req = _capture(workspace)
+        req.obligations = []
+        ledger.save_requirement(workspace, req)
+
+        results, diagnostics = run_proof_with_diagnostics(workspace, full=True)
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.NO_OBLIGATIONS
+        assert diagnostics.no_obligations == [req.id]
+
+    def test_a_run_that_produced_results_has_nothing_to_explain(self, workspace):
+        _capture(workspace)
+
+        results, diagnostics = run_proof_with_diagnostics(workspace, full=True)
+
+        assert results, "the captured requirement should have run"
+        assert diagnostics.reason is EmptyReason.NOT_EMPTY
+        assert diagnostics.evaluated == len(results)
+
+
+class TestTheGateFilterOutranksTheConfig:
+    """Both can exclude the same obligation. --gate is the user's explicit
+    flag, so it is the one to name — telling someone to edit a config file when
+    their own flag caused it sends them to the wrong place."""
+
+    def test_the_explicit_flag_is_blamed(self, workspace):
+        req = _capture(workspace)
+        (workspace.state_dir / PROOF_CONFIG_FILENAME).write_text(
+            '{"enabled_gates": ["perf"], "strictness": "strict"}'
+        )
+
+        _, diagnostics = run_proof_with_diagnostics(
+            workspace, full=True, gate_filter=Gate.PERF
+        )
+
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_GATE_FILTER
+        assert diagnostics.gate_filtered == [req.id]
+        assert diagnostics.config_filtered == []
+
+
+class TestTheTwoFiltersCanExcludeJointly:
+    """Review finding on the first version.
+
+    With obligations {unit, sec}, `--gate unit` and `enabled_gates: ["sec"]`,
+    NEITHER filter excludes everything on its own — so both `all(...)` checks
+    were false and the requirement fell into no bucket at all, surfacing as an
+    unclassified MIXED with no hint. Each filter is now tested for sufficiency
+    separately, and the joint case gets its own reason.
+    """
+
+    def _obligation_gates(self, req):
+        return {o.gate for o in req.obligations}
+
+    def test_the_joint_case_is_classified(self, workspace):
+        req = _capture(workspace)
+        gates = self._obligation_gates(req)
+        assert len(gates) >= 2, "this case needs a requirement with two gates"
+        first, second = sorted(gates, key=lambda g: g.value)[:2]
+        (workspace.state_dir / PROOF_CONFIG_FILENAME).write_text(
+            '{"enabled_gates": ["%s"], "strictness": "strict"}' % second.value
+        )
+
+        results, diagnostics = run_proof_with_diagnostics(
+            workspace, full=True, gate_filter=first
+        )
+
+        assert results == {}
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_FILTER_COMBINATION
+        assert diagnostics.filter_combination == [req.id]
+        # Neither alone is the cause, so neither may be blamed alone.
+        assert diagnostics.gate_filtered == []
+        assert diagnostics.config_filtered == []
+
+    def test_it_says_both_filters_are_involved(self, workspace):
+        diagnostics = ProofRunDiagnostics(
+            total_requirements=1, considered=1, filter_combination=["REQ-0001"]
+        )
+
+        described = diagnostics.describe()
+
+        assert "--gate" in described
+        assert "enabled_gates" in described
+
+    def test_a_filter_that_is_sufficient_alone_is_still_blamed_alone(self, workspace):
+        """The joint bucket must not swallow the simple cases."""
+        req = _capture(workspace)
+        assert Gate.PERF not in self._obligation_gates(req)
+
+        _, diagnostics = run_proof_with_diagnostics(
+            workspace, full=True, gate_filter=Gate.PERF
+        )
+
+        assert diagnostics.reason is EmptyReason.EXCLUDED_BY_GATE_FILTER
+        assert diagnostics.filter_combination == []
+
+
+class TestMixedCausesAreNotCollapsedIntoALie:
+    """Two requirements dropped for two reasons: naming either one is wrong."""
+
+    def test_it_reports_mixed(self, workspace):
+        a = _capture(workspace, where="src/auth/login.py")
+        b = _capture(workspace, where="src/billing/charge.py")
+        b.obligations = []
+        ledger.save_requirement(workspace, b)
+
+        _, diagnostics = run_proof_with_diagnostics(
+            workspace, full=True, gate_filter=Gate.PERF
+        )
+
+        assert diagnostics.reason is EmptyReason.MIXED
+        assert diagnostics.gate_filtered == [a.id]
+        assert diagnostics.no_obligations == [b.id]
+
+    def test_the_description_names_both(self, workspace):
+        diagnostics = ProofRunDiagnostics(
+            total_requirements=2,
+            considered=2,
+            scope_skipped=["REQ-0001"],
+            no_obligations=["REQ-0002"],
+        )
+
+        described = diagnostics.describe()
+
+        assert "out of scope" in described
+        assert "no obligations" in described
+
+
+class TestTheOldSignatureStillWorks:
+    """~60 call sites take the dict. Widening the return type was the cost the
+    issue flagged; the wrapper is what avoids it."""
+
+    def test_run_proof_returns_only_the_results(self, workspace):
+        _capture(workspace)
+
+        results = run_proof(workspace, full=True)
+
+        assert isinstance(results, dict)
+        assert results
+
+    def test_it_is_the_same_dict_the_detailed_call_returns(self, workspace):
+        _capture(workspace)
+
+        plain = run_proof(workspace, full=True)
+        detailed, _ = run_proof_with_diagnostics(workspace, full=True)
+
+        assert set(plain) == set(detailed)
+
+
+class TestScopeSkippedIsStillLogged:
+    """AC: `_report_scope_skipped` keeps working. #922 added it because a
+    silently dropped requirement let overall_passed=True coexist with a merge
+    gate blocking on that very requirement."""
+
+    def test_the_warning_still_fires(self, workspace, monkeypatch, caplog):
+        _capture(workspace)
+        monkeypatch.setattr(
+            "codeframe.core.proof.runner.intersects", lambda scope, changed: False
+        )
+        monkeypatch.setattr(
+            "codeframe.core.proof.runner.get_changed_scope", lambda ws: object()
+        )
+
+        with caplog.at_level("WARNING"):
+            run_proof_with_diagnostics(workspace)
+
+        assert any("not evaluated" in r.message for r in caplog.records), caplog.text


### PR DESCRIPTION
Closes #1138.

## What

`run_proof` returned only `dict[req_id, [(gate, outcome)]]`, and an empty dict has **six** causes. The runner computed every one of them and threw them away — `scope_skipped` got as far as a log line — so `cf proof run` had to infer the reason from the flags. Four consecutive review rounds on #1137 caught it inferring wrong, each time about a *different* cause. It ended up printing a candidate list: honest, and useless.

`run_proof_with_diagnostics(...) → (results, ProofRunDiagnostics)`. `run_proof` stays as a one-line wrapper, so the ~60 call sites that only want the dict are untouched — the additive approach the issue asks for.

## The reasons

| `EmptyReason` | Cause |
|---|---|
| `NO_REQUIREMENTS` | the ledger is empty |
| `EXCLUDED_BY_STATUS` | all WAIVED, or SATISFIED on a scoped run |
| `EXCLUDED_BY_SCOPE` | none intersect the changed files |
| `EXCLUDED_BY_GATE_FILTER` | `--gate` excluded every obligation |
| `EXCLUDED_BY_CONFIG` | `enabled_gates` did |
| `EXCLUDED_BY_FILTER_COMBINATION` | neither alone did, but their intersection is empty |
| `NO_OBLIGATIONS` | in-scope requirements define none |
| `MIXED` | more than one applies, so naming one would be a lie |

Diagnostics carries the **per-bucket requirement ids**, not just a verdict. With three requirements dropped for three reasons any single reason is wrong, so `reason` collapses only when the collapse is honest, and `describe()` enumerates otherwise.

The CLI names the cause and gives the matching remedy. `_report_scope_skipped` is unchanged (#922's warning still fires) and #1118's empty-ledger exit-2 is unchanged.

## Review finding, worth spelling out

`codex review` caught a real gap in the first version:

> With obligations `{unit, sec}`, `--gate unit` and `enabled_gates: ["sec"]`, no obligation runs but neither `all(...)` check is true. The requirement is left out of every diagnostics bucket.

Correct. It surfaced as an unclassified `MIXED` with **no hint at all** — the exact failure this PR exists to remove, in a case I had not thought of. Each filter is now tested for sufficiency *separately*, and the joint case gets its own reason and its own remedy ("drop `--gate`, or add that gate to `enabled_gates` — each filter alone leaves work to do, but they do not overlap"). Three tests cover it, including one asserting the joint bucket does **not** swallow the simple single-filter cases.

## A test file that had stopped testing

`tests/cli/test_proof_empty_ledger_1118.py` patched `runner.run_proof`, which the CLI no longer calls. The patch quietly stopped applying and those tests began asserting against a *live* run. It failed loudly here, but it is the same class as #1077 — a guard patching a function nothing calls.

Most of them are now driven for real rather than patched: a waived ledger, a `--gate` that matches no obligation, and a requirement with no obligations are all reachable states. Only the scope filter still needs a patch, because with no working-tree changes the detector fails closed and evaluates everything.

## Testing

- `tests/core/test_proof_run_diagnostics_1138.py` — **one test per reason**, as the AC asks, plus the joint-filter case, the mixed case, and the back-compat wrapper
- `tests/cli/test_proof_empty_ledger_1118.py` — rewritten for the new contract; 34 tests pass across both files
- Full backend suite + `ruff` reported in a comment

## Known limitation

The v2 proof router still returns results only. It does not currently explain an empty run to the web UI either, but that is a separate surface with its own response model and no acceptance criterion here — the issue's ask is `run_proof` and `cf proof run`. The diagnostics object is what a follow-up would serialise.