### PR TITLE
fix(ci): fail production deploys loudly when the environment is unconfigured (#1143)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -353,9 +353,76 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     environment:
       name: production
-      url: https://codeframe.example.com
+      # No url: production has never been deployed and has no host. A
+      # placeholder (codeframe.example.com) shipped here for a long time,
+      # which reads on the GitHub deployments page as a real target (#1143).
 
     steps:
+      # The `production` environment holds ZERO secrets while this job
+      # references two dozen, and GitHub resolves a missing environment secret
+      # to an empty string with no warning. Today that surfaces as an SSH auth
+      # failure five steps in — a symptom that says nothing about the cause.
+      # Worse, populating only the SSH secrets would let the job proceed and
+      # write a remote .env with AUTH_SECRET= — an empty JWT signing key.
+      #
+      # So: fail first, name every missing secret, and say what to do. This is
+      # option 3 from #1143 (guard, don't delete): staging is the only deploy
+      # target today, but launch is the direction of travel, so removing the
+      # job would just have to be rewritten later.
+      #
+      # Values are read from env, never interpolated into the script — an
+      # expression inside a run block executes on the runner (see the release
+      # job below for the same rule).
+      - name: Preflight — production must actually be configured
+        env:
+          # Required: without any of these the deploy is broken or unsafe.
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          HOST: ${{ secrets.HOST }}
+          USER: ${{ secrets.USER }}
+          PROJECT_PATH: ${{ secrets.PROJECT_PATH }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          API_PORT: ${{ secrets.API_PORT }}
+          API_URL: ${{ secrets.API_URL }}
+          WS_URL: ${{ secrets.WS_URL }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          PM2_BACKEND_NAME: ${{ secrets.PM2_BACKEND_NAME }}
+          PM2_FRONTEND_NAME: ${{ secrets.PM2_FRONTEND_NAME }}
+        run: |
+          set -euo pipefail
+          REQUIRED="SSH_KEY SSH_KNOWN_HOSTS TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET
+                    HOST USER PROJECT_PATH AUTH_SECRET ANTHROPIC_API_KEY
+                    API_PORT API_URL WS_URL CORS_ORIGINS
+                    PM2_BACKEND_NAME PM2_FRONTEND_NAME"
+
+          missing=""
+          for name in $REQUIRED; do
+            # Whitespace-only counts as missing: a secret set to " " is not set.
+            value="${!name:-}"
+            if [ -z "$(printf '%s' "$value" | tr -d '[:space:]')" ]; then
+              missing="${missing} ${name}"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::error::The production environment is not configured."
+            echo ""
+            echo "Missing (or blank) secrets:"
+            for name in $missing; do echo "  - ${name}"; done
+            echo ""
+            echo "GitHub exposes environment secrets only to jobs declaring that"
+            echo "environment, and 'production' currently holds none. Staging is"
+            echo "the only working deploy target. Set them with:"
+            echo "  gh secret set <NAME> --env production"
+            echo "and see the staging environment for the full expected set."
+            exit 1
+          fi
+
+          echo "✅ All required production secrets are present and non-empty."
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/tests/test_workflow_lint_wiring_1122.py
+++ b/tests/test_workflow_lint_wiring_1122.py
@@ -125,15 +125,27 @@ class TestEnvironmentSecretsAreReachable:
     #: the list here means adding one to a job without its environment fails.
     ENVIRONMENT_SECRETS = {"ANTHROPIC_API_KEY": "staging"}
 
-    #: (workflow, job) pairs knowingly referencing a secret their environment
-    #: does not supply. Exempted with a pointer, not silenced: the `production`
-    #: environment holds zero secrets, so deploy-production cannot work at all —
-    #: tracked in #1143, which is an operator decision (populate it, or delete
-    #: the job), not something a code change can fix.
-    KNOWN_GAPS = {("deploy.yml", "deploy-production")}
+    #: (workflow, job) pairs that reference a secret their environment does not
+    #: supply AND guard against it. The bare exemption these replace was a
+    #: promise nobody checked; #1143 turned it into a preflight step, so the
+    #: entry is now conditional on that step still being there.
+    #:
+    #: `production` holds zero secrets while deploy-production references two
+    #: dozen. Populating it is an operator decision; failing loudly first is not.
+    GUARDED = {("deploy.yml", "deploy-production")}
 
     def _jobs(self, path: Path) -> dict:
         return (yaml.safe_load(path.read_text()) or {}).get("jobs", {}) or {}
+
+    @staticmethod
+    def _has_preflight(job: dict) -> bool:
+        """A first step that refuses to continue when a secret is empty."""
+        for step in job.get("steps", []):
+            if "preflight" in step.get("name", "").lower() and "exit 1" in step.get(
+                "run", ""
+            ):
+                return True
+        return False
 
     def test_every_job_using_an_environment_secret_declares_it(self):
         offenders: list[str] = []
@@ -150,7 +162,12 @@ class TestEnvironmentSecretsAreReachable:
                     declared = job.get("environment")
                     if isinstance(declared, dict):
                         declared = declared.get("name")
-                    if (path.name, job_name) in self.KNOWN_GAPS:
+                    if (path.name, job_name) in self.GUARDED:
+                        # Only exempt while the guard actually exists.
+                        assert self._has_preflight(job), (
+                            f"{path.name}:{job_name} is exempt because it "
+                            "preflights its secrets — that step is now gone"
+                        )
                         continue
                     if declared != environment:
                         offenders.append(
@@ -162,6 +179,47 @@ class TestEnvironmentSecretsAreReachable:
             "these jobs will receive an empty secret at runtime:\n  "
             + "\n  ".join(offenders)
         )
+
+    def test_the_production_guard_runs_before_anything_uses_a_secret(self):
+        """#1143: the preflight is only useful as the FIRST step. Behind the SSH
+        setup it reports nothing the SSH failure had not already reported."""
+        job = self._jobs(REPO_ROOT / ".github" / "workflows" / "deploy.yml")[
+            "deploy-production"
+        ]
+        names = [s.get("name", "") for s in job["steps"]]
+
+        assert "preflight" in names[0].lower(), names[:3]
+
+    def test_the_production_guard_covers_every_secret_it_claims_to(self):
+        """The failure mode this replaces was a missing secret resolving to an
+        empty string in silence, so a guard that omits one is worse than none —
+        it says "configured" while a blank AUTH_SECRET goes to the remote .env.
+        """
+        import re
+
+        job = self._jobs(REPO_ROOT / ".github" / "workflows" / "deploy.yml")[
+            "deploy-production"
+        ]
+        preflight = next(
+            s for s in job["steps"] if "preflight" in s.get("name", "").lower()
+        )
+        checked = set(re.findall(r"[A-Z0-9_]{3,}", preflight["run"]))
+
+        # Every secret the step wires into its own env must be in the list it
+        # iterates — otherwise it is declared and never looked at.
+        for name in preflight.get("env", {}):
+            assert name in checked, f"{name} is passed to the guard but never checked"
+
+    def test_the_production_environment_has_no_fictional_url(self):
+        """It pointed at codeframe.example.com, which the GitHub deployments
+        page renders as a live link to a target that does not exist (#1143)."""
+        job = self._jobs(REPO_ROOT / ".github" / "workflows" / "deploy.yml")[
+            "deploy-production"
+        ]
+        environment = job.get("environment")
+
+        url = environment.get("url", "") if isinstance(environment, dict) else ""
+        assert "example.com" not in url, url
 
     def test_the_release_build_job_can_see_the_key_it_requires(self):
         """Specific to the guard: it sets MODEL_GUARD_REQUIRE_LIVE, so an empty


### PR DESCRIPTION
Closes #1143.

## The decision, recorded

The issue asks for one of three: populate `production`, delete the job, or guard it. **Option 3 — guard, do not delete.**

Staging is the only deploy target today, and the operator's framing is explicit: *"Nothing's live, there are no users. We're just trying to get to 'beta stage' on a staging server."* But the repo carries open **Launch:** issues, so deleting `deploy-production` would only have to be rewritten. Populating `production` is an operator decision a code change cannot make. Failing loudly first is not.

## Why the current state is worse than "it doesn't work"

`production` holds **zero** secrets while `deploy-production` references **24**. GitHub resolves a missing environment secret to an empty string with no warning.

- **Today**: it fails five steps in as an SSH auth error — a symptom that says nothing about the cause.
- **The trap**: populate only the SSH secrets and the job *proceeds*, writing a remote `.env` containing `AUTH_SECRET=`. That is the JWT signing key.

## What this adds

A preflight step that runs **first** — before checkout, before SSH — and refuses to continue unless all 15 genuinely-required secrets are present and non-blank (a secret set to `" "` counts as missing):

```
::error::The production environment is not configured.

Missing (or blank) secrets:
  - SSH_KEY
  - AUTH_SECRET
  ...

GitHub exposes environment secrets only to jobs declaring that environment, and
'production' currently holds none. Staging is the only working deploy target.
Set them with:
  gh secret set <NAME> --env production
```

Values are read from env, never interpolated into the run script — the rule #1130 established after finding that an expression inside a `run:` block executes on the runner.

Also drops `environment.url: https://codeframe.example.com`. A placeholder domain renders on the GitHub deployments page as a live link to a target that has never existed — the same class of thing as the stale staging URL fixed in #1145.

## The exemption became conditional

`tests/test_workflow_lint_wiring_1122.py` carried `KNOWN_GAPS = {("deploy.yml", "deploy-production")}` — a bare exemption, which is a promise nobody checks. It is now `GUARDED`, and the exemption itself asserts the preflight step still exists. Delete the guard and the scanner re-fails.

Three new tests:

| Test | What it prevents |
|---|---|
| the guard runs **first** | behind SSH setup it reports nothing the SSH failure had not already reported |
| it covers every secret it wires into its own env | a guard that omits one says "configured" while a blank `AUTH_SECRET` reaches the remote `.env` — worse than no guard |
| no fictional URL | the deployments page linking to a host that does not exist |

**Verified all three bite**: removing `AUTH_SECRET` from the checked list fails the coverage test; renaming the step fails three tests including the original scanner.

## Acceptance criteria

- [x] A decision recorded on whether production deploys are a supported path — not currently; the job is kept and guarded, with the reasoning in the workflow itself
- [x] `AUTH_SECRET` confirmed non-empty before any deploy writes the remote `.env` — twice now: the preflight, plus the job's existing fail-fast at the `.env` step
- [x] The bare exemption in `TestEnvironmentSecretsAreReachable` is gone
- [ ] *If kept: `production` holds every secret and one deploy is verified* — **deliberately not done.** That is the operator action this PR cannot take, and it is exactly what the preflight now demands before a deploy can proceed

## Testing

The production job cannot be exercised end to end for the same reason it needs this guard. What is verified: `actionlint` (with shellcheck) clean, the preflight's shell logic run standalone against set/blank/empty values, the three scanner tests proven to fail when the guard is removed, and the full backend suite (reported below).