### PR TITLE
fix(api): approve exactly the named tasks instead of the whole backlog (#1146)

### DIFF
--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -1225,6 +1225,7 @@ class ApprovalResult:
 def approve_tasks(
     workspace: Workspace,
     excluded_task_ids: Optional[list[str]] = None,
+    included_task_ids: Optional[list[str]] = None,
 ) -> ApprovalResult:
     """Approve tasks for execution by transitioning them to READY status.
 
@@ -1238,10 +1239,21 @@ def approve_tasks(
 
     Args:
         workspace: Target workspace
-        excluded_task_ids: Optional list of task IDs to exclude from approval
+        excluded_task_ids: Task IDs to exclude; everything else in BACKLOG is
+            approved. This is the original, exclusion-shaped contract.
+        included_task_ids: Approve exactly these and nothing else (#1146). The
+            intuitive shape, and mutually exclusive with the one above — a call
+            passing both is ambiguous, so it raises rather than picking one.
+            An id here that is not in BACKLOG raises too: silently approving
+            fewer tasks than asked for is the failure this parameter exists to
+            prevent.
 
     Returns:
         ApprovalResult with counts and IDs
+
+    Raises:
+        ValueError: both lists given, or an included id is not an approvable
+            BACKLOG task
 
     Example:
         result = approve_tasks(workspace, excluded_task_ids=["task-1", "task-2"])
@@ -1249,10 +1261,26 @@ def approve_tasks(
         if result.approved_count > 0:
             batch = start_approved_batch(workspace, result.approved_task_ids)
     """
-    excluded = set(excluded_task_ids or [])
+    if excluded_task_ids and included_task_ids:
+        raise ValueError(
+            "Pass excluded_task_ids or included_task_ids, not both — "
+            "they mean opposite things and there is no safe way to combine them"
+        )
 
     # Get all BACKLOG tasks
     backlog_tasks = tasks.list_tasks(workspace, status=TaskStatus.BACKLOG)
+
+    if included_task_ids is not None:
+        wanted = set(included_task_ids)
+        approvable = {t.id for t in backlog_tasks}
+        unknown = sorted(wanted - approvable)
+        if unknown:
+            raise ValueError(
+                "not approvable (unknown, or not in BACKLOG): " + ", ".join(unknown)
+            )
+        excluded = approvable - wanted
+    else:
+        excluded = set(excluded_task_ids or [])
 
     approved_ids = []
     excluded_ids = []

--- a/codeframe/core/runtime.py
+++ b/codeframe/core/runtime.py
@@ -1267,8 +1267,12 @@ def approve_tasks(
             "they mean opposite things and there is no safe way to combine them"
         )
 
-    # Get all BACKLOG tasks
-    backlog_tasks = tasks.list_tasks(workspace, status=TaskStatus.BACKLOG)
+    # Get all BACKLOG tasks. limit=None is load-bearing: list_tasks defaults to
+    # 100 (#743), so "approve everything" silently approved the first 100 of a
+    # larger backlog, and the inclusion path would 422 a perfectly valid id that
+    # happened to sort past the cap. Caught in review on #1146; the exclusion
+    # path had the same defect all along.
+    backlog_tasks = tasks.list_tasks(workspace, status=TaskStatus.BACKLOG, limit=None)
 
     if included_task_ids is not None:
         wanted = set(included_task_ids)

--- a/codeframe/ui/routers/tasks_v2.py
+++ b/codeframe/ui/routers/tasks_v2.py
@@ -18,7 +18,7 @@ from typing import Any, Literal, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from codeframe.core.workspace import Workspace
 from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
@@ -43,11 +43,27 @@ router = APIRouter(prefix="/api/v2/tasks", tags=["tasks-v2"])
 
 
 class ApproveTasksRequest(BaseModel):
-    """Request for task approval."""
+    """Request for task approval.
+
+    Accepts either shape (#1146). It used to accept only ``excluded_task_ids``,
+    and Pydantic's default is to DROP unknown fields — so the intuitive
+    ``{"task_ids": [...]}`` returned 200 having approved the entire backlog,
+    the exact inverse of the caller's intent, in silence. ``extra="forbid"``
+    closes that even for a field neither name covers.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     excluded_task_ids: list[str] = Field(
         default_factory=list,
-        description="Task IDs to exclude from approval",
+        description="Task IDs to exclude; every other BACKLOG task is approved",
+    )
+    task_ids: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Approve exactly these tasks and nothing else. Mutually exclusive "
+            "with excluded_task_ids."
+        ),
     )
     start_execution: bool = Field(
         default=False,
@@ -63,6 +79,15 @@ class ApproveTasksRequest(BaseModel):
         valid = ("plan", "react")
         if self.engine not in valid:
             raise ValueError(f"engine must be one of: {', '.join(valid)}")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_selection(self) -> "ApproveTasksRequest":
+        if self.task_ids is not None and self.excluded_task_ids:
+            raise ValueError(
+                "Pass task_ids or excluded_task_ids, not both — they mean "
+                "opposite things"
+            )
         return self
 
 
@@ -666,10 +691,16 @@ async def approve_tasks_endpoint(
     """
     try:
         # Approve tasks (transition BACKLOG → READY)
-        result = runtime.approve_tasks(
-            workspace,
-            excluded_task_ids=body.excluded_task_ids,
-        )
+        try:
+            result = runtime.approve_tasks(
+                workspace,
+                excluded_task_ids=body.excluded_task_ids,
+                included_task_ids=body.task_ids,
+            )
+        except ValueError as e:
+            # A named task that is not approvable. 422, not 500: the request is
+            # well-formed and the server is fine — the ids are wrong.
+            raise HTTPException(status_code=422, detail=api_error(str(e), "INVALID_TASK_IDS"))
 
         batch_id = None
         message = f"Approved {result.approved_count} task(s)."

--- a/tests/ui/test_batch_execution_offload.py
+++ b/tests/ui/test_batch_execution_offload.py
@@ -184,7 +184,7 @@ async def test_approve_with_execution_also_returns_immediately(
     monkeypatch.setattr(
         tasks_v2.runtime,
         "approve_tasks",
-        lambda ws, excluded_task_ids=None: type(
+        lambda ws, excluded_task_ids=None, included_task_ids=None: type(
             "R",
             (),
             {
@@ -267,7 +267,7 @@ class TestOneBatchPerWorkspace:
         monkeypatch.setattr(
             tasks_v2.runtime,
             "approve_tasks",
-            lambda ws, excluded_task_ids=None: type(
+            lambda ws, excluded_task_ids=None, included_task_ids=None: type(
                 "R",
                 (),
                 {

--- a/tests/ui/test_task_approval_shape_1146.py
+++ b/tests/ui/test_task_approval_shape_1146.py
@@ -56,7 +56,9 @@ def three_tasks(workspace):
 
 
 def _statuses(workspace) -> dict:
-    return {t.id: t.status for t in core_tasks.list_tasks(workspace)}
+    # limit=None: list_tasks defaults to 100, so the >100 cases below would
+    # otherwise assert about a page rather than the backlog.
+    return {t.id: t.status for t in core_tasks.list_tasks(workspace, limit=None)}
 
 
 class TestTheInclusionShapeApprovesExactlyThose:
@@ -165,6 +167,55 @@ class TestAmbiguousOrWrongRequestsAreRefused:
         client.post("/api/v2/tasks/approve", json={"taskIds": [three_tasks[0].id]})
 
         assert set(_statuses(workspace).values()) == {TaskStatus.BACKLOG}
+
+
+class TestABacklogLargerThanThePageSize:
+    """Review finding, and the exclusion path had it too.
+
+    `tasks.list_tasks` defaults to `limit=100` (#743). `approve_tasks` used that
+    default, so "approve everything" silently approved the first 100 of a bigger
+    backlog — and the new inclusion path would have 422'd a valid id that sorted
+    past the cap, which is precisely the "quietly does less than asked" failure
+    this PR exists to remove.
+    """
+
+    #: One past the default page size. Keeping it just over the boundary keeps
+    #: the test fast while still crossing it.
+    COUNT = 105
+
+    @pytest.fixture
+    def many_tasks(self, workspace):
+        return [
+            core_tasks.create(workspace, title=f"Bulk {i:03d}", description="d")
+            for i in range(self.COUNT)
+        ]
+
+    def test_approving_everything_reaches_past_the_page_size(
+        self, client, workspace, many_tasks
+    ):
+        res = client.post("/api/v2/tasks/approve", json={})
+
+        assert res.status_code == 200, res.text
+        assert res.json()["approved_count"] == self.COUNT
+        assert set(_statuses(workspace).values()) == {TaskStatus.READY}
+
+    def test_a_task_past_the_page_size_can_be_named(self, client, workspace, many_tasks):
+        chosen = many_tasks[-1].id
+
+        res = client.post("/api/v2/tasks/approve", json={"task_ids": [chosen]})
+
+        assert res.status_code == 200, res.text
+        assert res.json()["approved_task_ids"] == [chosen]
+        assert _statuses(workspace)[chosen] == TaskStatus.READY
+
+    def test_the_excluded_count_covers_the_whole_backlog(
+        self, client, many_tasks
+    ):
+        body = client.post(
+            "/api/v2/tasks/approve", json={"task_ids": [many_tasks[0].id]}
+        ).json()
+
+        assert body["excluded_count"] == self.COUNT - 1
 
 
 class TestTheCoreFunctionCarriesTheRule:

--- a/tests/ui/test_task_approval_shape_1146.py
+++ b/tests/ui/test_task_approval_shape_1146.py
@@ -1,0 +1,202 @@
+"""#1146 — POST /api/v2/tasks/approve silently approved everything.
+
+`ApproveTasksRequest` was exclusion-shaped: `excluded_task_ids`, no `task_ids`.
+Pydantic's default is to DROP unknown fields, so the intuitive inclusion payload
+
+    {"task_ids": ["<one-task>"]}
+
+returned **200** and transitioned every BACKLOG task to READY — the exact
+inverse of what the caller asked for, in silence.
+
+Found while writing the #1068 API lifecycle driver, which did exactly this. The
+test that "covered" scoped approval passed anyway: the chosen task *was* READY,
+and so was everything else. That is the failure mode worth pinning — a wrong
+result that looks right.
+
+Options 1 and 2 from the issue, together: accept the inclusion shape properly,
+and forbid unknown fields so the next mis-shaped payload is a 422 rather than a
+silent inversion.
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codeframe.core import tasks as core_tasks
+from codeframe.core.state_machine import TaskStatus
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    return create_or_load_workspace(tmp_path)
+
+
+@pytest.fixture
+def client(workspace):
+    from codeframe.ui.dependencies import get_v2_workspace
+    from codeframe.ui.routers import tasks_v2
+
+    app = FastAPI()
+    app.include_router(tasks_v2.router)
+    app.dependency_overrides[get_v2_workspace] = lambda: workspace
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def three_tasks(workspace):
+    return [
+        core_tasks.create(workspace, title=f"Task {i}", description="d")
+        for i in range(3)
+    ]
+
+
+def _statuses(workspace) -> dict:
+    return {t.id: t.status for t in core_tasks.list_tasks(workspace)}
+
+
+class TestTheInclusionShapeApprovesExactlyThose:
+    """The bug, from the caller's side."""
+
+    def test_only_the_named_task_becomes_ready(self, client, workspace, three_tasks):
+        chosen = three_tasks[0].id
+
+        res = client.post("/api/v2/tasks/approve", json={"task_ids": [chosen]})
+
+        assert res.status_code == 200, res.text
+        statuses = _statuses(workspace)
+        assert statuses[chosen] == TaskStatus.READY
+        # The assertion the old suite never made — and the reason it passed.
+        assert [statuses[t.id] for t in three_tasks[1:]] == [
+            TaskStatus.BACKLOG,
+            TaskStatus.BACKLOG,
+        ]
+
+    def test_the_response_reports_what_it_actually_did(self, client, three_tasks):
+        chosen = three_tasks[0].id
+
+        body = client.post(
+            "/api/v2/tasks/approve", json={"task_ids": [chosen]}
+        ).json()
+
+        assert body["approved_task_ids"] == [chosen]
+        assert body["approved_count"] == 1
+        assert body["excluded_count"] == 2
+
+
+class TestTheExclusionShapeIsUnchanged:
+    """The original contract still has callers; #1146 adds, it does not replace."""
+
+    def test_everything_but_the_excluded_is_approved(self, client, workspace, three_tasks):
+        skipped = three_tasks[2].id
+
+        res = client.post(
+            "/api/v2/tasks/approve", json={"excluded_task_ids": [skipped]}
+        )
+
+        assert res.status_code == 200, res.text
+        statuses = _statuses(workspace)
+        assert statuses[skipped] == TaskStatus.BACKLOG
+        assert [statuses[t.id] for t in three_tasks[:2]] == [
+            TaskStatus.READY,
+            TaskStatus.READY,
+        ]
+
+    def test_an_empty_body_still_approves_the_whole_backlog(
+        self, client, workspace, three_tasks
+    ):
+        assert client.post("/api/v2/tasks/approve", json={}).status_code == 200
+
+        assert set(_statuses(workspace).values()) == {TaskStatus.READY}
+
+
+class TestAmbiguousOrWrongRequestsAreRefused:
+    def test_both_lists_at_once_is_422(self, client, three_tasks):
+        res = client.post(
+            "/api/v2/tasks/approve",
+            json={
+                "task_ids": [three_tasks[0].id],
+                "excluded_task_ids": [three_tasks[1].id],
+            },
+        )
+
+        assert res.status_code == 422, res.text
+
+    def test_neither_list_is_silently_honoured(self, client, workspace, three_tasks):
+        """Ambiguity must not resolve into a mutation."""
+        client.post(
+            "/api/v2/tasks/approve",
+            json={
+                "task_ids": [three_tasks[0].id],
+                "excluded_task_ids": [three_tasks[1].id],
+            },
+        )
+
+        assert set(_statuses(workspace).values()) == {TaskStatus.BACKLOG}
+
+    def test_an_unknown_task_id_is_422_not_a_partial_approval(
+        self, client, workspace, three_tasks
+    ):
+        """Approving fewer tasks than named, quietly, is the same class of bug."""
+        res = client.post(
+            "/api/v2/tasks/approve",
+            json={"task_ids": [three_tasks[0].id, "no-such-task"]},
+        )
+
+        assert res.status_code == 422, res.text
+        assert set(_statuses(workspace).values()) == {TaskStatus.BACKLOG}
+
+    def test_an_unknown_field_is_422_rather_than_dropped(self, client, three_tasks):
+        """The general form of the bug: `extra="forbid"` so the next
+        mis-shaped payload cannot be silently reinterpreted."""
+        res = client.post(
+            "/api/v2/tasks/approve", json={"taskIds": [three_tasks[0].id]}
+        )
+
+        assert res.status_code == 422, res.text
+
+    def test_nothing_is_approved_when_an_unknown_field_is_rejected(
+        self, client, workspace, three_tasks
+    ):
+        client.post("/api/v2/tasks/approve", json={"taskIds": [three_tasks[0].id]})
+
+        assert set(_statuses(workspace).values()) == {TaskStatus.BACKLOG}
+
+
+class TestTheCoreFunctionCarriesTheRule:
+    """Core-first: the semantics live in runtime, not in the router, so the CLI
+    and any other surface get the same behaviour."""
+
+    def test_included_task_ids_approves_exactly_those(self, workspace, three_tasks):
+        from codeframe.core import runtime
+
+        result = runtime.approve_tasks(
+            workspace, included_task_ids=[three_tasks[1].id]
+        )
+
+        assert result.approved_task_ids == [three_tasks[1].id]
+        assert result.excluded_count == 2
+
+    def test_both_arguments_raise(self, workspace, three_tasks):
+        from codeframe.core import runtime
+
+        with pytest.raises(ValueError, match="not both"):
+            runtime.approve_tasks(
+                workspace,
+                excluded_task_ids=[three_tasks[0].id],
+                included_task_ids=[three_tasks[1].id],
+            )
+
+    def test_an_already_ready_task_is_not_silently_skipped(self, workspace, three_tasks):
+        """Only BACKLOG tasks are approvable. Naming one that is already READY
+        would otherwise approve nothing and report success."""
+        from codeframe.core import runtime
+
+        core_tasks.update_status(workspace, three_tasks[0].id, TaskStatus.READY)
+
+        with pytest.raises(ValueError, match="not approvable"):
+            runtime.approve_tasks(workspace, included_task_ids=[three_tasks[0].id])


### PR DESCRIPTION
Closes #1146.

## The bug, reproduced

`ApproveTasksRequest` was exclusion-shaped — `excluded_task_ids`, no `task_ids` — and Pydantic drops unknown fields by default. So the intuitive payload:

```http
POST /api/v2/tasks/approve
{"task_ids": ["<one-task>"]}
```

returned **200** and transitioned **every** backlog task to READY. The exact inverse of the request, in silence.

Reproduced against the pre-fix router by running this PR's test on `main`'s `tasks_v2.py`:

```
assert [statuses[t.id] for t in three_tasks[1:]] == [BACKLOG, BACKLOG]
E   AssertionError: assert [<TaskStatus.READY>, <TaskStatus.READY>] == [<TaskStatus.BACKLOG>, ...]
```

Ask for one task, get three.

## Why it went unnoticed

Found while writing #1068's API lifecycle driver, which did exactly this. Its test *"covered"* scoped approval and passed anyway — the chosen task **was** READY, and so was everything else. A wrong result that looks right, which is the same shape as #1066, #1077 and #1085.

No production caller hits this route today (neither the web UI nor the CLI), which is why it was cheap to fix now and would have been expensive after a client existed.

## The fix — options 1 and 2 from the issue, together

**`task_ids` is a real field** meaning "approve exactly these". The semantics live in `runtime.approve_tasks(included_task_ids=...)`, not the router, so the CLI and any other surface inherit them — core-first.

**`model_config = ConfigDict(extra="forbid")`**, so the *next* mis-shaped payload is a 422 rather than a silent reinterpretation. `{"taskIds": [...]}` no longer approves the backlog.

Two ambiguities now **refuse rather than resolve into a mutation**:

| Request | Before | Now |
|---|---|---|
| `{"task_ids": [a]}` | 200, approves a+b+c | 200, approves a |
| `{"task_ids": [a], "excluded_task_ids": [b]}` | 200, approves a+b+c | 422, nothing changes |
| `{"task_ids": [a, "nope"]}` | 200, approves a+b+c | 422, nothing changes |
| `{"taskIds": [a]}` | 200, approves a+b+c | 422, nothing changes |

The unknown-id case matters on its own: approving fewer tasks than named, quietly, is the same class of bug. Each of those rows has a test asserting **no task changed status**, not just the code.

The exclusion shape is untouched — this adds, it does not replace. Two tests pin that, including the empty-body "approve the whole backlog" behaviour.

## Option 3 — not taken here

The issue offers a repo-wide sweep setting `extra="forbid"` on every v2 request model. That is a much larger change with its own risk (any client sending a stray field starts getting 422s), and it deserves its own PR and its own audit of what currently gets dropped. Not filed as a follow-up yet — worth deciding whether the sweep is wanted before creating an issue for it.

## Testing

- `tests/ui/test_task_approval_shape_1146.py` — 12 tests; **verified the key one fails on `main`'s router** (transcript above) and the `extra="forbid"` pair fails when that line is removed
- `tests/ui/test_batch_execution_offload.py` — two stub lambdas had to widen. Worth noting: a non-autospec stub is exactly what let the signature drift stay invisible until the call failed
- Full backend suite + `ruff` reported below