### PR TITLE
test(lifecycle): drive the Golden Path through the browser (#1068)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -512,9 +512,14 @@ jobs:
         working-directory: tests/e2e
         run: npx playwright install --with-deps chromium
 
-      - name: Run Playwright smoke suite
+      - name: Run Playwright smoke + lifecycle suites
         working-directory: tests/e2e
-        run: npx playwright test --project=chromium --grep @smoke
+        # @lifecycle is the browser Golden Path (#1068). It runs on the mock
+        # provider — free, ~13s including server startup — so it belongs on
+        # every PR rather than in the nightly sweep. It is the only spec here
+        # that exercises the WRITE path (PRD upload, generation, execution)
+        # instead of asserting how seeded rows render.
+        run: npx playwright test --project=chromium --grep "@smoke|@lifecycle"
 
       - name: Upload Playwright report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ tests/e2e/test-results/
 tests/e2e/.auth/
 tests/e2e/.codeframe/
 tests/e2e/.e2e-workspace/
+tests/e2e/.e2e-lifecycle-workspace/
 tests/e2e/.e2e-state.db*
 test_audit_report.md
 tests/integration/.env.integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,11 +161,13 @@ uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"  # The CI gate (every
                                          # ~6.5 min locally. If it is much slower on your
                                          # machine, see "Suite speed" below.
 uv run pytest tests/core/                # Core module tests
-scripts/lifecycle --mode cli|api|all     # Lifecycle tests (run locally before a PR)
+scripts/lifecycle --mode cli|api|web|all # Lifecycle tests (run locally before a PR)
                                          # cli — real LLM calls, needs a key, costs money
                                          # api — Golden Path over HTTP on the mock provider,
                                          #       free, and also runs in normal CI (#1068)
-                                         # web exits 3 — not implemented (#948, #1068)
+                                         # web — Golden Path through the browser (Playwright),
+                                         #       free; runs in the e2e-browser-smoke CI job
+                                         # all — every one of them
 uv run ruff check .
 
 # Web UI

--- a/codeframe/adapters/llm/mock.py
+++ b/codeframe/adapters/llm/mock.py
@@ -18,11 +18,55 @@ from codeframe.adapters.llm.base import (
 )
 
 
+#: The task-decomposition prompt asks for this exact shape (core/tasks.py).
+#: Matched on a full sentence, not a keyword: a substring like "json" would
+#: reshape unrelated calls, which is the classifier mistake #1113/#1116/#1064
+#: each made in turn.
+_TASK_DECOMPOSITION_MARKER = "Return ONLY a JSON array of objects with these fields."
+
+#: What the mock answers that prompt with. Two tasks with a real dependency
+#: edge, because a decomposition with an empty graph is one the prompt itself
+#: calls wrong — and a lifecycle test that never exercises depends_on is not
+#: exercising the decomposer.
+_MOCK_DECOMPOSITION = """[
+  {
+    "title": "Implement the core function",
+    "description": "Add the function described by the PRD, with input validation.",
+    "depends_on_titles": [],
+    "complexity": 2,
+    "estimated_hours": 1.5,
+    "uncertainty": "low",
+    "files_to_modify": ["stats.py"]
+  },
+  {
+    "title": "Add a test for the core function",
+    "description": "Cover the happy path and one edge case.",
+    "depends_on_titles": ["Implement the core function"],
+    "complexity": 1,
+    "estimated_hours": 0.5,
+    "uncertainty": "low",
+    "files_to_modify": ["tests/test_stats.py"]
+  }
+]"""
+
+
 class MockProvider(LLMProvider):
     """Mock LLM provider for testing.
 
     Tracks all calls and returns configurable responses.
     Useful for unit tests and development without API costs.
+
+    The default response is the literal string ``"Mock response"``, which no
+    real caller can parse. That is fine for a provider nobody parses, but task
+    generation asks for a JSON array and #1115 correctly turned an unparseable
+    answer into a hard error — so `CODEFRAME_LLM_PROVIDER=mock` could not drive
+    the Golden Path's THINK step at all, and the lifecycle tests had to skip the
+    LLM branch entirely (#1068).
+
+    So the default is now shape-aware for exactly one prompt: the task
+    decomposition. Everything else is unchanged, and an explicitly queued
+    response or handler still wins — those are what a test uses to say what it
+    means.
     """
 
     def __init__(
@@ -140,12 +184,20 @@ class MockProvider(LLMProvider):
             self.response_index += 1
             return response
 
-        # Default response
+        # Shape-aware default: answer the task-decomposition prompt with
+        # something its parser can actually read. Only when the caller left the
+        # default in place — a test that set default_response meant it.
+        content = self.default_response
+        if content == "Mock response" and any(
+            _TASK_DECOMPOSITION_MARKER in str(m.get("content", "")) for m in messages
+        ):
+            content = _MOCK_DECOMPOSITION
+
         return LLMResponse(
-            content=self.default_response,
+            content=content,
             model=model,
             input_tokens=len(str(messages)),
-            output_tokens=len(self.default_response),
+            output_tokens=len(content),
         )
 
     def stream(

--- a/scripts/lifecycle
+++ b/scripts/lifecycle
@@ -5,12 +5,11 @@
 #   scripts/lifecycle [options]
 #
 # Options:
-#   --mode cli|api|all       Which test mode (default: cli)
+#   --mode cli|api|web|all   Which test mode (default: cli)
 #                            cli — real LLM calls, needs ANTHROPIC_API_KEY, costs money
 #                            api — Golden Path over HTTP on the mock provider, free
-#                            all — both
-#                            web is NOT implemented — it exits 3 rather than
-#                            reporting a false pass (#948, #1068)
+#                            web — Golden Path through the browser (Playwright), free
+#                            all — every one of them
 #   --model haiku|sonnet     LLM model to use (default: haiku, cheaper)
 #   --verbose / -v           Pass -s to pytest (show live output)
 #   --no-cleanup             Keep temp directories after test (for inspection)
@@ -48,30 +47,16 @@ case "$MODE" in
   *) echo "Error: --mode must be cli, api, web, or all" >&2; exit 1 ;;
 esac
 
-# `web` is still NOT implemented (#948/#1068). It used to resolve to a file whose
-# only content was a @pytest.mark.skip class raising NotImplementedError, so
-# pytest collected nothing but skips and exited 0 — while CLAUDE.md advertises
-# this script as the pre-PR gate. Fail loudly rather than report success for work
-# that does not exist. `api` is now real and runs on the mock provider.
-if [[ "$MODE" == "web" ]]; then
-  echo "Error: --mode web is not implemented." >&2
-  echo "" >&2
-  echo "  The web lifecycle test does not exist yet. It used to 'pass' by" >&2
-  echo "  collecting only skipped stubs — see issue #1068 for the plan." >&2
-  echo "" >&2
-  echo "  Implemented modes:  scripts/lifecycle --mode cli|api" >&2
-  exit 3
-fi
-
 case "$MODEL" in
   haiku|sonnet) ;;
   *) echo "Error: --model must be haiku or sonnet" >&2; exit 1 ;;
 esac
 
 # ── Check API key ────────────────────────────────────────────────────────────
-# `api` runs entirely on the mock provider: no key, no cost, no network. That is
-# the point of it — it can run on every PR, where the paid cli mode cannot.
-if [[ "$MODE" != "api" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+# `api` and `web` run entirely on the mock provider: no key, no cost, no
+# network. That is the point of them — they can run on every PR, where the paid
+# cli mode cannot.
+if [[ "$MODE" != "api" && "$MODE" != "web" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
   echo "Error: ANTHROPIC_API_KEY is not set." >&2
   echo "" >&2
   echo "Export it first:" >&2
@@ -88,6 +73,9 @@ fi
 # be selected at all, while the mock-driven api tests are deliberately unmarked
 # and are selected by that same default. Getting this wrong silently runs
 # nothing, which is the failure mode #948 was about.
+RUN_PYTEST=1
+RUN_PLAYWRIGHT=0
+
 case "$MODE" in
   cli)
     TEST_PATH="tests/lifecycle/test_cli_lifecycle.py"
@@ -97,13 +85,25 @@ case "$MODE" in
     TEST_PATH="tests/lifecycle/test_api_lifecycle.py"
     MARKER_ARGS=(-m "not lifecycle")
     ;;
+  web)
+    # Playwright, not pytest: the browser lifecycle spec lives in the #684/#703
+    # harness, which already starts both servers. RUN_PYTEST=0 skips the pytest
+    # leg entirely rather than running it against a path that holds no tests.
+    TEST_PATH="tests/e2e/lifecycle.spec.ts"
+    MARKER_ARGS=()
+    RUN_PYTEST=0
+    RUN_PLAYWRIGHT=1
+    ;;
   all)
-    TEST_PATH="tests/lifecycle/"
+    TEST_PATH="tests/lifecycle/ + tests/e2e/lifecycle.spec.ts"
+    PYTEST_PATH="tests/lifecycle/"
     # Always true, so it clears pytest.ini's default and selects both the
     # marked (cli) and unmarked (api) tests in one run.
     MARKER_ARGS=(-m "lifecycle or not lifecycle")
+    RUN_PLAYWRIGHT=1
     ;;
 esac
+PYTEST_PATH="${PYTEST_PATH:-$TEST_PATH}"
 
 # ── Cost warning ─────────────────────────────────────────────────────────────
 COST_HINT="~\$0.50–1.00"
@@ -113,7 +113,7 @@ fi
 if [[ "$MODE" == "all" ]]; then
   COST_HINT="~\$1.50–5.00"
 fi
-if [[ "$MODE" == "api" ]]; then
+if [[ "$MODE" == "api" || "$MODE" == "web" ]]; then
   COST_HINT="free (mock provider, no API calls)"
 fi
 
@@ -129,7 +129,12 @@ echo ""
 
 if [[ -n "$DRY_RUN" ]]; then
   echo "[dry-run] Would run:"
-  echo "  CODEFRAME_LIFECYCLE_MODEL=$MODEL uv run pytest $TEST_PATH ${MARKER_ARGS[*]} -v $VERBOSE"
+  if [[ "$RUN_PYTEST" == "1" ]]; then
+    echo "  CODEFRAME_LIFECYCLE_MODEL=$MODEL uv run pytest $PYTEST_PATH ${MARKER_ARGS[*]} -v $VERBOSE"
+  fi
+  if [[ "$RUN_PLAYWRIGHT" == "1" ]]; then
+    echo "  (cd tests/e2e && npx playwright test --project=chromium --grep @lifecycle)"
+  fi
   echo ""
   exit 0
 fi
@@ -146,7 +151,7 @@ fi
 
 # ── Build pytest args ─────────────────────────────────────────────────────────
 PYTEST_ARGS=(
-  "$TEST_PATH"
+  "$PYTEST_PATH"
   "${MARKER_ARGS[@]}"
   -v
   --tb=long
@@ -171,4 +176,18 @@ if [[ "$MODE" == "api" ]]; then
   export CODEFRAME_LLM_PROVIDER=mock
 fi
 
-uv run pytest "${PYTEST_ARGS[@]}"
+STATUS=0
+if [[ "$RUN_PYTEST" == "1" ]]; then
+  uv run pytest "${PYTEST_ARGS[@]}" || STATUS=$?
+fi
+
+if [[ "$RUN_PLAYWRIGHT" == "1" ]]; then
+  # The harness starts its own backend and frontend and sets the mock provider
+  # on the backend itself, so nothing is exported here.
+  echo ""
+  echo "  Browser lifecycle (Playwright)..."
+  ( cd "$(dirname "$0")/../tests/e2e" \
+      && npx playwright test --project=chromium --grep @lifecycle ) || STATUS=$?
+fi
+
+exit "$STATUS"

--- a/scripts/lifecycle
+++ b/scripts/lifecycle
@@ -150,21 +150,27 @@ if [[ -t 0 && -z "${LIFECYCLE_NO_CONFIRM:-}" ]]; then
 fi
 
 # ── Build pytest args ─────────────────────────────────────────────────────────
-PYTEST_ARGS=(
-  "$PYTEST_PATH"
-  "${MARKER_ARGS[@]}"
-  -v
-  --tb=long
-  --no-header
-  --timeout=1800
-)
+# Only when there is a pytest leg. `web` sets MARKER_ARGS=(), and under
+# `set -u` bash < 4.4 (macOS still ships 3.2) errors on "${empty[@]}" — so
+# building this unconditionally would break the one mode that never uses it.
+PYTEST_ARGS=()
+if [[ "$RUN_PYTEST" == "1" ]]; then
+  PYTEST_ARGS=(
+    "$PYTEST_PATH"
+    "${MARKER_ARGS[@]}"
+    -v
+    --tb=long
+    --no-header
+    --timeout=1800
+  )
 
-if [[ -n "$VERBOSE" ]]; then
-  PYTEST_ARGS+=(-s)
-fi
+  if [[ -n "$VERBOSE" ]]; then
+    PYTEST_ARGS+=(-s)
+  fi
 
-if [[ -n "$NO_CLEANUP" ]]; then
-  PYTEST_ARGS+=(--basetemp=/tmp/lifecycle-keep)
+  if [[ -n "$NO_CLEANUP" ]]; then
+    PYTEST_ARGS+=(--basetemp=/tmp/lifecycle-keep)
+  fi
 fi
 
 # ── Run ───────────────────────────────────────────────────────────────────────

--- a/tests/e2e/e2e-env.ts
+++ b/tests/e2e/e2e-env.ts
@@ -16,6 +16,18 @@ export const FRONTEND_URL = process.env.E2E_FRONTEND_URL || 'http://localhost:30
 /** Per-workspace data lives here (PRD, tasks, blockers, proof, token_usage). */
 export const WORKSPACE_DIR = process.env.E2E_WORKSPACE_DIR || path.join(__dirname, '.e2e-workspace');
 
+/**
+ * The backend's WORKSPACE_ROOT allowlist (#896) — the PARENT of the seeded
+ * workspace, so specs that need their own workspace (the #1068 lifecycle spec)
+ * can create a sibling and still be inside a real allowlist. Not the repo root
+ * and not unrestricted: the guard stays meaningful.
+ */
+export const WORKSPACE_ROOT = process.env.E2E_WORKSPACE_ROOT || path.dirname(WORKSPACE_DIR);
+
+/** A throwaway workspace the lifecycle spec builds from nothing (#1068). */
+export const LIFECYCLE_WORKSPACE_DIR =
+  process.env.E2E_LIFECYCLE_WORKSPACE_DIR || path.join(__dirname, '.e2e-lifecycle-workspace');
+
 /** Central platform-store DB (auth users, interactive sessions). */
 export const CENTRAL_DB_PATH = process.env.E2E_CENTRAL_DB || path.join(__dirname, '.e2e-state.db');
 

--- a/tests/e2e/lifecycle.spec.ts
+++ b/tests/e2e/lifecycle.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * The Golden Path through the browser, end to end (#1068).
+ *
+ * #948 deleted `tests/lifecycle/test_web_lifecycle.py` because it was green
+ * theatre: a `@pytest.mark.skip` class whose methods raised NotImplementedError,
+ * so `scripts/lifecycle --mode web` collected only skips and exited 0 while
+ * CLAUDE.md advertised it as the pre-PR gate. #1147 replaced the API half; this
+ * is the web half.
+ *
+ * What makes it different from every other spec here: the rest of the suite
+ * asserts how a PRE-SEEDED workspace renders. This one starts from an empty
+ * directory and drives the product — PRD upload, task generation, approval,
+ * execution — entirely through the UI, then checks the workspace actually
+ * changed. Rendering seeded rows cannot catch a broken write path; this can.
+ *
+ * Runs on `CODEFRAME_LLM_PROVIDER=mock` (set on the backend webServer in
+ * playwright.config.ts), so it is free and deterministic.
+ */
+import { test, expect, APIRequestContext, Page } from '@playwright/test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  BACKEND_URL,
+  LIFECYCLE_WORKSPACE_DIR,
+  LS_AUTH_TOKEN,
+  LS_WORKSPACE_PATH,
+  STORAGE_STATE_PATH,
+} from './e2e-env';
+import { trackConsoleErrors } from './helpers';
+
+const WORKSPACE = path.resolve(LIFECYCLE_WORKSPACE_DIR);
+
+const PRD_TITLE = 'Lifecycle CSV Stats';
+
+/**
+ * What the mock provider answers the task-decomposition prompt with
+ * (codeframe/adapters/llm/mock.py). Hard-coded on purpose: a lifecycle test
+ * that accepts "some cards appeared" cannot tell decomposition from an empty
+ * board with a spinner.
+ */
+const FIRST_TASK = 'Implement the core function';
+const SECOND_TASK = 'Add a test for the core function';
+const PRD_CONTENT = `# ${PRD_TITLE}
+
+## Requirements
+
+- Implement a mean function in stats.py
+- Add a test for the mean function
+`;
+
+/** The JWT global-setup obtained, so this spec can call the API directly. */
+function authToken(): string {
+  const state = JSON.parse(fs.readFileSync(STORAGE_STATE_PATH, 'utf-8'));
+  const entry = state.origins?.[0]?.localStorage?.find(
+    (item: { name: string }) => item.name === LS_AUTH_TOKEN,
+  );
+  if (!entry?.value) throw new Error('no auth_token in storageState');
+  return entry.value;
+}
+
+function git(...args: string[]) {
+  const result = spawnSync('git', args, { cwd: WORKSPACE, encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+  }
+}
+
+/**
+ * Point the browser at THIS spec's workspace instead of the seeded one.
+ *
+ * `addInitScript` runs before any page script on every navigation, which is the
+ * only reliable moment: the app reads localStorage during its first render, so
+ * writing it after `goto` races the auth guard.
+ */
+async function useLifecycleWorkspace(page: Page) {
+  const token = authToken();
+  await page.addInitScript(
+    ([tokenKey, tokenValue, pathKey, pathValue]) => {
+      window.localStorage.setItem(tokenKey, tokenValue);
+      window.localStorage.setItem(pathKey, pathValue);
+    },
+    [LS_AUTH_TOKEN, token, LS_WORKSPACE_PATH, WORKSPACE] as const,
+  );
+}
+
+/** Task title → status, read straight from the API. */
+async function taskStatuses(request: APIRequestContext): Promise<Map<string, string>> {
+  const res = await request.get(`${BACKEND_URL}/api/v2/tasks`, {
+    headers: { Authorization: `Bearer ${authToken()}` },
+    params: { workspace_path: WORKSPACE },
+  });
+  if (!res.ok()) return new Map();
+  const body = await res.json();
+  return new Map(
+    body.tasks.map((t: { title: string; status: string }) => [t.title, t.status]),
+  );
+}
+
+async function goto(page: Page, urlPath: string) {
+  await page.goto(urlPath, { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('main, [role="main"]').first()).toBeVisible({ timeout: 20000 });
+}
+
+// Serial: the later tests assert on state the first one created. fullyParallel
+// is on for the rest of the suite, and an out-of-order run here would report a
+// missing PRD rather than the pipeline failing.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('@lifecycle Golden Path through the web UI', () => {
+  test.beforeAll(async ({ request }) => {
+    // A real git repo: workspace init and the gates both need one.
+    fs.rmSync(WORKSPACE, { recursive: true, force: true });
+    fs.mkdirSync(WORKSPACE, { recursive: true });
+    git('init', '-q');
+    git('config', 'user.email', 'e2e@test.local');
+    git('config', 'user.name', 'E2E');
+    fs.writeFileSync(path.join(WORKSPACE, 'README.md'), '# lifecycle demo\n');
+    git('add', '-A');
+    git('commit', '-qm', 'init');
+
+    // Register it. The UI has no "create workspace from nothing" screen — it
+    // reads a path out of localStorage — so this one step is API-side. Every
+    // pipeline step after it goes through the browser.
+    const res = await request.post(`${BACKEND_URL}/api/v2/workspaces`, {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      data: { repo_path: WORKSPACE },
+    });
+    expect(res.status(), await res.text()).toBe(201);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await useLifecycleWorkspace(page);
+  });
+
+  test('a user builds a project from an empty workspace', async ({ page, request }) => {
+    const errors = trackConsoleErrors(page);
+
+    // ---- THINK: upload a PRD -------------------------------------------
+    await goto(page, '/prd');
+    // Scoped to the header: the empty state renders its own Upload PRD CTA, so
+    // an unscoped match is ambiguous on exactly the page this test starts from.
+    await page
+      .locator('header')
+      .getByRole('button', { name: /upload prd|upload new/i })
+      .click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByPlaceholder(/paste your prd markdown here/i).fill(PRD_CONTENT);
+    await dialog.getByRole('button', { name: /create prd/i }).click();
+
+    await expect(dialog).toBeHidden({ timeout: 20000 });
+    // The editor shows what was saved, not just a success toast.
+    await expect(page.getByText(/mean function in stats\.py/i).first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    // ---- THINK: generate tasks -----------------------------------------
+    const generate = page.getByRole('button', { name: /generate tasks/i });
+    await expect(generate).toBeEnabled();
+    await generate.click();
+
+    // Generation reports via a toast and does NOT navigate. Asserting the
+    // count here is what distinguishes "the button did something" from "the
+    // decomposer produced tasks".
+    await expect(page.getByText(/generated \d+ tasks? from prd/i)).toBeVisible({
+      timeout: 60000,
+    });
+
+    await goto(page, '/tasks');
+    const card = page.getByLabel(`View details for ${FIRST_TASK}`);
+    await expect(card).toBeVisible({ timeout: 30000 });
+    // The decomposition has a real dependency edge, which is the thing the
+    // prompt says an empty graph would mean it got wrong.
+    await expect(page.getByLabel(`View details for ${SECOND_TASK}`)).toBeVisible();
+
+    // ---- BUILD: approve one task ---------------------------------------
+    // Scoped to the card, not the board: `.first()` would silently act on
+    // whichever card the board happened to order first.
+    await card.getByRole('button', { name: /mark ready/i }).click();
+
+    // A READY task offers Execute; a BACKLOG one does not. Waiting on the
+    // button is waiting on the status transition having actually landed.
+    const execute = card.getByRole('button', { name: /^execute$/i });
+    await expect(execute).toBeVisible({ timeout: 30000 });
+
+    // ---- BUILD: run it --------------------------------------------------
+    await execute.click();
+    await expect(page).toHaveURL(/\/execution\//, { timeout: 30000 });
+    await expect(page.getByText(FIRST_TASK).first()).toBeVisible({ timeout: 30000 });
+
+    // The outcome is the task's status, polled from the API — NOT a text match
+    // on the page. `/done|completed|failed|blocked/` would have matched the
+    // sidebar's "Blockers" link and passed before the run finished, which is
+    // the sort of assertion that reports success for a run that never
+    // happened. mock completes in seconds; the budget is generous because this
+    // is the one genuinely async step.
+    await expect
+      .poll(async () => (await taskStatuses(request)).get(FIRST_TASK), {
+        timeout: 120000,
+      })
+      .toBe('DONE');
+
+    errors.assertClean();
+  });
+
+  test('the workspace on disk reflects what the browser did', async ({ request }) => {
+    // The UI can render anything. This asserts the pipeline actually wrote
+    // through — the failure mode a render-only spec cannot see.
+    const headers = { Authorization: `Bearer ${authToken()}` };
+    const params = { workspace_path: WORKSPACE };
+
+    // /latest, not the collection route — the list returns metadata only, so
+    // asserting on its body would have passed for a PRD with no content at all.
+    const prd = await request.get(`${BACKEND_URL}/api/v2/prd/latest`, { headers, params });
+    expect(prd.status(), await prd.text()).toBe(200);
+    expect(await prd.text()).toContain('mean function in stats.py');
+
+    const statuses = await taskStatuses(request);
+
+    // Exact, not "something moved": the approved task ran to completion and the
+    // one that was never approved is untouched. A looser assertion would pass
+    // if approval had leaked to the whole backlog — the #1146 failure mode.
+    expect(statuses.get(FIRST_TASK)).toBe('DONE');
+    expect(statuses.get(SECOND_TASK)).toBe('BACKLOG');
+  });
+
+  test('the seeded workspace was not touched', async ({ request }) => {
+    // This spec writes for real, and every other spec asserts against the
+    // seeded workspace. If the two ever share a directory those specs start
+    // failing for reasons that have nothing to do with them.
+    const { WORKSPACE_DIR } = await import('./e2e-env');
+    const seeded = await request.get(`${BACKEND_URL}/api/v2/tasks`, {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      params: { workspace_path: path.resolve(WORKSPACE_DIR) },
+    });
+
+    expect(seeded.status()).toBe(200);
+    const titles = (await seeded.json()).tasks.map((t: { title: string }) => t.title);
+    expect(titles).toContain('Set up database schema');
+    expect(titles).not.toContain(PRD_TITLE);
+  });
+});

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -5,7 +5,7 @@ import {
   CENTRAL_DB_PATH,
   FRONTEND_URL,
   STORAGE_STATE_PATH,
-  WORKSPACE_DIR,
+  WORKSPACE_ROOT,
 } from './e2e-env';
 
 /**
@@ -68,10 +68,16 @@ export default defineConfig({
   webServer: [
     {
       // WORKSPACE_ROOT is required: auth is on by default and the backend
-      // refuses to start without a workspace allowlist (#896). Pointing it at
-      // the seeded workspace also makes the suite exercise the allowlist the
-      // way a real deployment does, instead of running unrestricted.
-      command: `AUTH_SECRET=${AUTH_SECRET} DATABASE_PATH=${CENTRAL_DB_PATH} WORKSPACE_ROOT=${WORKSPACE_DIR} uv run uvicorn codeframe.ui.server:app --port ${BACKEND_PORT}`,
+      // refuses to start without a workspace allowlist (#896). It points at the
+      // PARENT of the seeded workspace, not the workspace itself, so the
+      // lifecycle spec can create its own sibling workspace and still be inside
+      // a real allowlist — the suite keeps exercising the guard the way a
+      // deployment does, rather than running unrestricted (#1068).
+      //
+      // CODEFRAME_LLM_PROVIDER=mock makes task generation and execution
+      // deterministic and free. Without it the backend defaults to anthropic
+      // and the lifecycle spec would need a paid key.
+      command: `AUTH_SECRET=${AUTH_SECRET} DATABASE_PATH=${CENTRAL_DB_PATH} WORKSPACE_ROOT=${WORKSPACE_ROOT} CODEFRAME_LLM_PROVIDER=mock uv run uvicorn codeframe.ui.server:app --port ${BACKEND_PORT}`,
       cwd: '../..',
       url: `${BACKEND_URL}/health`,
       reuseExistingServer: !process.env.CI,

--- a/tests/test_lifecycle_gates_948.py
+++ b/tests/test_lifecycle_gates_948.py
@@ -57,57 +57,67 @@ def _e2e_backend_job() -> dict:
     return workflow["jobs"]["e2e-backend-tests"]
 
 
-class TestUnimplementedLifecycleModesFailLoudly:
-    """AC1. The modes must not report success for a suite that does not exist."""
+class TestEveryAdvertisedModeIsReal:
+    """AC1, inverted. #948 wrote this class to prove `api` and `web` FAILED
+    rather than reporting success for a suite that did not exist. #1147 made
+    `api` real; #1068 makes `web` real. So the assertion flips: every mode the
+    help text offers must now resolve to a suite, and a typo must still be
+    rejected — those two are different failures and a caller wrapping this
+    script has to tell them apart.
+    """
 
-    # `api` is implemented as of #1068 and is asserted below to WORK. Only
-    # `web` remains unbuilt, so only `web` must still fail loudly.
-    @pytest.mark.parametrize("mode", ["web"])
-    def test_the_mode_exits_non_zero(self, mode: str):
+    @pytest.mark.parametrize("mode", ["cli", "api", "web", "all"])
+    def test_the_mode_resolves_to_a_real_suite(self, mode: str):
         proc = _run_lifecycle("--mode", mode)
-
-        assert proc.returncode != 0, (
-            f"--mode {mode} still exits 0 — a caller reads that as a pass"
-        )
-
-    @pytest.mark.parametrize("mode", ["web"])
-    def test_it_says_why_and_points_somewhere(self, mode: str):
-        proc = _run_lifecycle("--mode", mode)
-
-        assert "not implemented" in proc.stderr.lower(), proc.stderr
-        assert "#1068" in proc.stderr, "no pointer to the tracking issue"
-
-    @pytest.mark.parametrize("mode", ["web"])
-    def test_its_exit_code_differs_from_a_typo(self, mode: str):
-        """`--mode api` and `--mode banana` are different failures: one is
-        "not built yet", the other is "you mistyped". Same code would conflate
-        them for any script wrapping this one."""
-        unimplemented = _run_lifecycle("--mode", mode).returncode
-        typo = _run_lifecycle("--mode", "banana").returncode
-
-        assert unimplemented != typo
-
-    def test_the_implemented_mode_still_works(self):
-        proc = _run_lifecycle("--mode", "cli")
 
         assert proc.returncode == 0, proc.stderr
+        assert "not implemented" not in proc.stderr.lower(), proc.stderr
+
+    def test_a_typo_is_still_rejected(self):
+        assert _run_lifecycle("--mode", "banana").returncode != 0
+
+    def test_cli_mode_runs_the_paid_suite(self):
+        proc = _run_lifecycle("--mode", "cli")
+
         assert "test_cli_lifecycle.py" in proc.stdout
+        assert "-m lifecycle" in proc.stdout
 
     def test_api_mode_is_implemented_now(self):
-        """The flip #1068 asks for: `api` resolves to a real suite (#1068)."""
+        """#1147: `api` resolves to a real suite."""
         proc = _run_lifecycle("--mode", "api")
 
         assert proc.returncode == 0, proc.stderr
         assert "test_api_lifecycle.py" in proc.stdout
-        assert "not implemented" not in proc.stderr.lower()
 
-    def test_api_mode_needs_no_api_key(self):
-        """The whole point of driving it with the mock provider: it is free,
-        so CI can run it on every PR where the paid cli mode cannot."""
-        proc = _run_lifecycle("--mode", "api", drop_api_key=True)
+    def test_web_mode_is_implemented_now(self):
+        """#1068: `web` resolves to the browser spec, run by Playwright rather
+        than pytest — the reason it needed its own branch."""
+        proc = _run_lifecycle("--mode", "web")
+
+        assert proc.returncode == 0, proc.stderr
+        assert "lifecycle.spec.ts" in proc.stdout
+        assert "playwright" in proc.stdout.lower()
+        assert "pytest" not in proc.stdout, (
+            "web has no pytest leg; running one against a path with no tests "
+            "is how a mode reports success for nothing (#948)"
+        )
+
+    @pytest.mark.parametrize("mode", ["api", "web"])
+    def test_the_free_modes_need_no_api_key(self, mode: str):
+        """Both run on the mock provider. That is what lets CI run them on
+        every PR, where the paid cli mode cannot."""
+        proc = _run_lifecycle("--mode", mode, drop_api_key=True)
 
         assert proc.returncode == 0, proc.stderr
         assert "ANTHROPIC_API_KEY" not in proc.stderr
+
+    def test_all_runs_both_engines(self):
+        """`all` must not silently drop the browser half."""
+        proc = _run_lifecycle("--mode", "all")
+
+        assert proc.returncode == 0, proc.stderr
+        assert "pytest" in proc.stdout
+        assert "playwright" in proc.stdout.lower()
 
     def test_api_mode_selects_tests_rather_than_silently_matching_none(self):
         """pytest.ini defaults to `-m "not lifecycle"`, and the script used to
@@ -116,14 +126,9 @@ class TestUnimplementedLifecycleModesFailLoudly:
         silent success #948 removed the stubs for."""
         proc = _run_lifecycle("--mode", "api")
 
-        assert "-m not lifecycle" in proc.stdout or "not lifecycle" in proc.stdout
+        assert "not lifecycle" in proc.stdout
 
-    def test_all_still_works(self):
-        proc = _run_lifecycle("--mode", "all")
-
-        assert proc.returncode == 0, proc.stderr
-
-    def test_the_help_text_no_longer_advertises_them(self):
+    def test_the_help_text_offers_every_working_mode(self):
         proc = subprocess.run(
             [str(LIFECYCLE), "--help"],
             cwd=REPO_ROOT,
@@ -132,20 +137,43 @@ class TestUnimplementedLifecycleModesFailLoudly:
             timeout=30,
         )
 
-        assert "cli|api|web|all" not in proc.stdout, (
-            "--help still offers web, the one mode that cannot run"
+        assert "--mode cli|api|web|all" in proc.stdout, (
+            "every advertised mode is implemented now; the help text should "
+            "say so"
         )
-        assert "--mode cli|api|all" in proc.stdout, (
-            "--help must offer api now that it is implemented (#1068)"
-        )
+        assert "not implemented" not in proc.stdout.lower()
 
 
 class TestNoAdvertisedModeCollectsOnlySkips:
     """AC1's second half, measured rather than assumed."""
 
-    def test_the_web_stub_file_is_still_gone(self):
-        """`api` came back as a real suite in #1068; `web` has not."""
+    def test_the_python_web_stub_is_still_gone(self):
+        """The web lifecycle came back as a Playwright spec, NOT as the pytest
+        file #948 deleted. If that filename reappears, something recreated the
+        stub rather than using the browser harness."""
         assert not (REPO_ROOT / "tests" / "lifecycle" / "test_web_lifecycle.py").exists()
+
+    def test_the_browser_lifecycle_spec_exists_and_is_tagged(self):
+        """#1068's web half. The tag is how scripts/lifecycle and the CI job
+        select it — an untagged spec silently runs in neither."""
+        spec = (REPO_ROOT / "tests" / "e2e" / "lifecycle.spec.ts").read_text()
+
+        assert "@lifecycle" in spec
+        assert spec.count("test(") >= 2, "too thin to be a lifecycle suite"
+
+    def test_ci_runs_the_browser_lifecycle_spec(self):
+        """It is free and takes seconds, so it belongs on every PR. A spec that
+        only ever ran locally is the same gap #948 was about."""
+        workflow = yaml.safe_load(WORKFLOW.read_text())
+        steps = [
+            step.get("run", "")
+            for job in workflow["jobs"].values()
+            for step in job.get("steps", [])
+        ]
+
+        assert any("@lifecycle" in run for run in steps), (
+            "no CI step selects the browser lifecycle spec"
+        )
 
     def test_the_api_file_is_a_real_suite_not_a_stub(self):
         """It exists again — so assert it is the opposite of what #948 deleted:


### PR DESCRIPTION
Closes #1068. With this, **every mode `scripts/lifecycle` advertises is real** — the thing #948 spun the issue off to fix.

## What

`tests/e2e/lifecycle.spec.ts` starts from an **empty directory** and drives the product through the UI: PRD upload → task generation → approval → execution. Every other spec in the harness asserts how a *pre-seeded* workspace renders, which cannot catch a broken write path. 3 tests, **~13s** including server startup, free.

```
✓ a user builds a project from an empty workspace  (3.9s)
✓ the workspace on disk reflects what the browser did  (130ms)
✓ the seeded workspace was not touched  (143ms)
3 passed (12.8s)
```

## Three things had to change to make it possible

**1. `MockProvider` could not drive the THINK step at all.** Its default is the literal string `"Mock response"`, which no parser can read, and #1115 correctly turned an unparseable decomposition into a hard error:

```
TaskGenerationError: the response was truncated before the JSON array closed.
```

So `CODEFRAME_LLM_PROVIDER=mock` failed the Generate Tasks button, and the API lifecycle test had to pass `use_llm=false` to skip the LLM branch entirely. The mock now answers **exactly one** prompt with a valid shape — the task decomposition, matched on its full closing sentence rather than a keyword, because a substring classifier is the mistake #1113, #1116 and #1064 each made in turn. The canned answer carries a real dependency edge, since the prompt itself says an empty graph means the decomposition is wrong. Everything else is untouched, and a queued response or handler still wins.

**2. `WORKSPACE_ROOT` now points at the *parent* of the seeded workspace**, so the spec can create its own sibling and still sit inside a real allowlist (#896). Not unrestricted — the guard stays meaningful, and a third test asserts the seeded workspace was not touched, because this spec writes for real and every other spec asserts against that directory.

**3. `scripts/lifecycle` grew a Playwright leg.** `web` runs **no pytest at all** rather than running one against a path with no tests — that is how a mode reports success for nothing. `all` runs both engines.

| mode | runner | needs a key |
|---|---|---|
| `cli` | pytest `-m lifecycle` | yes, costs money |
| `api` | pytest `-m "not lifecycle"` | no |
| `web` | Playwright `--grep @lifecycle` | no |
| `all` | both | yes |

## The assertions are outcomes, not page text

The run's result is polled from the API as a **task status**:

```ts
await expect.poll(async () => (await taskStatuses(request)).get(FIRST_TASK)).toBe('DONE');
```

My first version matched `/done|completed|failed|blocked/i` on the page — which matches the sidebar's **Blockers** link and would have passed before the run even started. That is the exact class of assertion this suite exists to replace.

The persistence test is exact rather than "something moved": the approved task is `DONE` **and** the unapproved one is `BACKLOG`. A looser check would pass if approval had leaked to the whole backlog — the #1146 bug, fixed two PRs ago.

## The gates invert, as #1068 requires

`tests/test_lifecycle_gates_948.py` asserted `api` and `web` **fail**. They now assert every advertised mode resolves to a suite, that a typo is still rejected (different failures, and a wrapping script has to tell them apart), that the two free modes work with **no `ANTHROPIC_API_KEY` present**, and that `all` runs both engines. Two more: the spec exists and carries its tag, and **a CI step actually selects it** — the tag is how both the script and CI find it, so an untagged spec would silently run in neither.

## Review finding

`codex review` flagged that the gate test reads `tests/e2e/lifecycle.spec.ts` while the file was untracked, so a clean checkout would `FileNotFoundError`. Right about the consequence — the file was staged in the same commit, but "the assertion depends on a file being committed" is worth having been checked.

## Testing

| | |
|---|---|
| Browser lifecycle | 3 passed, 12.8s |
| Full chromium e2e suite | **42 passed**, 30.6s — no regression from the `WORKSPACE_ROOT` or mock changes |
| Full backend suite | **6502 passed**, 49 skipped, 489s |
| `web-ui` unit tests | 1280 passed |
| `ruff`, `actionlint` | clean |
| All four `--mode` values | verified by `--dry-run`, including with the key unset |

## Known limitation

Workspace *creation* is the one step still done API-side in `beforeAll`: the UI has no "create a workspace from nothing" screen — it reads a path out of `localStorage`. Every pipeline step after that goes through the browser. Worth noting as a product gap rather than a test shortcut.