### PR TITLE
ci: verify uv.lock matches pyproject.toml (#1164)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,14 @@ jobs:
         with:
           enable-cache: true
 
+      # Must run BEFORE `uv sync`, which re-locks on the fly and would mask the
+      # drift it is meant to catch. Nothing else in CI compares uv.lock against
+      # pyproject.toml, so a dependency change committed without `uv lock` passed
+      # every job and then failed the image build -- the Dockerfile uses
+      # `uv sync --frozen`, which refuses a mismatched lock (#1164, found via #968).
+      - name: Verify uv.lock is up to date with pyproject.toml
+        run: uv lock --check
+
       - name: Create virtual environment
         run: uv venv
 


### PR DESCRIPTION
Closes #1164.

## Problem

Nothing in CI checked that `uv.lock` was consistent with `pyproject.toml`. A dependency
change committed without regenerating the lock passed **every** job, then failed at image
build time — `Dockerfile:33,36` use `uv sync --frozen`, which refuses a lock that does not
match the manifest. The failure surfaces far from its cause, in a job most PRs never run.

This is not hypothetical. #968's root cause is precisely this drift in its benign
direction: `python-jose[cryptography]` and `passlib[argon2]` sat declared and locked with
zero importers anywhere in the tree, shipping in the wheel — and dragging in the
unmaintained `ecdsa` (CVE-2024-23342) — with nothing in CI able to notice.

## Change

One step, in the existing **Code Quality (Lint + Type Check)** job:

```yaml
- name: Verify uv.lock is up to date with pyproject.toml
  run: uv lock --check
```

Two deliberate placement decisions:

- **Existing job, not a new one.** Code Quality is already a required status check on
  `main`, so the guard actually blocks merge. A new job would need branch-protection
  changes to have any teeth — and would be advisory-only until someone made them.
- **Before `uv sync`, not after.** `uv sync` re-locks on the fly, so a check placed after
  it would validate a lockfile `uv` had just silently repaired — green forever, guarding
  nothing. It also needs no venv, so running it first fails fast.

## Verification

`uv lock --check` semantics confirmed locally against uv 0.9.30, checking the real exit
code rather than a piped one (a pipe returns `tail`'s status and would have made a useless
check look like a working one):

| State | Exit |
|---|---|
| `pyproject.toml` with an added dependency, lock not regenerated | **1** |
| Clean tree | **0** |

`--check` does not write `uv.lock` — the tree is unmodified after a failing run, so this
cannot rewrite the lock it is inspecting.

Current `main` passes the new check (144 packages resolved, exit 0), so this goes green on
merge rather than immediately red.

`actionlint .github/workflows/*.yml` is clean — per CLAUDE.md, since this repo has twice
shipped a workflow that parsed as YAML but would not compile.

## Scope

Only the `code-quality` job gets the step. Two other jobs share the same
`uv venv` / `uv sync` block; duplicating the check into them would triple the cost to
re-verify an invariant that is global to the commit and already enforced by a required
check.