### PR TITLE
refactor(workspace): one place a column migration is written (#1104)

### DIFF
--- a/codeframe/core/workspace.py
+++ b/codeframe/core/workspace.py
@@ -153,8 +153,20 @@ def _create_core_tables(cursor: sqlite3.Cursor) -> None:
 
     Every statement is ``IF NOT EXISTS``, so calling this on an existing
     database adds what is absent and touches nothing else. Column-level
-    migrations (ALTER TABLE) stay in ``_ensure_schema_upgrades``: this function
-    only guarantees that every object exists.
+    migrations (ALTER TABLE) live in ``_ensure_schema_upgrades``: this function
+    only guarantees that every table exists.
+
+    That split was not true when the function was extracted (#1060) — it
+    inherited 13 ALTERs from ``_init_database``, 12 of which
+    ``_ensure_schema_upgrades`` then performed a second time on the same rows.
+    #1104 moved the last one (``blockers.created_by``) out and deleted the
+    duplicates, so there is now exactly one place a column migration is
+    written. ``tests/core/test_schema_alter_split_1104.py`` keeps it that way.
+
+    Deleting them exposed why they had looked load-bearing: the ``tasks``
+    CREATE never listed the four #565 traceability columns, so even a brand new
+    database was getting them by migration, and ``idx_tasks_external_url``
+    indexed a column the CREATE did not declare. They are declared here now.
     """
     # Workspace metadata
     cursor.execute("""
@@ -205,6 +217,10 @@ def _create_core_tables(cursor: sqlite3.Cursor) -> None:
             lineage TEXT DEFAULT '[]',
             is_leaf INTEGER DEFAULT 1,
             hierarchical_id TEXT,
+            requirement_ids TEXT DEFAULT '[]',
+            github_issue_number INTEGER,
+            external_url TEXT,
+            auto_close_github_issue INTEGER DEFAULT 0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             FOREIGN KEY (workspace_id) REFERENCES workspace(id),
@@ -212,35 +228,6 @@ def _create_core_tables(cursor: sqlite3.Cursor) -> None:
             CHECK (status IN ('BACKLOG', 'READY', 'IN_PROGRESS', 'BLOCKED', 'FAILED', 'DONE', 'MERGED'))
         )
     """)
-
-    # Migration: Add columns to existing tasks table
-    # SQLite doesn't support IF NOT EXISTS for ALTER TABLE, so we check first
-    cursor.execute("PRAGMA table_info(tasks)")
-    columns = {row[1] for row in cursor.fetchall()}
-    if "depends_on" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN depends_on TEXT DEFAULT '[]'")
-    if "estimated_hours" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN estimated_hours REAL")
-    if "complexity_score" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN complexity_score INTEGER")
-    if "uncertainty_level" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN uncertainty_level TEXT")
-    if "github_issue_number" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN github_issue_number INTEGER")
-    if "parent_id" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN parent_id TEXT")
-    if "lineage" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN lineage TEXT DEFAULT '[]'")
-    if "is_leaf" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN is_leaf INTEGER DEFAULT 1")
-    if "hierarchical_id" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN hierarchical_id TEXT")
-    if "requirement_ids" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN requirement_ids TEXT DEFAULT '[]'")
-    if "external_url" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN external_url TEXT")
-    if "auto_close_github_issue" not in columns:
-        cursor.execute("ALTER TABLE tasks ADD COLUMN auto_close_github_issue INTEGER DEFAULT 0")
 
     # Append-only event log
     cursor.execute("""
@@ -272,12 +259,6 @@ def _create_core_tables(cursor: sqlite3.Cursor) -> None:
             CHECK (created_by IN ('system', 'agent', 'human'))
         )
     """)
-
-    # Migration: Add created_by column to existing blockers table
-    cursor.execute("PRAGMA table_info(blockers)")
-    blocker_columns = {row[1] for row in cursor.fetchall()}
-    if "created_by" not in blocker_columns:
-        cursor.execute("ALTER TABLE blockers ADD COLUMN created_by TEXT NOT NULL DEFAULT 'human'")
 
     # Checkpoints (state snapshots)
     cursor.execute("""
@@ -649,6 +630,15 @@ def _ensure_schema_upgrades(db_path: Path) -> None:
         if column not in batch_columns:
             cursor.execute(ddl)
     conn.commit()
+
+    # Add created_by column to the blockers table if it doesn't exist.
+    # Lived in _create_core_tables until #1104 moved it here, where the rest of
+    # the column migrations already were.
+    cursor.execute("PRAGMA table_info(blockers)")
+    blocker_columns = {row[1] for row in cursor.fetchall()}
+    if "created_by" not in blocker_columns:
+        cursor.execute("ALTER TABLE blockers ADD COLUMN created_by TEXT NOT NULL DEFAULT 'human'")
+        conn.commit()
 
     # Add tech_stack column to workspace table if it doesn't exist
     # First check if workspace table exists

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,10 +359,10 @@ def _workspace_db_template(tmp_path_factory):
 
     def _copy_template(db_path):
         # An EXISTING database is a migration, not a build: `_init_database`
-        # is `CREATE TABLE IF NOT EXISTS` plus ALTER TABLE steps, so copying
-        # over it would discard the caller's data and skip every migration —
-        # making migration tests pass for the wrong reason, because the
-        # template already contains the column the migration was meant to add.
+        # is `CREATE TABLE IF NOT EXISTS`, so copying over it would discard
+        # the caller's data and skip the schema work they asked for — making
+        # schema tests pass for the wrong reason, because the template already
+        # contains whatever they expected to be added.
         # Only a new file may be templated. The hot path is unaffected:
         # create_or_load_workspace builds at a fresh temp path.
         if Path(db_path).exists():

--- a/tests/core/test_blocker_origin.py
+++ b/tests/core/test_blocker_origin.py
@@ -84,9 +84,20 @@ class TestExistingBlockersMigration:
         assert fetched.created_by == BlockerOrigin.HUMAN
 
     def test_alter_table_migration_adds_created_by_column(self, tmp_path: Path):
-        """ALTER TABLE migration: initializing a DB without created_by column adds it."""
+        """ALTER TABLE migration: opening a DB without created_by adds it.
+
+        Drives `_ensure_schema_upgrades`, not `_init_database`: since #1104 the
+        latter is the fresh-workspace path and carries no column migrations.
+        That matches production, where `_init_database` only ever runs against a
+        brand new temp file and an existing database reaches
+        `_ensure_schema_upgrades` via `get_workspace`.
+        """
         import sqlite3
-        from codeframe.core.workspace import _init_database, CODEFRAME_DIR, STATE_DB_NAME
+        from codeframe.core.workspace import (
+            _ensure_schema_upgrades,
+            CODEFRAME_DIR,
+            STATE_DB_NAME,
+        )
 
         # Create a DB with the old blockers schema (no created_by column)
         repo = tmp_path / "old-repo"
@@ -118,8 +129,8 @@ class TestExistingBlockersMigration:
         conn.close()
         assert "created_by" not in columns_before
 
-        # Run the full init (triggers the ALTER TABLE migration)
-        _init_database(db_path)
+        # Run the upgrade path (triggers the ALTER TABLE migration)
+        _ensure_schema_upgrades(db_path)
 
         # Confirm column is present after migration
         conn = sqlite3.connect(str(db_path))

--- a/tests/core/test_schema_alter_split_1104.py
+++ b/tests/core/test_schema_alter_split_1104.py
@@ -1,0 +1,138 @@
+"""One function creates tables, one migrates columns (#1104).
+
+`_create_core_tables` was extracted from `_init_database` in #1060 and brought
+15 `ALTER TABLE` statements along with it — 12 on `tasks` that
+`_ensure_schema_upgrades` already performs verbatim, plus one on `blockers`.
+Because `_ensure_schema_upgrades` calls `_create_core_tables` first, its own
+`tasks` block always found the columns already present and did nothing.
+
+Duplicated migrations are not harmless: the next column added to one copy and
+not the other drifts silently, which is the same hazard #1060 closed one level
+up. These tests pin the split — CREATE-only in one place, ALTERs in the other —
+so the duplication cannot come back.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+# The tasks columns that were duplicated across both paths.
+DUPLICATED_TASK_COLUMNS = (
+    "depends_on",
+    "estimated_hours",
+    "complexity_score",
+    "uncertainty_level",
+    "github_issue_number",
+    "parent_id",
+    "lineage",
+    "is_leaf",
+    "hierarchical_id",
+    "requirement_ids",
+    "external_url",
+    "auto_close_github_issue",
+)
+
+
+class TestTheSplitIsHonest:
+    def test_create_core_tables_carries_no_alters(self):
+        """The name promises tables. It must not also migrate columns."""
+        from codeframe.core.workspace import _create_core_tables
+
+        # Every SQL literal in the body. The docstring talks *about* ALTER
+        # TABLE and comments explain where the migrations went, so scanning
+        # raw lines would flag prose; only executed statements count.
+        func = ast.parse(
+            textwrap.dedent(inspect.getsource(_create_core_tables))
+        ).body[0]
+        if ast.get_docstring(func) is not None:
+            del func.body[0]
+        statements = [
+            node.value
+            for node in ast.walk(func)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        ]
+        offenders = [s for s in statements if "ALTER TABLE" in s]
+        assert not offenders, (
+            "_create_core_tables performs column migrations:\n"
+            + "\n".join(offenders)
+        )
+
+    @pytest.mark.parametrize("column", DUPLICATED_TASK_COLUMNS)
+    def test_each_tasks_alter_appears_once_in_the_source(self, column):
+        """Two copies of a migration is how the two paths drift apart."""
+        source = Path("codeframe/core/workspace.py").read_text()
+        ddl = f"ALTER TABLE tasks ADD COLUMN {column}"
+        assert source.count(ddl) == 1, (
+            f"{ddl!r} appears {source.count(ddl)} times; it must appear exactly once"
+        )
+
+
+class TestNoOutcomeRegressed:
+    """Whoever performs the migration, a legacy database must come out current."""
+
+    def test_a_legacy_blockers_table_gains_created_by(self, tmp_path):
+        """`blockers.created_by` was migrated ONLY inside `_create_core_tables`.
+
+        Removing the ALTER without relocating it would leave every pre-#565
+        workspace without the column — and `blockers.create()` writes it.
+        """
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        db = tmp_path / "legacy_blockers.db"
+        _init_database(db)
+        conn = sqlite3.connect(db)
+        conn.execute("DROP TABLE blockers")
+        conn.execute(
+            "CREATE TABLE blockers (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL, "
+            "task_id TEXT, question TEXT NOT NULL, answer TEXT, "
+            "status TEXT NOT NULL DEFAULT 'OPEN', created_at TEXT NOT NULL, "
+            "answered_at TEXT)"
+        )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        _ensure_schema_upgrades(db)
+
+        conn = sqlite3.connect(db)
+        try:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(blockers)")}
+        finally:
+            conn.close()
+        assert "created_by" in cols, f"legacy blockers table not migrated: {sorted(cols)}"
+
+    def test_a_legacy_tasks_table_still_gains_every_column(self, tmp_path):
+        """The #1103 outcome, restated against the columns this issue moved."""
+        from codeframe.core.workspace import _ensure_schema_upgrades, _init_database
+
+        db = tmp_path / "legacy_tasks.db"
+        _init_database(db)
+        conn = sqlite3.connect(db)
+        conn.execute("DROP TABLE tasks")
+        conn.execute(
+            "CREATE TABLE tasks (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL, "
+            "title TEXT NOT NULL, description TEXT, status TEXT NOT NULL, "
+            "created_at TEXT NOT NULL, updated_at TEXT NOT NULL)"
+        )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        _ensure_schema_upgrades(db)
+
+        conn = sqlite3.connect(db)
+        try:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+        finally:
+            conn.close()
+        assert set(DUPLICATED_TASK_COLUMNS) <= cols, (
+            f"legacy tasks table was not migrated: {sorted(cols)}"
+        )

--- a/tests/core/test_workspace_db_template_979.py
+++ b/tests/core/test_workspace_db_template_979.py
@@ -127,12 +127,12 @@ class TestTheTemplateMatchesARealBuild:
 
 
 class TestAnExistingDatabaseIsAMigration:
-    """`_init_database` on an existing file migrates it — it does not rebuild.
+    """`_init_database` on an existing file tops it up — it does not rebuild.
 
     The template must only ever serve a *new* database. Copying over an
-    existing one discards its contents and skips every ALTER TABLE, which
-    makes migration tests pass for the wrong reason: the template already has
-    the column the migration was supposed to add.
+    existing one discards its contents and skips the schema work the caller
+    asked for, which makes schema tests pass for the wrong reason: the
+    template already has whatever they expected to be added.
     """
 
     def test_an_existing_database_keeps_its_data(self, tmp_path):
@@ -153,28 +153,22 @@ class TestAnExistingDatabaseIsAMigration:
         finally:
             conn.close()
 
-    def test_the_alter_table_migration_actually_runs(self, tmp_path):
-        """The concrete case: a pre-created_by blockers table gets the column."""
+    def test_a_missing_table_is_actually_created(self, tmp_path):
+        """The concrete case: a database missing `blockers` gets the table.
+
+        Was `test_the_alter_table_migration_actually_runs`, which watched a
+        legacy `blockers` table gain `created_by`. #1104 moved every column
+        migration to `_ensure_schema_upgrades`, so `_init_database` no longer
+        performs that one — see `test_schema_alter_split_1104.py`. What this
+        test is really for is unchanged: prove the REAL function ran and not a
+        template copy, on a file that already exists.
+        """
         from codeframe.core import workspace as ws
 
         db = tmp_path / "state.db"
         conn = sqlite3.connect(db)
-        conn.execute("""
-            CREATE TABLE blockers (
-                id TEXT PRIMARY KEY,
-                workspace_id TEXT NOT NULL,
-                task_id TEXT,
-                question TEXT NOT NULL,
-                answer TEXT,
-                status TEXT NOT NULL DEFAULT 'OPEN',
-                created_at TEXT NOT NULL,
-                answered_at TEXT
-            )
-        """)
-        conn.execute(
-            "INSERT INTO blockers (id, workspace_id, question, status, created_at) "
-            "VALUES ('b1', 'w1', 'q?', 'OPEN', '2026-01-01')"
-        )
+        conn.execute("CREATE TABLE keepsake (id TEXT PRIMARY KEY)")
+        conn.execute("INSERT INTO keepsake VALUES ('k1')")
         conn.commit()
         conn.close()
 
@@ -182,10 +176,14 @@ class TestAnExistingDatabaseIsAMigration:
 
         conn = sqlite3.connect(db)
         try:
-            columns = {r[1] for r in conn.execute("PRAGMA table_info(blockers)")}
-            assert "created_by" in columns
-            # Migrated, not replaced — a rebuild would have dropped the row.
-            assert conn.execute("SELECT id FROM blockers").fetchall() == [("b1",)]
+            tables = {
+                r[0] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            assert "blockers" in tables, "the template was copied instead"
+            # Topped up, not replaced — a rebuild would have dropped the row.
+            assert conn.execute("SELECT id FROM keepsake").fetchall() == [("k1",)]
         finally:
             conn.close()
 


### PR DESCRIPTION
Closes #1104.

## What was actually duplicated

`_create_core_tables` carried **13** `ALTER TABLE` statements (the issue estimated 15), not the pure CREATE-only helper its name promises:

| Statements | Also in `_ensure_schema_upgrades`? |
|---|---|
| 12 on `tasks` | **Yes — verbatim** (`workspace.py:719-763`) |
| 1 on `blockers.created_by` | No — this was its only home |

`_ensure_schema_upgrades` calls `_create_core_tables` first, so by the time its own `tasks` block ran, every column was already present and all 12 checks no-opped. The `batch_runs` (9), `workspace.tech_stack` and `prds` (5 + the #961 backfill) migrations were never duplicated — they live only on the upgrade path.

**No ordering constraint** of the kind #1060 found for indexes: nothing between the two runs reads those columns, the block carries no data backfill, and `_create_core_indexes` still runs last.

## The split, made honest

`_create_core_tables` creates tables. `_ensure_schema_upgrades` migrates columns. The duplicated `tasks` block is deleted; `blockers.created_by` moved to the upgrade path where every other column migration already was. No rename needed — the name is now true.

## The thing the duplication was hiding

Deleting the ALTERs broke the **fresh** path with `no such column: external_url`. The `tasks` CREATE never listed the four #565 traceability columns — `requirement_ids`, `github_issue_number`, `external_url`, `auto_close_github_issue` — so a brand new database was acquiring them by *migration*, and `idx_tasks_external_url` indexed a column its own CREATE did not declare. That is why the ALTERs looked load-bearing rather than duplicated. They are declared in the CREATE now.

Checked before adding them: no positional `INSERT INTO tasks VALUES (...)` and no `SELECT * FROM tasks` anywhere in the codebase, so column count and order are not load-bearing.

## No `SCHEMA_VERSION` bump

No object is added or removed. Every database already stamped at version 5 reached it through a path that produced all of these columns, on either route.

## Two tests retargeted (outcomes unchanged)

Both asserted a legacy `blockers` table gains `created_by` after **`_init_database`** — a path production never takes: `_init_database` only ever runs against a fresh temp file (`workspace.py:871`), and an existing database reaches `_ensure_schema_upgrades` via `get_workspace` (`workspace.py:963`).

- `test_blocker_origin.py::test_alter_table_migration_adds_created_by_column` — same assertions, driven through `_ensure_schema_upgrades`.
- `test_workspace_db_template_979.py::test_the_alter_table_migration_actually_runs` → `test_a_missing_table_is_actually_created`. Its class pins that the conftest template is never copied over an existing file; it just needed an observable that survives this change, so it now watches a missing *table* appear instead of a missing column.

The migration outcome itself is not lost — it is asserted in both of those and again in the new file.

## New: `tests/core/test_schema_alter_split_1104.py` (15 tests)

- `_create_core_tables` contains zero ALTER statements (AST-parsed SQL literals, so the docstring's prose about ALTER TABLE doesn't false-positive)
- each of the 12 `tasks` ALTERs appears exactly once in `workspace.py` — parametrized, in the style of the existing `test_the_index_is_created_exactly_once_in_the_source`
- a legacy `blockers` table still gains `created_by`
- a legacy `tasks` table still gains all 12 columns

Confirmed genuinely RED before the fix: 13 of the 15 failed, and the two outcome tests passed throughout — they are regression guards, not new behaviour.

## Acceptance criteria

- [x] No column migration is performed twice across the two paths
- [x] `_create_core_tables` stops carrying ALTERs (so no rename is needed)
- [x] `test_a_tasks_table_missing_columns_is_migrated_not_left_alone` still passes, untouched
- [x] The #1060 convergence and legacy-shape tests still pass, untouched

## Verification

- Full CI gate `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` — **6476 passed, 19 skipped**
- `uv run ruff check .` — clean
- `codex review --base main` — **no findings** (opencode skipped: it writes to the repo despite no `--auto`)

## Known limitations

- The remaining column migrations in `_ensure_schema_upgrades` are still hand-written `if column not in ...` blocks in three different styles (a tuple-driven loop for `batch_runs`, `sqlite_master`-guarded blocks for `prds`/`workspace`, an unguarded one for `blockers`). Unifying them was out of scope here; the duplication this issue was about is gone.
- Backend-only change with no user-visible surface, so there is no UI to demo — evidence is the test outcomes above.
