### PR TITLE
chore(release): 0.9.3 — anthropic <1.0 ceiling + version metadata fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.9.3]
+
+**Published `codeframe-ai 0.9.2` was dead on arrival, the same as `0.9.1` before it
+(#1168).** `pyproject.toml` pinned `anthropic>=0.18.0` with no ceiling. A fresh
+`uv tool install codeframe-ai` resolved that to `anthropic` 1.0.0, which removed
+`temperature` from `Messages.create()` — every LLM-backed command (`cf prd
+generate`, `cf tasks generate`, `cf work start`, ...) raised `TypeError` on the
+first call, on the exact install path the README documents. `uv.lock` resolves
+`anthropic` 0.70.0, so CI and every developer machine never saw it.
+
+This is the second consecutive release dead on arrival on the published-package
+install path while every existing gate stayed green — `0.9.1` shipped retired
+model IDs (#1112), `0.9.2` shipped this. Neither the test suite nor CI installs
+the published package the way a new user does; only the cold-start cleanroom
+harness (`scripts/quickstart-cleanroom/run.sh`) catches it, and it was not run
+against `0.9.2` before release.
+
+### Fixed
+
+- **`anthropic` is now pinned `>=0.18.0,<1.0` (#1168, #1174).** The ceiling is
+  load-bearing, not caution: it stops the next SDK major bump from silently
+  breaking every fresh install the same way. A new guard test
+  (`tests/adapters/test_sdk_kwargs_guard_614.py`) asserts every keyword argument
+  the adapter sends unconditionally is one the *installed* SDK still accepts, so
+  a future signature drift fails in CI instead of in a release.
+- **`codeframe.__version__` no longer lies (caught by pre-PR `codex review`
+  during this release).** It was a hand-typed literal (`"0.1.0"`) that had not
+  been bumped since the module was written, so `cf version`, every telemetry
+  event, and the Codex adapter's user-agent all reported `0.1.0` through the
+  `0.9.0`, `0.9.1` and `0.9.2` releases — the same "artifact metadata lies
+  about the artifact" failure class as #1112 and #1168, a third instance the
+  existing `tests/test_root_docs_950.py` version-drift guard never covered
+  because it only checked README/CHANGELOG against `pyproject.toml`, not the
+  package itself. `__version__` is now read from installed package metadata
+  via `importlib.metadata.version("codeframe-ai")` (falling back to
+  `"0.0.0+unknown"` for an uninstalled source checkout) so it can't drift from
+  `pyproject.toml` again, and the guard test now asserts the imported
+  `codeframe.__version__` matches the pyproject version too.
+
 ## [0.9.2]
 
 **0.9.1 could not work for anyone** and should not be used: it pinned five

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ THE CLOSED LOOP
 ---
 
 > [!NOTE]
-> **CodeFRAME is in public beta (`0.9.2`).** The vision and the Golden Path CLI
+> **CodeFRAME is in public beta (`0.9.3`).** The vision and the Golden Path CLI
 > (`cf init/prd/tasks/work/proof/pr`) and v2 API are stable enough to build on;
 > the web UI and anything marked "in progress" in
 > [`docs/PRODUCT_ROADMAP.md`](docs/PRODUCT_ROADMAP.md) are still moving, and

--- a/codeframe/__init__.py
+++ b/codeframe/__init__.py
@@ -5,7 +5,13 @@ An autonomous AI development system where multiple specialized agents
 collaborate to build software projects from requirements to deployment.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("codeframe-ai")
+except PackageNotFoundError:  # source checkout, never installed
+    __version__ = "0.0.0+unknown"
+
 __author__ = "Frank Bria"
 
 __all__ = ["__version__", "__author__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeframe-ai"
-version = "0.9.2"
+version = "0.9.3"
 description = "A project delivery system that orchestrates frontier coding agents: Think, Build, Prove, Ship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_root_docs_950.py
+++ b/tests/test_root_docs_950.py
@@ -137,6 +137,20 @@ class TestTheVersionAgrees:
 
         assert f"## [{self._pyproject_version()}]" in changelog
 
+    def test_the_package_reports_that_version_too(self):
+        """`codeframe.__version__` is what `cf version`, telemetry, and the
+        codex adapter actually report — this doc-version check covers README
+        and CHANGELOG but never the package itself, and that's exactly where
+        the drift lived: 0.9.0/0.9.1/0.9.2 all shipped `__version__ = "0.1.0"`,
+        hand-typed and never bumped alongside pyproject.toml."""
+        import importlib
+
+        import codeframe
+
+        importlib.reload(codeframe)
+
+        assert codeframe.__version__ == self._pyproject_version()
+
 
 class TestTheRoadmapDoesNotContradictItself:
     """PROVE and SHIP listed as pending exactly what the Web UI section listed as

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "codeframe-ai"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Published `codeframe-ai 0.9.2` is dead on arrival (#1168) — the second consecutive DOA release on the published-package install path (0.9.1 was #1112). `pyproject.toml` pinned `anthropic>=0.18.0` with no ceiling; a fresh `uv tool install codeframe-ai` resolves `anthropic` 1.0.0, which removed `temperature` from `Messages.create()`, so every LLM-backed command raises `TypeError`.

The fix itself (`anthropic>=0.18.0,<1.0` cap + `tests/adapters/test_sdk_kwargs_guard_614.py`) already landed on `main` in #1174. This PR is the release-prep bump: `0.9.2` → `0.9.3`.

**Pre-PR `codex review --base main` found a second, independent bug in this diff** (see review comment below): `codeframe.__version__` was a hand-typed literal that had never been bumped since the module was written, so `cf version`, every telemetry event, and the Codex adapter's user-agent all reported `0.1.0` through the `0.9.0`/`0.9.1`/`0.9.2` releases. Same failure class as #1112 and #1168 — an artifact whose own metadata lies about it — and the existing `tests/test_root_docs_950.py` version-drift guard didn't catch it because it only checks README/CHANGELOG against `pyproject.toml`, never the package itself. Fixed in this PR (not deferred): `__version__` is now sourced from `importlib.metadata.version("codeframe-ai")` instead of a literal, and the guard test now also asserts the imported `codeframe.__version__` matches the pyproject version.

## What

- `pyproject.toml`: version `0.9.2` → `0.9.3`
- `uv.lock`: regenerated (`uv lock`) to match
- `README.md`: beta banner version bump
- `CHANGELOG.md`: new `[0.9.3]` section — honest about this being the second consecutive DOA release, what closes the gap (the `<1.0` ceiling + guard test), and the codex-caught version-metadata bug
- `codeframe/__init__.py`: `__version__` now read from installed package metadata (`importlib.metadata.version("codeframe-ai")`, falling back to `"0.0.0+unknown"` for an uninstalled source checkout) instead of a hardcoded string
- `tests/test_root_docs_950.py`: new `test_the_package_reports_that_version_too` — verified it fails against the pre-fix `__init__.py` (`0.1.0` != `0.9.3`) and passes after the fix

## Verification

- `uv run pytest tests/adapters/test_sdk_kwargs_guard_614.py` — 4 passed
- `uv run pytest tests/test_root_docs_950.py` — 44 passed, 3 skipped (including the new and existing version-pin tests); 48 passed, 3 skipped when run together with the SDK-kwargs guard file above
- `uv run ruff check .` — all checks passed
- `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` (full CI gate, run before the version-metadata fix was added — no source outside `__init__.py`/the one new test changed since) — 6480 passed, 19 skipped, 0 failed (264.89s)
- `codex review --base main` — 1 finding (P2, version metadata), fixed in this PR; posted as a PR comment
- Cold-start cleanroom check against the actually-published package planned post-tag/post-publish (`scripts/quickstart-cleanroom/run.sh`), to confirm 0.9.3 is not DOA the way 0.9.1 and 0.9.2 were. #1168 will be closed only once that passes, not merely on a successful PyPI upload.

Closes #1168. Does **not** close #614 (its 15-minute quickstart budget criterion is tracked separately as #1171) or #1170 (lifting the ceiling via an SDK migration is future work).

No self-merge — this needs a maintainer merge decision.

