### PR TITLE
ci: check the unlocked dependency resolution, not just the lock (#1169)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,17 @@ permissions:
   contents: read
 
 jobs:
+  # A release must not ship a dependency range set that only resolves on this
+  # repo's lockfile (#1169). This resolves pyproject.toml from scratch against
+  # live PyPI and smoke-tests the result — the resolution a new user actually
+  # gets from `uv tool install codeframe-ai`.
+  unlocked-resolution:
+    name: Unlocked resolution
+    uses: ./.github/workflows/unlocked-resolution.yml
+
   build:
     name: Build sdist + wheel
+    needs: unlocked-resolution
     runs-on: ubuntu-latest
     # ANTHROPIC_API_KEY lives in the `staging` environment, and GitHub only
     # exposes environment secrets to jobs that declare that environment. The

--- a/.github/workflows/unlocked-resolution.yml
+++ b/.github/workflows/unlocked-resolution.yml
@@ -1,0 +1,79 @@
+name: Unlocked Resolution
+
+# Resolves the dependency *ranges* in pyproject.toml with no lockfile, against
+# live PyPI, and smoke-tests the result (#1169).
+#
+# Everything else in CI resolves uv.lock. A user running `uv tool install
+# codeframe-ai` gets none of it — pip/uv resolve the ranges from scratch, today,
+# against whatever is on PyPI today. The two resolutions drift apart silently and
+# continuously, and twice that drift shipped a dead-on-arrival release while
+# every gate was green:
+#
+#   0.9.1  retired Anthropic model IDs      -> every AI command 404'd    (#1112)
+#   0.9.2  anthropic>=0.18.0 -> 1.0.0, which
+#          removed `temperature`            -> every AI command TypeError'd (#1168)
+#
+# The schedule is the point: this break arrives from upstream, not from a commit
+# of ours, so it can appear on a day nobody pushed anything.
+#
+# Known limitation: a red scheduled run notifies via GitHub's normal workflow
+# notifications; it does not open an issue. Deliberate — one moving part.
+
+on:
+  schedule:
+    # Daily, 06:00 UTC — a few hours before a working day starts, so a break
+    # that landed on PyPI overnight is known before anyone tags a release.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+  workflow_call: # release.yml gates on this
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "tests/adapters/test_sdk_kwargs_guard_614.py"
+      - "tests/adapters/test_model_defaults_guard_1112.py"
+      - ".github/workflows/unlocked-resolution.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  unlocked-install:
+    name: Fresh resolve + smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up uv
+        # No enable-cache on purpose: a cached resolution is the locked
+        # resolution wearing a different hat, and defeats the whole job.
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Resolve the ranges, not the lock
+        # `uv pip install` is the pip-compatible interface: it ignores uv.lock
+        # and resolves pyproject.toml from scratch. `uv sync`/`uv run` would not.
+        run: |
+          uv venv --python 3.11 "$RUNNER_TEMP/unlocked"
+          uv pip install --python "$RUNNER_TEMP/unlocked" .
+          {
+            echo "### Resolved from pyproject.toml ranges (no lockfile)"
+            echo '```'
+            uv pip list --python "$RUNNER_TEMP/unlocked"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: cf --help imports the whole package
+        run: |
+          "$RUNNER_TEMP/unlocked/bin/cf" --help
+
+      - name: SDK signature + model-default guards against the resolved env
+        # Installing cleanly is not evidence: 0.9.2 installed fine and raised on
+        # the first API call. These two assert the adapters can actually call
+        # what the resolution produced.
+        run: |
+          "$RUNNER_TEMP/unlocked/bin/python" -m pytest \
+            tests/adapters/test_sdk_kwargs_guard_614.py \
+            tests/adapters/test_model_defaults_guard_1112.py \
+            -q

--- a/.github/workflows/unlocked-resolution.yml
+++ b/.github/workflows/unlocked-resolution.yml
@@ -40,6 +40,9 @@ jobs:
   unlocked-install:
     name: Fresh resolve + smoke test
     runs-on: ubuntu-latest
+    # Seconds in practice. The cap is for the unattended schedule: a stalled
+    # PyPI resolution would otherwise sit on a runner until the 6h default.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,18 @@ path the README documents while every gate was green:
 So: **a floor-only pin on an SDK is a latent DOA release.** Cap the major on
 anything whose call signature we depend on, and remember the lockfile hides it.
 `tests/adapters/test_sdk_kwargs_guard_614.py` catches the drift once it reaches
-the lock; only the cold-start harness catches it before that. Automating the
-gap is #1169.
+the lock. Before that, the **Unlocked Resolution** workflow
+(`.github/workflows/unlocked-resolution.yml`, #1169) catches it: it resolves the
+`pyproject.toml` ranges with no lockfile against live PyPI, installs into a
+throwaway env, and runs `cf --help` plus both SDK guards against *that* env. It
+runs daily on a schedule — this break arrives from upstream, so it can appear on
+a day nobody pushed — on PRs touching `pyproject.toml` or the guards, and as a
+required gate on `release.yml`. `tests/ci/test_unlocked_resolution_guard_1169.py`
+pins those properties.
+
+That job needs no API key and takes seconds, so it is not a replacement for the
+cold-start harness: it checks the *resolution*, the harness checks the
+*published package* on a clean container. Both still matter.
 
 #### Suite speed (#979)
 

--- a/tests/ci/test_unlocked_resolution_guard_1169.py
+++ b/tests/ci/test_unlocked_resolution_guard_1169.py
@@ -67,7 +67,12 @@ def test_the_release_is_gated_on_it():
         None,
     )
     assert gate, "release.yml does not call the unlocked-resolution workflow"
-    assert gate in release["jobs"]["build"]["needs"], (
+    # `needs:` is a string when there is one dependency and a list when there are
+    # several. Normalise, so this stays a membership check and never degrades
+    # into a substring match against a similarly-named job.
+    needs = release["jobs"]["build"]["needs"]
+    needs = [needs] if isinstance(needs, str) else needs
+    assert gate in needs, (
         f"release job 'build' does not need {gate!r}, so a tag can publish a "
         "release whose unlocked resolution was never checked"
     )

--- a/tests/ci/test_unlocked_resolution_guard_1169.py
+++ b/tests/ci/test_unlocked_resolution_guard_1169.py
@@ -1,0 +1,73 @@
+"""#1169 — the CI guard that resolves the *ranges*, not the lock.
+
+`uv.lock` is what CI, `uv sync` and every contributor resolve. `uv tool install
+codeframe-ai` gets none of it: pip/uv resolve the ranges in `pyproject.toml`
+from scratch against whatever is on PyPI today. Those two resolutions drift
+apart silently, and twice that drift shipped a dead-on-arrival release while
+every gate was green (#1112, #1168).
+
+`.github/workflows/unlocked-resolution.yml` closes the gap. These assertions
+pin the properties that make it worth having — delete any one of them and the
+job goes back to testing the lockfile, or stops blocking a release.
+"""
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+UNLOCKED = WORKFLOWS / "unlocked-resolution.yml"
+RELEASE = WORKFLOWS / "release.yml"
+
+
+def _load(path: Path) -> dict:
+    # PyYAML parses the bare `on:` key as the boolean True.
+    return yaml.safe_load(path.read_text())
+
+
+def _steps(workflow: dict) -> list[dict]:
+    return [s for job in workflow["jobs"].values() for s in job.get("steps", [])]
+
+
+def test_it_runs_on_a_schedule():
+    """This class of break arrives from upstream, not from a commit of ours."""
+    triggers = _load(UNLOCKED)[True]
+    assert "schedule" in triggers, (
+        "without a schedule the job only ever sees the resolution as of the last "
+        "push, which is exactly the blind spot that shipped 0.9.2"
+    )
+
+
+def test_it_never_installs_from_the_lockfile():
+    """`uv sync`/`uv run` resolve uv.lock — the resolution this job must NOT test."""
+    runs = " ".join(s.get("run", "") for s in _steps(_load(UNLOCKED)))
+    for locked in ("uv sync", "uv run", "uv lock"):
+        assert locked not in runs, f"{locked!r} reads uv.lock; this job must resolve the ranges"
+    assert "uv pip install" in runs
+
+
+def test_it_exercises_the_sdk_signature_guards_against_the_resolved_env():
+    """Installing is not enough — 0.9.2 installed fine and TypeError'd on first call."""
+    runs = " ".join(s.get("run", "") for s in _steps(_load(UNLOCKED)))
+    assert "test_sdk_kwargs_guard_614.py" in runs
+    assert "test_model_defaults_guard_1112.py" in runs
+
+
+def test_the_release_is_gated_on_it():
+    release = _load(RELEASE)
+    gate = next(
+        (
+            name
+            for name, job in release["jobs"].items()
+            if "unlocked-resolution.yml" in str(job.get("uses", ""))
+        ),
+        None,
+    )
+    assert gate, "release.yml does not call the unlocked-resolution workflow"
+    assert gate in release["jobs"]["build"]["needs"], (
+        f"release job 'build' does not need {gate!r}, so a tag can publish a "
+        "release whose unlocked resolution was never checked"
+    )


### PR DESCRIPTION
Closes #1169

## Problem

Everything in CI resolves `uv.lock`. A user running `uv tool install codeframe-ai`
gets none of it — pip/uv resolve the ranges in `pyproject.toml` from scratch,
today, against whatever is on PyPI today. Those two resolutions drift apart
silently and continuously, and twice that drift shipped a dead-on-arrival release
while `main`, CI and every developer machine were green (#1112, #1168).

The drift is not hypothetical. **Right now**, on this commit:

| Resolution | `anthropic` |
|---|---|
| `uv.lock` (what CI, `uv sync` and every contributor see) | 0.70.0 |
| unlocked, from the ranges (what a new user gets) | 0.125.0 |

Nothing in the repo looked at that second column.

## Change

New workflow `.github/workflows/unlocked-resolution.yml`:

- `uv venv` + `uv pip install .` — the pip-compatible interface, which ignores
  `uv.lock` and resolves `pyproject.toml` from scratch (`uv sync`/`uv run` would not)
- `cf --help` against that env — import smoke test
- `tests/adapters/test_sdk_kwargs_guard_614.py` and
  `test_model_defaults_guard_1112.py` run with *that env's* pytest — installing
  cleanly is not evidence, 0.9.2 installed fine and raised on the first API call
- no `enable-cache`: a cached resolution is the locked resolution wearing a hat

Triggers: **daily schedule** (this break arrives from upstream, so it can appear
on a day nobody pushed), `workflow_dispatch`, PRs touching `pyproject.toml` or
either guard, and `workflow_call` — `release.yml`'s `build` job now `needs` it,
so a tag cannot publish a release whose unlocked resolution was never checked.

`tests/ci/test_unlocked_resolution_guard_1169.py` pins the four properties that
make the job worth having, so a later edit can't quietly turn it back into
another lockfile test.

No API key needed; the job takes seconds.

## Acceptance criteria — evidence

| AC | Evidence |
|---|---|
| Resolves from ranges with no lockfile | job runs `uv pip install .`; workflow contains no `uv sync`/`uv run`/`uv lock`. Locked 0.70.0 vs unlocked 0.125.0 (table above) |
| Fails when the unlocked resolution produces an uncallable SDK | see next row |
| Runs on a schedule | `cron: "0 6 * * *"` |
| Gates the release | `release.yml` → `build: needs: unlocked-resolution` |
| Re-run against the 0.9.2 state reproduces a red build | ceiling removed → resolves `anthropic 1.1.0` → **4 failed**, `missing = {'temperature'}` on `Messages.create`/`stream`, sync and async. Same run against `main`'s capped state: **12 passed**, `cf --help` OK |

Replayed locally by copying `pyproject.toml`, changing `anthropic>=0.18.0,<1.0`
back to `anthropic>=0.18.0`, and running the job's exact steps.

## Known limitations

- A red scheduled run notifies through GitHub's normal workflow notifications;
  it does not open an issue. Deliberate — one moving part.
- This checks the *resolution*, not the *published package*. It is not a
  replacement for `scripts/quickstart-cleanroom/run.sh`, which installs from PyPI
  on a clean container with a real key. Both still matter; CLAUDE.md now says so.
- Resolution is checked on Python 3.11 only (the project minimum and CI version).

## Review

`codex review --base main`: no actionable correctness issues.
Local: `actionlint .github/workflows/*.yml` clean; `ruff`/`black` clean;
`uv run pytest tests/ci tests/adapters` → 235 passed.
