### PR TITLE
ci: bump the GLM Review pin three months forward, drop two grants (#1167)

### DIFF
--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -17,11 +17,21 @@ jobs:
       (github.event.pull_request.changed_files >= 5 ||
        github.event.pull_request.additions >= 20 ||
        github.event.pull_request.deletions >= 20)
-    uses: frankbria/glm-review/.github/workflows/review.yml@b877d15a0f8c0855d0d2ebdcce32ae09cec1bb2d # main
+    uses: frankbria/glm-review/.github/workflows/review.yml@00c986ec828acb6add2f4035f28b4918ef67b78e # main
+    # `issues: write` and `id-token: write` are gone (#1167). They were not
+    # optional on the old pin: GitHub fails a run when a caller grants less than
+    # the called job requests, and b877d15's job declared both. Upstream dropped
+    # them after verifying the reviewer never mints an OIDC token and that PR
+    # comments are authorised by `pull-requests`, not `issues`, even though they
+    # go through the shared /issues/{n}/comments endpoint.
+    #
+    # The new pin also uploads the agent's turn-by-turn transcript as a build
+    # artifact (14-day retention). This repo is public, so that artifact is too —
+    # it holds the PR diff and whatever repo files the reviewer opened, all of
+    # which are already public here. Set `upload_transcript: false` if that ever
+    # stops being true.
     permissions:
       contents: read
       pull-requests: write
-      issues: write
-      id-token: write
     secrets:
       ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/tests/ci/test_glm_review_caller_1167.py
+++ b/tests/ci/test_glm_review_caller_1167.py
@@ -1,0 +1,38 @@
+"""#1167 — the GLM Review caller grants only what the reviewer needs.
+
+The old pin (`b877d15`) declared `issues: write` and `id-token: write` on its
+job, and GitHub fails a run when a caller grants less than the called job
+requests — so this repo had to grant both. Upstream dropped them after verifying
+the reviewer never mints an OIDC token, and that a comment on a PR is authorised
+by `pull-requests` even though it posts through the shared
+`/issues/{n}/comments` endpoint.
+
+Re-adding either here would be a silent privilege regression: the workflow would
+still pass, because over-granting is legal. This is the only thing that would
+notice.
+"""
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+CALLER = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "glm-review.yml"
+
+
+def _review_job() -> dict:
+    return yaml.safe_load(CALLER.read_text())["jobs"]["review"]
+
+
+def test_it_grants_only_read_contents_and_pull_request_writes():
+    assert _review_job()["permissions"] == {"contents": "read", "pull-requests": "write"}
+
+
+def test_the_reusable_workflow_is_pinned_to_a_full_sha():
+    """A moving `@main` would reintroduce the grants without a diff to review."""
+    ref = _review_job()["uses"].split("@", 1)[1]
+    assert len(ref) == 40 and all(
+        c in "0123456789abcdef" for c in ref
+    ), f"glm-review is pinned to {ref!r}; pin a full commit SHA"


### PR DESCRIPTION
Refs #1167 (step 1 of 3 — deliberately does not close it)

## What this changes

- Bumps `frankbria/glm-review` from `b877d15` (2026-07-10) to `00c986e` (2026-08-10), five commits.
- Drops `issues: write` and `id-token: write` from the caller.
- Adds `tests/ci/test_glm_review_caller_1167.py` so neither grant can come back silently — over-granting is legal, so nothing else would notice.

## Why the pin bump is the first move

The gap contains `fc16d4f fix(review): persist agent transcript`. `claude-code-action` writes tool invocations to the workflow log but **not model turns**, which is precisely why #1167 says "the step produces no log output to distinguish [where it hangs]". The new pin uploads the full message stream as an artifact on `always()`, 14-day retention. The next failure is diagnosable instead of forensic.

## Why the two grants could not simply be removed before

They were not ours to drop. GitHub fails a run when a caller grants less than the called job requests, and `b877d15`'s job declared both. Upstream removed them after verifying:

- the reviewer never mints an OIDC token — it passes an explicit `github_token`, and `setupGitHubToken()` returns that immediately rather than running the OIDC → App-token exchange;
- a comment on a PR is authorised by `pull-requests`, not `issues`, even though it posts through the shared `/issues/{n}/comments` endpoint. That covers both comment paths — `track_progress` creates and rewrites the tracking comment via `issues.createComment`/`updateComment`, and the verdict folds into that same comment, so if any of it needed `issues: write` the review would not post at all.

The new pin also tightens the reviewer's own tool allowlist (`--disallowedTools` for `Write`/`Edit`/`git add|commit|rm`), which is relevant here given the local opencode/GLM reviewer has been observed writing to the repo tree.

## What this does NOT fix

`--max-turns 40` and `timeout-minutes: 20` are unchanged upstream, and they are what the failures actually hit:

| Run | Duration | Cause |
|---|---|---|
| [33091328400](https://github.com/frankbria/codeframe/actions/runs/33091328400) | 20m00s | killed by `timeout-minutes: 20` |
| [33092390181](https://github.com/frankbria/codeframe/actions/runs/33092390181) | 19m15s | `Reached maximum number of turns (40)` |

Successful runs take 6m44s–17m33s, so the reviewer sits right on both limits. Steps 2 and 3 of #1167 (raise the limits upstream; make the failure path replace the "Reviewing…" stub with an explicit notice) remain open.

## Correction to #1167's premise

The issue title says GLM Review "has never completed on a real code PR". That was written on 2026-08-25 and is no longer accurate. Of the last 14 non-skipped runs: **7 success, 4 cancelled, 3 failure** — roughly a coin flip, not a dead check. The successes post substantive reviews; the one on #1176 traced every `CallType` consumer through the DB, aggregation queries and web-ui, and surfaced a real pre-existing blast-radius issue in `_persist_token_usage`.

That matters for AC 4 ("if the reviewer cannot be made reliable, the workflow is removed"). It should not be exercised yet — the output when it completes is worth un-flaking. Posting the full run table to #1167 as well.

## Note on the transcript artifact

This repo is public, so the transcript artifact is public. It contains the PR diff and whatever repo files the reviewer opened — all already public here. Documented inline; `upload_transcript: false` is the lever if that stops being true.

## Verification

`actionlint .github/workflows/*.yml` clean. `uv run pytest tests/ci tests/test_workflow_lint_wiring_1122.py tests/test_claude_review_workflow_1011.py tests/test_deploy_audit_gate_1131.py` → 40 passed. The pin SHA is verified to resolve on `frankbria/glm-review`.

This PR is itself over the 5-file/20-line threshold, so GLM Review runs on it — the change is exercised by the thing it changes.
