### PR TITLE
feat(adapters): migrate the Anthropic adapter to the 1.x SDK, lift the <1.0 ceiling (#1170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+
+- **The Anthropic adapter runs on the `anthropic` 1.x SDK; the `<1.0` ceiling is
+  lifted to `>=1.0,<2` (#1170).** 0.9.3 capped the SDK to stop the bleeding from
+  #1168, which froze the project on the 0.x line. 1.x removed `temperature`,
+  `top_p` and `top_k` from `Messages.create()`; they did **not** move to
+  `output_config` (that parameter is `{effort, format}`). The adapter now sends
+  `temperature` in `extra_body`, which the SDK merges into the request JSON
+  verbatim — so the request on the wire is unchanged, and the #767 invariant
+  holds: `temperature=0.0` is a real request for deterministic sampling, never
+  "unset". Sampling is still accepted by the API on the models CodeFrame
+  defaults to (`claude-sonnet-4-5`, `claude-haiku-4-5`); the newer families that
+  reject it (Opus 4.7+, Opus 5, Sonnet 5) rejected it on 0.x too, so this is
+  behavioural parity rather than a new limitation. Verified against the live API
+  on 1.2.0 across all five paths the adapter uses — completion, tool use, tool
+  results, sync streaming, and async streaming including the interleaved-thinking
+  beta branch. No `httpx` -> `httpx2` work was needed: the adapter hands the SDK
+  no `httpx` objects. The major ceiling stays on purpose.
+
 ### Fixed
 
 - **Self-correction token/cost records were silently dropped (#1168 follow-up).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,8 @@ path the README documents while every gate was green:
 
 So: **a floor-only pin on an SDK is a latent DOA release.** Cap the major on
 anything whose call signature we depend on, and remember the lockfile hides it.
+The adapter now runs on `anthropic` 1.x and the pin is `>=1.0,<2` (#1170) — the
+*ceiling* is the lesson, not the version, so do not make it floor-only again.
 `tests/adapters/test_sdk_kwargs_guard_614.py` catches the drift once it reaches
 the lock. Before that, the **Unlocked Resolution** workflow
 (`.github/workflows/unlocked-resolution.yml`, #1169) catches it: it resolves the
@@ -205,6 +207,16 @@ runs daily on a schedule — this break arrives from upstream, so it can appear 
 a day nobody pushed — on PRs touching `pyproject.toml` or the guards, and as a
 required gate on `release.yml`. `tests/ci/test_unlocked_resolution_guard_1169.py`
 pins those properties.
+
+#1170 moved where the risk lives, so the #614 guard now carries two halves. The
+signature check stayed, but it got weaker: `temperature` was a real bet on the
+signature, while `extra_body` — where `temperature` travels on 1.x — is generic
+SDK plumbing that will never vanish. The second half is a wire-level test that
+drives the installed client through a mock transport and decodes the request
+body, so it fails if `extra_body` ever stops being merged into the request. It
+lives in that same file deliberately: this file and
+`test_model_defaults_guard_1112.py` are what Unlocked Resolution runs, and a
+guard that the unlocked job cannot see is not guarding the install path.
 
 That job needs no API key and takes seconds, so it is not a replacement for the
 cold-start harness: it checks the *resolution*, the harness checks the

--- a/codeframe/adapters/llm/anthropic.py
+++ b/codeframe/adapters/llm/anthropic.py
@@ -124,7 +124,13 @@ class AnthropicProvider(LLMProvider):
         # Pass temperature unconditionally: temperature=0.0 is a valid request
         # for deterministic sampling, not "unset". Guarding on `> 0` silently
         # dropped it and let the API default to 1.0 (#767).
-        kwargs["temperature"] = temperature
+        #
+        # It rides in extra_body because anthropic 1.x dropped the sampling
+        # kwargs from the typed signature (#1170); the SDK merges extra_body
+        # into the request JSON verbatim, so the wire request is unchanged. The
+        # model families that reject sampling (Opus 4.7+, Opus 5, Sonnet 5)
+        # rejected it on 0.x too — parity, not a new limitation.
+        kwargs["extra_body"] = {"temperature": temperature}
 
         if system:
             kwargs["system"] = system
@@ -175,10 +181,9 @@ class AnthropicProvider(LLMProvider):
             "max_tokens": max_tokens,
             "messages": self._convert_messages(messages),
         }
-        # Pass temperature unconditionally: temperature=0.0 is a valid request
-        # for deterministic sampling, not "unset". Guarding on `> 0` silently
-        # dropped it and let the API default to 1.0 (#767).
-        kwargs["temperature"] = temperature
+        # temperature in extra_body — same reasoning as complete() above
+        # (#767 invariant, #1170 transport).
+        kwargs["extra_body"] = {"temperature": temperature}
         if system:
             kwargs["system"] = system
         if tools:
@@ -350,10 +355,9 @@ class AnthropicProvider(LLMProvider):
             "messages": self._convert_messages(messages),
         }
 
-        # Pass temperature unconditionally: temperature=0.0 is a valid request
-        # for deterministic sampling, not "unset". Guarding on `> 0` silently
-        # dropped it and let the API default to 1.0 (#767).
-        kwargs["temperature"] = temperature
+        # temperature in extra_body — same reasoning as complete() above
+        # (#767 invariant, #1170 transport).
+        kwargs["extra_body"] = {"temperature": temperature}
 
         if system:
             kwargs["system"] = system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,16 @@ classifiers = [
 ]
 
 dependencies = [
-    # Ceiling is load-bearing, not caution (#614): anthropic 1.0.0 removed
-    # `temperature` (and the other sampling kwargs) from Messages.create(),
-    # so a floor-only pin let every fresh `uv tool install codeframe-ai`
-    # resolve to an SDK our adapter cannot call — published 0.9.2 was dead on
-    # arrival on exactly the path the README tells a new user to take. The
-    # lockfile hid it: CI resolves 0.70.0 and never sees 1.x.
-    # Raise this only together with the 1.x migration.
-    "anthropic>=0.18.0,<1.0",
+    # Ceiling is load-bearing, not caution (#614). anthropic 1.0.0 removed
+    # `temperature` (and the other sampling kwargs) from Messages.create(), and
+    # a floor-only pin let every fresh `uv tool install codeframe-ai` resolve to
+    # an SDK our adapter could not call — published 0.9.2 was dead on arrival on
+    # exactly the path the README tells a new user to take. The lockfile hid it:
+    # CI resolved 0.70.0 and never saw 1.x.
+    # The adapter migrated to 1.x in #1170, so the floor moved with it. The
+    # MAJOR ceiling stays: it is the lesson, not the version. Do not make this
+    # floor-only again — raise it only together with a 2.x migration.
+    "anthropic>=1.0,<2",
     # Runtime, not dev (#910): `cf review`'s security leg shells out to bandit,
     # and when it was missing the scan silently produced no findings — so every
     # clean `pip install` scored 100 and reported "approved" without ever

--- a/tests/adapters/test_llm_anthropic.py
+++ b/tests/adapters/test_llm_anthropic.py
@@ -16,7 +16,13 @@ def _provider() -> AnthropicProvider:
 
 @pytest.mark.parametrize("temperature", [0.0, 0.7])
 def test_complete_passes_temperature_unconditionally(monkeypatch, temperature):
-    """temperature=0.0 must reach the API, not be dropped (#767)."""
+    """temperature=0.0 must reach the API, not be dropped (#767, #1170).
+
+    On the 1.x SDK the kwarg is gone from ``Messages.create()``, so the adapter
+    sends it in ``extra_body`` — which the SDK merges into the request JSON
+    verbatim. The invariant is unchanged: 0.0 is a request for deterministic
+    sampling, never "unset".
+    """
     provider = _provider()
     fake_client = MagicMock()
     fake_client.messages.create.return_value = MagicMock()
@@ -28,12 +34,13 @@ def test_complete_passes_temperature_unconditionally(monkeypatch, temperature):
     provider.complete(messages=[{"role": "user", "content": "hi"}], temperature=temperature)
 
     kwargs = fake_client.messages.create.call_args.kwargs
-    assert kwargs["temperature"] == temperature
+    assert "temperature" not in kwargs, "1.x rejects the top-level kwarg"
+    assert kwargs["extra_body"]["temperature"] == temperature
 
 
 @pytest.mark.parametrize("temperature", [0.0, 0.7])
 async def test_async_complete_passes_temperature_unconditionally(monkeypatch, temperature):
-    """Async path must also pass temperature=0.0 (#767)."""
+    """Async path must also pass temperature=0.0 (#767, #1170)."""
 
     async def _create(**kwargs):
         _create.captured = kwargs
@@ -51,12 +58,13 @@ async def test_async_complete_passes_temperature_unconditionally(monkeypatch, te
         messages=[{"role": "user", "content": "hi"}], temperature=temperature
     )
 
-    assert _create.captured["temperature"] == temperature
+    assert "temperature" not in _create.captured
+    assert _create.captured["extra_body"]["temperature"] == temperature
 
 
 @pytest.mark.parametrize("temperature", [0.0, 0.7])
 def test_stream_passes_temperature_unconditionally(temperature):
-    """Sync streaming path must also pass temperature=0.0 (#767)."""
+    """Sync streaming path must also pass temperature=0.0 (#767, #1170)."""
     provider = _provider()
     fake_client = MagicMock()
     stream_cm = MagicMock()
@@ -67,4 +75,5 @@ def test_stream_passes_temperature_unconditionally(temperature):
     list(provider.stream(messages=[{"role": "user", "content": "hi"}], temperature=temperature))
 
     kwargs = fake_client.messages.stream.call_args.kwargs
-    assert kwargs["temperature"] == temperature
+    assert "temperature" not in kwargs, "1.x rejects the top-level kwarg"
+    assert kwargs["extra_body"]["temperature"] == temperature

--- a/tests/adapters/test_sdk_kwargs_guard_614.py
+++ b/tests/adapters/test_sdk_kwargs_guard_614.py
@@ -6,20 +6,35 @@
 published 0.9.2 was dead on arrival — the same shape of failure as #1112, and
 invisible to CI, which resolves the locked 0.70.0 and never sees 1.x.
 
+Since #1170 the project is *on* 1.x and `temperature` travels in `extra_body`
+instead — so it is no longer in this set. That is the point of keeping the guard
+keyed to what the adapter actually sends: the set moves with the adapter, and the
+assertion keeps meaning "the installed SDK accepts every kwarg we send".
+
 This asserts the contract that actually matters: every keyword the adapter passes
 unconditionally is one the *installed* SDK accepts. It fails the moment the lock
 moves to an SDK whose signature has drifted, whatever the pin says.
 
 Covers both entry points the adapter uses. `messages.stream()` is a separate
 signature from `messages.create()`, and the sync `stream()` also sends
-`temperature`, so it was exposed to this same break.
+`temperature` in `extra_body`, so it was exposed to this same break.
 
 Deliberately NOT asserted: `betas` and `thinking`, which `async_stream` sends only
 for interleaved extended thinking and already guards with a `TypeError` fallback
 (#766). Those are allowed to be absent; the kwargs below are not.
+
+The signature check alone got weaker at #1170: `extra_body` is generic SDK
+plumbing that will never vanish, whereas `temperature` was a real bet on the
+signature. So the wire-level test at the bottom carries the other half — that
+`extra_body` is still *merged into the request body*, which is the only reason
+routing `temperature` through it is acceptable. Both live here because this file
+(with test_model_defaults_guard_1112.py) is what the Unlocked Resolution workflow
+runs against a no-lockfile resolution of the pyproject ranges — the one place
+that sees what a fresh `uv tool install` would get.
 """
 
 import inspect
+import json
 
 import pytest
 
@@ -28,7 +43,7 @@ pytestmark = pytest.mark.v2
 # Every key AnthropicProvider puts into `kwargs` unconditionally, across
 # complete / async_complete (-> messages.create) and stream / async_stream
 # (-> messages.stream). The union is the same set for both.
-ADAPTER_KWARGS = {"model", "max_tokens", "messages", "temperature", "system", "tools"}
+ADAPTER_KWARGS = {"model", "max_tokens", "messages", "extra_body", "system", "tools"}
 
 
 def _missing(method) -> set[str]:
@@ -62,3 +77,52 @@ def test_async_client_accepts_every_kwarg_the_adapter_sends(call):
         f"installed anthropic SDK no longer accepts {sorted(missing)} on async "
         f"Messages.{call}(); AnthropicProvider still sends them."
     )
+
+
+@pytest.mark.parametrize("temperature", [0.0, 0.7])
+def test_temperature_reaches_the_request_body_over_the_wire(temperature):
+    """The #767 invariant, asserted where it actually matters: the HTTP body.
+
+    The kwarg tests in test_llm_anthropic.py mock ``messages.create`` and so
+    only prove what the adapter *hands* the SDK. This one drives the real
+    installed client through a mock transport and decodes the JSON it would
+    have put on the wire — so it fails if ``extra_body`` ever stops being
+    merged into the request, which is the half the signature check above can
+    no longer see.
+    """
+    import anthropic
+    import httpx2
+
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx2.Response(
+            200,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+    provider = AnthropicProvider(api_key="test-key")
+    provider._client = anthropic.Anthropic(
+        api_key="test-key",
+        http_client=anthropic.DefaultHttpxClient(
+            transport=httpx2.MockTransport(handler)
+        ),
+    )
+
+    provider.complete(
+        messages=[{"role": "user", "content": "hi"}], temperature=temperature
+    )
+
+    assert captured["body"]["temperature"] == temperature

--- a/tests/adapters/test_sdk_kwargs_guard_614.py
+++ b/tests/adapters/test_sdk_kwargs_guard_614.py
@@ -126,3 +126,79 @@ def test_temperature_reaches_the_request_body_over_the_wire(temperature):
     )
 
     assert captured["body"]["temperature"] == temperature
+
+
+#: A minimal well-formed SSE stream, enough for ``messages.stream()`` to build a
+#: final message. Only the request matters here; this is just a valid reply.
+_STREAM_SSE = "\n".join(
+    [
+        "event: message_start",
+        'data: {"type":"message_start","message":{"id":"m","type":"message",'
+        '"role":"assistant","model":"claude-sonnet-4-5","content":[],'
+        '"stop_reason":null,"stop_sequence":null,'
+        '"usage":{"input_tokens":1,"output_tokens":0}}}',
+        "",
+        "event: content_block_start",
+        'data: {"type":"content_block_start","index":0,'
+        '"content_block":{"type":"text","text":""}}',
+        "",
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":0,'
+        '"delta":{"type":"text_delta","text":"hi"}}',
+        "",
+        "event: content_block_stop",
+        'data: {"type":"content_block_stop","index":0}',
+        "",
+        "event: message_delta",
+        'data: {"type":"message_delta",'
+        '"delta":{"stop_reason":"end_turn","stop_sequence":null},'
+        '"usage":{"output_tokens":1}}',
+        "",
+        "event: message_stop",
+        'data: {"type":"message_stop"}',
+        "",
+    ]
+)
+
+
+@pytest.mark.parametrize("temperature", [0.0, 0.7])
+def test_temperature_reaches_the_stream_request_body_too(temperature):
+    """Same wire assertion for ``messages.stream()``, which is its own method.
+
+    ``stream()`` is a different SDK entry point from ``create()`` with its own
+    signature and its own manager, so "create merges extra_body" is not
+    evidence that stream does. Without this, the sync streaming path would rest
+    on exactly the signature-only check this file already says proves nothing
+    for a generic kwarg like ``extra_body``.
+    """
+    import anthropic
+    import httpx2
+
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_STREAM_SSE.encode(),
+        )
+
+    from codeframe.adapters.llm.anthropic import AnthropicProvider
+
+    provider = AnthropicProvider(api_key="test-key")
+    provider._client = anthropic.Anthropic(
+        api_key="test-key",
+        http_client=anthropic.DefaultHttpxClient(
+            transport=httpx2.MockTransport(handler)
+        ),
+    )
+
+    chunks = list(
+        provider.stream(
+            messages=[{"role": "user", "content": "hi"}], temperature=temperature
+        )
+    )
+
+    assert chunks == ["hi"], chunks
+    assert captured["body"]["temperature"] == temperature

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
 ]
 
 [[package]]
@@ -178,21 +179,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.70.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/be/a80a8678d39d77b2325b1a32a55d62ca9dc376984a3d66d351229d37da9c/anthropic-0.70.0.tar.gz", hash = "sha256:24078275246636d9fd38c94bb8cf64799ce7fc6bbad379422b36fa86b3e4deee", size = 480930, upload-time = "2025-10-15T16:54:33.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/1a/b5af41cc1fa14da277ec20ca5554dd2fcbc09b8523ac59b7a97fbb88e452/anthropic-1.2.0.tar.gz", hash = "sha256:12f8eedee7b7fb5685837b1371b7bfae1b281703f62355f4632598ec2fc53b34", size = 1137443, upload-time = "2026-08-27T20:29:12.68Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/81/da287ba25b9f8a16d27e822b3f2dad6ddf005fba3e3696f5dce818383850/anthropic-0.70.0-py3-none-any.whl", hash = "sha256:fa7d0dee6f2b871faa7cd0b77f6047e8006d5863618804204cf34b1b95819971", size = 337327, upload-time = "2025-10-15T16:54:32.087Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/78/3f8b52708b03309e511990700bb8d0ec7a0c9db3d2a1e0d1c3ca417a4604/anthropic-1.2.0-py3-none-any.whl", hash = "sha256:b60642b3e3cd6b8e3e328a2d3f2863ad2b6e743f1037e42cc0143f7df99f63c6", size = 1289535, upload-time = "2026-08-27T20:29:11.01Z" },
 ]
 
 [[package]]
@@ -654,7 +654,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "aiosqlite", specifier = ">=0.19.0" },
-    { name = "anthropic", specifier = ">=0.18.0,<1.0" },
+    { name = "anthropic", specifier = ">=1.0,<2" },
     { name = "bandit", specifier = ">=1.8.6" },
     { name = "bcrypt", specifier = ">=4.2.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1" },
@@ -1226,6 +1226,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1283,6 +1296,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -3176,6 +3215,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/cb/f57b149d7beed1a85b8266d0c60ebe4c46e79c9ba56bc17b898e17daf88e/tree_sitter_typescript-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8d4f0f9bcb61ad7b7509d49a1565ff2cc363863644a234e1e0fe10960e55aea0", size = 340245, upload-time = "2024-11-11T02:36:06.473Z" },
     { url = "https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
     { url = "https://files.pythonhosted.org/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refs #1170. (Deliberately not `Closes` — the issue is closed after post-merge verification.)

## What this does

0.9.3 capped `anthropic<1.0` to stop the bleeding from #1168. That froze us on the 0.x line. This migrates the adapter and moves the pin to `>=1.0,<2` — **the major ceiling stays**, because the ceiling is the lesson (#614), not the version.

## The issue's premise was wrong on one point

The issue's first scope item says: *"Confirm where sampling parameters live in 1.x (`output_config`)"*. They don't live anywhere.

Probing a real `anthropic` 1.2.0 install: `output_config` is `{effort, format}` — it has nothing to do with sampling — and `grep -r temperature` over the installed package returns **zero hits**. `temperature`/`top_p`/`top_k` were *removed* from the SDK, not relocated. So a parameter rename was never available.

## What was done instead

`temperature` now travels in `extra_body`, which the SDK merges into the request JSON verbatim. Verified by decoding the actual request body through a mock transport:

```
body keys: ['max_tokens', 'messages', 'model', 'temperature']
temperature in body: 0.0
```

This keeps the **#767 invariant** intact — `temperature=0.0` is a real request for deterministic sampling, never "unset" — and the request on the wire is unchanged from 0.x.

This is the route the Anthropic SDK's own 0.x→1.x upgrade guide prescribes for exactly this case: a call that pins a model which still accepts sampling *and* visibly depends on the setting. CodeFrame's defaults (`claude-sonnet-4-5`, `claude-haiku-4-5`) are in that set. The families that reject sampling (Opus 4.7+, Opus 5, Sonnet 5) **rejected it on 0.x too**, so this is behavioural parity, not a new limitation.

## The #614 guard needed rebalancing, not just an updated kwarg set

Simply swapping `temperature` → `extra_body` in `ADAPTER_KWARGS` would have quietly gutted the guard. `temperature` was a real bet on the SDK signature; `extra_body` is generic plumbing that will never vanish, so the signature check alone stops guarding the install path.

So the guard now carries two halves — the signature check, plus a wire-level test that drives the installed client through a mock transport and decodes the request body, failing if `extra_body` ever stops being merged. It lives in `test_sdk_kwargs_guard_614.py` on purpose: that file and `test_model_defaults_guard_1112.py` are what the **Unlocked Resolution** workflow runs against a no-lockfile resolution, and a guard that job cannot see is not guarding a fresh `uv tool install`.

## Verification

Every acceptance criterion, with the evidence:

| Criterion | Evidence |
|---|---|
| Adapter calls 1.x without removed kwargs | `complete` / `async_complete` / `stream` send `extra_body`; `async_stream` never sent sampling |
| `temperature=0.0` still reaches the API (#767) | 4 tests, incl. one decoding the real HTTP body |
| Streaming + tool-use verified, **not just compiled** | live against the API on 1.2.0 — see below |
| Ceiling lifted; guard green on 1.x | `anthropic>=1.0,<2`; guards 14/14 |
| Cold-start harness green on a source install | full run, matches documented baseline |

**Live run against the real API on `anthropic` 1.2.0** (`claude-haiku-4-5` / `claude-sonnet-4-5`):

```
1. complete()      -> 'PONG' stop=end_turn tokens=14/6
2. tool use        -> stop=tool_use calls=[('get_weather', {'city': 'Paris'})]
3. tool result     -> 'The weather in Paris is currently **12°C ... and raining**'
4. stream()        -> 2 chunks, joined='1 2 3'
5. async_stream()  -> text='HELLO', stop_reason=end_turn, tokens=15/5
6. beta thinking   -> thinking_deltas present, answer correct, usage 52/182
```

Path 6 covers the `beta.messages.stream(betas=..., thinking=...)` branch and its #766 `TypeError` fallback, which the plain stream test does not reach.

**`map_provider_error` (#1110) re-checked against real 1.x exception types** — the scope item asked for this and the mapping is class-name-based, so a rename would have silently broken it:

```
401 -> LLMAuthError            403 -> LLMAuthError
404 -> LLMModelNotFoundError   429 -> LLMRateLimitError
500 -> LLMOverloadedError
```

**Unlocked resolution reproduced locally** — the check that exists because #1112 and #1168 both shipped DOA while every other gate was green. A fresh venv, `uv pip install .` (ranges, no lockfile), resolves `anthropic 1.2.0` + `httpx2`, and both guards pass **14/14** against that env.

**Cold-start cleanroom on a source install** — 12/14 steps OK. The two failures are the documented pre-existing baseline, not regressions:

| Step | This run | Documented baseline (`docs/demos/quickstart-cleanroom.md`) |
|---|---|---|
| `6-work-start` | FAIL 247s exit 1, blocker filed | FAIL 163s/179s exit 1 — "the agent files a blocker rather than guessing (exit 1, by design)" |
| `6-proof-run` | FAIL exit 2 | FAIL exit 2 — open issue #1173 |

Every LLM-backed step passed on 1.x: `prd generate` 67s, `tasks generate` 28s, 247s of real agent iterations across three gate cycles.

**Full suite**: `6497 passed, 19 skipped, 0 failed` (9m26s). **Ruff**: clean.

**Third-party review** (pre-PR, on the branch diff at `7af44d7b`): `codex review` / `gpt-5.5` — *"The Anthropic SDK migration updates the adapter calls and guard tests consistently, and the targeted adapter tests pass under the updated lockfile. I did not identify any introduced, actionable correctness issues in the diff."*

## What was NOT needed (and why, so a reviewer doesn't wonder)

- **No `httpx` → `httpx2` migration.** 1.x moves its HTTP layer to `httpx2`, but that only matters for `httpx` objects crossing the SDK boundary. This adapter passes the SDK no `http_client`, no transports, no `Timeout`. The repo's other `httpx` use (GitHub, telemetry) never touches the SDK. Verified separately that `anthropic.NotFoundError(response=httpx.Response(...))` still constructs, so `test_model_defaults_guard_1112.py` needs no change either.
- **No Python floor bump.** 1.x needs ≥3.10; `requires-python` is already `>=3.11`.
- **Nothing else from the upgrade guide applies.** Not present in this repo: `with_raw_response`, `completions.create`, `HUMAN_PROMPT`/`AI_PROMPT`, raw `output_format={...}`, `compaction_control`, `parse(stream=)`, `Stream` isinstance checks, Bedrock clients, `top_p`/`top_k`.
- **`httpx2` is not declared as a dependency.** It arrives with `anthropic`, confirmed present in the unlocked no-lockfile resolution above — which is the environment that matters.

## Known limitations

1. **Sampling is still unusable on Opus 4.7+ / Opus 5 / Sonnet 5.** Those models 400 on any `temperature`, including the default. A user who overrides `CODEFRAME_LLM_MODEL` to one of them hits that — exactly as they did on 0.x. Fixing it means teaching the adapter which model families accept sampling; that is a behaviour change, out of scope here, and worth its own issue if anyone actually asks for those models.
2. **`async_stream` sends no `temperature` at all** — it never did, on 0.x either. So the ReAct streaming path runs at the API default rather than deterministic sampling. Pre-existing and untouched; flagged because #767 is about determinism and a reader may expect symmetry.

## Encountered but out of scope

Filed **#1181** (P2.35): `CredentialManager` blocks forever when the OS keyring backend is present but unresponsive. Found because it wedged the full suite for over an hour at 92%; `credentials.py` is not in this diff, and it reproduces with no `anthropic` involvement at all. The "keyring unavailable → file fallback" path only catches *exceptions*, never *hangs*, so a headless box with no D-Bus session bus hangs every credential read — including the `GET /api/v2/settings/keys` request handler. Local workaround: `PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring`.
