### PR TITLE
fix(credentials): bound keyring calls by time so a dead backend cannot hang (#1181)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,33 @@ CODEFRAME_CREDENTIAL_SECRET=<secret>  # Mixed into the PBKDF2 KDF for the
                                       # previously stored credentials become
                                       # undecryptable and must be re-entered.
 
+# Unresponsive keyring backends (#1181)
+CODEFRAME_DISABLE_KEYRING=1           # Skip the OS keyring entirely and use the
+                                      # encrypted file store. A backend that is
+                                      # installed and *selected* but never
+                                      # answers — SecretService on a headless
+                                      # box, container or SSH session with no
+                                      # session D-Bus — raises nothing, it
+                                      # blocks. Detection by exception therefore
+                                      # never fired, so the fallback never
+                                      # engaged and every credential read hung
+                                      # forever: the test suite wedged, and
+                                      # GET /api/v2/settings/keys hung a request
+                                      # thread. Every keyring call is now
+                                      # time-boxed and a timeout is treated
+                                      # exactly like KeyringError; the verdict
+                                      # is sticky per process, so the timeout is
+                                      # paid once, not once per request. This
+                                      # variable is the explicit opt-out (and
+                                      # avoids even the first timeout).
+CODEFRAME_KEYRING_TIMEOUT=2.0         # Seconds allowed per keyring call before
+                                      # falling through to the encrypted file.
+                                      # Read at call time, not import (#963).
+                                      # Raise it if a healthy backend with an
+                                      # unlock prompt needs longer.
+                                      # `PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring`
+                                      # remains the keyring-native equivalent.
+
 # Session token lifetime (#657 — defense-in-depth)
 JWT_LIFETIME_SECONDS=86400            # JWT validity window; default 24h (was 7d).
                                       # Shorter window limits exposure of the

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -129,6 +129,19 @@ class KeyringTimeoutError(KeyringError):  # type: ignore[misc,valid-type]
     """
 
 
+def _env_flag(name: str) -> bool:
+    """Whether an opt-in env flag is set. Truthy: ``1``, ``true``, ``yes``, ``on``.
+
+    Mirrors ``ui/server._env_flag`` rather than importing it — core stays
+    headless. An explicit allowlist, not "anything but 0", so
+    ``CODEFRAME_DISABLE_KEYRING=no`` means no.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _keyring_timeout() -> float:
     """Read the timeout per call, not at import (the #963 lesson)."""
     raw = os.environ.get("CODEFRAME_KEYRING_TIMEOUT")
@@ -622,7 +635,7 @@ class CredentialStore:
         """Check if keyring is available and working."""
         if not KEYRING_AVAILABLE:
             return False
-        if os.environ.get("CODEFRAME_DISABLE_KEYRING", "").lower() not in ("", "0", "false"):
+        if _env_flag("CODEFRAME_DISABLE_KEYRING"):
             return False
         if _KEYRING_TIMED_OUT:
             # An earlier call already proved this backend unresponsive (#1181).

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -131,9 +131,17 @@ class KeyringTimeoutError(KeyringError):  # type: ignore[misc,valid-type]
 
 def _keyring_timeout() -> float:
     """Read the timeout per call, not at import (the #963 lesson)."""
+    raw = os.environ.get("CODEFRAME_KEYRING_TIMEOUT")
+    if raw is None:
+        return DEFAULT_KEYRING_TIMEOUT
     try:
-        return float(os.environ.get("CODEFRAME_KEYRING_TIMEOUT", DEFAULT_KEYRING_TIMEOUT))
+        return float(raw)
     except ValueError:
+        logger.warning(
+            "CODEFRAME_KEYRING_TIMEOUT=%r is not a number; using %.1fs.",
+            raw,
+            DEFAULT_KEYRING_TIMEOUT,
+        )
         return DEFAULT_KEYRING_TIMEOUT
 
 

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -111,6 +111,14 @@ DEFAULT_KEYRING_TIMEOUT = 2.0
 # server, so without this every request would pay the timeout again (#1181).
 _KEYRING_TIMED_OUT = False
 
+# One keyring call at a time per process. Without it, a burst of concurrent
+# first callers each read _KEYRING_TIMED_OUT as False and each start its own
+# unkillable worker, so the sticky verdict would bound nothing. Serialized, the
+# losers wait on the lock and then see the verdict the winner set. Cheap: a
+# healthy keyring call is milliseconds, credential reads are rare, and the
+# backend serializes on its own socket anyway.
+_KEYRING_CALL_LOCK = threading.Lock()
+
 
 class KeyringTimeoutError(KeyringError):  # type: ignore[misc,valid-type]
     """A keyring call did not return within the timeout.
@@ -138,9 +146,16 @@ def _keyring_call(fn, *args):
     every call is time-boxed here instead.
 
     The blocked call cannot be cancelled (it is waiting inside libdbus), so the
-    worker thread is abandoned as a daemon. That is bounded: the sticky
-    ``_KEYRING_TIMED_OUT`` flag means at most one abandoned thread per process.
+    worker thread is abandoned as a daemon. That is bounded to one per process
+    by the sticky ``_KEYRING_TIMED_OUT`` flag plus the lock that makes the flag
+    mean something under concurrency.
     """
+    with _KEYRING_CALL_LOCK:
+        return _keyring_call_locked(fn, *args)
+
+
+def _keyring_call_locked(fn, *args):
+    """The body of :func:`_keyring_call`, run one caller at a time."""
     global _KEYRING_TIMED_OUT
 
     if _KEYRING_TIMED_OUT:

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -182,9 +182,10 @@ def _keyring_call_locked(fn, *args):
         except BaseException as exc:  # re-raised on the calling thread below
             outcome.append(("error", exc))
 
+    timeout = _keyring_timeout()
     worker = threading.Thread(target=run, daemon=True, name="codeframe-keyring")
     worker.start()
-    worker.join(_keyring_timeout())
+    worker.join(timeout)
 
     if worker.is_alive():
         _KEYRING_TIMED_OUT = True
@@ -192,7 +193,7 @@ def _keyring_call_locked(fn, *args):
             "Keyring backend did not respond within %.1fs; falling back to the "
             "encrypted credential file for the rest of this process. Set "
             "CODEFRAME_DISABLE_KEYRING=1 to skip the keyring entirely.",
-            _keyring_timeout(),
+            timeout,
         )
         raise KeyringTimeoutError("keyring call timed out")
 

--- a/codeframe/core/credentials.py
+++ b/codeframe/core/credentials.py
@@ -2,7 +2,12 @@
 
 This module provides:
 - Platform-native keyring integration (primary storage)
-- Encrypted file fallback when keyring unavailable
+- Encrypted file fallback when keyring unavailable — where "unavailable" includes
+  *unresponsive*, not just missing or raising: a backend can be installed and
+  selected yet never answer (SecretService with no session D-Bus), so every
+  keyring call is time-boxed and a timeout falls through to the file (#1181).
+  ``CODEFRAME_DISABLE_KEYRING=1`` skips the keyring outright;
+  ``CODEFRAME_KEYRING_TIMEOUT`` tunes the bound.
 - Environment variable override support
 - Credential validation and rotation
 
@@ -95,6 +100,83 @@ _MIGRATION_COMPLETE: set[Path] = set()
 # a process. The optional file lock (requires ``filelock``) extends that
 # serialization across processes.
 _MIGRATION_THREAD_LOCKS: dict[Path, threading.Lock] = {}
+
+# Default bound on any single keyring call. Long enough for a healthy
+# SecretService round-trip (including an unlock prompt round-trip), short enough
+# that a dead backend does not read as a hang.
+DEFAULT_KEYRING_TIMEOUT = 2.0
+
+# Sticky, per-process: once a keyring call has timed out, the backend is dead for
+# the life of this process. CredentialStore is constructed per request on the
+# server, so without this every request would pay the timeout again (#1181).
+_KEYRING_TIMED_OUT = False
+
+
+class KeyringTimeoutError(KeyringError):  # type: ignore[misc,valid-type]
+    """A keyring call did not return within the timeout.
+
+    Subclasses ``KeyringError`` on purpose: every existing call site already
+    treats a ``KeyringError`` as "keyring failed, use the encrypted file", which
+    is exactly the right response to a backend that never answers.
+    """
+
+
+def _keyring_timeout() -> float:
+    """Read the timeout per call, not at import (the #963 lesson)."""
+    try:
+        return float(os.environ.get("CODEFRAME_KEYRING_TIMEOUT", DEFAULT_KEYRING_TIMEOUT))
+    except ValueError:
+        return DEFAULT_KEYRING_TIMEOUT
+
+
+def _keyring_call(fn, *args):
+    """Run one keyring call under a timeout.
+
+    A backend that is installed and selected but unresponsive — SecretService on
+    a headless box with no session D-Bus — raises nothing, it blocks forever.
+    Detecting "unavailable" by exception alone therefore never fires (#1181), so
+    every call is time-boxed here instead.
+
+    The blocked call cannot be cancelled (it is waiting inside libdbus), so the
+    worker thread is abandoned as a daemon. That is bounded: the sticky
+    ``_KEYRING_TIMED_OUT`` flag means at most one abandoned thread per process.
+    """
+    global _KEYRING_TIMED_OUT
+
+    if _KEYRING_TIMED_OUT:
+        # Already proved unresponsive. Short-circuit *here*, not just in
+        # _check_keyring: a store built before the timeout still has
+        # _keyring_available=True, and store() chases a timed-out set_password
+        # with a delete_password. Without this each of those starts another
+        # unkillable worker and waits the timeout again.
+        raise KeyringTimeoutError("keyring backend already timed out in this process")
+
+    outcome: list = []
+
+    def run() -> None:
+        try:
+            outcome.append(("ok", fn(*args)))
+        except BaseException as exc:  # re-raised on the calling thread below
+            outcome.append(("error", exc))
+
+    worker = threading.Thread(target=run, daemon=True, name="codeframe-keyring")
+    worker.start()
+    worker.join(_keyring_timeout())
+
+    if worker.is_alive():
+        _KEYRING_TIMED_OUT = True
+        logger.warning(
+            "Keyring backend did not respond within %.1fs; falling back to the "
+            "encrypted credential file for the rest of this process. Set "
+            "CODEFRAME_DISABLE_KEYRING=1 to skip the keyring entirely.",
+            _keyring_timeout(),
+        )
+        raise KeyringTimeoutError("keyring call timed out")
+
+    kind, value = outcome[0]
+    if kind == "error":
+        raise value
+    return value
 
 
 def _get_migration_locks(storage_dir: Path) -> tuple[threading.Lock, Any | None]:
@@ -516,10 +598,16 @@ class CredentialStore:
         """Check if keyring is available and working."""
         if not KEYRING_AVAILABLE:
             return False
+        if os.environ.get("CODEFRAME_DISABLE_KEYRING", "").lower() not in ("", "0", "false"):
+            return False
+        if _KEYRING_TIMED_OUT:
+            # An earlier call already proved this backend unresponsive (#1181).
+            return False
 
         try:
-            # Try to get the keyring backend
-            kr = keyring.get_keyring()
+            # Try to get the keyring backend. Backend selection itself can block
+            # on a dead D-Bus, so it is time-boxed like every other call.
+            kr = _keyring_call(keyring.get_keyring)
             # Check if it's a real backend (not fail keyring)
             if "fail" in kr.__class__.__name__.lower():
                 return False
@@ -669,13 +757,13 @@ class CredentialStore:
         # Try keyring first
         if self._keyring_available:
             try:
-                keyring.set_password(self._keyring_service_name, key, data)
+                _keyring_call(keyring.set_password, self._keyring_service_name, key, data)
                 logger.debug(f"Stored {key} in keyring")
                 return
             except Exception as e:
                 logger.warning(f"Keyring storage failed, using encrypted file: {e}")
                 try:
-                    keyring.delete_password(self._keyring_service_name, key)
+                    _keyring_call(keyring.delete_password, self._keyring_service_name, key)
                 except Exception:
                     pass
                 self._keyring_available = False
@@ -705,11 +793,15 @@ class CredentialStore:
         # Try keyring first
         if self._keyring_available:
             try:
-                data = keyring.get_password(self._keyring_service_name, key)
+                data = _keyring_call(keyring.get_password, self._keyring_service_name, key)
                 if data:
                     return Credential.from_dict(json.loads(data))
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(f"Malformed credential data in keyring for {key}: {e}")
+            except KeyringTimeoutError:
+                # Unresponsive backend: stop asking it on this instance too, so
+                # the timeout is paid once rather than on every read (#1181).
+                self._keyring_available = False
             except Exception as e:
                 logger.debug(f"Keyring retrieval failed: {e}")
 
@@ -735,12 +827,17 @@ class CredentialStore:
         # Try keyring
         if self._keyring_available:
             try:
-                keyring.delete_password(self._keyring_service_name, key)
+                _keyring_call(keyring.delete_password, self._keyring_service_name, key)
                 logger.debug(f"Deleted {key} from keyring")
             except PasswordDeleteError:
                 # Not in the keyring (e.g. a file-only entry) — that is
                 # "nothing to do", not a failure. Continue to file cleanup.
                 logger.debug(f"{key} not present in keyring; nothing to delete there")
+            except KeyringTimeoutError:
+                # An unresponsive backend must degrade, not fail the delete: the
+                # entry may well be file-only, and the file cleanup below is the
+                # part that matters (#1181).
+                self._keyring_available = False
             except Exception as e:
                 logger.warning(f"Keyring deletion failed: {e}")
                 raise

--- a/codeframe/ui/routers/github_integrations_v2.py
+++ b/codeframe/ui/routers/github_integrations_v2.py
@@ -23,6 +23,7 @@ from typing import Any, Optional
 import httpx
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from codeframe.auth.api_keys import SCOPE_ADMIN
@@ -351,9 +352,15 @@ async def connect(
     # ambient token and the rollback below would persist it into this user's
     # store, where they could then use it (#900). Only a genuinely stored
     # prior credential is worth restoring.
-    prior_pat = manager.get_stored_credential(CredentialProvider.GIT_GITHUB)
+    prior_pat = await run_in_threadpool(
+        manager.get_stored_credential, CredentialProvider.GIT_GITHUB
+    )
     try:
-        manager.set_credential(CredentialProvider.GIT_GITHUB, body.pat)
+        # Off the event loop: this reaches the OS keyring, and an unresponsive
+        # backend parks the calling thread for the timeout (#1181).
+        await run_in_threadpool(
+            manager.set_credential, CredentialProvider.GIT_GITHUB, body.pat
+        )
     except Exception as e:
         logger.error("Failed to store GitHub PAT: %s", e, exc_info=True)
         raise HTTPException(
@@ -379,9 +386,13 @@ async def connect(
         logger.error("Failed to save integration config: %s", e, exc_info=True)
         try:
             if prior_pat is not None:
-                manager.set_credential(CredentialProvider.GIT_GITHUB, prior_pat)
+                await run_in_threadpool(
+                    manager.set_credential, CredentialProvider.GIT_GITHUB, prior_pat
+                )
             else:
-                manager.delete_credential(CredentialProvider.GIT_GITHUB)
+                await run_in_threadpool(
+                    manager.delete_credential, CredentialProvider.GIT_GITHUB
+                )
         except Exception:
             pass
         raise HTTPException(
@@ -415,7 +426,9 @@ async def disconnect(
     """Clear stored repo metadata and delete the GitHub PAT. Idempotent."""
     clear_github_integration_config(workspace)
     try:
-        manager.delete_credential(CredentialProvider.GIT_GITHUB)
+        await run_in_threadpool(
+            manager.delete_credential, CredentialProvider.GIT_GITHUB
+        )
     except Exception as e:
         # Treat absence as success; only surface hard failures.
         msg = str(e).lower()

--- a/codeframe/ui/routers/settings_v2.py
+++ b/codeframe/ui/routers/settings_v2.py
@@ -292,7 +292,13 @@ async def list_key_status(
     manager: CredentialManager = Depends(get_credential_manager_readonly),
 ) -> list[KeyStatusResponse]:
     """Return status of each known API key without exposing plaintext."""
-    return [_build_status(p, manager) for p in KEY_PROVIDERS]
+    # Off the event loop: a credential read reaches the OS keyring, and an
+    # unresponsive backend parks the calling thread for the timeout (#1181).
+    # On the loop that would stall every other in-flight request, not just this
+    # one — the same failure this bounds, one layer up.
+    return await run_in_threadpool(
+        lambda: [_build_status(p, manager) for p in KEY_PROVIDERS]
+    )
 
 
 @router.put(
@@ -318,7 +324,7 @@ async def store_key(
             ),
         )
     try:
-        manager.set_credential(cp, body.value)
+        await run_in_threadpool(manager.set_credential, cp, body.value)
     except Exception as e:
         logger.error(f"Failed to store credential: {e}", exc_info=True)
         raise HTTPException(
@@ -329,7 +335,9 @@ async def store_key(
         )
     # _resolve_provider validated `provider` against KEY_PROVIDERS, so the
     # cast is safe — clearer than a type: ignore.
-    return _build_status(cast(KeyProvider, provider), manager)
+    return await run_in_threadpool(
+        _build_status, cast(KeyProvider, provider), manager
+    )
 
 
 @router.delete(
@@ -346,7 +354,7 @@ async def delete_key(
     """Delete a stored credential. Idempotent — non-existent keys are a no-op."""
     cp = _resolve_provider(provider)
     try:
-        manager.delete_credential(cp)
+        await run_in_threadpool(manager.delete_credential, cp)
     except Exception as e:
         # Underlying store can raise on a hard keyring error; treat absence as success.
         msg = str(e).lower()
@@ -455,7 +463,7 @@ async def verify_key(
     (programmer bugs) raise 5xx.
     """
     cp = _resolve_provider(body.provider)
-    key = body.value if body.value else manager.get_credential(cp)
+    key = body.value if body.value else await run_in_threadpool(manager.get_credential, cp)
     if not key:
         return VerifyKeyResponse(
             provider=body.provider, valid=False, message="No key provided or stored"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,22 @@ def mock_env(monkeypatch) -> dict[str, str]:
 
 
 @pytest.fixture(autouse=True)
+def reset_keyring_timeout_verdict():
+    """Clear the process-sticky "keyring is unresponsive" verdict (#1181).
+
+    A single real timeout would otherwise disable the keyring for the rest of
+    the session and silently push every later keyring test onto the file
+    fallback — an order-dependent failure. Same treatment as
+    ``_MIGRATION_COMPLETE``.
+    """
+    import codeframe.core.credentials as credentials_module
+
+    credentials_module._KEYRING_TIMED_OUT = False
+    yield
+    credentials_module._KEYRING_TIMED_OUT = False
+
+
+@pytest.fixture(autouse=True)
 def reset_singletons():
     """Reset any singleton instances between tests.
 

--- a/tests/core/test_credentials_integration.py
+++ b/tests/core/test_credentials_integration.py
@@ -656,10 +656,20 @@ class TestKeyringIntegration:
     """
 
     def test_keyring_availability_check(self):
-        """Verify keyring availability detection works."""
+        """Availability detection reaches a verdict in bounded time (#1181).
+
+        This used to assert "importable implies available" — the very
+        assumption that let a backend which is installed and selected but
+        unresponsive (headless box, no session D-Bus) hang every credential
+        read forever. Importable is not responsive; the only invariant is that
+        a verdict comes back, and quickly.
+        """
+        import time
+
+        started = time.monotonic()
         store = CredentialStore()
-        # If we got here, keyring is available, so check should pass
-        assert store._keyring_available or not KEYRING_AVAILABLE
+        assert isinstance(store._keyring_available, bool)
+        assert time.monotonic() - started < 10
 
     def test_keyring_backend_detection(self):
         """Verify we can detect the keyring backend type."""

--- a/tests/core/test_keyring_timeout_1181.py
+++ b/tests/core/test_keyring_timeout_1181.py
@@ -170,7 +170,6 @@ class TestTheTimeoutVerdictIsStickyPerProcess:
         assert store._keyring_available is False
         assert store.retrieve(CredentialProvider.LLM_ANTHROPIC) is None
 
-
     def test_that_concurrent_first_callers_start_only_one_worker(
         self, tmp_path, blocking_keyring
     ):
@@ -247,6 +246,58 @@ class TestTheServerEndpointReturns:
         assert time.monotonic() - started < BOUND
         assert response.status_code == 200
         assert all(entry["source"] == "none" for entry in response.json())
+
+    @pytest.mark.asyncio
+    async def test_that_the_event_loop_stays_responsive_during_the_timeout(
+        self, tmp_path, blocking_keyring, monkeypatch
+    ):
+        """The handler must not pay the timeout *on the event loop*.
+
+        A blocking `join` in an `async def` route stalls every other in-flight
+        request for the duration, not just the caller — the same failure this
+        bounds, one layer up.
+        """
+        import asyncio
+
+        from codeframe.ui.routers import settings_v2
+
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GITHUB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+
+        manager = CredentialManager.__new__(CredentialManager)
+        manager._store = CredentialStore(tmp_path)
+
+        ticks = 0
+
+        async def heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.02)
+                ticks += 1
+
+        import httpx
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(settings_v2.router)
+        app.dependency_overrides[settings_v2.get_credential_manager_readonly] = (
+            lambda: manager
+        )
+
+        beat = asyncio.create_task(heartbeat())
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.get("/api/v2/settings/keys")
+        finally:
+            beat.cancel()
+
+        assert response.status_code == 200
+
+        # The keyring timeout is 0.3s here; a loop held hostage ticks ~0 times.
+        assert ticks >= 5, f"event loop was blocked (only {ticks} ticks)"
 
 
 class TestARealKeyringErrorStillBehavesAsBefore:

--- a/tests/core/test_keyring_timeout_1181.py
+++ b/tests/core/test_keyring_timeout_1181.py
@@ -1,0 +1,246 @@
+"""An unresponsive keyring backend must not hang the credential path (#1181).
+
+A backend that is installed and *selected* but never answers (SecretService on a
+headless box with no session D-Bus) raises nothing — it blocks. Detection by
+exception therefore never fires and the encrypted-file fallback never engages,
+so every credential read hangs forever: the test suite, the CLI, and the
+``GET /api/v2/settings/keys`` request thread alike.
+
+These tests pin the bound: every keyring call is time-boxed and a timeout is
+treated exactly like ``KeyringError``.
+"""
+
+import time
+
+import pytest
+
+from codeframe.core import credentials as creds
+from codeframe.core.credentials import (
+    Credential,
+    CredentialManager,
+    CredentialProvider,
+    CredentialStore,
+)
+
+pytestmark = pytest.mark.v2
+
+# Generous enough not to flake on a loaded CI box, small enough that a real hang
+# (unbounded) blows the assertion by orders of magnitude.
+BOUND = 6.0
+
+
+class BlockingKeyring:
+    """A backend that is present and selected, and never answers."""
+
+    def get_password(self, service, username):
+        time.sleep(3600)
+
+    def set_password(self, service, username, password):
+        time.sleep(3600)
+
+    def delete_password(self, service, username):
+        time.sleep(3600)
+
+
+@pytest.fixture(autouse=True)
+def _reset_sticky():
+    """The timeout verdict is process-sticky; keep it from leaking between tests."""
+    creds._KEYRING_TIMED_OUT = False
+    yield
+    creds._KEYRING_TIMED_OUT = False
+
+
+@pytest.fixture
+def blocking_keyring(monkeypatch):
+    """A backend that is selected instantly but blocks on every credential op.
+
+    Backend *selection* is deliberately fast here so each read/write/delete
+    reaches its own timeout — see ``blocking_backend_lookup`` for the other
+    half, where selection itself is what hangs.
+    """
+    backend = BlockingKeyring()
+    monkeypatch.setattr(creds, "KEYRING_AVAILABLE", True)
+    monkeypatch.setattr(creds.keyring, "get_keyring", lambda: backend)
+    monkeypatch.setattr(creds.keyring, "get_password", backend.get_password)
+    monkeypatch.setattr(creds.keyring, "set_password", backend.set_password)
+    monkeypatch.setattr(creds.keyring, "delete_password", backend.delete_password)
+    monkeypatch.setenv("CODEFRAME_KEYRING_TIMEOUT", "0.3")
+    return backend
+
+
+@pytest.fixture
+def blocking_backend_lookup(monkeypatch):
+    """``keyring.get_keyring()`` itself never returns.
+
+    Backend selection probes each candidate's priority, and SecretService's
+    probe talks to D-Bus — so selection is a blocking call in its own right,
+    not just a lookup of an already-chosen object.
+    """
+    monkeypatch.setattr(creds, "KEYRING_AVAILABLE", True)
+    monkeypatch.setattr(creds.keyring, "get_keyring", lambda: time.sleep(3600))
+    monkeypatch.setenv("CODEFRAME_KEYRING_TIMEOUT", "0.3")
+
+
+class TestBlockingBackendDegradesInBoundedTime:
+    def test_that_construction_does_not_hang_when_backend_selection_blocks(
+        self, tmp_path, blocking_backend_lookup
+    ):
+        started = time.monotonic()
+        store = CredentialStore(tmp_path)
+        assert time.monotonic() - started < BOUND
+        assert store._keyring_available is False
+
+    def test_that_a_blocked_selection_still_leaves_a_usable_store(
+        self, tmp_path, blocking_backend_lookup
+    ):
+        store = CredentialStore(tmp_path)
+        store.store(Credential(provider=CredentialProvider.LLM_ANTHROPIC, value="sk-b"))
+        assert store.retrieve(CredentialProvider.LLM_ANTHROPIC).value == "sk-b"
+
+    def test_that_a_full_store_retrieve_round_trip_uses_the_file_fallback(
+        self, tmp_path, blocking_keyring
+    ):
+        store = CredentialStore(tmp_path)
+        started = time.monotonic()
+
+        store.store(Credential(provider=CredentialProvider.LLM_ANTHROPIC, value="sk-x"))
+        retrieved = store.retrieve(CredentialProvider.LLM_ANTHROPIC)
+        store.delete(CredentialProvider.LLM_ANTHROPIC)
+
+        assert time.monotonic() - started < BOUND
+        assert retrieved is not None and retrieved.value == "sk-x"
+        assert (tmp_path / creds.ENCRYPTED_FILE_NAME).exists()
+        assert store.retrieve(CredentialProvider.LLM_ANTHROPIC) is None
+
+    def test_that_get_credential_returns_rather_than_hanging(
+        self, tmp_path, blocking_keyring, monkeypatch
+    ):
+        monkeypatch.delenv(CredentialProvider.LLM_ANTHROPIC.env_var, raising=False)
+        started = time.monotonic()
+        value = CredentialManager(tmp_path).get_credential(CredentialProvider.LLM_ANTHROPIC)
+        assert time.monotonic() - started < BOUND
+        assert value is None
+
+
+class TestTheTimeoutVerdictIsStickyPerProcess:
+    def test_that_a_second_store_does_not_pay_the_timeout_again(
+        self, tmp_path, blocking_keyring
+    ):
+        CredentialStore(tmp_path).retrieve(CredentialProvider.LLM_ANTHROPIC)
+        assert creds._KEYRING_TIMED_OUT is True
+
+        second = CredentialStore(tmp_path)
+        assert second._keyring_available is False
+
+    def test_that_a_store_built_before_the_timeout_stops_waiting_too(
+        self, tmp_path, blocking_keyring
+    ):
+        """The sticky verdict short-circuits the wrapper, not only the probe.
+
+        A store constructed before the backend died still believes the keyring
+        is available; without the short-circuit each of its calls would start
+        another unkillable worker and wait the timeout again.
+        """
+        stale = CredentialStore(tmp_path)
+        CredentialStore(tmp_path).retrieve(CredentialProvider.LLM_ANTHROPIC)
+        assert stale._keyring_available is True  # built before the verdict
+
+        started = time.monotonic()
+        stale.store(Credential(provider=CredentialProvider.LLM_ANTHROPIC, value="sk-c"))
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 0.3, f"paid the timeout again ({elapsed:.2f}s)"
+        assert stale.retrieve(CredentialProvider.LLM_ANTHROPIC).value == "sk-c"
+
+    def test_that_the_same_instance_stops_asking_a_dead_backend(
+        self, tmp_path, blocking_keyring
+    ):
+        store = CredentialStore(tmp_path)
+        store.retrieve(CredentialProvider.LLM_ANTHROPIC)
+        assert store._keyring_available is False
+
+    def test_that_delete_degrades_instead_of_raising(self, tmp_path, blocking_keyring):
+        """A timeout is "keyring failed", not "the delete failed"."""
+        store = CredentialStore(tmp_path)
+        store.store(Credential(provider=CredentialProvider.LLM_ANTHROPIC, value="sk-z"))
+        store._keyring_available = True  # pretend the backend came back
+
+        store.delete(CredentialProvider.LLM_ANTHROPIC)  # must not raise
+
+        assert store._keyring_available is False
+        assert store.retrieve(CredentialProvider.LLM_ANTHROPIC) is None
+
+
+class TestTheEscapeHatch:
+    def test_that_disable_keyring_skips_the_backend_entirely(
+        self, tmp_path, blocking_keyring, monkeypatch
+    ):
+        monkeypatch.setenv("CODEFRAME_DISABLE_KEYRING", "1")
+        store = CredentialStore(tmp_path)
+        assert store._keyring_available is False
+        assert creds._KEYRING_TIMED_OUT is False  # never even probed
+
+
+class TestTheServerEndpointReturns:
+    """``GET /api/v2/settings/keys`` reaches the keyring through ``_build_status``.
+
+    Unresponsive, it used to hang a request thread indefinitely (#1181).
+    """
+
+    def test_that_settings_keys_returns_rather_than_hanging(
+        self, tmp_path, blocking_keyring, monkeypatch
+    ):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from codeframe.ui.routers import settings_v2
+
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GITHUB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+
+        manager = CredentialManager.__new__(CredentialManager)
+        manager._store = CredentialStore(tmp_path)
+
+        app = FastAPI()
+        app.include_router(settings_v2.router)
+        app.dependency_overrides[settings_v2.get_credential_manager_readonly] = lambda: manager
+
+        started = time.monotonic()
+        response = TestClient(app).get("/api/v2/settings/keys")
+
+        assert time.monotonic() - started < BOUND
+        assert response.status_code == 200
+        assert all(entry["source"] == "none" for entry in response.json())
+
+
+class TestARealKeyringErrorStillBehavesAsBefore:
+    def test_that_a_raising_backend_is_unavailable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(creds, "KEYRING_AVAILABLE", True)
+        monkeypatch.setattr(
+            creds.keyring, "get_keyring", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        assert CredentialStore(tmp_path)._keyring_available is False
+
+    def test_that_a_working_backend_is_still_used(self, tmp_path, monkeypatch):
+        calls = {}
+
+        class Working:
+            def set_password(self, service, username, password):
+                calls[username] = password
+
+            def get_password(self, service, username):
+                return calls.get(username)
+
+        backend = Working()
+        monkeypatch.setattr(creds, "KEYRING_AVAILABLE", True)
+        monkeypatch.setattr(creds.keyring, "get_keyring", lambda: backend)
+        monkeypatch.setattr(creds.keyring, "set_password", backend.set_password)
+        monkeypatch.setattr(creds.keyring, "get_password", backend.get_password)
+
+        store = CredentialStore(tmp_path)
+        assert store._keyring_available is True
+        store.store(Credential(provider=CredentialProvider.LLM_ANTHROPIC, value="sk-y"))
+
+        assert calls["LLM_ANTHROPIC"]  # went to the keyring, not the file
+        assert not (tmp_path / creds.ENCRYPTED_FILE_NAME).exists()
+        assert store.retrieve(CredentialProvider.LLM_ANTHROPIC).value == "sk-y"

--- a/tests/core/test_keyring_timeout_1181.py
+++ b/tests/core/test_keyring_timeout_1181.py
@@ -171,6 +171,42 @@ class TestTheTimeoutVerdictIsStickyPerProcess:
         assert store.retrieve(CredentialProvider.LLM_ANTHROPIC) is None
 
 
+    def test_that_concurrent_first_callers_start_only_one_worker(
+        self, tmp_path, blocking_keyring
+    ):
+        """The sticky verdict has to survive a burst, or it bounds nothing.
+
+        Unserialized, every thread in a burst of concurrent requests reads the
+        flag as False, starts its own unkillable worker and waits the full
+        timeout — one leaked thread per in-flight request.
+        """
+        import threading
+
+        before = {t for t in threading.enumerate() if t.name == "codeframe-keyring"}
+        stores = [CredentialStore(tmp_path) for _ in range(8)]
+        barrier = threading.Barrier(len(stores))
+
+        def hammer(store):
+            barrier.wait()
+            store.retrieve(CredentialProvider.LLM_ANTHROPIC)
+
+        started = time.monotonic()
+        threads = [threading.Thread(target=hammer, args=(s,)) for s in stores]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(BOUND)
+        elapsed = time.monotonic() - started
+
+        assert not any(t.is_alive() for t in threads), "a caller never returned"
+        leaked = {
+            t for t in threading.enumerate() if t.name == "codeframe-keyring"
+        } - before
+        assert len(leaked) <= 1, f"leaked {len(leaked)} blocked keyring threads"
+        # Eight callers, one timeout between them — not eight serialized ones.
+        assert elapsed < 1.0, f"burst paid the timeout more than once ({elapsed:.2f}s)"
+
+
 class TestTheEscapeHatch:
     def test_that_disable_keyring_skips_the_backend_entirely(
         self, tmp_path, blocking_keyring, monkeypatch

--- a/tests/core/test_keyring_timeout_1181.py
+++ b/tests/core/test_keyring_timeout_1181.py
@@ -215,6 +215,27 @@ class TestTheEscapeHatch:
         assert store._keyring_available is False
         assert creds._KEYRING_TIMED_OUT is False  # never even probed
 
+    @pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+    def test_that_truthy_values_disable(self, tmp_path, blocking_keyring, monkeypatch, value):
+        monkeypatch.setenv("CODEFRAME_DISABLE_KEYRING", value)
+        assert CredentialStore(tmp_path)._keyring_available is False
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+    def test_that_non_truthy_values_do_not_disable(
+        self, tmp_path, monkeypatch, value
+    ):
+        """An explicit allowlist, not "anything but 0" — `=no` must mean no."""
+        working = type("Working", (), {
+            "get_password": lambda self, s, u: None,
+            "set_password": lambda self, s, u, p: None,
+            "delete_password": lambda self, s, u: None,
+        })()
+        monkeypatch.setattr(creds, "KEYRING_AVAILABLE", True)
+        monkeypatch.setattr(creds.keyring, "get_keyring", lambda: working)
+        monkeypatch.setenv("CODEFRAME_DISABLE_KEYRING", value)
+
+        assert CredentialStore(tmp_path)._keyring_available is True
+
 
 class TestTheServerEndpointReturns:
     """``GET /api/v2/settings/keys`` reaches the keyring through ``_build_status``.

--- a/tests/ui/test_no_blocking_credential_calls_1181.py
+++ b/tests/ui/test_no_blocking_credential_calls_1181.py
@@ -32,11 +32,19 @@ BLOCKING_CREDENTIAL_CALLS = {
 
 
 def _offenders(path: Path) -> list[str]:
-    """Credential calls made directly inside an `async def` route body.
+    """Credential calls *invoked* inside an `async def` route body.
 
-    A call is fine if it is an argument to `run_in_threadpool` — that is the
-    wrapped form. Anything else in an async body is on the loop, since a plain
-    `def` helper called from async is still executing on the loop thread.
+    The wrapped form — `await run_in_threadpool(manager.get_credential, cp)` —
+    passes for a structural reason, not a special case: the method is passed by
+    reference, so it produces no `ast.Call` node of its own and there is nothing
+    to flag. Only an actual invocation in an async body is reported.
+
+    Deliberately strict about nested helpers: a `def` defined inside the route
+    and handed to `run_in_threadpool` really does run off the loop, but this
+    still flags the calls inside it. No router uses that shape, and the failure
+    mode of strictness is a loud, obvious test failure — where the failure mode
+    of cleverness is a hole. Move such a helper to module scope if it ever shows
+    up.
     """
     tree = ast.parse(path.read_text())
     found = []
@@ -45,17 +53,8 @@ def _offenders(path: Path) -> list[str]:
         if not isinstance(node, ast.AsyncFunctionDef):
             continue
 
-        offloaded = {
-            id(arg)
-            for sub in ast.walk(node)
-            if isinstance(sub, ast.Call)
-            and isinstance(sub.func, ast.Name)
-            and sub.func.id == "run_in_threadpool"
-            for arg in sub.args
-        }
-
         for sub in ast.walk(node):
-            if not isinstance(sub, ast.Call) or id(sub.func) in offloaded:
+            if not isinstance(sub, ast.Call):
                 continue
             func = sub.func
             if isinstance(func, ast.Attribute) and func.attr in BLOCKING_CREDENTIAL_CALLS:
@@ -91,3 +90,11 @@ def test_that_the_guard_can_actually_see_an_offender(tmp_path):
         "    return await run_in_threadpool(manager.get_credential, PROVIDER)\n"
     )
     assert _offenders(good) == []
+
+    # A sync helper is not a route, so its calls are not on the loop.
+    sync_only = tmp_path / "sync_router.py"
+    sync_only.write_text(
+        "def helper(manager):\n"
+        "    return manager.get_credential(PROVIDER)\n"
+    )
+    assert _offenders(sync_only) == []

--- a/tests/ui/test_no_blocking_credential_calls_1181.py
+++ b/tests/ui/test_no_blocking_credential_calls_1181.py
@@ -1,0 +1,93 @@
+"""No async route may call a credential method straight on the event loop (#1181).
+
+A credential call reaches the OS keyring. That read is now bounded — but bounded
+still means it parks the calling thread for up to `CODEFRAME_KEYRING_TIMEOUT`,
+and on the event loop that stalls every other in-flight request, not just the
+caller. It is the same failure #1181 fixes, one layer up, and it reappeared once
+already: `settings_v2` was fixed and `github_integrations_v2` still had four.
+
+So this walks the AST of every router rather than trusting review to catch the
+next one.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+ROUTERS = Path(__file__).resolve().parents[2] / "codeframe" / "ui" / "routers"
+
+# Methods that can reach the keyring backend.
+BLOCKING_CREDENTIAL_CALLS = {
+    "get_credential",
+    "get_stored_credential",
+    "set_credential",
+    "delete_credential",
+    "get_credential_source",
+    "list_credentials",
+    "rotate_credential",
+}
+
+
+def _offenders(path: Path) -> list[str]:
+    """Credential calls made directly inside an `async def` route body.
+
+    A call is fine if it is an argument to `run_in_threadpool` — that is the
+    wrapped form. Anything else in an async body is on the loop, since a plain
+    `def` helper called from async is still executing on the loop thread.
+    """
+    tree = ast.parse(path.read_text())
+    found = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+
+        offloaded = {
+            id(arg)
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Name)
+            and sub.func.id == "run_in_threadpool"
+            for arg in sub.args
+        }
+
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call) or id(sub.func) in offloaded:
+                continue
+            func = sub.func
+            if isinstance(func, ast.Attribute) and func.attr in BLOCKING_CREDENTIAL_CALLS:
+                found.append(f"{path.name}:{sub.lineno} {node.name}() -> .{func.attr}()")
+
+    return found
+
+
+def test_that_no_async_route_blocks_the_loop_on_a_credential_call():
+    offenders = [
+        line
+        for path in sorted(ROUTERS.glob("*.py"))
+        for line in _offenders(path)
+    ]
+    assert not offenders, (
+        "credential calls on the event loop — wrap them in run_in_threadpool:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_that_the_guard_can_actually_see_an_offender(tmp_path):
+    """A guard that cannot fail is not a guard."""
+    bad = tmp_path / "bad_router.py"
+    bad.write_text(
+        "async def route(manager):\n"
+        "    return manager.get_credential(PROVIDER)\n"
+    )
+    assert _offenders(bad) == ["bad_router.py:2 route() -> .get_credential()"]
+
+    good = tmp_path / "good_router.py"
+    good.write_text(
+        "async def route(manager):\n"
+        "    return await run_in_threadpool(manager.get_credential, PROVIDER)\n"
+    )
+    assert _offenders(good) == []


### PR DESCRIPTION
Closes #1181

## The bug

`credentials.py` implemented "keyring unavailable" as *raises, or is the fail backend*:

```python
kr = keyring.get_keyring()
if "fail" in kr.__class__.__name__.lower():
    return False
return True
```

A backend that is installed and **selected** but unresponsive raises nothing — it blocks. On a headless box (WSL2, a container, an SSH session with no session D-Bus) the SecretService backend is importable and gets selected, and the D-Bus call waits with no timeout. Detection by exception therefore never fires, the encrypted-file fallback never engages, and the caller hangs forever.

That is not just a test annoyance: `GET /api/v2/settings/keys` reaches this through `_build_status`, so an unresponsive keyring hangs a server request thread indefinitely, and the same blocking read sits under every CLI/agent credential lookup.

## The fix

Bound it by **time**, not only by exception. Every keyring call now runs through `_keyring_call`, which joins a daemon worker with a timeout and raises `KeyringTimeoutError` — deliberately a `KeyringError` subclass, so the "keyring failed, use the encrypted file" handling already present at each call site does the right thing with no new branching.

A blocked call cannot be cancelled (it is parked inside libdbus), so the worker is abandoned. That is bounded: the timeout verdict is sticky per process **and short-circuits the wrapper itself**, so a store built before the backend died stops waiting too — at most one abandoned thread per process, and the timeout is paid once rather than once per request.

`delete()` re-raised on any keyring failure, which would have turned a timeout into a failed delete. A timeout there now degrades to the encrypted-file cleanup, which is the part that matters.

New knobs, both documented in `CLAUDE.md`:

| Variable | Effect |
|---|---|
| `CODEFRAME_DISABLE_KEYRING=1` | Skip the keyring outright — the explicit opt-out, and avoids even the first timeout |
| `CODEFRAME_KEYRING_TIMEOUT` | Seconds per call, default `2.0`, read at call time rather than import (#963) |

`PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring` remains the keyring-native equivalent and is now documented next to them.

## Acceptance criteria

- [x] A blocking backend does not hang `CredentialManager`; it degrades to the encrypted file store within a bounded time
- [x] `GET /api/v2/settings/keys` returns rather than hanging when the keyring is unresponsive
- [x] A test pins the timeout path with a deliberately blocking fake backend
- [x] The local workaround is documented

## Evidence

The gate the issue reported as wedging:

```
$ env -u PYTHON_KEYRING_BACKEND uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle" -q
31 failed, 6485 passed, 19 skipped, 2 deselected in 445.36s (0:07:25)
```

It **completes**, on the same WSL2 box where it previously sat at 92% for over an hour. All 31 failures reproduce identically on `main` (verified in a clean worktree, `31 failed in 7.06s`) — they are ANSI/terminal-width assertions in CLI output tests, an ambient property of this machine, untouched by this diff.

Affected suites on the final code: `263 passed`. `ruff check` clean.

## Tests

`tests/core/test_keyring_timeout_1181.py` — 12 tests across two deliberately different failure shapes: a backend that is *selected instantly but blocks on every credential op*, and one where `keyring.get_keyring()` **itself** never returns (backend selection probes each candidate's priority, and SecretService's probe talks to D-Bus, so selection is a blocking call in its own right). Covers construction, store/retrieve/delete round-trip through the file fallback, `get_credential`, the sticky verdict on both new and pre-existing store instances, `delete` degrading instead of raising, the escape hatch, the endpoint, and that a healthy backend is still used in preference to the file.

Two changes to existing tests, both deliberate:

- `test_keyring_availability_check` asserted "importable implies available" — precisely the assumption that caused this bug. It now asserts a verdict comes back, and quickly.
- The root `conftest.py` resets the sticky verdict per test, the same treatment `_MIGRATION_COMPLETE` gets. Without it a single real timeout silently pushes every later keyring test onto the file fallback, which is an order-dependent failure.

## Review

`codex review` (cross-family, pre-PR) raised two P2s, both fixed in this branch before opening:

1. The sticky flag was only honored in `_check_keyring`, so a store built before the timeout — and `store()`'s own `delete_password` retry after a timed-out `set_password` — would start another stuck worker and wait again. `_keyring_call` now short-circuits.
2. The fixture claimed to block backend lookup while `get_keyring` returned instantly, so the tests did not actually prove the selection-time hang was bounded. Split into two fixtures, each with its own test.

## Follow-up fixes from review (all in this branch)

| Finding | Source | Status |
|---|---|---|
| Sticky flag honored only in `_check_keyring`, so a pre-existing store — and `store()`'s own cleanup `delete_password` — started another blocked worker | `codex review`, pre-PR | Fixed: `_keyring_call` short-circuits |
| Fixture claimed to block backend lookup while `get_keyring` returned instantly, so the selection-time hang was never actually proven bounded | `codex review`, pre-PR | Fixed: split into two fixtures with their own tests |
| Concurrent first callers each pass the flag check and each leak a worker, so the sticky verdict bounds nothing under a burst | `codex review`, post-PR | Fixed: `_KEYRING_CALL_LOCK`; mutation-checked at "leaked 8 blocked keyring threads" |
| `list_key_status` is `async def` and called `_build_status` on the event loop, so the bounded-but-blocking join stalled *every* in-flight request | `claude-review` | Fixed: credential calls in async handlers go through `run_in_threadpool`; mutation-checked at "event loop was blocked (only 0 ticks)" |
| Unparseable `CODEFRAME_KEYRING_TIMEOUT` fell back silently | `claude-review` | Fixed: logs the value it ignored |
| Timeout env var read twice on the timeout path | `claude-review` | Fixed: read once |

## Known limitations

- The abandoned worker thread is unavoidable: there is no way to interrupt a call parked in libdbus. Bounded to one per process by the sticky verdict.
- The verdict is sticky for the life of the process: a keyring that comes back (D-Bus started after the fact) is not re-probed until restart. Deliberate — re-probing would reintroduce a per-call timeout on the common bad case, and the file fallback is correct in the meantime.
- Sticky state is per process, not per worker, so a multi-worker server pays the first timeout once per worker.
- The lock changes contention shape: a *healthy* backend sitting on a real unlock prompt now queues other credential accesses behind it, where before each caller raced independently. Deliberate — independent racing is exactly what leaked a thread per request, and either outcome (prompt resolves, or the timeout trips the sticky verdict) is bounded, which the old behavior was not.
- Under a burst against a hung backend each request occupies a Starlette threadpool slot while queueing on the lock. Bounded by the threadpool size rather than unbounded; inherent to moving blocking work off the loop, and it matters only if this is ever deployed multi-tenant rather than single-operator.

https://claude.ai/code/session_011pR6Wqk15b3ESqXDiheNMZ