### PR TITLE
docs: design-partner program for the beta cohort (#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **`DESIGN_PARTNERS.md` — the beta design-partner program (#619).** #618 shipped
+  the intake path but nothing said what applying got you. The page states the
+  offer (direct line to the maintainer, roadmap influence weighted ahead of
+  general requests, opt-in public credit, continuity into commercial pricing),
+  the commitment (real usage over a full cycle, a bi-weekly cadence, and either a
+  paid pilot or a written time commitment), a 5-10 team cohort, the six intake
+  questions, and activation the week after the launch announcement. It reuses the
+  existing `hello@codeframe.sh` + pinned-Discussion intake rather than opening a
+  second inbox, and publishes no pilot price — `LICENSING.md` says pricing is
+  still being finalized and a number here would contradict it. Linked from
+  `README.md` and `LICENSING.md`; `tests/test_design_partners_619.py` and the
+  `ROOT_DOCS` link check pin all of it.
+
 ### Changed
 
 - **The Anthropic adapter runs on the `anthropic` 1.x SDK; the `<1.0` ceiling is

--- a/DESIGN_PARTNERS.md
+++ b/DESIGN_PARTNERS.md
@@ -1,0 +1,102 @@
+# Design Partners
+
+CodeFRAME is in public beta. We are recruiting a small cohort of teams who will
+run real autonomous development work through it — PRD to merged PR — and tell us
+where it breaks.
+
+This is not a waitlist. It is a working relationship with a short feedback loop,
+and it is deliberately small.
+
+**Cohort: 5–10 teams.** Applications open the week after the public launch
+announcement (see [Timeline](#timeline)).
+
+## What you get
+
+- **A direct line to the maintainer.** A private channel — not the issue tracker,
+  not a support queue. You describe what broke; you get an answer from the person
+  who wrote it.
+- **Roadmap influence.** Partners see the roadmap before it is public and their
+  input is weighted ahead of general feature requests. When two things compete
+  for the next phase, partner need decides it. This is the whole point of the
+  cohort: we would rather build the thing five real teams are blocked on than the
+  thing that reads well in a README.
+- **Public credit.** Your team or company named as a launch design partner, in
+  the README and in launch materials — opt-in, and you can decline or withdraw at
+  any time without affecting anything else here.
+- **Continuity on what comes next.** Commercial licensing and a hosted offering
+  are planned but not priced (see [LICENSING.md](LICENSING.md)). Partners get
+  first access to both and their pilot terms honored when pricing lands.
+
+## What you commit
+
+- **Regular real usage.** CodeFRAME on work that matters to you, on a real
+  repository, over at least one full development cycle. Kicking the tires for an
+  afternoon tells neither of us anything.
+- **A feedback cadence.** A standing 30-minute call every two weeks for the
+  duration of the program, plus async reports when something breaks. The cadence
+  is the deliverable — a partner we never hear from is not a partner.
+- **Skin in the game — one of two tracks:**
+  - **Paid pilot (preferred).** A paid engagement for the program term. Pricing
+    is not published yet and pilot terms are agreed one-to-one; partner terms are
+    honored when general pricing lands. A paid signal is the most honest
+    signal there is about whether this is worth building, which is why we ask
+    for it.
+  - **Explicit time commitment.** If a purchase is not possible on your side,
+    a written commitment of named people and hours per month instead. Same
+    cadence, same expectations.
+
+Either track is a real commitment. We would rather have five teams who mean it
+than fifty who signed up.
+
+## Who this is for
+
+A good fit is a team that already ships software with AI coding agents in the
+loop and is frustrated with what happens at the edges — before code gets written,
+and after. If you are evaluating whether to adopt agents at all, the beta is open
+to you, but the design-partner cohort is probably not the right entry point yet.
+
+## How to apply
+
+The intake is the same early-access path published in
+[LICENSING.md](LICENSING.md) — we are not running a second inbox:
+
+- Email **hello@codeframe.sh**, subject `Design partner`, or
+- Reply in the pinned *Early access & commercial interest*
+  [discussion](https://github.com/frankbria/codeframe/discussions) if you would
+  rather do it in the open.
+
+Answer these in whichever channel you pick. They are the whole application:
+
+1. **Workflow.** What does your path from idea to merged code look like today,
+   and where does it hurt most?
+2. **Scale.** How many engineers, how many repositories, and roughly how many
+   changes land per week?
+3. **Engines.** Which coding agents do you already use — Claude Code, Codex,
+   OpenCode, Kilocode, something else, none yet?
+4. **Stack and environment.** Languages, CI, and where CodeFRAME would run
+   (laptops, a shared server, cloud).
+5. **What you want out of it.** The specific outcome that would make this worth
+   your time.
+6. **Track.** Paid pilot or time commitment, and who on your team would own the
+   relationship.
+
+We read every one and reply either way.
+
+## Timeline
+
+| When | What |
+| --- | --- |
+| Launch announcement | Program page goes public; intake is already live |
+| The week after the announcement | Applications open and are reviewed as they arrive |
+| Within two weeks of applying | Intro call, fit decision, and track agreed |
+| From kickoff | Bi-weekly cadence begins; roadmap access opens |
+
+Applications are reviewed in the order they arrive. Once the cohort is full we
+will say so here rather than leaving the form open.
+
+## The fine print
+
+Nothing here changes the software license: CodeFRAME is
+[AGPL-3.0](LICENSE) for partners and everyone else, and the name and logo remain
+trademarks — see [TRADEMARKS.md](TRADEMARKS.md). Partnership terms, including any
+confidentiality on your side or ours, are agreed in writing before kickoff.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -78,6 +78,8 @@ commercial need, **tell us now** — early conversations shape what we build.
   if you'd rather do it in the open. This is the capture point for launch —
   even before pricing is published.
 - **Design partners & early access:** email **hello@codeframe.sh** or reply to
-  the same pinned discussion to be included.
+  the same pinned discussion to be included. See
+  [DESIGN_PARTNERS.md](DESIGN_PARTNERS.md) for what the design-partner program
+  offers and asks for.
 
 We read every one.

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ CodeFRAME is in **public beta**.
 - **Security:** found a vulnerability? Report it privately via [GitHub private vulnerability reporting](https://github.com/frankbria/codeframe/security/advisories/new) (or `security@codeframe.sh`) -- never a public issue. See [SECURITY.md](SECURITY.md) for scope and response expectations.
 - **Licensing:** CodeFRAME is [AGPL-3.0](LICENSE), an open-core stance. [LICENSING.md](LICENSING.md) explains what that means for individuals, internal company use, and embedding -- and how to reach us about **commercial licensing or a hosted offering** (both planned). Commercial inquiries: `licensing@codeframe.sh`.
 - **Trademark:** the code is AGPL-3.0, but the **CodeFRAME name and logo are trademarks** and are *not* covered by the code license. See [TRADEMARKS.md](TRADEMARKS.md) before using the name for a fork or product.
-- **Early access / design partners:** email `hello@codeframe.sh` or reply to the pinned [Discussion](https://github.com/frankbria/codeframe/discussions) to be included.
+- **Early access / design partners:** we are recruiting 5-10 teams for the beta design-partner cohort -- see [DESIGN_PARTNERS.md](DESIGN_PARTNERS.md) for what partners get and commit. To be included, email `hello@codeframe.sh` or reply to the pinned [Discussion](https://github.com/frankbria/codeframe/discussions).
 - **Help & community:** [Discussions -> Q&A](https://github.com/frankbria/codeframe/discussions/categories/q-a) for questions, [Ideas](https://github.com/frankbria/codeframe/discussions/categories/ideas) for feature requests, and [bug reports](https://github.com/frankbria/codeframe/issues/new/choose) for confirmed bugs.
 
 ---

--- a/tests/test_design_partners_619.py
+++ b/tests/test_design_partners_619.py
@@ -1,0 +1,91 @@
+"""The design-partner program had no written offer (#619).
+
+Announcement traffic is a one-shot event: when it arrives there has to be a page
+that says what a partner gets, what they owe, and where to apply. #618 shipped
+the intake path (`hello@codeframe.sh` + the pinned Discussion); this pins that
+`DESIGN_PARTNERS.md` exists, states the four things the issue asked for, and
+reuses that same intake rather than inventing a second one that nobody watches.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOC = REPO_ROOT / "DESIGN_PARTNERS.md"
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return DOC.read_text()
+
+
+class TestTheProgramIsWrittenDown:
+    def test_the_doc_exists(self):
+        assert DOC.exists(), "DESIGN_PARTNERS.md is the program; without it there is none"
+
+    def test_it_says_what_partners_get_and_what_they_commit(self, text: str):
+        """AC1. Both halves, or it is a wish list rather than a deal."""
+        headings = re.findall(r"^#{2,3} (.+)$", text, re.MULTILINE)
+        joined = " | ".join(headings).lower()
+
+        assert "what you get" in joined, f"no offer section; headings were {headings}"
+        assert "what you commit" in joined, f"no commitment section; headings were {headings}"
+
+    def test_the_offer_names_the_three_promised_benefits(self, text: str):
+        """AC1: direct line to the maintainer, roadmap influence, public credit."""
+        low = text.lower()
+        for promise in ("direct line", "roadmap", "credit"):
+            assert promise in low, f"the offer never mentions {promise!r}"
+
+    def test_the_commitment_asks_for_a_paid_pilot_or_a_time_commitment(self, text: str):
+        """AC1's sharpest clause — 'paid signal beats free'. A program that asks
+        for nothing selects for people who will not show up."""
+        low = text.lower()
+        assert "paid pilot" in low
+        assert "time commitment" in low
+
+    def test_it_states_the_cohort_size_and_a_feedback_cadence(self, text: str):
+        """AC2's target, and the cadence that makes the loop tight."""
+        assert re.search(r"5\s*[-–—]\s*10 teams", text), "cohort size 5-10 is not stated"
+        assert re.search(r"\bcadence\b", text, re.IGNORECASE)
+
+
+class TestIntake:
+    def test_the_intake_questions_cover_workflow_scale_and_engines(self, text: str):
+        """AC2. These three decide whether a team is a fit at all."""
+        low = text.lower()
+        for topic in ("workflow", "scale", "engine"):
+            assert topic in low, f"intake never asks about {topic!r}"
+
+    def test_intake_reuses_the_618_signup_path(self, text: str):
+        """AC3. A second, unwatched inbox is worse than no inbox."""
+        assert "hello@codeframe.sh" in text
+        assert "discussions" in text.lower()
+
+    def test_it_does_not_invent_a_second_contact_address(self, text: str):
+        """The only addresses this repo answers are the ones already published."""
+        published = {"hello@codeframe.sh", "licensing@codeframe.sh", "security@codeframe.sh"}
+        found = set(re.findall(r"[\w.+-]+@[\w.-]+\.\w+", text))
+
+        assert not (found - published), f"unpublished contact address: {found - published}"
+
+
+class TestActivation:
+    def test_activation_is_tied_to_the_announcement(self, text: str):
+        """AC4. The program goes live the week after the public announcement —
+        a date would already be stale, the trigger will not be."""
+        low = text.lower()
+        assert "announcement" in low
+        assert re.search(r"week after", low), "the activation trigger is not stated"
+
+
+class TestItIsReachable:
+    """A launch page nobody links to does not capture launch traffic."""
+
+    @pytest.mark.parametrize("doc", ["README.md", "LICENSING.md"])
+    def test_the_doc_is_linked_from(self, doc: str):
+        assert "DESIGN_PARTNERS.md" in (REPO_ROOT / doc).read_text()

--- a/tests/test_root_docs_950.py
+++ b/tests/test_root_docs_950.py
@@ -32,6 +32,7 @@ ROOT_DOCS = [
     "CHANGELOG.md",
     "SECURITY.md",
     "LICENSING.md",
+    "DESIGN_PARTNERS.md",
     "CLAUDE.md",
 ]
 


### PR DESCRIPTION
Closes #619.

## What

`DESIGN_PARTNERS.md` — the written offer for the beta design-partner cohort.
#618 shipped the intake path (`hello@codeframe.sh` + the pinned Discussion) but
nothing said what applying got you, so there was nothing to point launch traffic at.

| Acceptance criterion | Where it lands |
| --- | --- |
| What partners get / what they commit | `## What you get` (direct line to the maintainer, roadmap influence weighted ahead of general requests, opt-in public credit, continuity into commercial pricing) and `## What you commit` (real usage over a full development cycle, a standing bi-weekly 30-min call, and **either a paid pilot or a written time commitment**) |
| Target 5–10 teams; intake questions defined | Cohort size stated up front; `## How to apply` lists six questions covering workflow, scale, engines, stack/environment, desired outcome, and track |
| Intake wired to the #618 early-access signup | Same address and same pinned Discussion — explicitly *not* a second inbox |
| Activation plan | `## Timeline` table: intake already live, applications open the week after the launch announcement, intro call within two weeks, cadence from kickoff |

Linked from `README.md` (Security, licensing & support) and `LICENSING.md`
(Get in touch), and added to the `ROOT_DOCS` link check.

## Two deliberate omissions

- **No pilot price.** `LICENSING.md` says pricing is still being finalized; a
  number here would contradict the page this one links to. Paid pilot is the
  preferred track, terms agreed 1:1, partner terms honored when pricing lands.
- **No new intake surface.** A second form or address is one more thing to watch
  and one more place for an application to die.

## Tests

`tests/test_design_partners_619.py` pins the four acceptance criteria — the two
required sections, the three promised benefits, the paid-pilot-or-time-commitment
clause, the 5–10 cohort size and cadence, the three intake topics, that intake
reuses #618's path, that the activation trigger is stated, and that both README
and LICENSING link the page. One guard is about drift rather than AC:
`test_it_does_not_invent_a_second_contact_address` fails if any address other than
the three this repo actually answers appears.

`DESIGN_PARTNERS.md` also joins `ROOT_DOCS` in `tests/test_root_docs_950.py`, so
its relative links are checked in CI like every other root doc.

## Known limitations

- The program's promises (bi-weekly calls, roadmap access, credit in the README)
  are commitments a human has to honor; nothing here enforces or tracks them.
- The pinned Discussion is linked at the category root, not a specific thread —
  matching how `LICENSING.md` already links it. If that thread gets a stable URL,
  both pages should be updated together.
- Review: `codex review --base main` on the branch diff, no findings. (opencode/GLM
  skipped — it writes to the tree on this repo.)

https://claude.ai/code/session_01CXUZEUpwUmZM8nj6QUYHk8
