### PR TITLE
refactor(cli): drop dead helpers and unify provider-key validation (#970)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -2059,8 +2059,8 @@ def prd_stress_test(
     """
     from codeframe.core.workspace import get_workspace
     from codeframe.core import prd as prd_module
-    from codeframe.core.llm_resolution import resolve_llm_settings, create_provider
-    from codeframe.cli.validators import require_api_key_for_provider
+    from codeframe.core.llm_resolution import create_provider
+    from codeframe.cli.validators import require_keys_for_engine
     from codeframe.core.prd_stress_test import (
         StressTestError,
         stress_test_prd,
@@ -2091,10 +2091,9 @@ def prd_stress_test(
 
     # Build provider: flag → env → config → anthropic, validating the
     # matching API key (#768)
-    settings = resolve_llm_settings(
+    settings = require_keys_for_engine(
         workspace.repo_path, provider_flag=llm_provider, model_flag=llm_model
     )
-    require_api_key_for_provider(settings.provider_type)
     provider = create_provider(settings)
 
     # Run stress test
@@ -2321,15 +2320,12 @@ def tasks_generate(
         if not no_llm:
             # Validate the key matching the resolved provider
             # (flag → env → config → anthropic), #768
-            from codeframe.cli.validators import require_api_key_for_provider
-            from codeframe.core.llm_resolution import (
-                create_provider,
-                resolve_llm_settings,
-            )
-            settings = resolve_llm_settings(
+            from codeframe.cli.validators import require_keys_for_engine
+            from codeframe.core.llm_resolution import create_provider
+
+            settings = require_keys_for_engine(
                 workspace.repo_path, provider_flag=llm_provider, model_flag=llm_model
             )
-            require_api_key_for_provider(settings.provider_type)
             provider = create_provider(settings)
 
         try:
@@ -3039,10 +3035,7 @@ def work_start(
 
         # Validate API key before creating run record (avoids dangling IN_PROGRESS state)
         if execute:
-            from codeframe.core.engine_registry import (
-                is_external_engine,
-                resolve_engine,
-            )
+            from codeframe.core.engine_registry import resolve_engine
 
             # Same reason: execute_agent resolves the engine, and the gated
             # cloud engine (#966) raises there — after the run record exists.
@@ -3052,23 +3045,11 @@ def work_start(
                 console.print(f"[red]Error:[/red] {exc}")
                 raise typer.Exit(1)
 
-            if engine == "codex":
-                # Not the OpenAI key check: `codex login` is the common way in
-                # and sets no env var at all (#1010).
-                from codeframe.cli.validators import require_codex_auth
-                require_codex_auth()
-            elif engine == "cloud":
-                from codeframe.cli.validators import require_e2b_api_key
-                require_e2b_api_key()
-            elif not is_external_engine(engine):
-                # Builtin engines: validate the key matching the resolved
-                # provider (flag → env → config → anthropic), #768
-                from codeframe.cli.validators import require_api_key_for_provider
-                from codeframe.core.llm_resolution import resolve_llm_settings
-                settings = resolve_llm_settings(
-                    workspace.repo_path, provider_flag=llm_provider
-                )
-                require_api_key_for_provider(settings.provider_type)
+            from codeframe.cli.validators import require_keys_for_engine
+
+            require_keys_for_engine(
+                workspace.repo_path, engine=engine, provider_flag=llm_provider
+            )
 
         # Start the run
         run = runtime.start_task_run(workspace, task.id)
@@ -3658,10 +3639,9 @@ def work_retry(
 
         # Validate the key matching the resolved provider (env → config →
         # anthropic) before any state modifications, #768
-        from codeframe.cli.validators import require_api_key_for_provider
-        from codeframe.core.llm_resolution import resolve_llm_settings
-        settings = resolve_llm_settings(workspace.repo_path)
-        require_api_key_for_provider(settings.provider_type)
+        from codeframe.cli.validators import require_keys_for_engine
+
+        require_keys_for_engine(workspace.repo_path)
 
         # Reset task to READY if it's FAILED or BLOCKED
         if task.status in (TaskStatus.FAILED, TaskStatus.BLOCKED):
@@ -4388,8 +4368,11 @@ def batch_run(
     isolation: str = typer.Option(
         "none",
         "--isolation",
-        help="Task execution isolation: none (default) or worktree",
-        click_type=click.Choice(["none", "worktree"], case_sensitive=False),
+        help=(
+            "Task execution isolation: none (default). Worktree isolation is "
+            "single-task only: `cf work start <task> --execute --isolation worktree`."
+        ),
+        click_type=click.Choice(["none"], case_sensitive=False),
     ),
     cloud_timeout: int = typer.Option(
         30,
@@ -4486,26 +4469,6 @@ def batch_run(
             console.print("[red]Error:[/red] Specify task IDs or use --all-ready/--all-blocked")
             raise typer.Exit(1)
 
-        # Reject unsupported isolation up front — before the API-key check and
-        # before any batch is created. CLOUD is not implemented; WORKTREE is
-        # enabled only for the single-run path (`cf work start`, #787) — the
-        # batch subprocess path can't reach the gitignored .codeframe DB from a
-        # worktree, so it stays rejected here until that's solved.
-        from codeframe.core.sandbox.context import IsolationLevel, validate_isolation
-        if IsolationLevel(isolation) == IsolationLevel.WORKTREE:
-            console.print(
-                "[red]Error:[/red] worktree isolation is not yet supported for "
-                "batch runs (subprocess workers can't reach the workspace state "
-                "DB in a worktree). Use it with a single task: "
-                "`cf work start <task> --execute --isolation worktree`."
-            )
-            raise typer.Exit(1)
-        try:
-            validate_isolation(IsolationLevel(isolation))
-        except (ValueError, NotImplementedError) as exc:
-            console.print(f"[red]Error:[/red] {exc}")
-            raise typer.Exit(1)
-
         # Show execution plan
         console.print("\n[bold]Batch Execution Plan[/bold]")
         console.print(f"  Strategy: {strategy}")
@@ -4532,25 +4495,11 @@ def batch_run(
             return
 
         # Validate API key before batch execution
-        from codeframe.core.engine_registry import is_external_engine
+        from codeframe.cli.validators import require_keys_for_engine
 
-        if engine == "codex":
-            # Not the OpenAI key check: `codex login` is the common way in
-            # and sets no env var at all (#1010).
-            from codeframe.cli.validators import require_codex_auth
-            require_codex_auth()
-        elif engine == "cloud":
-            from codeframe.cli.validators import require_e2b_api_key
-            require_e2b_api_key()
-        elif not is_external_engine(engine):
-            # Builtin engines: validate the key matching the resolved
-            # provider (flag → env → config → anthropic), #768
-            from codeframe.cli.validators import require_api_key_for_provider
-            from codeframe.core.llm_resolution import resolve_llm_settings
-            settings = resolve_llm_settings(
-                workspace.repo_path, provider_flag=llm_provider
-            )
-            require_api_key_for_provider(settings.provider_type)
+        require_keys_for_engine(
+            workspace.repo_path, engine=engine, provider_flag=llm_provider
+        )
 
         # Execute batch
         if max_retries > 0:

--- a/codeframe/cli/commands/__init__.py
+++ b/codeframe/cli/commands/__init__.py
@@ -1,5 +1,0 @@
-"""CLI command modules for CodeFRAME v2.
-
-Each module provides a Typer sub-application for a specific domain.
-Commands follow the pattern: codeframe <domain> <verb> [args] [--options]
-"""

--- a/codeframe/cli/helpers.py
+++ b/codeframe/cli/helpers.py
@@ -1,56 +1,10 @@
 """Shared CLI helper utilities.
 
-This module provides common utilities used across CLI command modules:
-- require_auth: Authentication check for API client
-- format_date: Safe date string formatting
-- console: Shared Rich Console instance
-
 Usage:
-    from codeframe.cli.helpers import require_auth, format_date, console
+    from codeframe.cli.helpers import console
 """
 
-import typer
 from rich.console import Console
-
-from codeframe.cli.api_client import APIClient
 
 # Shared console instance for all CLI modules
 console = Console()
-
-
-def require_auth(client: APIClient) -> None:
-    """Check if client is authenticated, exit with error if not.
-
-    Args:
-        client: APIClient instance to check for authentication
-
-    Raises:
-        typer.Exit: If client is not authenticated (exit code 1)
-    """
-    if not client.token:
-        console.print("[yellow]Not logged in.[/yellow]")
-        console.print("Please log in: codeframe auth login")
-        raise typer.Exit(1)
-
-
-def format_date(date_str: str | None, length: int = 10) -> str:
-    """Safely extract date portion from an ISO datetime string.
-
-    Args:
-        date_str: ISO datetime string (e.g., "2024-01-15T10:30:00Z") or None
-        length: Number of characters to extract (default 10 for YYYY-MM-DD)
-
-    Returns:
-        Truncated date string or empty string if input is falsy or too short
-
-    Examples:
-        >>> format_date("2024-01-15T10:30:00Z")
-        '2024-01-15'
-        >>> format_date(None)
-        ''
-        >>> format_date("short")
-        ''
-    """
-    if not date_str or len(date_str) < length:
-        return ""
-    return date_str[:length]

--- a/codeframe/cli/validators.py
+++ b/codeframe/cli/validators.py
@@ -1,10 +1,18 @@
 """CLI validation helpers for pre-command checks."""
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import typer
 from codeframe.core.env_provenance import load_env_files
 from rich.console import Console
+
+if TYPE_CHECKING:  # pragma: no cover - import-time cost the CLI does not pay
+    from pathlib import Path
+
+    from codeframe.core.llm_resolution import LLMSettings
 
 console = Console()
 
@@ -151,3 +159,53 @@ def require_codex_auth() -> None:
         "environment or a .env file."
     )
     raise typer.Exit(1)
+
+
+def require_keys_for_engine(
+    repo_path: Path,
+    engine: str | None = None,
+    provider_flag: str | None = None,
+    model_flag: str | None = None,
+) -> LLMSettings | None:
+    """Validate the credentials the resolved engine/provider needs (#970).
+
+    The single place that answers "can this run reach a model?". It used to be
+    copy-pasted across `cf work start`, `cf work batch run` and `cf tasks
+    generate`, so any change to key handling landed on two of the three sites.
+
+    Args:
+        repo_path: Workspace repo path, for `.codeframe/config.yaml` resolution.
+        engine: Engine name, or None for commands that only ever use the
+            builtin LLM path (`cf tasks generate`, `cf prd stress-test`).
+        provider_flag: `--llm-provider`, if the command has one.
+        model_flag: `--llm-model`, if the command has one.
+
+    Returns:
+        The resolved LLM settings when a provider is involved (the caller
+        usually feeds them straight to `create_provider`), or None for an
+        external engine, which brings its own credentials.
+
+    Raises:
+        typer.Exit: If a required key or login cannot be found.
+    """
+    from codeframe.core.engine_registry import is_external_engine
+    from codeframe.core.llm_resolution import resolve_llm_settings
+
+    if engine == "codex":
+        # Not the OpenAI key check: `codex login` is the common way in and sets
+        # no env var at all (#1010).
+        require_codex_auth()
+        return None
+    if engine == "cloud":
+        require_e2b_api_key()
+        return None
+    if engine is not None and is_external_engine(engine):
+        return None
+
+    # Builtin engines: validate the key matching the resolved provider
+    # (flag → env → config → anthropic), #768
+    settings = resolve_llm_settings(
+        repo_path, provider_flag=provider_flag, model_flag=model_flag
+    )
+    require_api_key_for_provider(settings.provider_type)
+    return settings

--- a/codeframe/cli/validators.py
+++ b/codeframe/cli/validators.py
@@ -181,9 +181,11 @@ def require_keys_for_engine(
         model_flag: `--llm-model`, if the command has one.
 
     Returns:
-        The resolved LLM settings when a provider is involved (the caller
-        usually feeds them straight to `create_provider`), or None for an
-        external engine, which brings its own credentials.
+        The resolved LLM settings when a builtin engine's LLM provider is
+        involved (the caller usually feeds them straight to `create_provider`),
+        or None for an external engine. An external engine still has its own
+        credentials checked here — codex and cloud above — it just has no
+        provider to resolve.
 
     Raises:
         typer.Exit: If a required key or login cannot be found.

--- a/docs/CLI_WIREFRAME.md
+++ b/docs/CLI_WIREFRAME.md
@@ -89,7 +89,7 @@ Each command:
 **Purpose:** Create/register a workspace.
 
 **CLI module:**
-- `codeframe/cli/commands/workspace.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.workspace.create_or_load(repo_path) -> Workspace`
@@ -108,7 +108,7 @@ Each command:
 **Purpose:** Show current workspace summary + task counts + latest activity.
 
 **CLI module:**
-- `codeframe/cli/commands/status.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.workspace.get_current() -> Workspace`
@@ -280,7 +280,7 @@ Each command:
 **Purpose:** AI-driven interactive PRD generation.
 
 **CLI module:**
-- `codeframe/cli/commands/prd.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.prd.start_discovery_session(workspace_id) -> DiscoverySession`
@@ -304,7 +304,7 @@ Each command:
 **Purpose:** Store PRD text + metadata.
 
 **CLI module:**
-- `codeframe/cli/commands/prd.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.prd.load_file(path) -> str`
@@ -320,7 +320,7 @@ Each command:
 **Purpose:** Iterative PRD improvement based on feedback.
 
 **CLI module:**
-- `codeframe/cli/commands/prd.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.prd.get(workspace_id, prd_id) -> PrdRecord`
@@ -463,7 +463,7 @@ Each command:
 **Purpose:** Generate tasks from PRD.
 
 **CLI module:**
-- `codeframe/cli/commands/tasks.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.prd.get_latest(workspace_id) -> PrdRecord`
@@ -516,7 +516,7 @@ Each command:
 **Purpose:** Begin execution of a task.
 
 **CLI module:**
-- `codeframe/cli/commands/work.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `workspace = codeframe.core.workspace.get_current()`
@@ -562,7 +562,7 @@ Each command:
 **Purpose:** Execute multiple tasks in sequence (or parallel in Phase 2).
 
 **CLI module:**
-- `codeframe/cli/commands/work.py` (batch subcommand group)
+- `codeframe/cli/app.py` (batch subcommand group)
 
 **Core calls:**
 - `batch = codeframe.core.conductor.start_batch(workspace_id, task_ids, strategy, max_parallel)`
@@ -655,7 +655,7 @@ cf work batch resume abc123 --force   # Re-run all tasks
 **Purpose:** List open blockers.
 
 **CLI module:**
-- `codeframe/cli/commands/blockers.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `codeframe.core.blockers.list_open(workspace_id) -> list[Blocker]`
@@ -687,7 +687,7 @@ cf work batch resume abc123 --force   # Re-run all tasks
 **Purpose:** Run verification gates.
 
 **CLI module:**
-- `codeframe/cli/commands/gates.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `result = codeframe.core.gates.run(workspace_id, repo_path) -> GateResult`
@@ -708,7 +708,7 @@ cf work batch resume abc123 --force   # Re-run all tasks
 **Purpose:** Export changes safely.
 
 **CLI module:**
-- `codeframe/cli/commands/artifacts.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `patch_path = codeframe.core.runtime.export_patch(workspace_id, repo_path, out_path=None)`
@@ -737,7 +737,7 @@ cf work batch resume abc123 --force   # Re-run all tasks
 **Purpose:** Begin task execution with automatic branch creation.
 
 **CLI module:**
-- `codeframe/cli/commands/work.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `branch_name = codeframe.core.git.create_feature_branch(workspace_id, task_id)`
@@ -871,7 +871,7 @@ codeframe pr status
 **Purpose:** Show git status summary with CodeFRAME context.
 
 **CLI module:**
-- `codeframe/cli/commands/git.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `status = codeframe.core.git.get_enhanced_status(workspace_id)`
@@ -884,7 +884,7 @@ codeframe pr status
 **Purpose:** Snapshot durable state + optionally repo ref.
 
 **CLI module:**
-- `codeframe/cli/commands/checkpoints.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `checkpoint = codeframe.core.checkpoints.create(workspace_id, name)`
@@ -914,7 +914,7 @@ codeframe pr status
 **Purpose:** Print a short status report of the workspace.
 
 **CLI module:**
-- `codeframe/cli/commands/summary.py`
+- `codeframe/cli/app.py`
 
 **Core calls:**
 - `prd = prd.get_latest(...)`
@@ -981,7 +981,7 @@ cf import ralph /path/to/project --workspace /path/to/workspace
 **Purpose:** Start FastAPI server as a wrapper over core.
 
 **CLI module:**
-- `codeframe/cli/commands/server.py`
+- `codeframe/cli/app.py`
 
 **Server module:**
 - `codeframe/server/app.py`

--- a/tests/cli/test_cli_dead_surface_970.py
+++ b/tests/cli/test_cli_dead_surface_970.py
@@ -176,18 +176,27 @@ class TestEveryCommandRejectsAMissingKeyIdentically:
 
 
 class TestBatchHelpDoesNotAdvertiseWorktree:
-    def test_help_no_longer_offers_worktree(self):
-        """The advertised choices must be the accepted ones."""
+    def _isolation_choices(self, *path):
+        """The choices `--help` renders, read off the command itself.
+
+        Not scraped from the rendered help: Rich wraps that to the terminal
+        width and paints it with ANSI, so the same command reads differently
+        on a CI runner than it does locally.
+        """
+        import typer
+
         from codeframe.cli.app import app
 
-        result = runner.invoke(app, ["work", "batch", "run", "--help"])
-        assert result.exit_code == 0
-        assert "[none|worktree]" not in result.output
-        assert "[none]" in result.output
+        command = typer.main.get_command(app)
+        for name in path:
+            command = command.commands[name]
+        param = next(p for p in command.params if "--isolation" in p.opts)
+        return list(param.type.choices)
+
+    def test_help_no_longer_offers_worktree(self):
+        """The advertised choices must be the accepted ones."""
+        assert self._isolation_choices("work", "batch", "run") == ["none"]
 
     def test_work_start_still_offers_worktree(self):
         """#787: the single-run path really does support it."""
-        from codeframe.cli.app import app
-
-        result = runner.invoke(app, ["work", "start", "--help"])
-        assert "worktree" in result.output
+        assert "worktree" in self._isolation_choices("work", "start")

--- a/tests/cli/test_cli_dead_surface_970.py
+++ b/tests/cli/test_cli_dead_surface_970.py
@@ -1,0 +1,193 @@
+"""Issue #970: the CLI's dead surface and its triplicated key validation.
+
+The CLI is the product's primary surface, so its source is the most-read code
+in the repo. Three things made it misleading:
+
+- ``helpers.py`` exported two functions nobody imported;
+- ``codeframe/cli/commands/`` was an empty package that read as an
+  in-progress refactor;
+- the engine/provider key-validation block was copy-pasted across three
+  commands, so a change to key handling would land on two of the three sites.
+
+And ``cf work batch run --help`` advertised an ``--isolation`` value the
+command unconditionally rejected.
+"""
+
+import importlib
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+pytestmark = pytest.mark.v2
+
+runner = CliRunner()
+
+
+class TestHelpersHasOnlyLiveCode:
+    def test_console_is_still_exported(self):
+        """Three command modules import it — it is the module's only reason to exist."""
+        from codeframe.cli.helpers import console
+
+        assert console is not None
+
+    @pytest.mark.parametrize("name", ["require_auth", "format_date"])
+    def test_dead_helpers_are_gone(self, name):
+        helpers = importlib.import_module("codeframe.cli.helpers")
+        assert not hasattr(helpers, name), (
+            f"{name} has no caller anywhere in the repo; it must not survive"
+        )
+
+    def test_module_docstring_does_not_advertise_them(self):
+        helpers = importlib.import_module("codeframe.cli.helpers")
+        doc = helpers.__doc__ or ""
+        assert "require_auth" not in doc and "format_date" not in doc
+
+
+class TestEmptyCommandsPackageRemoved:
+    def test_package_directory_is_gone(self):
+        import codeframe.cli as cli_pkg
+
+        assert not (Path(cli_pkg.__file__).parent / "commands").exists()
+
+    def test_package_is_not_importable(self):
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module("codeframe.cli.commands")
+
+
+class TestSingleKeyValidationHelper:
+    """One helper, used by every command that needs a key."""
+
+    def test_helper_exists(self):
+        from codeframe.cli.validators import require_keys_for_engine
+
+        assert callable(require_keys_for_engine)
+
+    def test_builtin_engine_validates_the_resolved_provider(self, tmp_path, monkeypatch):
+        from codeframe.cli import validators
+
+        seen = []
+        monkeypatch.setattr(
+            validators, "require_api_key_for_provider", lambda pt: seen.append(pt)
+        )
+        settings = validators.require_keys_for_engine(tmp_path, engine="react")
+        assert seen == [settings.provider_type]
+
+    def test_no_engine_validates_the_resolved_provider(self, tmp_path, monkeypatch):
+        """`cf tasks generate` / `cf prd stress-test` have no engine at all."""
+        from codeframe.cli import validators
+
+        seen = []
+        monkeypatch.setattr(
+            validators, "require_api_key_for_provider", lambda pt: seen.append(pt)
+        )
+        settings = validators.require_keys_for_engine(tmp_path)
+        assert settings is not None and seen == [settings.provider_type]
+
+    def test_codex_engine_uses_codex_auth_not_the_openai_key(self, tmp_path, monkeypatch):
+        """#1010: `codex login` sets no env var, so the key check is wrong there."""
+        from codeframe.cli import validators
+
+        calls = []
+        monkeypatch.setattr(validators, "require_codex_auth", lambda: calls.append("codex"))
+        monkeypatch.setattr(
+            validators,
+            "require_api_key_for_provider",
+            lambda pt: calls.append("provider"),
+        )
+        assert validators.require_keys_for_engine(tmp_path, engine="codex") is None
+        assert calls == ["codex"]
+
+    def test_cloud_engine_uses_the_e2b_key(self, tmp_path, monkeypatch):
+        from codeframe.cli import validators
+
+        calls = []
+        monkeypatch.setattr(validators, "require_e2b_api_key", lambda: calls.append("e2b"))
+        monkeypatch.setattr(
+            validators,
+            "require_api_key_for_provider",
+            lambda pt: calls.append("provider"),
+        )
+        assert validators.require_keys_for_engine(tmp_path, engine="cloud") is None
+        assert calls == ["e2b"]
+
+    def test_other_external_engines_need_no_key(self, tmp_path, monkeypatch):
+        from codeframe.cli import validators
+
+        calls = []
+        monkeypatch.setattr(
+            validators, "require_api_key_for_provider", lambda pt: calls.append(pt)
+        )
+        assert validators.require_keys_for_engine(tmp_path, engine="claude-code") is None
+        assert calls == []
+
+
+class TestEveryCommandRejectsAMissingKeyIdentically:
+    """The point of the extraction: one message, not three that can drift."""
+
+    def _workspace(self, tmp_path):
+        from codeframe.core import prd, tasks
+        from codeframe.core.state_machine import TaskStatus
+        from codeframe.core.workspace import create_or_load_workspace
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ws = create_or_load_workspace(repo)
+        prd.store(ws, content="# p\n\nBuild a thing.", title="p")
+        task = tasks.create(ws, title="t", description="d", status=TaskStatus.READY)
+        return repo, ws, task
+
+    @pytest.fixture(autouse=True)
+    def _no_keys_anywhere(self, monkeypatch):
+        """No key in the environment, and none to be found in any .env either."""
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        # Both bindings: validators imported the name, and other call sites on
+        # the command path reach it through the module.
+        monkeypatch.setattr("codeframe.cli.validators.load_env_files", lambda *a, **k: None)
+        for module in ("codeframe.core.env_provenance", "codeframe.cli.app"):
+            monkeypatch.setattr(f"{module}.load_env_files", lambda *a, **k: None)
+
+    def _run(self, argv):
+        from codeframe.cli.app import app
+
+        return runner.invoke(app, argv)
+
+    def test_all_three_commands_share_one_message(self, tmp_path):
+        repo, ws, task = self._workspace(tmp_path)
+
+        results = [
+            self._run(["tasks", "generate", "-w", str(repo)]),
+            self._run(["work", "start", task.id[:8], "--execute", "-w", str(repo)]),
+            self._run(["work", "batch", "run", task.id[:8], "-w", str(repo)]),
+        ]
+        for r in results:
+            assert r.exit_code == 1, r.output
+            assert "ANTHROPIC_API_KEY is not set" in r.output, r.output
+
+    def test_work_start_does_not_leave_a_dangling_run(self, tmp_path):
+        """The key check must stay ahead of the run record."""
+        from codeframe.core import tasks as tasks_module
+        from codeframe.core.state_machine import TaskStatus
+
+        repo, ws, task = self._workspace(tmp_path)
+        self._run(["work", "start", task.id[:8], "--execute", "-w", str(repo)])
+        assert tasks_module.get(ws, task.id).status != TaskStatus.IN_PROGRESS
+
+
+class TestBatchHelpDoesNotAdvertiseWorktree:
+    def test_help_no_longer_offers_worktree(self):
+        """The advertised choices must be the accepted ones."""
+        from codeframe.cli.app import app
+
+        result = runner.invoke(app, ["work", "batch", "run", "--help"])
+        assert result.exit_code == 0
+        assert "[none|worktree]" not in result.output
+        assert "[none]" in result.output
+
+    def test_work_start_still_offers_worktree(self):
+        """#787: the single-run path really does support it."""
+        from codeframe.cli.app import app
+
+        result = runner.invoke(app, ["work", "start", "--help"])
+        assert "worktree" in result.output

--- a/tests/cli/test_work_exit_codes.py
+++ b/tests/cli/test_work_exit_codes.py
@@ -213,7 +213,9 @@ class TestBatchRunExitCodes:
 class TestIsolationRejection:
     """Issue #787: `--isolation worktree` is now accepted for the single-run
     path (`cf work start`) but still rejected for batch runs (the subprocess
-    worker can't reach the workspace state DB in a worktree)."""
+    worker can't reach the workspace state DB in a worktree). Since #970 batch
+    rejects it at parse time — the same shape as `cloud` below — instead of
+    advertising a value it would then refuse."""
 
     def _workspace_with_task(self, tmp_path):
         repo = tmp_path / "repo"
@@ -235,14 +237,18 @@ class TestIsolationRejection:
         # The run was started (task moved to IN_PROGRESS), not rejected.
         assert tasks.get(ws, task.id).status == TaskStatus.IN_PROGRESS
 
-    def test_work_batch_run_rejects_worktree(self, tmp_path):
+    def test_work_batch_run_rejects_worktree_at_parse_time(self, tmp_path):
+        """#970: batch never offered a working worktree mode, so it is no longer
+        a parseable choice — `--help` and the accepted values now agree."""
         repo, ws, task = self._workspace_with_task(tmp_path)
         result = runner.invoke(
             app,
             ["work", "batch", "run", task.id[:8], "--isolation", "worktree", "-w", str(repo)],
         )
-        assert result.exit_code == 1
-        assert "not yet supported for batch" in result.output
+        assert result.exit_code != 0
+        # `none` is batch's only choice since #970, so Click phrases it as
+        # "is not 'none'" rather than "is not one of".
+        assert "worktree" in result.output and "'none'" in result.output
 
     def test_work_start_allows_none(self, tmp_path):
         """--isolation none must NOT hit any rejection path (sanity)."""
@@ -272,5 +278,7 @@ class TestIsolationRejection:
             ["work", "batch", "run", task.id[:8], "--isolation", "cloud", "-w", str(repo)],
         )
         assert result.exit_code != 0
-        assert "cloud" in result.output and "is not one of" in result.output
+        # `none` is batch's only choice since #970, so Click phrases it as
+        # "is not 'none'" rather than "is not one of".
+        assert "cloud" in result.output and "'none'" in result.output
         assert tasks.get(ws, task.id).status != TaskStatus.IN_PROGRESS


### PR DESCRIPTION
Closes #970

## What changed

The CLI is the product's primary surface, so its source is the most-read code in the repo. Three things in it misled a reader, and one thing misled a user.

**Dead surface removed.** `helpers.py` exported `require_auth` and `format_date`, which nothing imported — three modules import only `console`, and that is all the module holds now. `codeframe/cli/commands/` was an empty package that read as an in-progress refactor; it is gone. `docs/CLI_WIREFRAME.md` — a Primary Contract doc — pointed sixteen "CLI module" entries at files *inside* that package which never existed. They now name `codeframe/cli/app.py`, where every one of those commands actually lives.

**One key-validation helper.** The engine/provider block was copy-pasted across five call sites, so a change to key handling would have landed on some of them and not others. It is now `validators.require_keys_for_engine(repo_path, engine=..., provider_flag=..., model_flag=...)`, used by `cf work start`, `cf work batch run`, `cf tasks generate`, `cf prd stress-test` and `cf work retry`. It returns the resolved `LLMSettings` the provider callers already needed, so nothing resolves settings twice, and it keeps the two special cases the duplicated code had: codex goes through `require_codex_auth` (`codex login` sets no env var, #1010) and cloud through `require_e2b_api_key`.

**`--isolation worktree` no longer advertised on batch.** `cf work batch run --help` offered it and the command then unconditionally rejected it — batch subprocess workers can't reach the gitignored `.codeframe` DB from a worktree (#787). `none` is now its only choice, so the advertised values and the accepted ones agree, and the guidance moved into the option's help text where a reader sees it *before* typing the flag. `cf work start` is unaffected and still supports worktree.

## Verification

All four acceptance criteria demonstrated by running the CLI, not just by tests:

```
$ python -c "import codeframe.cli.helpers as h; ..."
helpers.py public names: ['Console', 'console']
commands package: No module named 'codeframe.cli.commands'
```

The same message from all three commands, with no key in the environment and none in any `.env`:

```
$ cf tasks generate           → Error: ANTHROPIC_API_KEY is not set. ...   [exit 1]
$ cf work start <id> --execute → Error: ANTHROPIC_API_KEY is not set. ...  [exit 1]
$ cf work batch run <id>      → Error: ANTHROPIC_API_KEY is not set. ...   [exit 1]
```

```
$ cf work batch run --help
│ --isolation   [none]   Task execution isolation: none (default). Worktree
│                        isolation is single-task only: `cf work start
│                        <task> --execute --isolation worktree`.

$ cf work batch run <id> --isolation worktree
Invalid value for '--isolation': 'worktree' is not 'none'.
```

`uv run pytest tests/cli/` — 621 passed. `uv run ruff check .` — clean. Full non-e2e suite run separately.

New: `tests/cli/test_cli_dead_surface_970.py` (16 tests) covers the dead surface staying dead, each branch of the new helper, the shared message across the three commands, `cf work start` not leaving a dangling `IN_PROGRESS` task when the key check fires, and the help/accepted-values agreement.

## Test change, called out deliberately

`test_work_exit_codes.py::TestIsolationRejection::test_work_batch_run_rejects_worktree` asserted the old runtime rejection message (exit 1). Batch now refuses the value at parse time, so it is renamed `..._at_parse_time` and asserts that shape instead — the same shape the neighbouring `--isolation cloud` test in that class has always used. The behaviour it guards (batch does not run with worktree isolation) is unchanged and still enforced.

## Known limitations

- Batch's runtime `validate_isolation` call went away with the rejection branch. With `none` as the only parseable value it was unreachable; re-add it alongside any future widening of the choices.
- The helper covers the five commands that validate keys today. `cf env check` and the adapter paths have their own credential handling and were left alone.

## Review

`codex review --base main`: no findings — "consolidates CLI credential validation and removes misleading dead surfaces without introducing an actionable regression."

https://claude.ai/code/session_01CXUZEUpwUmZM8nj6QUYHk8
