### PR TITLE
refactor(web-ui): single source for status maps, USD formatter and workspace key (#971)

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -50,7 +50,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "jest": "^30.5.0",
         "jest-environment-jsdom": "^30.5.0",
-        "msw": "^2.15.0",
         "postcss": "^8.5.26",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
@@ -1549,93 +1548,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
-      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
-      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.7",
-        "@inquirer/type": "^4.0.7",
-        "cli-width": "^4.1.0",
-        "fast-wrap-ansi": "^0.2.0",
-        "mute-stream": "^3.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
-      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2291,31 +2203,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mswjs/interceptors": {
-      "version": "0.41.9",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
-      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
@@ -2562,31 +2449,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
-      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.6.0",
@@ -4437,27 +4299,10 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
-      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5698,16 +5543,6 @@
         "url": "https://polar.sh/cva"
       }
     },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5851,20 +5686,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6605,33 +6426,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-string-truncated-width": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-string-width": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-string-truncated-width": "^3.0.2"
-      }
-    },
-    "node_modules/fast-wrap-ansi": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
-      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-string-width": "^3.0.2"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6969,16 +6763,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphql": {
-      "version": "16.14.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
-      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7066,17 +6850,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/headers-polyfill": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
-      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.10",
-        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hermes-estree": {
@@ -7343,13 +7116,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -9721,90 +9487,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/msw": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
-      "integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/confirm": "^6.0.11",
-        "@mswjs/interceptors": "^0.41.3",
-        "@open-draft/deferred-promise": "^3.0.0",
-        "@types/statuses": "^2.0.6",
-        "cookie": "^1.1.1",
-        "graphql": "^16.13.2",
-        "headers-polyfill": "^5.0.1",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "path-to-regexp": "^6.3.0",
-        "picocolors": "^1.1.1",
-        "rettime": "^0.11.11",
-        "statuses": "^2.0.2",
-        "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.1",
-        "type-fest": "^5.5.0",
-        "until-async": "^3.0.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/msw/node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/msw/node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -10015,13 +9697,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10187,13 +9862,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10660,13 +10328,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/rettime": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
-      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -10747,13 +10408,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.35.3",
@@ -10915,23 +10569,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -11194,19 +10831,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -11417,26 +11041,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/tldts": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
-      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.4.3"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
-      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -11740,16 +11344,6 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
-      }
-    },
-    "node_modules/until-async": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -54,7 +54,6 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "jest": "^30.5.0",
     "jest-environment-jsdom": "^30.5.0",
-    "msw": "^2.15.0",
     "postcss": "^8.5.26",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",

--- a/web-ui/src/__tests__/lib/format.test.ts
+++ b/web-ui/src/__tests__/lib/format.test.ts
@@ -1,0 +1,34 @@
+import { formatUsd, formatCount, formatRelativeTime } from '@/lib/format';
+
+describe('formatUsd', () => {
+  it('defaults to 4 fraction digits', () => {
+    expect(formatUsd(1.5)).toBe('$1.5000');
+    expect(formatUsd(0)).toBe('$0.0000');
+  });
+
+  it('honours a wider maximum for small-magnitude costs', () => {
+    expect(formatUsd(0.0000125, { maximumFractionDigits: 6 })).toBe('$0.000013');
+    expect(formatUsd(1.5, { maximumFractionDigits: 6 })).toBe('$1.5000');
+  });
+
+  it('honours an explicit fixed precision', () => {
+    expect(formatUsd(1.5, { minimumFractionDigits: 2, maximumFractionDigits: 2 })).toBe('$1.50');
+  });
+
+  it('groups thousands', () => {
+    expect(formatUsd(1234.5)).toBe('$1,234.5000');
+  });
+});
+
+describe('formatCount', () => {
+  it('groups thousands', () => {
+    expect(formatCount(1234567)).toBe('1,234,567');
+    expect(formatCount(0)).toBe('0');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  it('still works after the module gained currency helpers', () => {
+    expect(formatRelativeTime(new Date().toISOString())).toBe('just now');
+  });
+});

--- a/web-ui/src/__tests__/lib/sharedConstants.guard.test.ts
+++ b/web-ui/src/__tests__/lib/sharedConstants.guard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Guard test for issue #971.
+ *
+ * The status maps, the USD formatter and the workspace-storage key were each
+ * duplicated verbatim across several components, and nothing linked the copies
+ * together — so adding a status, or changing a storage key, silently left one
+ * surface behind. These are source scans rather than behavioural tests on
+ * purpose: what regressed was the *absence* of a single definition, which no
+ * render test can observe. Precedent: `api.contract.test.ts`.
+ */
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const SRC = join(__dirname, '..', '..');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      out.push(...sourceFiles(full));
+    } else if (/\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const ALL_SOURCES = sourceFiles(SRC);
+const rel = (f: string) => f.slice(SRC.length + 1);
+
+describe('#971 — status maps have a single definition', () => {
+  it('is declared only in lib/taskStatusInfo.ts', () => {
+    const offenders = ALL_SOURCES.filter(
+      (f) =>
+        rel(f) !== join('lib', 'taskStatusInfo.ts') &&
+        /^\s*(export\s+)?const\s+(STATUS_LABEL|STATUS_BADGE_VARIANT)\b/m.test(readFileSync(f, 'utf8'))
+    ).map(rel);
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('#971 — one USD formatter', () => {
+  it('has no hand-rolled currency toFixed in components or pages', () => {
+    const offenders: string[] = [];
+    for (const file of ALL_SOURCES) {
+      const source = readFileSync(file, 'utf8');
+      source.split('\n').forEach((line, i) => {
+        // `toFixed(4)` is only ever a USD amount here. Deliberately not
+        // matching a `$` next to a toFixed: `${(ms / 1000).toFixed(1)}` is a
+        // template sigil, not a currency sign, and the two are
+        // indistinguishable by regex. Non-USD precision (durations) is fine.
+        if (/toFixed\(4\)/.test(line)) {
+          offenders.push(`${rel(file)}:${i + 1}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('declares no local currency formatter outside lib/format.ts', () => {
+    const offenders = ALL_SOURCES.filter(
+      (f) =>
+        rel(f) !== join('lib', 'format.ts') &&
+        /function\s+format(Currency|Cost|BadgeCost|Usd|USD)\b/.test(readFileSync(f, 'utf8'))
+    ).map(rel);
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('#971 — workspace storage key has a single definition', () => {
+  it('appears as a literal only in lib/workspace-storage.ts', () => {
+    const offenders = ALL_SOURCES.filter(
+      (f) =>
+        rel(f) !== join('lib', 'workspace-storage.ts') &&
+        readFileSync(f, 'utf8').includes('codeframe_workspace_path')
+    ).map(rel);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/web-ui/src/app/costs/page.tsx
+++ b/web-ui/src/app/costs/page.tsx
@@ -10,6 +10,7 @@ import { TopTasksTable } from '@/components/costs/TopTasksTable';
 import { AgentCostBars } from '@/components/costs/AgentCostBars';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
 import { costsApi } from '@/lib/api';
+import { formatUsd } from '@/lib/format';
 import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import type {
   CostSummaryResponse,
@@ -23,15 +24,6 @@ const DAY_OPTIONS = [
   { value: 30, label: 'Last 30 days' },
   { value: 90, label: 'Last 90 days' },
 ];
-
-function formatCurrency(value: number, fractionDigits = 4): string {
-  return value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: fractionDigits,
-    maximumFractionDigits: fractionDigits,
-  });
-}
 
 export default function CostsPage() {
   const {
@@ -130,7 +122,7 @@ export default function CostsPage() {
                     data-testid="total-spend"
                     className="text-2xl font-bold"
                   >
-                    {formatCurrency(data.total_spend_usd)}
+                    {formatUsd(data.total_spend_usd)}
                   </p>
                 </CardContent>
               </Card>
@@ -160,7 +152,7 @@ export default function CostsPage() {
                     data-testid="avg-cost"
                     className="text-2xl font-bold"
                   >
-                    {formatCurrency(data.avg_cost_per_task)}
+                    {formatUsd(data.avg_cost_per_task)}
                   </p>
                 </CardContent>
               </Card>

--- a/web-ui/src/app/sessions/[id]/SessionDetailClient.tsx
+++ b/web-ui/src/app/sessions/[id]/SessionDetailClient.tsx
@@ -12,6 +12,7 @@ import { AgentChatPanel } from '@/components/sessions/AgentChatPanel';
 import { AgentTerminal } from '@/components/sessions/AgentTerminal';
 import { SplitPane } from '@/components/sessions/SplitPane';
 import { sessionsApi } from '@/lib/api';
+import { formatUsd } from '@/lib/format';
 import type { ChatMessage, Session } from '@/types';
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -163,7 +164,7 @@ export function SessionDetailClient({ sessionId }: SessionDetailClientProps) {
         </Badge>
 
         <span className="font-mono text-xs text-muted-foreground">
-          ${(session.cost_usd ?? 0).toFixed(4)}
+          {formatUsd(session.cost_usd ?? 0)}
         </span>
 
         <div className="ml-auto flex items-center gap-2">

--- a/web-ui/src/components/costs/AgentCostBars.tsx
+++ b/web-ui/src/components/costs/AgentCostBars.tsx
@@ -1,23 +1,11 @@
 'use client';
 
 import type { AgentCostsResponse } from '@/types';
+import { formatUsd, formatCount } from '@/lib/format';
 
 interface AgentCostBarsProps {
   data: AgentCostsResponse;
   isLoading?: boolean;
-}
-
-function formatNumber(n: number): string {
-  return n.toLocaleString('en-US');
-}
-
-function formatCost(value: number): string {
-  return value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 6,
-  });
 }
 
 export function AgentCostBars({ data, isLoading }: AgentCostBarsProps) {
@@ -75,7 +63,7 @@ export function AgentCostBars({ data, isLoading }: AgentCostBarsProps) {
                 />
               </div>
               <span className="whitespace-nowrap text-right font-medium tabular-nums">
-                {formatCost(agent.total_cost_usd)}
+                {formatUsd(agent.total_cost_usd, { maximumFractionDigits: 6 })}
               </span>
             </li>
           );
@@ -89,13 +77,13 @@ export function AgentCostBars({ data, isLoading }: AgentCostBarsProps) {
         <div>
           <span className="text-muted-foreground">Input tokens:</span>{' '}
           <span className="font-medium tabular-nums">
-            {formatNumber(data.total_input_tokens)}
+            {formatCount(data.total_input_tokens)}
           </span>
         </div>
         <div>
           <span className="text-muted-foreground">Output tokens:</span>{' '}
           <span className="font-medium tabular-nums">
-            {formatNumber(data.total_output_tokens)}
+            {formatCount(data.total_output_tokens)}
           </span>
         </div>
         <div>

--- a/web-ui/src/components/costs/SpendBarChart.tsx
+++ b/web-ui/src/components/costs/SpendBarChart.tsx
@@ -2,6 +2,7 @@
 
 import { format, parseISO } from 'date-fns';
 import type { DailyCostPoint } from '@/types';
+import { formatUsd } from '@/lib/format';
 
 interface SpendBarChartProps {
   daily: DailyCostPoint[];
@@ -12,15 +13,6 @@ const CHART_HEIGHT = 220;
 const CHART_PADDING_TOP = 12;
 const Y_AXIS_WIDTH = 56;
 const X_AXIS_HEIGHT = 28;
-
-function formatCurrency(value: number): string {
-  return value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
-  });
-}
 
 export function SpendBarChart({ daily, days }: SpendBarChartProps) {
   const hasData = daily.length > 0 && daily.some((d) => d.cost_usd > 0);
@@ -55,7 +47,7 @@ export function SpendBarChart({ daily, days }: SpendBarChartProps) {
           style={{ width: Y_AXIS_WIDTH, height: CHART_HEIGHT }}
         >
           {tickValues.map((v) => (
-            <span key={v}>{formatCurrency(v)}</span>
+            <span key={v}>{formatUsd(v)}</span>
           ))}
         </div>
 
@@ -77,7 +69,7 @@ export function SpendBarChart({ daily, days }: SpendBarChartProps) {
                 <div
                   key={point.date}
                   data-testid={`bar-${point.date}`}
-                  title={`${point.date}: ${formatCurrency(point.cost_usd)}`}
+                  title={`${point.date}: ${formatUsd(point.cost_usd)}`}
                   className="flex-1 rounded-t bg-primary/80 transition-colors hover:bg-primary"
                   style={{ height: `${barHeight}px`, minWidth: 4 }}
                 />

--- a/web-ui/src/components/costs/TopTasksTable.tsx
+++ b/web-ui/src/components/costs/TopTasksTable.tsx
@@ -2,23 +2,11 @@
 
 import Link from 'next/link';
 import type { TaskCostEntry } from '@/types';
+import { formatUsd, formatCount } from '@/lib/format';
 
 interface TopTasksTableProps {
   tasks: TaskCostEntry[];
   isLoading?: boolean;
-}
-
-function formatNumber(n: number): string {
-  return n.toLocaleString('en-US');
-}
-
-function formatCost(value: number): string {
-  return value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 6,
-  });
 }
 
 export function TopTasksTable({ tasks, isLoading }: TopTasksTableProps) {
@@ -73,13 +61,13 @@ export function TopTasksTable({ tasks, isLoading }: TopTasksTableProps) {
                 {task.agent_id}
               </td>
               <td className="px-3 py-2 text-right tabular-nums">
-                {formatNumber(task.input_tokens)}
+                {formatCount(task.input_tokens)}
               </td>
               <td className="px-3 py-2 text-right tabular-nums">
-                {formatNumber(task.output_tokens)}
+                {formatCount(task.output_tokens)}
               </td>
               <td className="px-3 py-2 text-right font-medium tabular-nums">
-                {formatCost(task.total_cost_usd)}
+                {formatUsd(task.total_cost_usd, { maximumFractionDigits: 6 })}
               </td>
             </tr>
           ))}

--- a/web-ui/src/components/sessions/AgentChatPanel.tsx
+++ b/web-ui/src/components/sessions/AgentChatPanel.tsx
@@ -6,6 +6,7 @@ import { ArtificialIntelligence01Icon, ArrowRight01Icon, Alert01Icon, Idea01Icon
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useAgentChat } from '@/hooks/useAgentChat';
+import { formatUsd } from '@/lib/format';
 import type { ChatMessage, AgentChatStatus } from '@/types';
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -270,7 +271,7 @@ export function AgentChatPanel({
           </Badge>
         </div>
         <span className="font-mono text-xs text-muted-foreground">
-          ${costUsd.toFixed(4)}
+          {formatUsd(costUsd)}
         </span>
       </div>
 

--- a/web-ui/src/components/sessions/SessionCard.tsx
+++ b/web-ui/src/components/sessions/SessionCard.tsx
@@ -17,6 +17,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { formatUsd } from '@/lib/format';
 import type { Session } from '@/types';
 
 interface SessionCardProps {
@@ -50,7 +51,7 @@ export function SessionCard({ session, onEnd }: SessionCardProps) {
         {/* Details */}
         <p className="truncate text-xs text-muted-foreground">{workspaceName}</p>
         <p className="mt-0.5 text-xs text-muted-foreground">{session.model}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">${session.cost_usd.toFixed(4)}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{formatUsd(session.cost_usd)}</p>
 
         {/* Action buttons */}
         <div className="mt-2 flex gap-1">

--- a/web-ui/src/components/tasks/TaskCard.tsx
+++ b/web-ui/src/components/tasks/TaskCard.tsx
@@ -8,60 +8,19 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
-import { STATUS_INFO } from '@/lib/taskStatusInfo';
-import type { Task, TaskStatus, ProofRequirement, TaskCostEntry } from '@/types';
+import { STATUS_INFO, STATUS_BADGE_VARIANT, STATUS_LABEL } from '@/lib/taskStatusInfo';
+import { formatUsd, formatCount } from '@/lib/format';
+import type { Task, ProofRequirement, TaskCostEntry } from '@/types';
 
 /** Format cost for the inline badge.
  *
  * AI per-task costs commonly sit below $0.01, so 2dp would display "$0.00"
- * and hide real spend. Mirrors TopTasksTable's 4dp precision under $1 and
- * falls back to 2dp once costs cross a dollar.
+ * and hide real spend. 4dp under a cent, 2dp above — a compact badge does not
+ * have room for more.
  */
-function formatBadgeCost(value: number): string {
-  if (value < 0.01) {
-    return value.toLocaleString('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 4,
-      maximumFractionDigits: 4,
-    });
-  }
-  if (value < 1) {
-    return `$${value.toFixed(2)}`;
-  }
-  return value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+function badgeCost(value: number): string {
+  return value < 0.01 ? formatUsd(value) : formatUsd(value, { minimumFractionDigits: 2 });
 }
-
-function formatTokens(n: number): string {
-  return n.toLocaleString('en-US');
-}
-
-/** Map backend TaskStatus to badge variant name. */
-const STATUS_BADGE_VARIANT: Record<TaskStatus, string> = {
-  BACKLOG: 'backlog',
-  READY: 'ready',
-  IN_PROGRESS: 'in-progress',
-  DONE: 'done',
-  BLOCKED: 'blocked',
-  FAILED: 'failed',
-  MERGED: 'merged',
-};
-
-/** Human-readable status labels. */
-const STATUS_LABEL: Record<TaskStatus, string> = {
-  BACKLOG: 'Backlog',
-  READY: 'Ready',
-  IN_PROGRESS: 'In Progress',
-  DONE: 'Done',
-  BLOCKED: 'Blocked',
-  FAILED: 'Failed',
-  MERGED: 'Merged',
-};
 
 interface TaskCardProps {
   task: Task;
@@ -204,14 +163,14 @@ export function TaskCard({
                   className="h-5 gap-1 px-1.5 text-[10px]"
                 >
                   <HugeiconsIcon icon={MoneyBag02Icon} className="h-3 w-3" />
-                  <span className="tabular-nums">{formatBadgeCost(costEntry.total_cost_usd)}</span>
+                  <span className="tabular-nums">{badgeCost(costEntry.total_cost_usd)}</span>
                 </Badge>
               </TooltipTrigger>
               <TooltipContent className="max-w-[220px] space-y-0.5 text-xs">
-                <p>Input tokens: {formatTokens(costEntry.input_tokens)}</p>
-                <p>Output tokens: {formatTokens(costEntry.output_tokens)}</p>
+                <p>Input tokens: {formatCount(costEntry.input_tokens)}</p>
+                <p>Output tokens: {formatCount(costEntry.output_tokens)}</p>
                 <p className="font-medium">
-                  Total: {formatBadgeCost(costEntry.total_cost_usd)}
+                  Total: {badgeCost(costEntry.total_cost_usd)}
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/web-ui/src/components/tasks/TaskColumn.tsx
+++ b/web-ui/src/components/tasks/TaskColumn.tsx
@@ -3,18 +3,8 @@
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TaskCard } from './TaskCard';
+import { STATUS_LABEL } from '@/lib/taskStatusInfo';
 import type { Task, TaskStatus, ProofRequirement, TaskCostEntry } from '@/types';
-
-/** Human-readable column headers. */
-const STATUS_LABEL: Record<TaskStatus, string> = {
-  BACKLOG: 'Backlog',
-  READY: 'Ready',
-  IN_PROGRESS: 'In Progress',
-  DONE: 'Done',
-  BLOCKED: 'Blocked',
-  FAILED: 'Failed',
-  MERGED: 'Merged',
-};
 
 interface TaskColumnProps {
   status: TaskStatus;

--- a/web-ui/src/components/tasks/TaskDetailModal.tsx
+++ b/web-ui/src/components/tasks/TaskDetailModal.tsx
@@ -14,7 +14,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { STATUS_INFO } from '@/lib/taskStatusInfo';
+import { STATUS_INFO, STATUS_BADGE_VARIANT, STATUS_LABEL } from '@/lib/taskStatusInfo';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -22,27 +22,7 @@ import { GitHubIssueBadge } from './GitHubIssueBadge';
 import useSWR from 'swr';
 import { tasksApi } from '@/lib/api';
 import { useRequirementsLookup } from '@/hooks/useRequirementsLookup';
-import type { Task, TaskStatus, ApiError, TaskListResponse } from '@/types';
-
-const STATUS_BADGE_VARIANT: Record<TaskStatus, string> = {
-  BACKLOG: 'backlog',
-  READY: 'ready',
-  IN_PROGRESS: 'in-progress',
-  DONE: 'done',
-  BLOCKED: 'blocked',
-  FAILED: 'failed',
-  MERGED: 'merged',
-};
-
-const STATUS_LABEL: Record<TaskStatus, string> = {
-  BACKLOG: 'Backlog',
-  READY: 'Ready',
-  IN_PROGRESS: 'In Progress',
-  DONE: 'Done',
-  BLOCKED: 'Blocked',
-  FAILED: 'Failed',
-  MERGED: 'Merged',
-};
+import type { Task, ApiError, TaskListResponse } from '@/types';
 
 interface TaskDetailModalProps {
   taskId: string | null;

--- a/web-ui/src/hooks/useNotifications.ts
+++ b/web-ui/src/hooks/useNotifications.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { getSelectedWorkspacePath } from '@/lib/workspace-storage';
+import { getSelectedWorkspacePath, STORAGE_KEY as WORKSPACE_PATH_KEY } from '@/lib/workspace-storage';
 import type { AppNotification, AppNotificationBatchStatus, AppNotificationType } from '@/types';
 
 export const NOTIFICATIONS_STORAGE_KEY_PREFIX = 'codeframe_notifications';
@@ -113,7 +113,7 @@ export function useNotifications(): UseNotificationsReturn {
         reload(); // localStorage.clear() — refresh defensively
         return;
       }
-      if (key === 'codeframe_workspace_path') {
+      if (key === WORKSPACE_PATH_KEY) {
         reload();
         return;
       }

--- a/web-ui/src/lib/eventStyles.ts
+++ b/web-ui/src/lib/eventStyles.ts
@@ -18,11 +18,8 @@ import {
   ArrowTurnBackwardIcon,
   Alert02Icon,
   Cancel01Icon,
-  CommandLineIcon,
-  AlertDiamondIcon,
   Loading03Icon,
   WifiDisconnected01Icon,
-  FileEditIcon,
 } from '@hugeicons/core-free-icons';
 
 // ── Agent state derivation ─────────────────────────────────────────────
@@ -112,16 +109,6 @@ export const agentStateIcons: Record<UIAgentState, IconSvgElement> = {
   FAILED: Cancel01Icon,
   DISCONNECTED: WifiDisconnected01Icon,
 };
-
-/**
- * Icon data for specific event sub-types used inside event detail renderers
- * (e.g. shell output uses a terminal icon, errors use a diamond alert).
- */
-export const eventDetailIcons = {
-  shellCommand: CommandLineIcon,
-  errorDetail: AlertDiamondIcon,
-  fileChange: FileEditIcon,
-} as const;
 
 // ── Connection status dot ──────────────────────────────────────────────
 

--- a/web-ui/src/lib/format.ts
+++ b/web-ui/src/lib/format.ts
@@ -14,3 +14,31 @@ export function formatRelativeTime(isoDate: string): string {
   const diffDays = Math.floor(diffHours / 24);
   return `${diffDays}d ago`;
 }
+
+/**
+ * Format a USD amount. The single currency formatter for the app — cost,
+ * session and task surfaces must agree on the same figure.
+ *
+ * Defaults to exactly 4 fraction digits, the precision per-call LLM costs need.
+ * Pass `maximumFractionDigits: 6` where sub-cent figures would otherwise round
+ * to zero, or a fixed 2 where the amount is known to be dollars.
+ */
+export function formatUsd(
+  value: number,
+  {
+    minimumFractionDigits = 4,
+    maximumFractionDigits = minimumFractionDigits,
+  }: { minimumFractionDigits?: number; maximumFractionDigits?: number } = {}
+): string {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits,
+    maximumFractionDigits,
+  });
+}
+
+/** Format a plain count (tokens, rows) with thousands separators. */
+export function formatCount(n: number): string {
+  return n.toLocaleString('en-US');
+}

--- a/web-ui/src/lib/taskStatusInfo.ts
+++ b/web-ui/src/lib/taskStatusInfo.ts
@@ -46,3 +46,25 @@ export const STATUS_INFO: Record<TaskStatus, StatusInfo> = {
     nextSteps: 'This task is complete.',
   },
 };
+
+/** Map backend TaskStatus to badge variant name. */
+export const STATUS_BADGE_VARIANT: Record<TaskStatus, string> = {
+  BACKLOG: 'backlog',
+  READY: 'ready',
+  IN_PROGRESS: 'in-progress',
+  DONE: 'done',
+  BLOCKED: 'blocked',
+  FAILED: 'failed',
+  MERGED: 'merged',
+};
+
+/** Human-readable status labels, used for badges and board column headers. */
+export const STATUS_LABEL: Record<TaskStatus, string> = {
+  BACKLOG: 'Backlog',
+  READY: 'Ready',
+  IN_PROGRESS: 'In Progress',
+  DONE: 'Done',
+  BLOCKED: 'Blocked',
+  FAILED: 'Failed',
+  MERGED: 'Merged',
+};

--- a/web-ui/src/lib/workspace-storage.ts
+++ b/web-ui/src/lib/workspace-storage.ts
@@ -6,7 +6,9 @@
  * explicit workspace selection.
  */
 
-const STORAGE_KEY = 'codeframe_workspace_path';
+/** localStorage key holding the active workspace path. Exported so consumers
+ * that watch for changes to it (e.g. useNotifications) cannot drift. */
+export const STORAGE_KEY = 'codeframe_workspace_path';
 const RECENT_WORKSPACES_KEY = 'codeframe_recent_workspaces';
 const MAX_RECENT_WORKSPACES = 5;
 


### PR DESCRIPTION
Closes #971.

## What

Four verbatim duplications in `web-ui`, each one a place where two surfaces could drift apart:

| Duplication | Was | Now |
|---|---|---|
| `STATUS_BADGE_VARIANT` / `STATUS_LABEL` | copied into `TaskCard`, `TaskDetailModal`, `TaskColumn` | `lib/taskStatusInfo.ts` (both task components already imported it for `STATUS_INFO`) |
| USD formatting | 4 local formatters + raw `toFixed(4)` in 3 more files | `formatUsd()` in `lib/format.ts` |
| Token/row counts | 3 copies of `n.toLocaleString('en-US')` | `formatCount()` in `lib/format.ts` |
| `'codeframe_workspace_path'` | hardcoded in `useNotifications`, duplicating an unexported const | `workspace-storage.ts` exports `STORAGE_KEY` |

Plus: `eventDetailIcons` deleted (no importer, and it orphaned 3 icon imports), `msw` dropped (declared dev dependency no test imports).

Net **-357 lines** of source.

## The formatters were not identical

Worth calling out, because the obvious reading of the issue ("one formatter") would have been a silent behaviour change. The four differed:

- `costs/page.tsx`, `SpendBarChart` — 4dp fixed
- `TopTasksTable`, `AgentCostBars` — min 4dp, **max 6dp** (sub-cent agent costs)
- `TaskCard.formatBadgeCost` — tiered: 4dp under a cent, 2dp above

So `formatUsd(value, { minimumFractionDigits?, maximumFractionDigits? })` defaults to 4dp and each caller keeps its intended precision. Collapsing to one fixed precision would have changed three rendered surfaces.

**Only rendered change:** session costs gain thousands separators — `$1,234.5000` vs `$1234.5000`. Same precision, and `CostsPage.test.tsx`'s pinned strings (`$1.2345`, `$0.3086`) are unchanged.

## Test approach

`sharedConstants.guard.test.ts` is a source scan, not a render test — what regressed here was the *absence* of a single definition, which no render test can observe. (Precedent: `api.contract.test.ts`.) Three rules, each mutation-checked:

| Mutation | Guard |
|---|---|
| re-declare `STATUS_LABEL` in `TaskColumn` | ✅ fails |
| restore `${cost.toFixed(4)}` in `SessionCard` | ✅ fails |
| restore the `'codeframe_workspace_path'` literal | ✅ fails |
| all reverted | ✅ 10/10 pass |

One rule was deliberately narrowed during review: an early version banned a `$` adjacent to any `toFixed`, which false-positived on `RunHistoryPanel`'s `${(ms / 1000).toFixed(1)}` — a template sigil, not a currency sign, and the two are indistinguishable by regex. It now matches `toFixed(4)` only, which is the acceptance criterion's actual wording.

## Verification

| Gate | Result |
|---|---|
| `npm test` | 1290/1290 pass, 106 suites |
| `npm run build` | exit 0 (clean `.next`) |
| `npm run lint` | clean (`--max-warnings 0`) |
| `npx tsc --noEmit` | clean |
| `npm ci` | exit 0 |
| `codex review` (pre-PR, third-party) | no findings |

All five acceptance criteria demonstrated with command output in the session.

## Known limitations

**The lockfile was pruned by hand, not regenerated** — and that is worth a look from a reviewer.

`npm install` on this repo rewrites unrelated `@emnapi/*` optional-dependency entries and the resulting lock then fails `npm ci` (`Invalid: lock file's @emnapi/wasi-threads@1.2.1 does not satisfy @1.2.3`). **This reproduces on untouched `main`** with a bare `npm install` and no other change, so it is pre-existing, not introduced here. Root cause: `main`'s lock records `@napi-rs/wasm-runtime@1.2.3` with a stale dependency set (only `@tybys/wasm-util`), so `npm ci` passes only as long as nothing forces re-resolution.

`npm --package-lock-only` also dropped four `@emnapi/*` entries that belong to tailwind/unrs rather than msw, and `npm ci` then demanded them back. This PR therefore deletes exactly msw's 34 subtree entries and leaves every other byte as `main` had it — a pure-deletion lock diff, verified with `npm ci` exit 0.

That underlying lock inconsistency is untouched here and will bite the next dependency change. Worth its own issue; I did not file one as part of this P3 cleanup.

Two scope notes: `formatCount` was not in the acceptance criteria — it is the same duplication class in the same three files, so it is folded in. Per-status *colors* remain in each component's badge variant styling; only the name maps are centralized.

https://claude.ai/code/session_01CXUZEUpwUmZM8nj6QUYHk8
