### PR TITLE
docs: sweep stale docs and phantom CLI commands, with a guard test (#972)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ codeframe/
 ├── cli/app.py      # Typer CLI entry + subcommands
 ├── ui/             # FastAPI server (thin adapter over core)
 │   ├── server.py, models.py, dependencies.py
-│   └── routers/    # 16 v2 router modules
+│   └── routers/    # 23 router modules (21 v2 REST + 2 WebSocket)
 ├── auth/           # API key service + auth dependencies
 ├── lib/            # rate_limiter.py, audit_logger.py, metrics_tracker.py
 └── platform_store/ # Control-plane store: auth, api keys, audit logs,
@@ -293,7 +293,7 @@ cf checkpoint create|list|restore
 cf summary
 
 # Environment
-cf env check|install|doctor
+cf env check|doctor|install-missing|auto-install
 
 # GitHub PR
 cf pr create|list|get|status|merge|close
@@ -523,8 +523,6 @@ REDIS_URL=redis://localhost:6379
 # With the default in-memory storage each worker keeps its OWN counters, so the
 # effective limit — including auth brute-force protection — multiplies by the
 # worker count. The server logs a WARNING at startup when this is detected.
-
-CODEFRAME_API_KEY_SECRET=<secret>     # API key hashing
 
 # Credential-file confidentiality (#772 — opt-in)
 CODEFRAME_CREDENTIAL_SECRET=<secret>  # Mixed into the PBKDF2 KDF for the

--- a/codeframe/cli/__init__.py
+++ b/codeframe/cli/__init__.py
@@ -3,8 +3,8 @@
 The Typer entry point lives in :mod:`codeframe.cli.app` and is exposed as the
 ``codeframe`` / ``cf`` console scripts (see ``pyproject.toml``):
 
-    codeframe = "codeframe.cli.app:app"
-    cf        = "codeframe.cli.app:app"
+    codeframe = "codeframe.cli.app:main"
+    cf        = "codeframe.cli.app:main"
 
 This package ``__init__`` is intentionally empty so that importing
 ``codeframe.cli.app`` does not drag in unrelated command modules as a side

--- a/codeframe/cli/env_commands.py
+++ b/codeframe/cli/env_commands.py
@@ -313,7 +313,7 @@ def install_missing(
         transient=True,
     ) as progress:
         progress.add_task(f"Installing {tool}...", total=None)
-        result = installer.install_tool(tool, confirm=False)
+        result = installer.install_tool(tool)
 
     # Report result
     if result.success:
@@ -396,7 +396,7 @@ def auto_install(
             progress.update(task, description=f"Installing {tool}...")
 
             if installer.can_install(tool):
-                result = installer.install_tool(tool, confirm=False)
+                result = installer.install_tool(tool)
                 results.append(result)
             else:
                 results.append(None)

--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1053,7 +1053,10 @@ def find_batch_by_prefix(workspace: Workspace, prefix: str) -> list[BatchRun]:
 def cancel_batch(workspace: Workspace, batch_id: str) -> BatchRun:
     """Cancel a running batch.
 
-    Sends SIGTERM to any running subprocesses and marks the batch as cancelled.
+    Marks the batch CANCELLED and emits ``BATCH_CANCELLED``. It does **not**
+    signal anything already running: in-flight tasks run to completion, and the
+    worker pool notices the terminal status on its next check. Use
+    ``stop_batch(force=True)`` if you need the harder stop.
 
     Args:
         workspace: Target workspace

--- a/codeframe/core/installer.py
+++ b/codeframe/core/installer.py
@@ -4,14 +4,13 @@ This module provides:
 - Platform-specific tool installation
 - Installation verification
 - Installation history tracking
-- Rollback capabilities
 
 Usage:
     from codeframe.core.installer import ToolInstaller
 
     installer = ToolInstaller()
     if installer.can_install("pytest"):
-        result = installer.install_tool("pytest", confirm=True)
+        result = installer.install_tool("pytest")
         if result.success:
             print(f"Installed {result.tool_name}")
 """
@@ -137,14 +136,12 @@ class PipInstaller:
     def install_tool(
         self,
         tool_name: str,
-        confirm: bool = True,
         force: bool = False,
     ) -> InstallResult:
         """Install a Python package.
 
         Args:
             tool_name: Name of the package to install
-            confirm: Whether to prompt for confirmation
             force: Reinstall even if already installed
 
         Returns:
@@ -254,7 +251,6 @@ class NpmInstaller:
     def install_tool(
         self,
         tool_name: str,
-        confirm: bool = True,
         force: bool = False,
         global_install: bool = True,
     ) -> InstallResult:
@@ -262,7 +258,6 @@ class NpmInstaller:
 
         Args:
             tool_name: Name of the package to install
-            confirm: Whether to prompt for confirmation
             force: Reinstall even if already installed
             global_install: Install globally or locally
 
@@ -375,14 +370,12 @@ class CargoInstaller:
     def install_tool(
         self,
         tool_name: str,
-        confirm: bool = True,
         force: bool = False,
     ) -> InstallResult:
         """Install a Rust tool.
 
         Args:
             tool_name: Name of the tool to install
-            confirm: Whether to prompt for confirmation
             force: Reinstall even if already installed
 
         Returns:
@@ -469,7 +462,6 @@ class SystemInstaller:
     def install_tool(
         self,
         tool_name: str,
-        confirm: bool = True,
         force: bool = False,
     ) -> InstallResult:
         """Install a system tool.
@@ -478,7 +470,6 @@ class SystemInstaller:
 
         Args:
             tool_name: Name of the tool to install
-            confirm: Whether to prompt for confirmation
             force: Reinstall even if already installed
 
         Returns:
@@ -577,14 +568,12 @@ class ToolInstaller:
     def install_tool(
         self,
         tool_name: str,
-        confirm: bool = True,
         force: bool = False,
     ) -> InstallResult:
         """Install a tool.
 
         Args:
             tool_name: Name of the tool to install
-            confirm: Whether to prompt for confirmation
             force: Reinstall even if already installed
 
         Returns:
@@ -598,7 +587,7 @@ class ToolInstaller:
                 message=f"No installer available for {tool_name}",
             )
 
-        result = installer.install_tool(tool_name, confirm=confirm, force=force)
+        result = installer.install_tool(tool_name, force=force)
 
         # Record in history
         if result.success:

--- a/codeframe/ui/routers/environment_v2.py
+++ b/codeframe/ui/routers/environment_v2.py
@@ -224,9 +224,9 @@ async def install_tool(
                 ),
             )
 
-        # Attempt installation (confirm=False for non-interactive server usage)
+        # Attempt installation (never interactive)
         # Offload: subprocess package installs — blocks for minutes (#732).
-        result = await run_in_threadpool(installer.install_tool, body.tool_name, confirm=False)
+        result = await run_in_threadpool(installer.install_tool, body.tool_name)
 
         return InstallResultResponse(
             success=result.success,

--- a/docs/AGENT_SYSTEM_REFERENCE.md
+++ b/docs/AGENT_SYSTEM_REFERENCE.md
@@ -113,6 +113,6 @@ CLI (typer) ─┬── core.* ─── adapters.*
 Server (fastapi) ─┘
 ```
 
-v2 router modules include: `blockers_v2`, `prd_v2`, `tasks_v2`, `workspace_v2`, `batches_v2`, `api_key_v2`, `discovery_v2`, `checkpoints_v2`, `schedule_v2`, `templates_v2`, `git_v2`, `review_v2`, `pr_v2`, `environment_v2`, `proof_v2`.
+The 21 v2 REST router modules are: `batches_v2`, `blockers_v2`, `checkpoints_v2`, `costs_v2`, `diagnose_v2`, `discovery_v2`, `environment_v2`, `events_v2`, `gates_v2`, `git_v2`, `github_integrations_v2`, `interactive_sessions_v2`, `pr_v2`, `prd_v2`, `proof_v2`, `review_v2`, `schedule_v2`, `settings_v2`, `tasks_v2`, `templates_v2`, `workspace_v2` — plus the two WebSocket routers `session_chat_ws` and `terminal_ws`. (The API-key routes live in `codeframe/auth/api_key_router.py`, not under `routers/`.)
 
 See `docs/PHASE_2_DEVELOPER_GUIDE.md` for full router details.

--- a/docs/CLI_WIREFRAME.md
+++ b/docs/CLI_WIREFRAME.md
@@ -1037,7 +1037,7 @@ cf import ralph /path/to/project --workspace /path/to/workspace
 8) `tasks analyze` - dependency graph visualization and analysis
 
 ### Phase 2: Git Integration & PR Workflow (NEW HIGH PRIORITY)
-9) `codeframe git_integration` module implementation
+9) `codeframe/git/github_integration.py` module implementation
 10) Enhanced `work start --create-branch` with automatic branch management
 11) `pr create` with AI-generated comprehensive descriptions
 12) `pr merge` with automated verification and merge strategies

--- a/docs/CLI_WIREFRAME.md
+++ b/docs/CLI_WIREFRAME.md
@@ -163,7 +163,7 @@ Each command:
 
 **Core calls:**
 - `codeframe.core.installer.ToolInstaller.can_install(tool) -> bool`
-- `codeframe.core.installer.ToolInstaller.install_tool(tool, confirm) -> InstallResult`
+- `codeframe.core.installer.ToolInstaller.install_tool(tool) -> InstallResult`
 
 **Supported installers:**
 - PipInstaller: pytest, ruff, mypy, black, flake8, pylint, isort, bandit, coverage, pre-commit, httpx, requests
@@ -181,7 +181,7 @@ Each command:
 
 **Core calls:**
 - `codeframe.core.environment.EnvironmentValidator.validate_environment(project_path) -> ValidationResult`
-- `codeframe.core.installer.ToolInstaller.install_tool(tool, confirm) -> InstallResult` (for each missing tool)
+- `codeframe.core.installer.ToolInstaller.install_tool(tool) -> InstallResult` (for each missing tool)
 
 **State writes:**
 - Installation history in `.codeframe/environment.json`
@@ -190,7 +190,8 @@ Each command:
 
 ## Configuration: `codeframe config ...`
 
-### `codeframe config init [--detect] [--force]`
+### `codeframe config init [--detect] [--force]` — **NOT IMPLEMENTED**
+> Config is written by `codeframe init` and edited by hand in `.codeframe/config.yaml`.
 **Purpose:** Initialize project environment configuration.
 
 **CLI module:**
@@ -211,7 +212,8 @@ Each command:
 
 ---
 
-### `codeframe config show`
+### `codeframe config show` — **NOT IMPLEMENTED**
+> Use `codeframe status`, or read `.codeframe/config.yaml` directly.
 **Purpose:** Display current project configuration.
 
 **Core calls:**
@@ -222,7 +224,9 @@ Each command:
 
 ---
 
-### `codeframe config set <key> <value>`
+### `codeframe config set <key> <value>` — **NOT IMPLEMENTED**
+> Edit `.codeframe/config.yaml` directly. (`codeframe config telemetry` is the one
+> `config` subcommand that exists.)
 **Purpose:** Set individual configuration values.
 
 **Core calls:**
@@ -316,7 +320,8 @@ Each command:
 
 ---
 
-### `codeframe prd refine <prd-id>`
+### `codeframe prd refine <prd-id>` — **NOT IMPLEMENTED**
+> Use `codeframe prd stress-test`, then `codeframe prd update`.
 **Purpose:** Iterative PRD improvement based on feedback.
 
 **CLI module:**
@@ -497,9 +502,9 @@ Each command:
 
 **Future state:**
 - Allow other task attributes to be set, like `provider`, etc.
-- `codeframe task set <attribute> <task_id> <attribute_value>`
+- `codeframe tasks set <attribute> <task_id> <attribute_value>`
 
-### `codeframe tasks get status <task_id>`
+### `codeframe tasks show <task_id>`
 **Purpose:** Get current state.
 
 **Core calls:**
@@ -602,16 +607,20 @@ Each command:
 
 ---
 
-### `codeframe work batch cancel <batch_id>`
-**Purpose:** Cancel a running batch.
+### `codeframe work batch stop <batch_id> [--force]`
+**Purpose:** Stop a running batch.
 
 **Core calls:**
-- `codeframe.core.conductor.cancel_batch(workspace_id, batch_id)`
+- `codeframe.core.conductor.stop_batch(workspace, batch_id, force)`
 - `codeframe.core.events.emit(workspace_id, "BATCH_CANCELLED", payload)`
 
+**CLI options:**
+- `--force, -f`: Terminate running subprocesses immediately (SIGTERM)
+
 **Behavior:**
-- Sends SIGTERM to running subprocesses
 - Marks batch as CANCELLED
+- Without `--force`: in-flight tasks run to completion; the execution loop exits after them
+- With `--force`: also sends SIGTERM to every running subprocess in the batch
 - Does not affect already-completed tasks
 
 ---
@@ -731,7 +740,9 @@ cf work batch resume abc123 --force   # Re-run all tasks
 
 ---
 
-## Git Integration & PR Management: `codeframe git ...` / `codeframe pr ...`
+## Git Integration & PR Management: `codeframe pr ...`
+> The `codeframe git ...` group is **NOT IMPLEMENTED** — git work is done through `patch`,
+> `commit` and `pr`.
 
 ### `codeframe work start <task_id> --create-branch`
 **Purpose:** Begin task execution with automatic branch creation.
@@ -867,7 +878,8 @@ codeframe pr status
 
 ---
 
-### `codeframe git status` (Enhanced)
+### `codeframe git status` (Enhanced) — **NOT IMPLEMENTED**
+> Use `codeframe status` for the CodeFRAME-aware summary.
 **Purpose:** Show git status summary with CodeFRAME context.
 
 **CLI module:**

--- a/docs/CLI_WIREFRAME.md
+++ b/docs/CLI_WIREFRAME.md
@@ -1026,7 +1026,7 @@ cf import ralph /path/to/project --workspace /path/to/workspace
 
 ### Phase 0: Enhanced PRD & Discovery (NEW HIGH PRIORITY)
 1) `prd generate` - AI-driven interactive PRD generation with follow-up questions
-2) `prd refine` - iterative PRD improvement based on user feedback
+2) `prd refine` - iterative PRD improvement based on user feedback — **NOT IMPLEMENTED**
 3) Enhanced `init` with auto-discovery and environment configuration
 4) PRD versioning and change tracking
 
@@ -1034,7 +1034,7 @@ cf import ralph /path/to/project --workspace /path/to/workspace
 5) Enhanced `tasks generate` with dependency analysis and effort estimation
 6) Task template system for common implementation patterns
 7) Critical path identification and workstream grouping
-8) `tasks analyze` - dependency graph visualization and analysis
+8) `tasks analyze` - dependency graph visualization and analysis — **NOT IMPLEMENTED**
 
 ### Phase 2: Git Integration & PR Workflow (NEW HIGH PRIORITY)
 9) `codeframe/git/github_integration.py` module implementation
@@ -1076,7 +1076,7 @@ cf import ralph /path/to/project --workspace /path/to/workspace
 **Batch Execution (already complete):**
 - `work batch run` ✓ DONE (enhanced with git integration)
 - `work batch status` ✓ DONE
-- `work batch cancel` ✓ DONE
+- `work batch stop` ✓ DONE
 - Parallel execution & retry ✓ DONE
 - Observability ✓ DONE
 

--- a/docs/PHASE_2_CLI_API_MAPPING.md
+++ b/docs/PHASE_2_CLI_API_MAPPING.md
@@ -14,8 +14,8 @@ These are the core workflow commands from `docs/GOLDEN_PATH.md`.
 
 | CLI Command | Core Module | Core Function | V2 Route | Method | Status |
 |-------------|-------------|---------------|----------|--------|--------|
-| `cf init <repo>` | `core.workspace` | `create_or_load_workspace()` | `/api/v2/workspaces` | POST | ⚠️ Missing |
-| `cf init --detect` | `core.workspace` | `create_or_load_workspace()` | `/api/v2/workspaces` | POST | ⚠️ Missing |
+| `cf init <repo>` | `core.workspace` | `create_or_load_workspace()` | `/api/v2/workspaces` | POST | ✅ Present |
+| `cf init --detect` | `core.workspace` | `create_or_load_workspace()` | `/api/v2/workspaces` | POST | ✅ Present |
 | `cf status` | `core.project_status` | `get_workspace_status()` | `/api/v2/projects/status` | GET | ✅ Present |
 
 ### PRD Commands
@@ -63,16 +63,16 @@ Both end up with PRD records managed by `core.prd`.
 | `cf work resume <id>` | `core.runtime` | `resume_run()` | `/api/v2/tasks/{id}/resume` | POST | ✅ Present |
 | `cf work status <id>` | `core.runtime` | `get_run()` | `/api/v2/tasks/{id}/run` | GET | ✅ Present |
 | `cf work follow <id>` | `core.streaming` | `tail_run_output()` | `/api/v2/tasks/{id}/stream` | GET (SSE) | ✅ Present |
-| `cf work diagnose <id>` | `core.diagnostic_agent` | `diagnose_task()` | `/api/v2/tasks/{id}/diagnose` | POST | ⚠️ Missing |
+| `cf work diagnose <id>` | `core.diagnostic_agent` | `diagnose_task()` | `/api/v2/tasks/{id}/diagnose` | POST | ✅ Present |
 
 ### Batch Commands
 
 | CLI Command | Core Module | Core Function | V2 Route | Method | Status |
 |-------------|-------------|---------------|----------|--------|--------|
 | `cf work batch run` | `core.conductor` | `start_batch()` | `/api/v2/tasks/execute` | POST | ✅ Present |
-| `cf work batch status` | `core.conductor` | `get_batch_status()` | `/api/v2/batches/{id}` | GET | ⚠️ Missing |
-| `cf work batch stop` | `core.conductor` | `stop_batch()` | `/api/v2/batches/{id}/stop` | POST | ⚠️ Missing |
-| `cf work batch resume` | `core.conductor` | `resume_batch()` | `/api/v2/batches/{id}/resume` | POST | ⚠️ Missing |
+| `cf work batch status` | `core.conductor` | `get_batch_status()` | `/api/v2/batches/{id}` | GET | ✅ Present |
+| `cf work batch stop` | `core.conductor` | `stop_batch()` | `/api/v2/batches/{id}/stop` | POST | ✅ Present |
+| `cf work batch resume` | `core.conductor` | `resume_batch()` | `/api/v2/batches/{id}/resume` | POST | ✅ Present |
 
 ### Blocker Commands
 
@@ -93,7 +93,7 @@ Both end up with PRD records managed by `core.prd`.
 | `cf checkpoint show <id>` | `core.checkpoints` | `get()` | `/api/v2/checkpoints/{id}` | GET | ✅ Present |
 | `cf checkpoint restore <id>` | `core.checkpoints` | `restore()` | `/api/v2/checkpoints/{id}/restore` | POST | ✅ Present |
 | `cf checkpoint delete <id>` | `core.checkpoints` | `delete()` | `/api/v2/checkpoints/{id}` | DELETE | ✅ Present |
-| `cf checkpoint diff` | `core.checkpoints` | `diff()` | `/api/v2/checkpoints/{a}/diff/{b}` | GET | ✅ Present |
+| `cf checkpoint diff` (**NOT IMPLEMENTED**) | `core.checkpoints` | `diff()` | `/api/v2/checkpoints/{a}/diff/{b}` | GET | ✅ Present |
 
 ### Schedule Commands
 
@@ -129,19 +129,19 @@ These support the Golden Path but aren't in the critical path.
 
 | CLI Command | Core Module | Core Function | V2 Route | Method | Status |
 |-------------|-------------|---------------|----------|--------|--------|
-| `cf pr create` | `git.github_integration` | `create_pull_request()` | `/api/v2/pr` | POST | ⚠️ Missing |
-| `cf pr list` | `git.github_integration` | `list_pull_requests()` | `/api/v2/pr` | GET | ⚠️ Missing |
-| `cf pr status` | `git.github_integration` | `get_pull_request()` | `/api/v2/pr/status` | GET | ⚠️ Missing |
-| `cf pr merge` | `git.github_integration` | `merge_pull_request()` | `/api/v2/pr/{number}/merge` | POST | ⚠️ Missing |
-| `cf pr close` | `git.github_integration` | `close_pull_request()` | `/api/v2/pr/{number}/close` | POST | ⚠️ Missing |
+| `cf pr create` | `git.github_integration` | `create_pull_request()` | `/api/v2/pr` | POST | ✅ Present |
+| `cf pr list` | `git.github_integration` | `list_pull_requests()` | `/api/v2/pr` | GET | ✅ Present |
+| `cf pr status` | `git.github_integration` | `get_pull_request()` | `/api/v2/pr/status` | GET | ✅ Present |
+| `cf pr merge` | `git.github_integration` | `merge_pull_request()` | `/api/v2/pr/{number}/merge` | POST | ✅ Present |
+| `cf pr close` | `git.github_integration` | `close_pull_request()` | `/api/v2/pr/{number}/close` | POST | ✅ Present |
 
 ### Environment Commands
 
 | CLI Command | Core Module | Core Function | V2 Route | Method | Status |
 |-------------|-------------|---------------|----------|--------|--------|
-| `cf env check` | `core.environment` | `check_environment()` | `/api/v2/env/check` | GET | ⚠️ Missing |
-| `cf env doctor` | `core.environment` | `run_doctor()` | `/api/v2/env/doctor` | GET | ⚠️ Missing |
-| `cf env install` | `core.installer` | `install_tool()` | `/api/v2/env/install` | POST | ⚠️ Missing |
+| `cf env check` | `core.environment` | `check_environment()` | `/api/v2/env/check` | GET | ✅ Present |
+| `cf env doctor` | `core.environment` | `run_doctor()` | `/api/v2/env/doctor` | GET | ✅ Present |
+| `cf env install-missing` | `core.installer` | `install_tool()` | `/api/v2/env/install` | POST | ✅ Present |
 
 ### Review Commands
 
@@ -153,7 +153,7 @@ These support the Golden Path but aren't in the critical path.
 
 | CLI Command | Core Module | Core Function | V2 Route | Method | Status |
 |-------------|-------------|---------------|----------|--------|--------|
-| `cf gates run` | `core.gates` | `run_gate()` | `/api/v2/gates/run` | POST | ⚠️ Missing |
+| `cf gates run` | `core.gates` | `run_gate()` | `/api/v2/gates/run` | POST | ✅ Present |
 
 ### PROOF9 Commands
 

--- a/tests/ci/test_documented_commands_resolve_972.py
+++ b/tests/ci/test_documented_commands_resolve_972.py
@@ -1,0 +1,103 @@
+"""Every ``cf``/``codeframe`` command in the docs must exist (#972).
+
+Stale docs are expensive: a phantom command is a support ticket, or an agent
+turn wasted discovering the command was never built. #614 found eight of them
+by hand; this test is the repeatable version, so the next one cannot ship.
+
+The rule: every command path a shipped doc spells out either resolves in the
+live Typer tree, or its line is explicitly marked ``NOT IMPLEMENTED``.
+``GOLDEN_PATH.md`` and ``CLI_WIREFRAME.md`` are specs of intended behaviour, so
+marking is the honest option there — deleting would lose the design intent.
+"""
+
+import itertools
+import re
+from pathlib import Path
+
+import pytest
+import typer.main
+
+from codeframe.cli.app import app
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Docs a user actually reads. Everything under docs/archive is history.
+DOC_FILES = [REPO_ROOT / "README.md", REPO_ROOT / "CLAUDE.md"] + sorted(
+    (REPO_ROOT / "docs").glob("*.md")
+)
+
+# `cf work batch run`, `codeframe pr create|list|merge`. The lookbehind keeps
+# `codeframe/core/foo.py` and `--codeframe` from reading as invocations.
+INVOCATION = re.compile(r"(?<![\w./-])(?:cf|codeframe)((?:\s+[a-z][a-z0-9_|-]*)+)")
+
+# A subcommand name. Anything else (a flag, `<task_id>`, `TASK`) ends the path.
+SUBCOMMAND = re.compile(r"^[a-z][a-z0-9-]*$")
+
+NOT_IMPLEMENTED_MARKER = "NOT IMPLEMENTED"
+
+
+def _command_tree():
+    return typer.main.get_command(app)
+
+
+def _unresolvable(root, words):
+    """Return the first command path in `words` the Typer tree does not have.
+
+    Walks word by word from the root. Stops at the first token that is not a
+    subcommand name (a flag or an argument placeholder) or once a leaf command
+    is reached — everything after that is arguments, not command names.
+    """
+    node, path = root, []
+    for word in words:
+        subcommands = getattr(node, "commands", None)
+        if not subcommands or not SUBCOMMAND.match(word):
+            return None
+        if word not in subcommands:
+            return " ".join(path + [word])
+        node = subcommands[word]
+        path.append(word)
+    return None
+
+
+def _documented_commands():
+    """Yield (location, command_path, source_line) for every doc invocation."""
+    for doc in DOC_FILES:
+        rel = doc.relative_to(REPO_ROOT)
+        for lineno, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            if NOT_IMPLEMENTED_MARKER in line:
+                continue
+            for match in INVOCATION.finditer(line):
+                # `pr create|list|merge` documents three commands on one line.
+                alternatives = [word.split("|") for word in match.group(1).split()]
+                for words in itertools.product(*alternatives):
+                    yield f"{rel}:{lineno}", words, line.strip()
+
+
+def test_every_documented_command_resolves():
+    root = _command_tree()
+    failures = []
+    seen = set()
+    for location, words, line in _documented_commands():
+        phantom = _unresolvable(root, words)
+        if phantom and (location, phantom) not in seen:
+            seen.add((location, phantom))
+            failures.append(f"  {location}: `{phantom}` — in: {line[:100]}")
+
+    assert not failures, (
+        "Docs name commands the CLI does not have. Fix the doc, or mark the line "
+        f"`{NOT_IMPLEMENTED_MARKER}` if it is intended-but-unbuilt:\n"
+        + "\n".join(failures)
+    )
+
+
+def test_extractor_still_sees_the_cli():
+    """Guard the guard: a regex that matches nothing would pass vacuously."""
+    root = _command_tree()
+    resolved = [
+        words
+        for _, words, _ in _documented_commands()
+        if _unresolvable(root, words) is None
+    ]
+    assert len(resolved) > 50, f"extractor found only {len(resolved)} commands in docs"

--- a/tests/ci/test_documented_commands_resolve_972.py
+++ b/tests/ci/test_documented_commands_resolve_972.py
@@ -33,7 +33,10 @@ DOC_FILES = [REPO_ROOT / "README.md", REPO_ROOT / "CLAUDE.md"] + sorted(
 INVOCATION = re.compile(r"(?<![\w./-])(?:cf|codeframe)((?:\s+[a-z][a-z0-9_|-]*)+)")
 
 # A subcommand name. Anything else (a flag, `<task_id>`, `TASK`) ends the path.
-SUBCOMMAND = re.compile(r"^[a-z][a-z0-9-]*$")
+# Underscores are allowed even though every command today is hyphenated: if this
+# rejected them, an underscored command name would silently end the walk instead
+# of being checked, which is the exact blind spot this test exists to close.
+SUBCOMMAND = re.compile(r"^[a-z][a-z0-9_-]*$")
 
 NOT_IMPLEMENTED_MARKER = "NOT IMPLEMENTED"
 

--- a/tests/ci/test_documented_commands_resolve_972.py
+++ b/tests/ci/test_documented_commands_resolve_972.py
@@ -32,11 +32,17 @@ DOC_FILES = [REPO_ROOT / "README.md", REPO_ROOT / "CLAUDE.md"] + sorted(
 # `codeframe/core/foo.py` and `--codeframe` from reading as invocations.
 INVOCATION = re.compile(r"(?<![\w./-])(?:cf|codeframe)((?:\s+[a-z][a-z0-9_|-]*)+)")
 
-# A subcommand name. Anything else (a flag, `<task_id>`, `TASK`) ends the path.
-# Underscores are allowed even though every command today is hyphenated: if this
-# rejected them, an underscored command name would silently end the walk instead
-# of being checked, which is the exact blind spot this test exists to close.
-SUBCOMMAND = re.compile(r"^[a-z][a-z0-9_-]*$")
+# The leading subcommand name in a word. Underscores are allowed even though
+# every command today is hyphenated: if this rejected them, an underscored
+# command name would silently end the walk instead of being checked, which is
+# the exact blind spot this test exists to close.
+#
+# It matches a PREFIX, not the whole word, so `stop<batch_id>` and `stop(x)`
+# both yield `stop`. INVOCATION gets that truncation for free from its per-word
+# charset; without it here the two extraction paths disagree about the same
+# content, and a phantom glued to a placeholder escapes the bare-command walk.
+# A word with no such prefix at all (`--flag`, `<task_id>`, `TASK`) ends the path.
+SUBCOMMAND = re.compile(r"^[a-z][a-z0-9_-]*")
 
 # The docs also name commands without the binary: checklist and roadmap entries
 # like ``- `work batch cancel` ✓ DONE``. Those went unchecked until GLM review on
@@ -62,12 +68,14 @@ def _unresolvable(root, words):
     node, path = root, []
     for word in words:
         subcommands = getattr(node, "commands", None)
-        if not subcommands or not SUBCOMMAND.match(word):
+        match = SUBCOMMAND.match(word) if subcommands else None
+        if not match:
             return None
-        if word not in subcommands:
-            return " ".join(path + [word])
-        node = subcommands[word]
-        path.append(word)
+        name = match.group(0)
+        if name not in subcommands:
+            return " ".join(path + [name])
+        node = subcommands[name]
+        path.append(name)
     return None
 
 

--- a/tests/ci/test_documented_commands_resolve_972.py
+++ b/tests/ci/test_documented_commands_resolve_972.py
@@ -38,6 +38,13 @@ INVOCATION = re.compile(r"(?<![\w./-])(?:cf|codeframe)((?:\s+[a-z][a-z0-9_|-]*)+
 # of being checked, which is the exact blind spot this test exists to close.
 SUBCOMMAND = re.compile(r"^[a-z][a-z0-9_-]*$")
 
+# The docs also name commands without the binary: checklist and roadmap entries
+# like ``- `work batch cancel` ✓ DONE``. Those went unchecked until GLM review on
+# #1196 pointed out the gap, so a phantom could hide there indefinitely. Only a
+# backticked span whose FIRST word is a real top-level command is considered —
+# without that anchor, any backticked prose would be walked as a command path.
+BACKTICKED = re.compile(r"`([a-z][a-z0-9_ |-]*)`")
+
 NOT_IMPLEMENTED_MARKER = "NOT IMPLEMENTED"
 
 
@@ -66,14 +73,21 @@ def _unresolvable(root, words):
 
 def _documented_commands():
     """Yield (location, command_path, source_line) for every doc invocation."""
+    top_level = set(_command_tree().commands)
     for doc in DOC_FILES:
         rel = doc.relative_to(REPO_ROOT)
         for lineno, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
             if NOT_IMPLEMENTED_MARKER in line:
                 continue
-            for match in INVOCATION.finditer(line):
+            spans = [m.group(1) for m in INVOCATION.finditer(line)]
+            spans += [
+                m.group(1)
+                for m in BACKTICKED.finditer(line)
+                if m.group(1).split()[:1] and m.group(1).split()[0] in top_level
+            ]
+            for span in spans:
                 # `pr create|list|merge` documents three commands on one line.
-                alternatives = [word.split("|") for word in match.group(1).split()]
+                alternatives = [word.split("|") for word in span.split()]
                 for words in itertools.product(*alternatives):
                     yield f"{rel}:{lineno}", words, line.strip()
 

--- a/tests/ci/test_documented_commands_resolve_972.py
+++ b/tests/ci/test_documented_commands_resolve_972.py
@@ -43,7 +43,7 @@ SUBCOMMAND = re.compile(r"^[a-z][a-z0-9_-]*$")
 # #1196 pointed out the gap, so a phantom could hide there indefinitely. Only a
 # backticked span whose FIRST word is a real top-level command is considered —
 # without that anchor, any backticked prose would be walked as a command path.
-BACKTICKED = re.compile(r"`([a-z][a-z0-9_ |-]*)`")
+BACKTICKED = re.compile(r"`([a-z][^`]*)`")
 
 NOT_IMPLEMENTED_MARKER = "NOT IMPLEMENTED"
 

--- a/tests/core/test_installer.py
+++ b/tests/core/test_installer.py
@@ -186,7 +186,7 @@ class TestPipInstaller:
         # Mock which to return None (not installed) so installation proceeds
         with patch("shutil.which", return_value=None):
             with patch("subprocess.run", return_value=mock_result):
-                result = installer.install_tool("pytest", confirm=False)
+                result = installer.install_tool("pytest")
 
         assert result.status == InstallStatus.SUCCESS
         assert result.success is True
@@ -200,7 +200,7 @@ class TestPipInstaller:
         mock_result.stderr = "ERROR: Could not find package"
 
         with patch("subprocess.run", return_value=mock_result):
-            result = installer.install_tool("nonexistent_package", confirm=False)
+            result = installer.install_tool("nonexistent_package")
 
         assert result.status == InstallStatus.FAILED
         assert result.success is False
@@ -209,7 +209,7 @@ class TestPipInstaller:
         """Test installing tool that's already installed."""
         installer = PipInstaller()
         with patch("shutil.which", return_value="/usr/bin/pytest"):
-            result = installer.install_tool("pytest", confirm=False, force=False)
+            result = installer.install_tool("pytest", force=False)
 
         assert result.status == InstallStatus.SKIPPED
         assert "already installed" in result.message.lower()
@@ -258,7 +258,7 @@ class TestNpmInstaller:
         """Test that global install skips when tool is already installed."""
         installer = NpmInstaller()
         with patch("shutil.which", return_value="/usr/local/bin/eslint"):
-            result = installer.install_tool("eslint", confirm=False, force=False, global_install=True)
+            result = installer.install_tool("eslint", force=False, global_install=True)
 
         assert result.status == InstallStatus.SKIPPED
         assert "already installed" in result.message.lower()
@@ -273,7 +273,7 @@ class TestNpmInstaller:
 
         with patch("subprocess.run", return_value=mock_result):
             with patch("shutil.which", return_value="/usr/local/bin/eslint"):
-                result = installer.install_tool("eslint", confirm=False, force=True, global_install=True)
+                result = installer.install_tool("eslint", force=True, global_install=True)
 
         assert result.status == InstallStatus.SUCCESS
 
@@ -287,7 +287,7 @@ class TestNpmInstaller:
 
         # Even with tool "found", local install should proceed
         with patch("subprocess.run", return_value=mock_result):
-            result = installer.install_tool("eslint", confirm=False, force=False, global_install=False)
+            result = installer.install_tool("eslint", force=False, global_install=False)
 
         assert result.status == InstallStatus.SUCCESS
 
@@ -349,7 +349,7 @@ class TestCargoInstaller:
         installer = CargoInstaller()
         # ripgrep package -> rg binary
         with patch("shutil.which", return_value="/home/user/.cargo/bin/rg"):
-            result = installer.install_tool("ripgrep", confirm=False, force=False)
+            result = installer.install_tool("ripgrep", force=False)
 
         assert result.status == InstallStatus.SKIPPED
         assert "already installed" in result.message.lower()
@@ -364,7 +364,7 @@ class TestCargoInstaller:
 
         with patch("subprocess.run", return_value=mock_result):
             with patch("shutil.which", return_value="/home/user/.cargo/bin/rg"):
-                result = installer.install_tool("ripgrep", confirm=False, force=True)
+                result = installer.install_tool("ripgrep", force=True)
 
         assert result.status == InstallStatus.SUCCESS
 
@@ -378,7 +378,7 @@ class TestCargoInstaller:
 
         # rust-src has no binary, so it should always attempt install
         with patch("subprocess.run", return_value=mock_result):
-            result = installer.install_tool("rust-src", confirm=False, force=False)
+            result = installer.install_tool("rust-src", force=False)
 
         assert result.status == InstallStatus.SUCCESS
 
@@ -518,7 +518,7 @@ class TestInstallerIntegration:
 
         with patch("subprocess.run", return_value=mock_result):
             with patch("shutil.which", side_effect=which_side_effect):
-                result = installer.install_tool("pytest", confirm=False)
+                result = installer.install_tool("pytest")
 
         assert result.success is True
 
@@ -549,7 +549,7 @@ class TestInstallerIntegration:
         with patch("subprocess.run", return_value=mock_result):
             with patch("shutil.which", side_effect=which_side_effect):
                 for tool in tools:
-                    result = installer.install_tool(tool, confirm=False)
+                    result = installer.install_tool(tool)
                     results.append(result)
 
         assert all(r.success for r in results)


### PR DESCRIPTION
Closes #972

## What

Adds the repeatable check the issue asks for, then fixes everything it found.

`tests/ci/test_documented_commands_resolve_972.py` extracts every `cf`/`codeframe` invocation from `README.md`, `CLAUDE.md` and `docs/*.md` — including the `a|b|c` alternation form the docs use — and resolves each against the live Typer tree. A path that does not resolve fails unless its line is explicitly marked `NOT IMPLEMENTED`. `GOLDEN_PATH.md` and `CLI_WIREFRAME.md` are specs of intended behaviour, so marking is the honest option there; deleting would lose the design intent.

A second test guards the guard: an extractor regex that matched nothing would pass vacuously, so it asserts the extractor still resolves >50 real commands.

## Phantom commands it found (12, beyond the #614 sweep)

| Doc | Claimed | Reality |
|---|---|---|
| `CLAUDE.md:296` | `cf env install` | `install-missing` / `auto-install` |
| `CLI_WIREFRAME:193/214/225` | `config init` / `show` / `set` | only `config telemetry` exists |
| `CLI_WIREFRAME:319` | `prd refine` | never built |
| `CLI_WIREFRAME:500` | `task set` | typo for `tasks set` |
| `CLI_WIREFRAME:502` | `tasks get status` | `tasks show` |
| `CLI_WIREFRAME:605` | `work batch cancel` | `work batch stop` |
| `CLI_WIREFRAME:734/870` | `codeframe git ...`, `git status` | no `git` group at all |
| `PHASE_2_CLI_API_MAPPING:96` | `cf checkpoint diff` | endpoint exists, CLI command does not |
| `PHASE_2_CLI_API_MAPPING:144` | `cf env install` | `install-missing` |

## Non-CLI drift in the same sweep

- **Router count.** `CLAUDE.md` said "16 v2 router modules"; the filesystem has 23 (21 v2 REST + 2 WebSocket). `AGENT_SYSTEM_REFERENCE`'s list was also stale and named `api_key_v2`, which lives in `auth/`, not `routers/`.
- **`CODEFRAME_API_KEY_SECRET`.** Documented as "API key hashing", but no code path reads it — `auth/api_keys.py` hashes with unsalted SHA256. Removed from the docs (the AC allows wired-or-removed).
- **`cancel_batch`.** Docstring claimed it SIGTERMs running subprocesses; it only flips status and emits the event. `stop_batch(force=True)` is the one that signals — verified.
- **`installer.py`.** Advertised "Rollback capabilities" that do not exist. Every `install_tool` also carried a `confirm` parameter documented as "prompt for confirmation" that no body ever read. Removed the parameter rather than documenting the lie — the CLI does its own `typer.confirm`, which is the right layer for it.
- **`cli/__init__.py`.** Named the console-script entry point `app:app`; `pyproject.toml` says `app:main`.
- **15 stale `⚠️ Missing` markers** in `PHASE_2_CLI_API_MAPPING`. Every one of those endpoints was verified present against the live FastAPI route table.

## Acceptance criteria

- [x] Every backticked `cf`/`codeframe` command in docs either exists in `cf --help` or is explicitly marked NOT IMPLEMENTED — enforced by the new test
- [x] `CLAUDE.md` router count matches the filesystem; `CODEFRAME_API_KEY_SECRET` removed from the docs
- [x] `cancel_batch`, `installer.py` and `cli/__init__.py` docstrings describe only what the code does
- [x] A repeatable test asserts every documented command resolves in the Typer app

## Verification

- `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` — **6580 passed, 19 skipped**, 0 failures
- `uv run ruff check .` — clean
- Guard proven to bite: injecting `` `cf frobnicate widgets` `` into `QUICKSTART.md` fails the test with `docs/QUICKSTART.md:512: 'frobnicate'`

## Third-party review

`codex review --uncommitted` raised two P2 findings, both valid and both fixed in this branch:

1. `CLI_WIREFRAME` still documented `install_tool(tool, confirm)` after the parameter was deleted.
2. The `work batch stop` section named `cancel_batch` as its core call and promised SIGTERM on the default path, while the CLI actually calls `stop_batch(..., force=force)` and only SIGTERMs under `--force`.

## Known limitations

- The checker only reads `README.md`, `CLAUDE.md` and `docs/*.md`. Docstrings, `web-ui/`, and `docs/archive/` are out of scope — archive is deliberately historical.
- It validates command **paths**, not flags. `cf work start --create-branch` (a phantom flag #614 caught by hand) would not be caught by this test.
- `cancel_batch` is now visibly near-redundant with `stop_batch(force=False)`. Left alone here — deleting a public core function is beyond a docs sweep.
