### PR TITLE
fix(discovery): claim the single active session atomically (#1042)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,15 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
 - Don't implement UI concepts (tabs, panels, progress bars) inside `codeframe/core/`
 - Don't "clean up the repo" as a goal — only refactor to enable the pipeline
 - Don't update task status from `agent.py` — let `runtime.py` handle transitions
+- **Don't write to `discovery_sessions` without honouring the single-active-session
+  index** (#1042). A workspace holds at most one row with
+  `state != 'completed' AND COALESCE(is_complete, 0) = 0`, enforced by
+  `idx_discovery_sessions_one_active`. So: create the row only via
+  `_claim_session` (a plain INSERT, whose UNIQUE violation means "already
+  active"), and update it only via `_save_session`. Any write that follows an
+  LLM call must pass `require_active=True` — `/reset` can land during that call,
+  and an unconditional write resurrects the session the user just abandoned.
+  `submit_answer` and `pause_discovery` learned this the hard way.
 - Don't skip web UI testing when verifying features that have a web surface
 - **Don't leave a CI gate disabled when its feature area becomes active.** Re-enable `DISABLED:` / `# COMMENTED OUT:` jobs before the first PR in that area. Verify `frontend-tests` is wired into `test-summary`.
 - **A CI run that fails with ZERO jobs and no logs means the workflow file will not compile** (#1122). `gh run view --log-failed` returns `log not found`, the jobs API is empty, and the run ignores its own trigger filters — so it looks like an unrelated trigger bug rather than an outage. YAML validity is not enough: `yaml.safe_load()` parses these files fine; it is GitHub's expression pass that rejects them. Run `actionlint .github/workflows/*.yml` first — the `workflow-lint` job in `test.yml` now enforces this on every PR, but it is the first thing to run locally when a workflow misbehaves. This shipped twice undetected: `deploy.yml` (staging down for a week, an empty `${{ }}` inside a `run:` block) and `claude-review` (#1011).

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1735,6 +1735,7 @@ def prd_generate(
         ValidationError,
         IncompleteSessionError,
         get_active_session,
+        reset_discovery,
     )
     from codeframe.core.events import emit_for_workspace, EventType
     from codeframe.planning.prd_templates import PrdTemplateManager
@@ -1796,16 +1797,22 @@ def prd_generate(
             # Check for active session
             try:
                 active = get_active_session(workspace)
-                if active and active.answered_count > 0:
-                    if typer.confirm(
+                if (
+                    active
+                    and active.answered_count > 0
+                    and typer.confirm(
                         f"Found incomplete session with {active.answered_count} answers. Resume?"
-                    ):
-                        session = active
-                        console.print("[green]✓[/green] Resuming previous session")
-                    else:
-                        session = PrdDiscoverySession(workspace)
-                        session.start_discovery()
+                    )
+                ):
+                    session = active
+                    console.print("[green]✓[/green] Resuming previous session")
                 else:
+                    if active:
+                        # Starting fresh abandons the active session. Say so to
+                        # the database: a workspace holds at most one active
+                        # session, so start_discovery() would otherwise be
+                        # refused outright (#1042).
+                        reset_discovery(workspace, session_id=active.session_id)
                     session = PrdDiscoverySession(workspace)
                     session.start_discovery()
             except NoApiKeyError as e:

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1801,17 +1801,20 @@ def prd_generate(
                     active
                     and active.answered_count > 0
                     and typer.confirm(
-                        f"Found incomplete session with {active.answered_count} answers. Resume?"
+                        f"Found incomplete session with {active.answered_count} answers. "
+                        "Resume? (declining abandons it)"
                     )
                 ):
                     session = active
                     console.print("[green]✓[/green] Resuming previous session")
                 else:
-                    if active:
+                    if active and not active.is_complete():
                         # Starting fresh abandons the active session. Say so to
                         # the database: a workspace holds at most one active
                         # session, so start_discovery() would otherwise be
-                        # refused outright (#1042).
+                        # refused outright (#1042). A session whose Q&A is
+                        # finished does NOT hold the slot, and resetting it
+                        # would destroy a PRD the user can still generate.
                         reset_discovery(workspace, session_id=active.session_id)
                     session = PrdDiscoverySession(workspace)
                     session.start_discovery()

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -31,6 +31,20 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _is_unique_violation(exc: sqlite3.IntegrityError) -> bool:
+    """True only for a UNIQUE-constraint failure.
+
+    Matching on the message would also catch a PRIMARY KEY collision, which is a
+    different bug and must not be reported as "a session is already active".
+    ``sqlite_errorname`` is exact; it exists on the Python floor this project
+    targets (3.11+), so the message check is only a belt-and-braces fallback.
+    """
+    name = getattr(exc, "sqlite_errorname", None)
+    if name is not None:
+        return name == "SQLITE_CONSTRAINT_UNIQUE"
+    return "UNIQUE constraint failed" in str(exc)
+
+
 class DiscoveryError(Exception):
     """Base exception for discovery errors."""
 
@@ -350,7 +364,7 @@ class PrdDiscoverySession:
         except sqlite3.IntegrityError as exc:
             self.session_id = None
             self.state = SessionState.IDLE
-            if "UNIQUE" not in str(exc):
+            if not _is_unique_violation(exc):
                 # A foreign-key or CHECK violation is a different bug; reporting
                 # it as "already active" would send the caller somewhere useless.
                 raise
@@ -498,7 +512,7 @@ Be warm and encouraging. Just output the question, nothing else."""
             if validation.get("follow_up"):
                 # Replace current question with follow-up
                 self._current_question = validation["follow_up"]
-                self._save_session()
+                self._require_still_active()
                 return {
                     "accepted": False,
                     "feedback": validation["reason"],
@@ -528,7 +542,7 @@ Be warm and encouraging. Just output the question, nothing else."""
         else:
             self._current_question = next_question
 
-        self._save_session()
+        self._require_still_active()
 
         return {
             "accepted": True,
@@ -673,6 +687,13 @@ Be warm and encouraging. Just output the question, nothing else."""
             Blocker ID for resume
         """
         self.state = SessionState.PAUSED
+
+        # Write the state change BEFORE creating the blocker. A reset can have
+        # completed this row and a new session claimed the slot while discovery
+        # was running, in which case this write is refused — and a blocker
+        # created first would be left orphaned, with the session row never
+        # recording its id and the user never seeing the resume hint (#1042).
+        self._save_session()
 
         question = (
             f"Discovery session paused: {reason}\n"
@@ -873,6 +894,25 @@ Follow the template structure exactly. This PRD should be sufficient to generate
         conn.commit()
         conn.close()
 
+    def _require_still_active(self) -> None:
+        """Save, but only while this session still holds the workspace's slot.
+
+        ``submit_answer`` validates and generates against state it read *before*
+        a multi-second LLM call, so a ``/reset`` can land in between — the same
+        window ``start_discovery`` has. Writing unconditionally would resurrect
+        the row the reset completed, and if a new session had claimed the slot
+        meanwhile the UPDATE would hit the unique index and surface as a raw
+        SQL 500 (#1042).
+
+        Raises:
+            SessionResetError: If the session was reset while the call ran.
+        """
+        if not self._save_session(require_active=True):
+            self.state = SessionState.COMPLETED
+            raise SessionResetError(
+                "Discovery session was reset while this answer was being processed."
+            )
+
     def _claim_session(self) -> None:
         """INSERT the session row, claiming the workspace's active-session slot.
 
@@ -950,6 +990,16 @@ Follow the template structure exactly. This PRD should be sufficient to generate
             cursor = conn.execute(sql, params)
             conn.commit()
             return cursor.rowcount > 0
+        except sqlite3.IntegrityError as exc:
+            # Reachable from resume_discovery()/pause_discovery(), which move a
+            # row back into the active set: if the workspace claimed the slot in
+            # the meantime, that write is refused. Name the reason rather than
+            # letting a raw "UNIQUE constraint failed" reach the CLI.
+            if not _is_unique_violation(exc):
+                raise
+            raise ActiveSessionExistsError(
+                "Another discovery session is already active for this workspace."
+            ) from exc
         finally:
             conn.close()
 
@@ -1006,27 +1056,49 @@ def _ensure_discovery_schema(workspace: Workspace) -> None:
         ("idx_discovery_sessions_one_active",),
     ).fetchone()
     if not index_exists:
+        # `is_complete` is nullable (INTEGER DEFAULT 0), and `is_complete = 0` is
+        # *unknown* for a NULL, not true — a legacy NULL row would fall outside
+        # both the backfill and the index, leaving two rows the route considers
+        # active with nothing to stop it. COALESCE in both places, identically.
+        #
+        # NOT EXISTS rather than `id NOT IN (...)`: SQLite permits NULL in a TEXT
+        # PRIMARY KEY, and a single NULL id makes `NOT IN` evaluate to NULL for
+        # every row — the backfill would update nothing and the index build would
+        # then fail on the duplicates it was supposed to clear.
         cursor.execute(
             """
             UPDATE discovery_sessions
             SET state = 'completed', updated_at = ?
-            WHERE state != 'completed' AND is_complete = 0
-              AND id NOT IN (
-                  SELECT id FROM (
-                      SELECT id, MAX(updated_at)
+            WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0
+              AND NOT EXISTS (
+                  SELECT 1 FROM (
+                      SELECT id AS keep_id, MAX(updated_at)
                       FROM discovery_sessions
-                      WHERE state != 'completed' AND is_complete = 0
+                      WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0
                       GROUP BY workspace_id
-                  )
+                  ) AS newest
+                  WHERE newest.keep_id IS discovery_sessions.id
               )
             """,
             (_utc_now().isoformat(),),
         )
-        cursor.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_sessions_one_active "
-            "ON discovery_sessions(workspace_id) "
-            "WHERE state != 'completed' AND is_complete = 0"
-        )
+        try:
+            cursor.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_sessions_one_active "
+                "ON discovery_sessions(workspace_id) "
+                "WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0"
+            )
+        except sqlite3.DatabaseError:
+            # This function runs on every discovery entry point, so letting the
+            # index build propagate would brick discovery for the workspace
+            # permanently, with no recovery path. Losing the constraint is the
+            # status quo ante; losing discovery is worse. Retried next call.
+            logger.warning(
+                "Could not build the single-active-session index for workspace %s; "
+                "concurrent discovery starts are unguarded until this succeeds.",
+                workspace.id,
+                exc_info=True,
+            )
 
     conn.commit()
     conn.close()

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -11,6 +11,7 @@ This module is headless - no FastAPI or HTTP dependencies.
 import json
 import logging
 import os
+import sqlite3
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -50,6 +51,27 @@ class ValidationError(DiscoveryError):
 
 class IncompleteSessionError(DiscoveryError):
     """Raised when trying to generate PRD from incomplete session."""
+
+    pass
+
+
+class ActiveSessionExistsError(DiscoveryError):
+    """Raised when a workspace already holds an active discovery session.
+
+    The workspace's single active-session slot is claimed by a partial UNIQUE
+    index, so this is raised on the losing INSERT of a concurrent ``/start``
+    — the case the route's read-then-write check cannot catch (#1042).
+    """
+
+    pass
+
+
+class SessionResetError(DiscoveryError):
+    """Raised when a session is reset out from under an in-flight operation.
+
+    ``POST /reset`` completes the claim row while the opening-question LLM call
+    is still running; the save that follows must not resurrect it (#1042).
+    """
 
     pass
 
@@ -320,7 +342,22 @@ class PrdDiscoverySession:
 
         # Claim the workspace's single active-session slot before the opening LLM
         # call, which takes minutes (#902) — a concurrent /start must see it.
-        self._save_session()
+        # The claim is a plain INSERT against the partial UNIQUE index, so the
+        # slot is won in the database rather than by the route's read-then-write
+        # check, which two concurrent starts can both pass (#1042).
+        try:
+            self._claim_session()
+        except sqlite3.IntegrityError as exc:
+            self.session_id = None
+            self.state = SessionState.IDLE
+            if "UNIQUE" not in str(exc):
+                # A foreign-key or CHECK violation is a different bug; reporting
+                # it as "already active" would send the caller somewhere useless.
+                raise
+            raise ActiveSessionExistsError(
+                "A discovery session is already active for this workspace."
+            ) from exc
+
         try:
             self._current_question = self._generate_opening_question()
         except BaseException:
@@ -332,7 +369,18 @@ class PrdDiscoverySession:
             self.session_id = None
             self.state = SessionState.IDLE
             raise
-        self._save_session()
+
+        # A /reset that landed during that call already completed the claim row.
+        # require_active makes this an UPDATE that matches nothing in that case,
+        # instead of the INSERT OR REPLACE that used to flip the row back to
+        # `discovering` and undo the reset (#1042).
+        if not self._save_session(require_active=True):
+            self._delete_session()
+            self.session_id = None
+            self.state = SessionState.IDLE
+            raise SessionResetError(
+                "Discovery session was reset while the opening question was being generated."
+            )
 
         logger.info(f"Started discovery session {self.session_id}")
 
@@ -825,40 +873,85 @@ Follow the template structure exactly. This PRD should be sufficient to generate
         conn.commit()
         conn.close()
 
-    def _save_session(self) -> None:
-        """Save session state to database."""
-        conn = get_db_connection(self.workspace)
-        cursor = conn.cursor()
+    def _claim_session(self) -> None:
+        """INSERT the session row, claiming the workspace's active-session slot.
 
+        Raises:
+            sqlite3.IntegrityError: If the workspace already holds an active
+                session (the partial UNIQUE index built by
+                :func:`_ensure_discovery_schema`).
+        """
         now = _utc_now().isoformat()
-        qa_history_json = json.dumps(self._qa_history)
-        coverage_json = json.dumps(self._coverage) if self._coverage else None
+        conn = get_db_connection(self.workspace)
+        try:
+            conn.execute(
+                """
+                INSERT INTO discovery_sessions
+                    (id, workspace_id, state, qa_history, current_question,
+                     coverage, blocker_id, is_complete, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.session_id,
+                    self.workspace.id,
+                    self.state.value,
+                    json.dumps(self._qa_history),
+                    self._current_question,
+                    json.dumps(self._coverage) if self._coverage else None,
+                    self._blocker_id,
+                    1 if self._is_complete else 0,
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
-        cursor.execute(
-            """
-            INSERT OR REPLACE INTO discovery_sessions
-                (id, workspace_id, state, qa_history, current_question,
-                 coverage, blocker_id, is_complete, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?,
-                    COALESCE((SELECT created_at FROM discovery_sessions WHERE id = ?), ?),
-                    ?)
-            """,
-            (
-                self.session_id,
-                self.workspace.id,
-                self.state.value,
-                qa_history_json,
-                self._current_question,
-                coverage_json,
-                self._blocker_id,
-                1 if self._is_complete else 0,
-                self.session_id,
-                now,
-                now,
-            ),
-        )
-        conn.commit()
-        conn.close()
+    def _save_session(self, require_active: bool = False) -> bool:
+        """Save session state to database.
+
+        UPDATE-only: the row is created once by :meth:`_claim_session`. It used
+        to be an ``INSERT OR REPLACE``, which re-created a row a concurrent
+        ``/reset`` had completed — and, once the partial UNIQUE index exists,
+        would have deleted a competing active row to make room (#1042).
+
+        Args:
+            require_active: Only write if the stored row is still non-completed.
+                Used by the post-LLM save in :meth:`start_discovery` so a
+                ``/reset`` that landed mid-call is not undone.
+
+        Returns:
+            True if a row was written, False if ``require_active`` matched none.
+        """
+        now = _utc_now().isoformat()
+        sql = """
+            UPDATE discovery_sessions
+            SET state = ?, qa_history = ?, current_question = ?, coverage = ?,
+                blocker_id = ?, is_complete = ?, updated_at = ?
+            WHERE id = ? AND workspace_id = ?
+        """
+        params = [
+            self.state.value,
+            json.dumps(self._qa_history),
+            self._current_question,
+            json.dumps(self._coverage) if self._coverage else None,
+            self._blocker_id,
+            1 if self._is_complete else 0,
+            now,
+            self.session_id,
+            self.workspace.id,
+        ]
+        if require_active:
+            sql += " AND state != 'completed'"
+
+        conn = get_db_connection(self.workspace)
+        try:
+            cursor = conn.execute(sql, params)
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
 
 
 def _ensure_discovery_schema(workspace: Workspace) -> None:
@@ -896,6 +989,44 @@ def _ensure_discovery_schema(workspace: Workspace) -> None:
         "CREATE INDEX IF NOT EXISTS idx_discovery_sessions_state "
         "ON discovery_sessions(state)"
     )
+
+    # One active session per workspace, enforced by the database rather than by
+    # a read-then-write check two concurrent /start calls can both pass (#1042).
+    # The predicate matches the route's notion of "active" (`not is_complete()`):
+    # a session whose Q&A is done but whose PRD has not been generated has always
+    # allowed a new start, and must keep doing so.
+    #
+    # Run the backfill only while the index is absent. A workspace created before
+    # #1042 can already hold several non-completed rows, and CREATE UNIQUE INDEX
+    # would fail outright on them — so complete all but the newest per workspace
+    # first. (SQLite returns the bare `id` from the row supplying `MAX`, which is
+    # what picks the newest here.)
+    index_exists = cursor.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+        ("idx_discovery_sessions_one_active",),
+    ).fetchone()
+    if not index_exists:
+        cursor.execute(
+            """
+            UPDATE discovery_sessions
+            SET state = 'completed', updated_at = ?
+            WHERE state != 'completed' AND is_complete = 0
+              AND id NOT IN (
+                  SELECT id FROM (
+                      SELECT id, MAX(updated_at)
+                      FROM discovery_sessions
+                      WHERE state != 'completed' AND is_complete = 0
+                      GROUP BY workspace_id
+                  )
+              )
+            """,
+            (_utc_now().isoformat(),),
+        )
+        cursor.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_sessions_one_active "
+            "ON discovery_sessions(workspace_id) "
+            "WHERE state != 'completed' AND is_complete = 0"
+        )
 
     conn.commit()
     conn.close()

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -688,12 +688,15 @@ Be warm and encouraging. Just output the question, nothing else."""
         """
         self.state = SessionState.PAUSED
 
-        # Write the state change BEFORE creating the blocker. A reset can have
-        # completed this row and a new session claimed the slot while discovery
-        # was running, in which case this write is refused — and a blocker
-        # created first would be left orphaned, with the session row never
-        # recording its id and the user never seeing the resume hint (#1042).
-        self._save_session()
+        # Write the state change BEFORE creating the blocker, and require the row
+        # to still be non-completed. A `/reset` can have landed while discovery
+        # was running, and an unconditional write would flip that row back to
+        # `paused` — resurrecting the session the user just abandoned. The unique
+        # index alone does not catch this: it only fires once a *replacement*
+        # session holds the slot (#1042). Creating the blocker first would also
+        # orphan it here, leaving the session row with no `blocker_id` and the
+        # user with no resume hint.
+        self._require_still_active()
 
         question = (
             f"Discovery session paused: {reason}\n"
@@ -705,7 +708,11 @@ Be warm and encouraging. Just output the question, nothing else."""
             self.workspace, question=question, task_id=None, created_by="system"
         )
         self._blocker_id = blocker.id
-        self._save_session()
+        # Guarded for the same reason. A reset landing between these two writes
+        # leaves the blocker open with nothing pointing at it — but that window
+        # is the microseconds between two local writes, not the minutes of an
+        # LLM call, and there is no blocker-delete to unwind it with.
+        self._require_still_active()
 
         logger.info(f"Session paused with blocker {blocker.id}")
         return blocker.id
@@ -897,8 +904,8 @@ Follow the template structure exactly. This PRD should be sufficient to generate
     def _require_still_active(self) -> None:
         """Save, but only while this session still holds the workspace's slot.
 
-        ``submit_answer`` validates and generates against state it read *before*
-        a multi-second LLM call, so a ``/reset`` can land in between — the same
+        ``submit_answer`` and ``pause_discovery`` act on state read *before* a
+        multi-second LLM call, so a ``/reset`` can land in between — the same
         window ``start_discovery`` has. Writing unconditionally would resurrect
         the row the reset completed, and if a new session had claimed the slot
         meanwhile the UPDATE would hit the unique index and surface as a raw
@@ -910,7 +917,7 @@ Follow the template structure exactly. This PRD should be sufficient to generate
         if not self._save_session(require_active=True):
             self.state = SessionState.COMPLETED
             raise SessionResetError(
-                "Discovery session was reset while this answer was being processed."
+                f"Discovery session {self.session_id} was reset and can no longer be updated."
             )
 
     def _claim_session(self) -> None:

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -21,8 +21,10 @@ from codeframe.lib.rate_limiter import rate_limit_ai, rate_limit_standard
 from codeframe.core import prd_discovery, prd, tasks
 from codeframe.core.tasks import TaskGenerationError
 from codeframe.core.prd_discovery import (
+    ActiveSessionExistsError,
     DiscoveryError,
     NoApiKeyError,
+    SessionResetError,
     ValidationError,
     IncompleteSessionError,
 )
@@ -123,21 +125,26 @@ async def start_discovery(
     Raises:
         HTTPException:
             - 400: Discovery session already active
+            - 409: Session was reset while the opening question was generating
             - 500: API key not configured or processing error
     """
+
+    def _already_active(session_id: Optional[str], answered_count: int) -> HTTPException:
+        return HTTPException(
+            status_code=400,
+            detail={
+                "error": "Discovery session already active",
+                "session_id": session_id,
+                "answered_count": answered_count,
+                "hint": "Use POST /api/v2/discovery/{session_id}/answer to continue",
+            },
+        )
+
     try:
         # Check for existing active session
         existing = await run_in_threadpool(prd_discovery.get_active_session, workspace)
         if existing and not existing.is_complete():
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "Discovery session already active",
-                    "session_id": existing.session_id,
-                    "answered_count": existing.answered_count,
-                    "hint": "Use POST /api/v2/discovery/{session_id}/answer to continue",
-                },
-            )
+            raise _already_active(existing.session_id, existing.answered_count)
 
         # Start new session
         # LLM round trip: minutes, not milliseconds (#902).
@@ -150,6 +157,17 @@ async def start_discovery(
             question=question or {},
         )
 
+    except ActiveSessionExistsError:
+        # The check above is a fast path, not a guarantee: two concurrent starts
+        # both pass it and the database decides the winner (#1042). Report the
+        # loser exactly as the pre-check would have.
+        winner = await run_in_threadpool(prd_discovery.get_active_session, workspace)
+        raise _already_active(
+            winner.session_id if winner else None,
+            winner.answered_count if winner else 0,
+        )
+    except SessionResetError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except NoApiKeyError as e:
         raise HTTPException(
             status_code=500,

--- a/codeframe/ui/routers/discovery_v2.py
+++ b/codeframe/ui/routers/discovery_v2.py
@@ -161,7 +161,15 @@ async def start_discovery(
         # The check above is a fast path, not a guarantee: two concurrent starts
         # both pass it and the database decides the winner (#1042). Report the
         # loser exactly as the pre-check would have.
-        winner = await run_in_threadpool(prd_discovery.get_active_session, workspace)
+        try:
+            winner = await run_in_threadpool(prd_discovery.get_active_session, workspace)
+        except Exception:
+            # get_active_session builds an LLM provider, so it can raise
+            # (NoApiKeyError, UntrustedBaseURLError). An exception raised inside
+            # an except block is not caught by its own try, so that would escape
+            # as an unlogged 500 in place of the 400 the caller has earned.
+            logger.warning("Could not identify the winning session", exc_info=True)
+            winner = None
         raise _already_active(
             winner.session_id if winner else None,
             winner.answered_count if winner else 0,

--- a/tests/cli/test_prd_generate_active_slot_1042.py
+++ b/tests/cli/test_prd_generate_active_slot_1042.py
@@ -1,0 +1,140 @@
+"""`cf prd generate` and the workspace's single active-session slot (#1042).
+
+A workspace now holds at most one *active* discovery session, enforced by a
+partial UNIQUE index. Two CLI consequences fall out of that:
+
+1. Declining "Resume?" means abandoning the existing session, so the command
+   must say so to the database — otherwise `start_discovery()` is refused.
+2. A session whose Q&A is finished does NOT hold the slot. Resetting it would
+   destroy a PRD the user can still generate, and it was never necessary.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.app import app
+from codeframe.core.workspace import Workspace, create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    return create_or_load_workspace(tmp_path)
+
+
+def _provider() -> MagicMock:
+    provider = MagicMock()
+
+    def complete(messages, **_kwargs):
+        content = messages[0]["content"] if messages else ""
+        response = MagicMock()
+        if "assess the current coverage" in content.lower():
+            response.content = json.dumps(
+                {"scores": {}, "average": 10, "ready_for_prd": False, "reasoning": "early"}
+            )
+        else:
+            response.content = "What problem are you trying to solve?"
+        response.input_tokens, response.output_tokens = 10, 5
+        return response
+
+    provider.complete.side_effect = complete
+    return provider
+
+
+def _seed_session(workspace: Workspace, answered: int, is_complete: int) -> str:
+    """Persist a session row directly — the CLI only reads it back."""
+    from codeframe.core.prd_discovery import _ensure_discovery_schema
+
+    _ensure_discovery_schema(workspace)
+    qa = json.dumps(
+        [{"question": f"q{i}", "answer": f"a{i}", "timestamp": "2026-01-01"} for i in range(answered)]
+    )
+    conn = get_db_connection(workspace)
+    conn.execute(
+        "INSERT INTO discovery_sessions (id, workspace_id, state, qa_history,"
+        " current_question, coverage, blocker_id, is_complete, created_at, updated_at)"
+        " VALUES ('seeded', ?, 'discovering', ?, 'What next?', NULL, NULL, ?,"
+        " '2026-01-01', '2026-01-01')",
+        (workspace.id, qa, is_complete),
+    )
+    conn.commit()
+    conn.close()
+    return "seeded"
+
+
+def _states(workspace: Workspace) -> dict[str, str]:
+    conn = get_db_connection(workspace)
+    try:
+        return dict(conn.execute("SELECT id, state FROM discovery_sessions").fetchall())
+    finally:
+        conn.close()
+
+
+@patch("codeframe.core.llm_resolution.create_provider")
+class TestDecliningResume:
+    def test_declining_abandons_the_old_session_and_starts_a_new_one(
+        self, mock_create_provider, workspace: Workspace, monkeypatch
+    ):
+        mock_create_provider.return_value = _provider()
+        monkeypatch.chdir(workspace.repo_path)
+        seeded = _seed_session(workspace, answered=2, is_complete=0)
+
+        result = runner.invoke(
+            app,
+            ["prd", "generate", "-w", str(workspace.repo_path)],
+            input="n\n/quit\ny\n",  # decline resume, then quit
+            env={"ANTHROPIC_API_KEY": "test-key"},
+        )
+
+        states = _states(workspace)
+        assert states[seeded] == "completed", (
+            f"declining must abandon the old session; got {states} / {result.output}"
+        )
+        fresh = [sid for sid, state in states.items() if sid != seeded and state != "completed"]
+        assert len(fresh) == 1, f"a new session should have started: {states}"
+
+    def test_the_prompt_says_declining_is_destructive(
+        self, mock_create_provider, workspace: Workspace, monkeypatch
+    ):
+        mock_create_provider.return_value = _provider()
+        monkeypatch.chdir(workspace.repo_path)
+        _seed_session(workspace, answered=2, is_complete=0)
+
+        result = runner.invoke(
+            app,
+            ["prd", "generate", "-w", str(workspace.repo_path)],
+            input="n\n/quit\ny\n",
+            env={"ANTHROPIC_API_KEY": "test-key"},
+        )
+
+        assert "abandons" in result.output, result.output
+
+
+@patch("codeframe.core.llm_resolution.create_provider")
+class TestFinishedSessionIsPreserved:
+    def test_a_finished_qa_session_is_not_reset(
+        self, mock_create_provider, workspace: Workspace, monkeypatch
+    ):
+        """It does not hold the slot, and its PRD can still be generated."""
+        mock_create_provider.return_value = _provider()
+        monkeypatch.chdir(workspace.repo_path)
+        seeded = _seed_session(workspace, answered=4, is_complete=1)
+
+        result = runner.invoke(
+            app,
+            ["prd", "generate", "-w", str(workspace.repo_path)],
+            input="n\n/quit\ny\n",
+            env={"ANTHROPIC_API_KEY": "test-key"},
+        )
+
+        states = _states(workspace)
+        assert states[seeded] == "discovering", (
+            f"a finished-Q&A session must survive; got {states} / {result.output}"
+        )

--- a/tests/core/test_prd_discovery_single_active_1042.py
+++ b/tests/core/test_prd_discovery_single_active_1042.py
@@ -554,3 +554,49 @@ class TestMigrationSurvivesLegacyRows:
         assert _active_rows(workspace) == []
         assert get_active_session(workspace) is None
         assert len(blockers.list_all(workspace)) == before
+
+
+class TestGetActiveSessionPicksTheSlotHolder:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_a_finished_session_does_not_shadow_the_new_one(
+        self, mock_provider_class, workspace: Workspace, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`get_active_session` uses a *looser* predicate than the unique index.
+
+        It filters on `state != 'completed'` only — no `is_complete` — and picks
+        by recency. So when a finished-Q&A row and a freshly-claimed session
+        coexist (exactly what "finished sessions don't hold the slot" allows),
+        the right answer depends entirely on the new row's `updated_at` being
+        strictly later. Nothing else pins that, so pin it here.
+        """
+        from codeframe.core.prd_discovery import PrdDiscoverySession, get_active_session
+
+        mock_provider_class.return_value = _provider_returning()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # get_active_session (#917)
+
+        finished = PrdDiscoverySession(workspace, api_key="test-key")
+        finished.start_discovery()
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET is_complete = 1 WHERE id = ?",
+            (finished.session_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        fresh = PrdDiscoverySession(workspace, api_key="test-key")
+        fresh.start_discovery()
+
+        # Both rows are non-completed, so both are in get_active_session's scope.
+        conn = get_db_connection(workspace)
+        in_scope = conn.execute(
+            "SELECT id FROM discovery_sessions WHERE state != 'completed'"
+        ).fetchall()
+        conn.close()
+        assert len(in_scope) == 2, "the premise: two rows the looser predicate admits"
+
+        active = get_active_session(workspace)
+        assert active is not None
+        assert active.session_id == fresh.session_id, (
+            "the finished session must not shadow the one holding the slot"
+        )

--- a/tests/core/test_prd_discovery_single_active_1042.py
+++ b/tests/core/test_prd_discovery_single_active_1042.py
@@ -1,0 +1,304 @@
+"""Atomic single-active-session claim for PRD discovery (#1042).
+
+``POST /api/v2/discovery/start`` enforced "one active session per workspace"
+with a read-then-write and no uniqueness constraint behind it, so two concurrent
+starts could each INSERT a ``discovering`` row and the loser became an orphan.
+The same table also let ``POST /reset`` be undone: ``_save_session`` used
+``INSERT OR REPLACE``, so the post-LLM save flipped a row a concurrent reset had
+just completed back to ``discovering``.
+"""
+
+import sqlite3
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeframe.core.workspace import Workspace, create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+ACTIVE_INDEX = "idx_discovery_sessions_one_active"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    return create_or_load_workspace(tmp_path)
+
+
+def _provider_returning(content: str = "What are you building?") -> MagicMock:
+    provider = MagicMock()
+    response = MagicMock()
+    response.content = content
+    response.input_tokens = 10
+    response.output_tokens = 5
+    provider.complete.return_value = response
+    return provider
+
+
+def _active_rows(workspace: Workspace) -> list[str]:
+    conn = get_db_connection(workspace)
+    rows = conn.execute(
+        "SELECT id FROM discovery_sessions WHERE state != 'completed' AND is_complete = 0"
+    ).fetchall()
+    conn.close()
+    return [row[0] for row in rows]
+
+
+class TestConcurrentStartClaimsOneSlot:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_two_concurrent_starts_yield_one_active_session(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """Both threads pass the read check; exactly one may keep the slot."""
+        from codeframe.core.prd_discovery import ActiveSessionExistsError, PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+
+        # Both threads sit here after reading the table and before writing,
+        # which is precisely the window the read-then-write check leaves open.
+        at_the_gate = threading.Barrier(2)
+        errors: list[BaseException] = []
+        started: list[str] = []
+
+        def start():
+            session = PrdDiscoverySession(workspace, api_key="test-key")
+            at_the_gate.wait(timeout=10)
+            try:
+                session.start_discovery()
+                started.append(session.session_id)
+            except BaseException as exc:  # noqa: BLE001 - recorded and asserted below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=start) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        assert len(started) == 1, f"expected one winner, got {started} / {errors}"
+        assert len(errors) == 1
+        assert isinstance(errors[0], ActiveSessionExistsError)
+        assert _active_rows(workspace) == started
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_serial_second_start_raises_rather_than_orphaning(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        from codeframe.core.prd_discovery import ActiveSessionExistsError, PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+
+        first = PrdDiscoverySession(workspace, api_key="test-key")
+        first.start_discovery()
+
+        second = PrdDiscoverySession(workspace, api_key="test-key")
+        with pytest.raises(ActiveSessionExistsError):
+            second.start_discovery()
+
+        assert _active_rows(workspace) == [first.session_id]
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_finished_qa_session_still_allows_a_new_start(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """A session with is_complete=1 awaiting PRD generation is not "active".
+
+        The route's guard is ``not existing.is_complete()``, so this start has
+        always been allowed — the uniqueness predicate must agree with it.
+        """
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+
+        first = PrdDiscoverySession(workspace, api_key="test-key")
+        first.start_discovery()
+
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET is_complete = 1 WHERE id = ?", (first.session_id,)
+        )
+        conn.commit()
+        conn.close()
+
+        second = PrdDiscoverySession(workspace, api_key="test-key")
+        second.start_discovery()
+
+        assert _active_rows(workspace) == [second.session_id]
+
+
+class TestMigrationToleratesExistingDuplicates:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_stale_duplicates_are_reconciled_before_the_index_builds(
+        self, mock_provider_class, workspace: Workspace, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A pre-#1042 workspace can already hold several non-completed rows."""
+        from codeframe.core.prd_discovery import _ensure_discovery_schema, get_active_session
+
+        mock_provider_class.return_value = _provider_returning()
+        # get_active_session() resolves a provider off the env (#917), not the
+        # patched class.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        _ensure_discovery_schema(workspace)
+        conn = get_db_connection(workspace)
+        conn.execute(f"DROP INDEX IF EXISTS {ACTIVE_INDEX}")
+        for suffix, updated in (("old", "2020-01-01"), ("mid", "2021-01-01"), ("new", "2022-01-01")):
+            conn.execute(
+                """
+                INSERT INTO discovery_sessions
+                    (id, workspace_id, state, qa_history, current_question,
+                     coverage, blocker_id, is_complete, created_at, updated_at)
+                VALUES (?, ?, 'discovering', '[]', 'q?', NULL, NULL, 0, ?, ?)
+                """,
+                (f"session-{suffix}", workspace.id, updated, updated),
+            )
+        conn.commit()
+        conn.close()
+
+        _ensure_discovery_schema(workspace)
+
+        assert _active_rows(workspace) == ["session-new"]
+        active = get_active_session(workspace)
+        assert active is not None and active.session_id == "session-new"
+
+        conn = get_db_connection(workspace)
+        index = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?", (ACTIVE_INDEX,)
+        ).fetchone()
+        conn.close()
+        assert index is not None, "unique index must exist after reconciliation"
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_duplicates_in_other_workspaces_are_untouched(
+        self, mock_provider_class, tmp_path: Path, workspace: Workspace
+    ):
+        """Reconciliation is per workspace — it keeps one active row for each."""
+        from codeframe.core.prd_discovery import _ensure_discovery_schema
+
+        mock_provider_class.return_value = _provider_returning()
+
+        _ensure_discovery_schema(workspace)
+        conn = get_db_connection(workspace)
+        conn.execute(f"DROP INDEX IF EXISTS {ACTIVE_INDEX}")
+        conn.execute(
+            "INSERT INTO workspace (id, repo_path, tech_stack, created_at, updated_at) "
+            "VALUES ('other-workspace', ?, NULL, '2020-01-01', '2020-01-01')",
+            (str(tmp_path / "other"),),
+        )
+        for workspace_id in (workspace.id, "other-workspace"):
+            for suffix, updated in (("old", "2020-01-01"), ("new", "2022-01-01")):
+                conn.execute(
+                    """
+                    INSERT INTO discovery_sessions
+                        (id, workspace_id, state, qa_history, current_question,
+                         coverage, blocker_id, is_complete, created_at, updated_at)
+                    VALUES (?, ?, 'discovering', '[]', 'q?', NULL, NULL, 0, ?, ?)
+                    """,
+                    (f"{workspace_id}-{suffix}", workspace_id, updated, updated),
+                )
+        conn.commit()
+        conn.close()
+
+        _ensure_discovery_schema(workspace)
+
+        conn = get_db_connection(workspace)
+        rows = conn.execute(
+            "SELECT id FROM discovery_sessions "
+            "WHERE state != 'completed' AND is_complete = 0 ORDER BY id"
+        ).fetchall()
+        conn.close()
+        assert [row[0] for row in rows] == [
+            f"{workspace.id}-new",
+            "other-workspace-new",
+        ]
+
+
+class TestResetDuringInFlightStart:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_post_llm_save_does_not_resurrect_a_reset_session(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """`/reset` lands while the opening-question call is still running."""
+        from codeframe.core.prd_discovery import (
+            PrdDiscoverySession,
+            SessionResetError,
+            get_active_session,
+            reset_discovery,
+        )
+
+        provider = MagicMock()
+
+        def complete(*_args, **_kwargs):
+            reset_discovery(workspace)
+            response = MagicMock()
+            response.content = "What are you building?"
+            response.input_tokens = 10
+            response.output_tokens = 5
+            return response
+
+        provider.complete.side_effect = complete
+        mock_provider_class.return_value = provider
+
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+        with pytest.raises(SessionResetError):
+            session.start_discovery()
+
+        assert _active_rows(workspace) == []
+        assert get_active_session(workspace) is None
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_a_fresh_start_succeeds_after_the_reset_race(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        from codeframe.core.prd_discovery import (
+            PrdDiscoverySession,
+            SessionResetError,
+            reset_discovery,
+        )
+
+        provider = MagicMock()
+        calls = {"n": 0}
+
+        def complete(*_args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                reset_discovery(workspace)
+            response = MagicMock()
+            response.content = "What are you building?"
+            response.input_tokens = 10
+            response.output_tokens = 5
+            return response
+
+        provider.complete.side_effect = complete
+        mock_provider_class.return_value = provider
+
+        with pytest.raises(SessionResetError):
+            PrdDiscoverySession(workspace, api_key="test-key").start_discovery()
+
+        retry = PrdDiscoverySession(workspace, api_key="test-key")
+        retry.start_discovery()
+        assert _active_rows(workspace) == [retry.session_id]
+
+
+class TestUniqueIndexIsEnforcedInTheDatabase:
+    def test_a_second_active_row_is_rejected_by_sqlite(self, workspace: Workspace):
+        """The guarantee is the constraint, not the Python check around it."""
+        from codeframe.core.prd_discovery import _ensure_discovery_schema
+
+        _ensure_discovery_schema(workspace)
+
+        conn = get_db_connection(workspace)
+        insert = """
+            INSERT INTO discovery_sessions
+                (id, workspace_id, state, qa_history, current_question,
+                 coverage, blocker_id, is_complete, created_at, updated_at)
+            VALUES (?, ?, 'discovering', '[]', 'q?', NULL, NULL, 0,
+                    '2026-01-01', '2026-01-01')
+        """
+        conn.execute(insert, ("first", workspace.id))
+        conn.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(insert, ("second", workspace.id))
+        conn.close()

--- a/tests/core/test_prd_discovery_single_active_1042.py
+++ b/tests/core/test_prd_discovery_single_active_1042.py
@@ -431,8 +431,8 @@ class TestPauseDoesNotOrphanABlocker:
         that gets refused is orphaned, and its resume hint never reaches anyone."""
         from codeframe.core import blockers
         from codeframe.core.prd_discovery import (
-            ActiveSessionExistsError,
             PrdDiscoverySession,
+            SessionResetError,
             reset_discovery,
         )
 
@@ -447,7 +447,7 @@ class TestPauseDoesNotOrphanABlocker:
         holder.start_discovery()
 
         before = len(blockers.list_all(workspace))
-        with pytest.raises(ActiveSessionExistsError):
+        with pytest.raises(SessionResetError):
             stale.pause_discovery("user interrupted")
 
         assert len(blockers.list_all(workspace)) == before, "orphaned blocker created"
@@ -522,3 +522,35 @@ class TestMigrationSurvivesLegacyRows:
         conn.close()
         assert index is not None, "index must still build over a NULL-id row"
         assert get_active_session(workspace) is not None, "discovery must still work"
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_pause_does_not_resurrect_a_reset_session(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """The unique index only fires once a *replacement* holds the slot.
+
+        With no replacement, an unconditional pause write matches the completed
+        row and flips it back to `paused` — undoing the reset and leaving the
+        abandoned session active again.
+        """
+        from codeframe.core import blockers
+        from codeframe.core.prd_discovery import (
+            PrdDiscoverySession,
+            SessionResetError,
+            get_active_session,
+            reset_discovery,
+        )
+
+        mock_provider_class.return_value = _provider_returning()
+
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+        session.start_discovery()
+        reset_discovery(workspace, session_id=session.session_id)
+
+        before = len(blockers.list_all(workspace))
+        with pytest.raises(SessionResetError):
+            session.pause_discovery("user interrupted")
+
+        assert _active_rows(workspace) == []
+        assert get_active_session(workspace) is None
+        assert len(blockers.list_all(workspace)) == before

--- a/tests/core/test_prd_discovery_single_active_1042.py
+++ b/tests/core/test_prd_discovery_single_active_1042.py
@@ -302,3 +302,36 @@ class TestUniqueIndexIsEnforcedInTheDatabase:
         with pytest.raises(sqlite3.IntegrityError):
             conn.execute(insert, ("second", workspace.id))
         conn.close()
+
+
+class TestResumeIntoATakenSlot:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_resume_reports_the_conflict_rather_than_a_raw_sqlite_error(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """resume_discovery flips a session back to `discovering`.
+
+        If the workspace claimed its slot meanwhile, that write is refused —
+        the caller should learn why, not read "UNIQUE constraint failed".
+        """
+        from codeframe.core.prd_discovery import (
+            ActiveSessionExistsError,
+            PrdDiscoverySession,
+            SessionState,
+        )
+
+        mock_provider_class.return_value = _provider_returning()
+
+        abandoned = PrdDiscoverySession(workspace, api_key="test-key")
+        abandoned.start_discovery()
+        abandoned.state = SessionState.COMPLETED
+        abandoned._save_session()
+
+        holder = PrdDiscoverySession(workspace, api_key="test-key")
+        holder.start_discovery()
+
+        abandoned.state = SessionState.DISCOVERING
+        with pytest.raises(ActiveSessionExistsError):
+            abandoned._save_session()
+
+        assert _active_rows(workspace) == [holder.session_id]

--- a/tests/core/test_prd_discovery_single_active_1042.py
+++ b/tests/core/test_prd_discovery_single_active_1042.py
@@ -144,7 +144,13 @@ class TestMigrationToleratesExistingDuplicates:
         _ensure_discovery_schema(workspace)
         conn = get_db_connection(workspace)
         conn.execute(f"DROP INDEX IF EXISTS {ACTIVE_INDEX}")
-        for suffix, updated in (("old", "2020-01-01"), ("mid", "2021-01-01"), ("new", "2022-01-01")):
+        # created_at ordering is deliberately the REVERSE of updated_at ordering,
+        # so a backfill that kept the newest by the wrong column would fail here.
+        for suffix, created, updated in (
+            ("old", "2022-01-01", "2020-01-01"),
+            ("mid", "2021-01-01", "2021-01-01"),
+            ("new", "2020-01-01", "2022-01-01"),
+        ):
             conn.execute(
                 """
                 INSERT INTO discovery_sessions
@@ -152,7 +158,7 @@ class TestMigrationToleratesExistingDuplicates:
                      coverage, blocker_id, is_complete, created_at, updated_at)
                 VALUES (?, ?, 'discovering', '[]', 'q?', NULL, NULL, 0, ?, ?)
                 """,
-                (f"session-{suffix}", workspace.id, updated, updated),
+                (f"session-{suffix}", workspace.id, created, updated),
             )
         conn.commit()
         conn.close()
@@ -171,10 +177,10 @@ class TestMigrationToleratesExistingDuplicates:
         assert index is not None, "unique index must exist after reconciliation"
 
     @patch("codeframe.core.prd_discovery.AnthropicProvider")
-    def test_duplicates_in_other_workspaces_are_untouched(
+    def test_reconciliation_keeps_one_active_row_per_workspace(
         self, mock_provider_class, tmp_path: Path, workspace: Workspace
     ):
-        """Reconciliation is per workspace — it keeps one active row for each."""
+        """Reconciliation partitions by workspace rather than reducing to one row."""
         from codeframe.core.prd_discovery import _ensure_discovery_schema
 
         mock_provider_class.return_value = _provider_returning()
@@ -335,3 +341,184 @@ class TestResumeIntoATakenSlot:
             abandoned._save_session()
 
         assert _active_rows(workspace) == [holder.session_id]
+
+
+class TestSubmitAnswerHasTheSameWindow:
+    """`submit_answer` validates against state read before a multi-second LLM
+    call, so a `/reset` can land in between — exactly the `/start` window."""
+
+    def _session_with(self, workspace: Workspace, provider: MagicMock):
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        with patch(
+            "codeframe.core.prd_discovery.AnthropicProvider", return_value=_provider_returning()
+        ):
+            session = PrdDiscoverySession(workspace, api_key="test-key")
+            session.start_discovery()
+        session._llm_provider = provider
+        return session
+
+    def _answer_provider(self, workspace: Workspace, on_first_call) -> MagicMock:
+        """Adequate-answer validation, then a next question; hook the first call."""
+        provider = MagicMock()
+        replies = ['{"adequate": true, "reason": "ok"}', "What else?"]
+        calls = {"n": 0}
+
+        def complete(*_args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                on_first_call()
+            response = MagicMock()
+            response.content = replies[min(calls["n"] - 1, len(replies) - 1)]
+            response.input_tokens, response.output_tokens = 10, 5
+            return response
+
+        provider.complete.side_effect = complete
+        return provider
+
+    def test_reset_during_answer_is_not_undone(self, workspace: Workspace):
+        from codeframe.core.prd_discovery import (
+            SessionResetError,
+            get_active_session,
+            reset_discovery,
+        )
+
+        session = self._session_with(
+            workspace, self._answer_provider(workspace, lambda: reset_discovery(workspace))
+        )
+
+        with pytest.raises(SessionResetError):
+            session.submit_answer("A todo app for teams, offline-first.")
+
+        assert _active_rows(workspace) == []
+        assert get_active_session(workspace) is None
+
+    def test_a_competing_session_does_not_produce_a_raw_sql_error(
+        self, workspace: Workspace
+    ):
+        """The regression this guards: an unguarded UPDATE moves the reset row
+        back into the index's active set, and the route reports the SQL text."""
+        from codeframe.core.prd_discovery import (
+            PrdDiscoverySession,
+            SessionResetError,
+            reset_discovery,
+        )
+
+        def reset_then_start_a_new_one():
+            reset_discovery(workspace)
+            with patch(
+                "codeframe.core.prd_discovery.AnthropicProvider",
+                return_value=_provider_returning(),
+            ):
+                PrdDiscoverySession(workspace, api_key="test-key").start_discovery()
+
+        session = self._session_with(
+            workspace, self._answer_provider(workspace, reset_then_start_a_new_one)
+        )
+
+        with pytest.raises(SessionResetError):
+            session.submit_answer("A todo app for teams, offline-first.")
+
+        assert len(_active_rows(workspace)) == 1
+
+
+class TestPauseDoesNotOrphanABlocker:
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_a_refused_pause_creates_no_blocker(
+        self, mock_provider_class, workspace: Workspace
+    ):
+        """The state write must come first: a blocker created before a write
+        that gets refused is orphaned, and its resume hint never reaches anyone."""
+        from codeframe.core import blockers
+        from codeframe.core.prd_discovery import (
+            ActiveSessionExistsError,
+            PrdDiscoverySession,
+            reset_discovery,
+        )
+
+        mock_provider_class.return_value = _provider_returning()
+
+        stale = PrdDiscoverySession(workspace, api_key="test-key")
+        stale.start_discovery()
+
+        # The slot changes hands while `stale` is still held in memory.
+        reset_discovery(workspace, session_id=stale.session_id)
+        holder = PrdDiscoverySession(workspace, api_key="test-key")
+        holder.start_discovery()
+
+        before = len(blockers.list_all(workspace))
+        with pytest.raises(ActiveSessionExistsError):
+            stale.pause_discovery("user interrupted")
+
+        assert len(blockers.list_all(workspace)) == before, "orphaned blocker created"
+        assert _active_rows(workspace) == [holder.session_id]
+
+
+class TestMigrationSurvivesLegacyRows:
+    def _seed(self, workspace: Workspace, rows):
+        conn = get_db_connection(workspace)
+        conn.execute(f"DROP INDEX IF EXISTS {ACTIVE_INDEX}")
+        for session_id, is_complete, updated in rows:
+            conn.execute(
+                """
+                INSERT INTO discovery_sessions
+                    (id, workspace_id, state, qa_history, current_question,
+                     coverage, blocker_id, is_complete, created_at, updated_at)
+                VALUES (?, ?, 'discovering', '[]', 'q?', NULL, NULL, ?, ?, ?)
+                """,
+                (session_id, workspace.id, is_complete, updated, updated),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_a_null_is_complete_row_is_reconciled_not_skipped(self, workspace: Workspace):
+        """`is_complete = 0` is *unknown* for NULL, so a bare `= 0` predicate
+        leaves a legacy row outside both the backfill and the index."""
+        from codeframe.core.prd_discovery import _ensure_discovery_schema
+
+        _ensure_discovery_schema(workspace)
+        self._seed(workspace, [("legacy", None, "2020-01-01"), ("live", 0, "2022-01-01")])
+
+        _ensure_discovery_schema(workspace)
+
+        conn = get_db_connection(workspace)
+        active = conn.execute(
+            "SELECT id FROM discovery_sessions "
+            "WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0"
+        ).fetchall()
+        conn.close()
+        assert [row[0] for row in active] == ["live"]
+
+    def test_a_null_id_row_does_not_brick_discovery(
+        self, workspace: Workspace, monkeypatch: pytest.MonkeyPatch
+    ):
+        """SQLite permits NULL in a TEXT PRIMARY KEY, and one NULL makes
+        `id NOT IN (...)` NULL for every row — the backfill would no-op and the
+        index build would then fail on every discovery call, forever."""
+        from codeframe.core.prd_discovery import _ensure_discovery_schema, get_active_session
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # get_active_session (#917)
+
+        _ensure_discovery_schema(workspace)
+        conn = get_db_connection(workspace)
+        conn.execute(f"DROP INDEX IF EXISTS {ACTIVE_INDEX}")
+        conn.execute(
+            "INSERT INTO discovery_sessions (id, workspace_id, state, qa_history,"
+            " current_question, coverage, blocker_id, is_complete, created_at, updated_at)"
+            " VALUES (NULL, ?, 'discovering', '[]', 'q?', NULL, NULL, 0,"
+            " '2020-01-01', '2020-01-01')",
+            (workspace.id,),
+        )
+        conn.commit()
+        conn.close()
+        self._seed(workspace, [("live", 0, "2022-01-01")])
+
+        _ensure_discovery_schema(workspace)  # must not raise
+
+        conn = get_db_connection(workspace)
+        index = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?", (ACTIVE_INDEX,)
+        ).fetchone()
+        conn.close()
+        assert index is not None, "index must still build over a NULL-id row"
+        assert get_active_session(workspace) is not None, "discovery must still work"

--- a/tests/core/test_prd_discovery_template_defects_961.py
+++ b/tests/core/test_prd_discovery_template_defects_961.py
@@ -318,11 +318,23 @@ class TestResetDiscoveryScope:
         try:
             for i in range(count):
                 sid = f"session-{i}"
+                # Only the newest row may be *active*: #1042 added a partial
+                # UNIQUE index on (workspace_id) WHERE state != 'completed' AND
+                # is_complete = 0. The older rows are finished-Q&A sessions
+                # awaiting PRD generation — still `discovering`, still in
+                # reset_discovery's `state != 'completed'` scope, which is the
+                # over-broad reset this test guards against.
                 conn.execute(
                     "INSERT INTO discovery_sessions "
-                    "(id, workspace_id, state, qa_history, created_at, updated_at) "
-                    "VALUES (?, ?, 'discovering', '[]', ?, ?)",
-                    (sid, ws.id, f"2026-01-0{i + 1}T00:00:00", f"2026-01-0{i + 1}T00:00:00"),
+                    "(id, workspace_id, state, qa_history, is_complete, created_at, updated_at) "
+                    "VALUES (?, ?, 'discovering', '[]', ?, ?, ?)",
+                    (
+                        sid,
+                        ws.id,
+                        0 if i == count - 1 else 1,
+                        f"2026-01-0{i + 1}T00:00:00",
+                        f"2026-01-0{i + 1}T00:00:00",
+                    ),
                 )
                 ids.append(sid)
             conn.commit()

--- a/tests/ui/test_discovery_start_errors.py
+++ b/tests/ui/test_discovery_start_errors.py
@@ -68,3 +68,46 @@ class TestStartDiscoveryConflict:
 
         assert response.status_code == 500
         assert "db is on fire" in response.json()["detail"]
+
+
+class TestStartDiscoveryLosesTheRace:
+    """The pre-check is a fast path; the database decides the winner (#1042)."""
+
+    def test_losing_claim_returns_the_same_structured_400(self, test_client):
+        from codeframe.core.prd_discovery import ActiveSessionExistsError
+
+        winner = MagicMock()
+        winner.is_complete.return_value = False
+        winner.session_id = "sess-winner"
+        winner.answered_count = 0
+
+        # First call is the pre-check (nothing active yet — both requests got
+        # here); the second is the post-conflict lookup that names the winner.
+        with patch(
+            "codeframe.core.prd_discovery.get_active_session",
+            side_effect=[None, winner],
+        ), patch(
+            "codeframe.core.prd_discovery.start_discovery_session",
+            side_effect=ActiveSessionExistsError("already active"),
+        ):
+            response = test_client.post("/api/v2/discovery/start")
+
+        assert response.status_code == 400, response.text
+        detail = response.json()["detail"]
+        assert isinstance(detail, dict), f"detail was stringified: {detail!r}"
+        assert detail["error"] == "Discovery session already active"
+        assert detail["session_id"] == "sess-winner"
+
+    def test_reset_during_start_returns_409(self, test_client):
+        from codeframe.core.prd_discovery import SessionResetError
+
+        with patch(
+            "codeframe.core.prd_discovery.get_active_session", return_value=None
+        ), patch(
+            "codeframe.core.prd_discovery.start_discovery_session",
+            side_effect=SessionResetError("session was reset"),
+        ):
+            response = test_client.post("/api/v2/discovery/start")
+
+        assert response.status_code == 409, response.text
+        assert "reset" in response.json()["detail"]


### PR DESCRIPTION
Closes #1042

## Problem

`POST /api/v2/discovery/start` enforced "one active discovery session per
workspace" with a read-then-write:

```python
existing = get_active_session(workspace)      # read
if existing and not existing.is_complete(): 400
session = start_discovery_session(workspace)  # write
```

Nothing made that atomic, and `discovery_sessions` had no uniqueness
constraint. Two concurrent starts could both pass the check and each INSERT a
`discovering` row; `get_active_session` takes the latest by `updated_at`, so
the loser became an orphan nothing ever surfaced. #928 removed the *long*
(multi-minute) version of this window by moving the claim ahead of the opening
LLM call; what remained was the original millisecond one.

Same root cause, second symptom: `_save_session` used `INSERT OR REPLACE`, so
a `POST /reset` that landed during the opening-question call was undone by the
save that followed — the row flipped straight back to `discovering`.

## Approach

**The claim moves into the database.** `_ensure_discovery_schema` builds a
partial unique index:

```sql
CREATE UNIQUE INDEX idx_discovery_sessions_one_active
ON discovery_sessions(workspace_id)
WHERE state != 'completed' AND is_complete = 0
```

The predicate deliberately mirrors the route's own notion of "active"
(`not existing.is_complete()`), so a session whose Q&A is finished but whose
PRD has not been generated still allows a new start — as it always has.

**The migration reconciles first.** A pre-#1042 workspace can already hold
several non-completed rows, and `CREATE UNIQUE INDEX` refuses to build over
them. The backfill completes all but the newest row per workspace, and runs
only while the index is absent, so it is a one-time cost rather than a query
on every schema check.

**`start_discovery` claims with a plain INSERT** (`_claim_session`) and
translates the UNIQUE violation into `ActiveSessionExistsError`. The route maps
it to the *same* structured 400 its pre-check produces — the pre-check is now a
fast path, not the guarantee, and a client cannot tell which path rejected it.

**`_save_session` is UPDATE-only.** The row is created once, by the claim.
`INSERT OR REPLACE` was not just resurrecting reset rows; once the unique index
exists it would have *deleted* a competing active row to make space. The
post-LLM save in `start_discovery` additionally requires the row to still be
non-completed, so a `/reset` that landed mid-call stands: the claim is rolled
back and `SessionResetError` surfaces as a 409.

**`submit_answer` had the identical window.** Both of its saves land after a
multi-second LLM call, on state read before it, so `/reset` during `/answer`
was undone there too. They go through the same guard now, and the route answers
409 like `/start`.

**`cf prd generate`** declining to resume an incomplete session now resets it
first — abandoning it is exactly what that answer means, and the claim would
otherwise be refused. A session whose Q&A is finished is left alone: it never
held the slot, and its PRD can still be generated.

## Acceptance criteria

| Criterion | Evidence |
|---|---|
| Concurrent `/start` yields exactly one active session (second gets 400) | Two callers barriered inside the read-then-write gap: `main` leaves **2** active rows, this branch leaves **1** and the loser raises `ActiveSessionExistsError`. Over real HTTP, 4 simultaneous POSTs → 1×200 + 3×400 carrying the winner's `session_id`, one DB row |
| Migration tolerates workspaces that already have multiple non-completed rows | Seeded 3 `discovering` rows with the index dropped; after `_ensure_discovery_schema`, 2 orphans → `completed`, newest kept, index present, `get_active_session` returns the live one |
| `/reset` during an in-flight start is not undone by the post-LLM save | `main`: row flips back to `discovering`. This branch: row stays `completed`, claim deleted, `SessionResetError` → 409 |
| ...and the same holds for `/reset` during `/answer` | `main`: row flips back to `discovering`. This branch: stays `completed`, `SessionResetError` → 409 |

Every criterion was demoed against `main` and against the branch, so the
evidence is a behaviour change rather than a passing run.

## Tests

`tests/core/test_prd_discovery_single_active_1042.py` (14) — the barriered
concurrent start, the serial second start, the finished-Q&A session that must
still allow a start, the migration backfill (single- and multi-workspace), the
reset race and recovery from it, the constraint enforced at the SQLite level,
the resume-into-a-taken-slot path, the `submit_answer` reset race and its
competing-session variant, the orphaned-blocker pause, and both NULL migration
holes. `tests/ui/test_discovery_start_errors.py` gains the two router mappings
(race → structured 400, reset → 409), and
`tests/cli/test_prd_generate_active_slot_1042.py` covers the CLI branch.

`tests/core/test_prd_discovery_template_defects_961.py` needed its *fixture*
adjusted: it seeded three simultaneously-active rows, which the new constraint
makes impossible. The older rows are now finished-Q&A sessions — still
`discovering`, still inside `reset_discovery`'s `state != 'completed'` scope,
which is the over-broad reset that test guards. Its assertions are unchanged.

## Known limitations

- **`resume_discovery` into a taken slot fails rather than evicting.** It now
  reports `ActiveSessionExistsError` instead of raw SQL, but whether resuming a
  paused session should evict the current slot holder is a product decision this
  PR does not make. Filed as a follow-up rather than guessed.
- The unique index's predicate is duplicated in three places (the index, the
  backfill, and `get_active_session`'s looser `state != 'completed'`). They
  agree today; nothing enforces that they keep agreeing.
- `reset_discovery`'s scope stays `state != 'completed'`, which is broader than
  the index predicate. That is deliberate — it must still be able to close a
  finished-Q&A session — but it means "active" has two definitions in this
  module.
- Reconciled rows get a fresh `updated_at`, matching `reset_discovery`'s
  behaviour, so the original timestamp of an orphaned session is not preserved.

## Review

`codex review --base main` on the first revision: no findings. An independent
internal reviewer then found that the constraint was only half-applied — the
`submit_answer` window, an orphaned blocker on a refused pause, and two NULL
holes in the migration (one of which could brick discovery for a workspace
permanently). All fixed in `f7b9cdc6`, each with a test that fails on revert;
full triage in the PR comments.