### PR TITLE
ci: guard the two silent-failure modes in reusable-workflow calls

### DIFF
--- a/.github/workflows/check-workflow-calls.yml
+++ b/.github/workflows/check-workflow-calls.yml
@@ -1,0 +1,48 @@
+name: Check workflow calls
+
+# Guards the two ways a reusable-workflow call can be misconfigured so that it
+# never runs and never says so (frankbria/glm-review#9):
+#
+#   1. A calling job granting LESS than the called workflow declares. GitHub
+#      refuses the run before any job exists, so it is a `startup_failure` with
+#      no log and no annotation naming the missing scope. Listing a
+#      `permissions:` block sets every scope you did NOT list to `none`, so the
+#      denial never appears in the caller's own text.
+#
+#   2. A caller `concurrency:` group that can expand to the same string as the
+#      callee's. The callee joins that group while its parent still holds it and
+#      cancels the parent on queue — a sibling repo had a run end in 2 seconds
+#      having started no jobs at all. Those groups were not identical text; they
+#      merely expanded the same, so the checker compares possible expansions.
+#
+# This repo's caller is correct today — the guard is preventive. It cannot live
+# inside review.yml: in both failures that workflow never starts, so a guard
+# inside it would never run either.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  # Also on direct pushes to main: a workflow edit landing there is otherwise
+  # never checked, and no later PR re-checks it unless that PR happens to touch
+  # .github/workflows/**. Reports after the fact rather than blocking, which is
+  # still the difference between silence and a red mark.
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  # Neither trigger fires when the *upstream callee* changes its declared
+  # permissions, since no push or PR here touches that.
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: frankbria/glm-review/.github/workflows/check-workflow-calls.yml@21fea324f518b964919709eebbbb9f5b3acde489 # main @ 2026-09-08
+    with:
+      # Same commit as the workflow above: the reusable workflow and the checker
+      # script it runs live in one repo, and leaving the script on main while the
+      # workflow is pinned reintroduces the pin-vs-content drift this guard
+      # exists to catch.
+      guard_ref: 21fea324f518b964919709eebbbb9f5b3acde489
+    permissions:
+      contents: read


### PR DESCRIPTION
Installs [frankbria/glm-review](https://github.com/frankbria/glm-review)'s workflow-call guard. **This repo's caller is correct today** — the guard is preventive, not a fix.

## What it guards

Two ways a reusable-workflow call can be misconfigured so that it never runs and never says so. Together they left sibling repo `narrative-modeling-app` with **266 consecutive runs producing no review at all**, over two months, while looking configured the whole time ([glm-review#9](https://github.com/frankbria/glm-review/issues/9)).

**1. A calling job granting less than the callee declares.** GitHub refuses the run *before any job exists*, so it's a `startup_failure` with no log and no annotation naming the missing scope. It stays invisible because **listing a `permissions:` block sets every scope you did not list to `none`** — the denial never appears in the text that causes it.

**2. A caller `concurrency:` group that can expand to the callee's.** The callee joins that group while its parent still holds it and cancels the parent on queue — one run there ended in 2 seconds having started no jobs. The colliding groups were not identical text; they merely expanded the same, because `||` yields its first truthy operand. The checker compares possible expansions, not strings.

## Configuration notes specific to this repo

- **SHA-pinned, matching your existing `glm-review.yml`.** That file pins `review.yml@77dfa9c…`, so the guard is pinned too rather than tracking `@main`.
- **`guard_ref` is pinned to the same commit as the workflow.** The reusable workflow and the checker script it runs live in one repo; leaving the script on `main` while the workflow is pinned would reintroduce the pin-vs-content drift this guard exists to catch.
- **Runs on `pull_request`, on `push` to `main`, and on demand.** The push trigger closes a self-sustaining gap: a workflow edit landing directly on `main` is otherwise never checked, and no later PR re-checks it unless that PR happens to touch `.github/workflows/**`.

## Verification

Ran the checker against this repo's actual workflows, resolving every callee at its pinned ref over the network:

```
OK: 11 file(s) checked — every reusable-workflow call grants the scopes its
callee declares, and no concurrency group can collide with its callee's.
```

That `OK` is non-vacuous: the checker refuses to print it when any call went unverified and reports the count instead. The count includes the guard's own call, so it is self-verifying.

## Context

Your `glm-review.yml` was already re-pinned to `77dfa9c` earlier, which resolved the 20-minute job-timeout failures this repo saw previously — that was a different problem from the two above, and it is already fixed. Nothing here changes your reviewer's behaviour.

The same guard is now installed in `narrative-modeling-app` (#592) and `auto-author` (#614), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdSq9dMfiLL12RHcmcPER7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdSq9dMfiLL12RHcmcPER7)_