### PR TITLE
fix(cli): guard Rich markup by running the commands, not scanning for field names (#1054)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,16 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   and an unconditional write resurrects the session the user just abandoned.
   `submit_answer` and `pause_discovery` learned this the hard way.
 - Don't skip web UI testing when verifying features that have a web surface
+- **Don't render user text through Rich without escaping it**, and don't write
+  a new `except Exception as e: console.print(f"...{e}")` — use
+  `codeframe.cli.helpers.print_error`, which escapes once (#1054). An exception
+  message quotes user input, so rendering it raw made the handler itself raise
+  `MarkupError` and turned a caught error into an uncaught crash. The guard is
+  `tests/cli/test_rich_hostile_data_1054.py`: it seeds hostile markup into every
+  user-supplied field and *runs the commands*, because the field-name scanner it
+  replaced was too narrow four times in one review cycle — a local bound one
+  statement earlier carries no field name at all. Every registered command must
+  appear in its `RUN` or `EXEMPT` table; a new command fails CI until classified.
 - **Don't leave a CI gate disabled when its feature area becomes active.** Re-enable `DISABLED:` / `# COMMENTED OUT:` jobs before the first PR in that area. Verify `frontend-tests` is wired into `test-summary`.
 - **A CI run that fails with ZERO jobs and no logs means the workflow file will not compile** (#1122). `gh run view --log-failed` returns `log not found`, the jobs API is empty, and the run ignores its own trigger filters — so it looks like an unrelated trigger bug rather than an outage. YAML validity is not enough: `yaml.safe_load()` parses these files fine; it is GitHub's expression pass that rejects them. Run `actionlint .github/workflows/*.yml` first — the `workflow-lint` job in `test.yml` now enforces this on every PR, but it is the first thing to run locally when a workflow misbehaves. This shipped twice undetected: `deploy.yml` (staging down for a week, an empty `${{ }}` inside a `run:` block) and `claude-review` (#1011).
 

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -26,6 +26,7 @@ from rich.console import Console
 from rich.markup import escape
 
 # Import auth subapp for credential management
+from codeframe.cli.helpers import print_error
 from codeframe.cli.auth_commands import auth_app
 from codeframe.cli.pr_commands import pr_app
 from codeframe.cli.env_commands import env_app
@@ -462,7 +463,7 @@ def init(
         console.print("  cf status                    View workspace status")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -772,7 +773,7 @@ def status(
         console.print("Run 'codeframe init <path>' to initialize.")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1105,7 +1106,7 @@ def prd_templates_export(
         manager.export_template(template_id, output_path)
         console.print(f"[green]✓[/green] Exported template '{template_id}' to {output_path}")
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         console.print("\nAvailable templates:")
         for t in manager.list_templates():
             console.print(f"  {t.id}")
@@ -1142,7 +1143,7 @@ def prd_templates_import(
         console.print(f"[dim]Sections: {len(template.sections)}[/dim]")
         console.print(f"[dim]Saved to: .codeframe/templates/prd/{template.id}.yaml[/dim]")
     except Exception as e:
-        console.print(f"[red]Error:[/red] Failed to import template: {e}")
+        print_error(e, prefix="Error: Failed to import template:")
         raise typer.Exit(1)
 
 
@@ -1200,10 +1201,10 @@ def prd_add(
         console.print("Next: codeframe tasks generate")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1239,7 +1240,7 @@ def prd_show(
         if prd_id:
             record = prd.get_by_id(workspace, prd_id)
             if not record:
-                console.print(f"[red]Error:[/red] PRD not found: {prd_id}")
+                console.print(f"[red]Error:[/red] PRD not found: {escape(prd_id)}")
                 raise typer.Exit(1)
         else:
             record = prd.get_latest(workspace)
@@ -1255,21 +1256,21 @@ def prd_show(
 
         if full:
             console.print("\n" + "-" * 40 + "\n")
-            console.print(record.content)
+            console.print(escape(record.content))
         else:
             # Show first 500 chars as preview
-            preview = record.content[:500]
+            preview = escape(record.content[:500])
             if len(record.content) > 500:
                 preview += "\n\n[dim]... (use --full to see complete PRD)[/dim]"
             console.print("\n" + preview)
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1308,10 +1309,10 @@ def prd_list(
             console.print()
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1350,7 +1351,7 @@ def prd_delete(
         # Get the PRD first to show title
         record = prd.get_by_id(workspace, prd_id)
         if not record:
-            console.print(f"[red]Error:[/red] PRD not found: {prd_id}")
+            console.print(f"[red]Error:[/red] PRD not found: {escape(prd_id)}")
             raise typer.Exit(1)
 
         # Confirm unless --force
@@ -1363,7 +1364,7 @@ def prd_delete(
         # Delete
         deleted = prd.delete(workspace, prd_id)
         if not deleted:
-            console.print(f"[red]Error:[/red] PRD not found: {prd_id}")
+            console.print(f"[red]Error:[/red] PRD not found: {escape(prd_id)}")
             raise typer.Exit(1)
 
         # Emit event
@@ -1377,12 +1378,12 @@ def prd_delete(
         console.print(f"[green]PRD deleted:[/green] {escape(record.title)}")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1444,18 +1445,18 @@ def prd_export(
         success = prd.export_to_file(workspace, actual_id, file_path, force=force)
 
         if not success:
-            console.print(f"[red]Error:[/red] PRD not found: {prd_id}")
+            console.print(f"[red]Error:[/red] PRD not found: {escape(prd_id)}")
             raise typer.Exit(1)
 
         console.print(f"[green]PRD exported:[/green] {file_path}")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1486,7 +1487,7 @@ def prd_versions(
         versions = prd.get_versions(workspace, prd_id)
 
         if not versions:
-            console.print(f"[red]Error:[/red] PRD not found: {prd_id}")
+            console.print(f"[red]Error:[/red] PRD not found: {escape(prd_id)}")
             raise typer.Exit(1)
 
         console.print(f"\n[bold]Version History ({len(versions)} versions):[/bold]\n")
@@ -1501,12 +1502,12 @@ def prd_versions(
             console.print()
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1565,12 +1566,12 @@ def prd_diff(
                 console.print(line)
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1615,7 +1616,7 @@ def prd_update(
         # Check if PRD exists
         existing = prd.get_by_id(workspace, prd_id)
         if not existing:
-            console.print(f"[red]Error:[/red] PRD not found: {prd_id}")
+            console.print(f"[red]Error:[/red] PRD not found: {escape(prd_id)}")
             raise typer.Exit(1)
 
         # Load new content
@@ -1646,12 +1647,12 @@ def prd_update(
         console.print(f"  Changes: {message}")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -1790,7 +1791,7 @@ def prd_generate(
                 session = PrdDiscoverySession(workspace)
                 session.resume_discovery(resume)
             except (ValueError, NoApiKeyError) as e:
-                console.print(f"[red]Error:[/red] {e}")
+                print_error(e)
                 raise typer.Exit(1)
             console.print(f"[green]✓[/green] Loaded {session.answered_count} previous answers")
         else:
@@ -1819,7 +1820,7 @@ def prd_generate(
                     session = PrdDiscoverySession(workspace)
                     session.start_discovery()
             except NoApiKeyError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                print_error(e)
                 # The NoApiKeyError text already names the resolved provider's
                 # key; a hardcoded ANTHROPIC_API_KEY hint contradicts it (#917).
                 console.print("\n[dim]Set the API key named above to use AI discovery.[/dim]")
@@ -1945,7 +1946,7 @@ def prd_generate(
                     # (#961). Re-prompting cannot help, so leave the loop
                     # rather than spinning — and never show a traceback. Must
                     # follow ValidationError, which subclasses this.
-                    console.print(f"[red]Error:[/red] {e}")
+                    print_error(e)
                     raise typer.Exit(1)
                 except KeyboardInterrupt:
                     console.print("\n")
@@ -1962,7 +1963,7 @@ def prd_generate(
         try:
             prd_record = session.generate_prd(template_id=template)
         except IncompleteSessionError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            print_error(e)
             raise typer.Exit(1)
 
         # Emit event
@@ -1996,12 +1997,12 @@ def prd_generate(
         console.print("[red]Error:[/red] No workspace found. Run 'codeframe init' first.")
         raise typer.Exit(1)
     except NoApiKeyError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -2084,7 +2085,7 @@ def prd_stress_test(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     # Load PRD
@@ -2113,7 +2114,7 @@ def prd_stress_test(
     except StressTestError as e:
         # extract_goals now raises rather than returning [] (#927). Without this
         # the CLI shows a traceback where every other failure here is a red line.
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
         # A provider failure (auth, network, rate limit) is not a StressTestError
@@ -2201,7 +2202,7 @@ def prd_stress_test(
             try:
                 result = stress_test_prd(new_record.content, provider, max_depth=max_depth)
             except StressTestError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                print_error(e)
                 raise typer.Exit(1)
         else:
             console.print("[yellow]Warning:[/yellow] Failed to create new PRD version.")
@@ -2409,12 +2410,12 @@ def tasks_generate(
         console.print("  codeframe tasks set status READY --all  Mark all tasks ready")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except tasks.TaskGenerationError as e:
         # The core message is surface-neutral because the web UI toasts it too
         # (#1115 review); the CLI-specific remedy belongs here.
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         console.print(
             "  Retry with [bold]cf tasks generate[/bold], or "
             "[bold]cf tasks generate --no-llm[/bold] to extract bullets directly."
@@ -2426,7 +2427,7 @@ def tasks_generate(
         # its exit code as a second message: "Error: 1" (#1113).
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -2452,10 +2453,10 @@ def tasks_tree(
         else:
             typer.echo("No tasks found.")
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -2539,13 +2540,13 @@ def tasks_list(
         console.print(f"\n[dim]Total: {len(task_list)} | {' | '.join(count_parts)}[/dim]")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -2666,7 +2667,7 @@ def tasks_set(
         workspace = get_workspace(workspace_path)
 
         if attribute.lower() != "status":
-            console.print(f"[red]Error:[/red] Unknown attribute '{attribute}'")
+            console.print(f"[red]Error:[/red] Unknown attribute '{escape(attribute)}'")
             console.print("Supported attributes: status")
             raise typer.Exit(1)
 
@@ -2691,7 +2692,10 @@ def tasks_set(
                 console.print("Or use --all to update all tasks.")
                 raise typer.Exit(1)
             if not value:
-                console.print(f"[red]Error:[/red] Missing value. Usage: tasks set status {task_id} READY")
+                console.print(
+                    "[red]Error:[/red] Missing value. Usage: "
+                    f"tasks set status {escape(task_id)} READY"
+                )
                 raise typer.Exit(1)
             actual_value = value
             actual_task_id = task_id
@@ -2718,10 +2722,14 @@ def tasks_set(
             # Single task mode
             matching = tasks.find_by_prefix(workspace, actual_task_id)
             if not matching:
-                console.print(f"[red]Error:[/red] No task found matching '{actual_task_id}'")
+                console.print(
+                    f"[red]Error:[/red] No task found matching '{escape(actual_task_id)}'"
+                )
                 raise typer.Exit(1)
             if len(matching) > 1:
-                console.print(f"[red]Error:[/red] Multiple tasks match '{actual_task_id}':")
+                console.print(
+                    f"[red]Error:[/red] Multiple tasks match '{escape(actual_task_id)}':"
+                )
                 for t in matching:
                     console.print(f"  {t.id}: {escape(t.title[:40])}")
                 console.print("Please provide a more specific ID.")
@@ -2787,13 +2795,13 @@ def tasks_set(
     except typer.Exit:
         raise  # Re-raise typer.Exit to preserve exit code
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -2855,11 +2863,11 @@ def tasks_delete(
             matching = tasks.find_by_prefix(workspace, task_id)
 
             if not matching:
-                console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+                console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
                 raise typer.Exit(1)
 
             if len(matching) > 1:
-                console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+                console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
                 for t in matching:
                     console.print(f"  {t.id}: {escape(t.title[:40])}")
                 console.print("Please provide a more specific ID.")
@@ -2898,10 +2906,10 @@ def tasks_delete(
     except typer.Exit:
         raise
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3023,11 +3031,11 @@ def work_start(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3114,7 +3122,7 @@ def work_start(
                     raise typer.Exit(1)
 
             except ValueError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                print_error(e)
                 raise typer.Exit(1)
 
         elif stub:
@@ -3129,10 +3137,10 @@ def work_start(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except InvalidTransitionError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3175,11 +3183,11 @@ def work_resume(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3247,7 +3255,7 @@ def work_resume(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3280,11 +3288,11 @@ def work_stop(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3303,7 +3311,7 @@ def work_stop(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3394,7 +3402,7 @@ def work_show(
 
         run = runtime.get_latest_run(workspace, task_id)
         if not run:
-            console.print(f"[dim]No run found for task {task_id}[/dim]")
+            console.print(f"[dim]No run found for task {escape(task_id)}[/dim]")
             raise typer.Exit(0)
 
         console.print(f"\n[bold]Run Details[/bold] — {task_id[:8]}")
@@ -3488,11 +3496,11 @@ def work_diagnose(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3529,7 +3537,7 @@ def work_diagnose(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3636,11 +3644,11 @@ def work_retry(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3707,10 +3715,10 @@ def work_retry(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except InvalidTransitionError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3745,11 +3753,11 @@ def work_update_description(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3774,7 +3782,7 @@ def work_update_description(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -3828,11 +3836,11 @@ def work_follow(
         matching = tasks_module.find_by_prefix(workspace, task_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No task found matching '{task_id}'")
+            console.print(f"[red]Error:[/red] No task found matching '{escape(task_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple tasks match '{task_id}':")
+            console.print(f"[red]Error:[/red] Multiple tasks match '{escape(task_id)}':")
             for t in matching[:5]:
                 console.print(f"  {t.id[:8]} - {escape(t.title)}")
             raise typer.Exit(1)
@@ -3951,7 +3959,7 @@ def work_follow(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -4290,7 +4298,7 @@ def work_rerun(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -4585,7 +4593,7 @@ def batch_run(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -4798,7 +4806,7 @@ def batch_stop(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -4903,7 +4911,7 @@ def batch_resume(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -5299,7 +5307,9 @@ def blocker_list(
                 status_str = "[green]RESOLVED[/green]"
 
             task_str = b.task_id[:8] if b.task_id else "-"
-            question_str = b.question[:50] + "..." if len(b.question) > 50 else b.question
+            question_str = escape(
+                b.question[:50] + "..." if len(b.question) > 50 else b.question
+            )
 
             table.add_row(b.id[:8], status_str, task_str, question_str)
 
@@ -5336,7 +5346,7 @@ def blocker_show(
         blocker = blockers.get(workspace, blocker_id)
 
         if not blocker:
-            console.print(f"[red]Error:[/red] Blocker not found: {blocker_id}")
+            console.print(f"[red]Error:[/red] Blocker not found: {escape(blocker_id)}")
             raise typer.Exit(1)
 
         # Status color
@@ -5365,7 +5375,7 @@ def blocker_show(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -5446,7 +5456,7 @@ def blocker_answer(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -5484,7 +5494,7 @@ def blocker_resolve(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -5548,7 +5558,7 @@ def patch_export(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -5704,7 +5714,7 @@ def commit_create(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -5800,7 +5810,7 @@ def checkpoint_list(
 
             table.add_row(
                 cp.id[:8],
-                cp.name,
+                escape(cp.name),
                 str(summary.get("total_tasks", 0)),
                 git_ref,
                 cp.created_at.strftime("%Y-%m-%d %H:%M"),
@@ -5853,7 +5863,8 @@ def checkpoint_show(
             console.print(f"  Git ref: {git_ref}")
 
         if checkpoint.snapshot.get("prd"):
-            console.print(f"  PRD: {checkpoint.snapshot['prd'].get('title', 'Unknown')}")
+            prd_title = checkpoint.snapshot["prd"].get("title", "Unknown")
+            console.print(f"  PRD: {escape(str(prd_title))}")
 
         console.print("\n[bold]Task Summary:[/bold]")
         for status, count in tasks_by_status.items():
@@ -5904,7 +5915,7 @@ def checkpoint_restore(
         console.print(f"[red]Error:[/red] No workspace found at {path}")
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -6061,7 +6072,7 @@ def schedule_show(
         console.print("[bold]Task Assignments:[/bold]")
         for task_id, assignment in sorted(schedule.task_assignments.items(), key=lambda x: x[1].start_time):
             task = task_lookup.get(task_id)
-            title = task.title if task else f"Task {task_id}"
+            title = escape(task.title) if task else f"Task {escape(task_id)}"
             agent_str = f"Agent {assignment.assigned_agent}" if assignment.assigned_agent is not None else ""
             console.print(
                 f"  [{assignment.start_time:5.1f}h - {assignment.end_time:5.1f}h] "
@@ -6071,7 +6082,7 @@ def schedule_show(
         console.print()
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         # A deliberate exit is not an error. typer.Exit subclasses
@@ -6079,7 +6090,7 @@ def schedule_show(
         # its exit code as a second message: "Error: 1" (#1113).
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -6169,7 +6180,7 @@ def schedule_predict(
         console.print()
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         # A deliberate exit is not an error. typer.Exit subclasses
@@ -6177,7 +6188,7 @@ def schedule_predict(
         # its exit code as a second message: "Error: 1" (#1113).
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -6251,7 +6262,7 @@ def schedule_bottlenecks(
                 console.print()
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         # A deliberate exit is not an error. typer.Exit subclasses
@@ -6259,7 +6270,7 @@ def schedule_bottlenecks(
         # its exit code as a second message: "Error: 1" (#1113).
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -6412,10 +6423,10 @@ def templates_apply(
         console.print("  codeframe tasks set status READY --all  Mark all tasks ready")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except typer.Exit:
         # A deliberate exit is not an error. typer.Exit subclasses
@@ -6423,7 +6434,7 @@ def templates_apply(
         # its exit code as a second message: "Error: 1" (#1113).
         raise
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -6493,7 +6504,7 @@ def main() -> None:
     except UntrustedBaseURLError as e:
         # A deliberate refusal, not a crash: show the operator what was
         # blocked and how to proceed, without a traceback (#903).
-        console.print(f"\n[red]Refusing to run:[/red] {e}\n")
+        print_error(e, prefix="Refusing to run:")
         # sys.exit, not typer.Exit: main() *is* the console-script entry point,
         # so there is no Click standalone loop above it to turn Exit into a
         # clean status — it would surface as a traceback under the message.

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -6504,7 +6504,8 @@ def main() -> None:
     except UntrustedBaseURLError as e:
         # A deliberate refusal, not a crash: show the operator what was
         # blocked and how to proceed, without a traceback (#903).
-        print_error(e, prefix="Refusing to run:")
+        # the blank lines set this refusal apart from surrounding output
+        print_error(e, prefix="\nRefusing to run:", suffix="\n")
         # sys.exit, not typer.Exit: main() *is* the console-script entry point,
         # so there is no Click standalone loop above it to turn Exit into a
         # clean status — it would surface as a traceback under the message.

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1143,7 +1143,7 @@ def prd_templates_import(
         console.print(f"[dim]Sections: {len(template.sections)}[/dim]")
         console.print(f"[dim]Saved to: .codeframe/templates/prd/{template.id}.yaml[/dim]")
     except Exception as e:
-        print_error(e, prefix="Error: Failed to import template:")
+        print_error(f"Failed to import template: {e}")
         raise typer.Exit(1)
 
 

--- a/codeframe/cli/auth_commands.py
+++ b/codeframe/cli/auth_commands.py
@@ -50,7 +50,7 @@ from codeframe.cli.api_client import (
     get_api_base_url,
     is_insecure_transport,
 )
-from codeframe.cli.helpers import console
+from codeframe.cli.helpers import console, print_error
 from codeframe.core.credentials import (
     CredentialManager,
     CredentialProvider,
@@ -528,7 +528,7 @@ def whoami():
         raise typer.Exit(1)
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
 
@@ -680,7 +680,7 @@ def setup_credential(
     try:
         manager.set_credential(provider_enum, value)
     except CredentialStoreUnreadableError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     console.print(f"[green]Successfully stored credential for {provider_enum.display_name}[/green]")
 
@@ -861,7 +861,7 @@ def rotate_credential(
     try:
         manager.rotate_credential(provider_enum, value)
     except CredentialStoreUnreadableError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     console.print(f"[green]Successfully rotated credential for {provider_enum.display_name}[/green]")
 
@@ -983,7 +983,7 @@ def api_key_create(
         console.print("[yellow]Save this key securely - it will not be shown again.[/yellow]\n")
 
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
     except Exception as e:
         logger.debug(f"API key creation error: {e}")
@@ -1188,7 +1188,7 @@ def set_password(
     try:
         _set_user_password(get_db_for_cli(), email, password)
     except LookupError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     console.print(f"[green]✓ Password updated for {email}[/green]")
@@ -1210,7 +1210,7 @@ def deactivate_user(
     try:
         _set_user_active(get_db_for_cli(), email, False)
     except LookupError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     console.print(f"[green]✓ {email} deactivated; its API keys no longer authenticate[/green]")
@@ -1229,7 +1229,7 @@ def activate_user(
     try:
         _set_user_active(get_db_for_cli(), email, True)
     except LookupError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     console.print(f"[green]✓ {email} activated[/green]")

--- a/codeframe/cli/dashboard_commands.py
+++ b/codeframe/cli/dashboard_commands.py
@@ -9,6 +9,8 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from codeframe.cli.helpers import print_error
+
 console = Console()
 
 dashboard_app = typer.Typer(
@@ -56,7 +58,7 @@ def dashboard(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         console.print("[dim]Run 'codeframe init' to create a workspace first.[/dim]")
         raise typer.Exit(1)
 

--- a/codeframe/cli/engines_commands.py
+++ b/codeframe/cli/engines_commands.py
@@ -16,6 +16,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from codeframe.cli.helpers import print_error
 from codeframe.core import engine_stats
 from codeframe.core.workspace import get_workspace
 
@@ -104,7 +105,7 @@ def engines_check(
     try:
         reqs = check_requirements(name, _config_root())
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     if not reqs:

--- a/codeframe/cli/helpers.py
+++ b/codeframe/cli/helpers.py
@@ -18,5 +18,10 @@ def print_error(exc: object, prefix: str = "Error:", suffix: str = "") -> None:
     title, a filename, a provider name. Rendering it raw made the `except`
     handler itself raise ``MarkupError``, so a caught error became an uncaught
     crash (#1054). Escaping here means the 91 call sites cannot get it wrong.
+
+    ``prefix``/``suffix`` are rendered as markup, so they must be static,
+    trusted strings — never user input, an exception message, or anything
+    derived from either. They exist to reproduce a handful of bespoke messages
+    the migration would otherwise have reworded; only ``exc`` is escaped.
     """
     console.print(f"[red]{prefix}[/red] {escape(str(exc))}{suffix}")

--- a/codeframe/cli/helpers.py
+++ b/codeframe/cli/helpers.py
@@ -1,10 +1,22 @@
 """Shared CLI helper utilities.
 
 Usage:
-    from codeframe.cli.helpers import console
+    from codeframe.cli.helpers import console, print_error
 """
 
 from rich.console import Console
+from rich.markup import escape
 
 # Shared console instance for all CLI modules
 console = Console()
+
+
+def print_error(exc: object, prefix: str = "Error:", suffix: str = "") -> None:
+    """Render an error through Rich, treating the message as data.
+
+    Exception text is never markup, and it routinely quotes user input — a task
+    title, a filename, a provider name. Rendering it raw made the `except`
+    handler itself raise ``MarkupError``, so a caught error became an uncaught
+    crash (#1054). Escaping here means the 91 call sites cannot get it wrong.
+    """
+    console.print(f"[red]{prefix}[/red] {escape(str(exc))}{suffix}")

--- a/codeframe/cli/pr_commands.py
+++ b/codeframe/cli/pr_commands.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 import typer
 from rich.table import Table
 
-from codeframe.cli.helpers import console
+from codeframe.cli.helpers import console, print_error
 from codeframe.git.github_integration import GitHubAPIError, GitHubIntegration
 
 logger = logging.getLogger(__name__)
@@ -169,7 +169,7 @@ def _get_github_config() -> tuple[str, str]:
     try:
         return resolve_github_credentials(workspace, user_id=None)
     except GitHubResolutionError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         console.print(
             "From the CLI you can also: export GITHUB_TOKEN=ghp_yourtoken "
             "and export GITHUB_REPO=owner/repo"
@@ -223,7 +223,7 @@ def create_pr(
             try:
                 branch = get_current_branch()
             except RuntimeError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                print_error(e)
                 raise typer.Exit(1)
 
         # Validate not on base branch
@@ -460,7 +460,7 @@ def _check_merge_gate(
         blocking_reqs = list_blocking_requirements(workspace)
     except Exception as e:
         # Fail closed, like the API path: a broken ledger blocks the merge.
-        console.print(f"[red]PROOF9 gate check failed:[/red] {e} — merge blocked")
+        print_error(e, prefix="PROOF9 gate check failed:", suffix=" — merge blocked")
         raise typer.Exit(1)
     if not blocking_reqs:
         # Consistent with `cf proof run` (#1118): say so when the ledger is
@@ -662,7 +662,7 @@ def pr_status():
         try:
             current_branch = get_current_branch()
         except RuntimeError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            print_error(e)
             raise typer.Exit(1)
 
         async def _status():

--- a/codeframe/cli/proof_commands.py
+++ b/codeframe/cli/proof_commands.py
@@ -11,7 +11,10 @@ from typing import Optional
 import click
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
+
+from codeframe.cli.helpers import print_error
 
 console = Console()
 
@@ -63,7 +66,7 @@ def capture(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     # Interactive prompts for missing fields
@@ -108,7 +111,7 @@ def capture(
         source_issue=source_issue,
     )
 
-    console.print(f"\n[green]✓[/green] Created [bold]{req.id}[/bold]: {req.title}")
+    console.print(f"\n[green]✓[/green] Created [bold]{req.id}[/bold]: {escape(req.title)}")
     console.print(f"  Glitch type: [cyan]{req.glitch_type.value if req.glitch_type else 'unknown'}[/cyan]")
     console.print(f"  Obligations: {', '.join(o.gate.value for o in req.obligations)}")
     console.print(f"  Scope files: {', '.join(req.scope.files) or 'none'}")
@@ -167,7 +170,7 @@ def run(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     gate_filter = None
@@ -319,7 +322,7 @@ def list_reqs(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     status_filter = None
@@ -353,7 +356,7 @@ def list_reqs(
 
         table.add_row(
             req.id,
-            req.title[:50],
+            escape(req.title[:50]),
             f"[{sev_color}]{req.severity.value}[/{sev_color}]",
             f"[{status_color}]{req.status.value}[/{status_color}]",
             ", ".join(o.gate.value for o in req.obligations),
@@ -381,15 +384,15 @@ def show(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     req = ledger.get_requirement(workspace, req_id)
     if not req:
-        console.print(f"[red]Error:[/red] Requirement {req_id} not found.")
+        console.print(f"[red]Error:[/red] Requirement {escape(req_id)} not found.")
         raise typer.Exit(1)
 
-    console.print(f"\n[bold]{req.id}[/bold]: {req.title}")
+    console.print(f"\n[bold]{req.id}[/bold]: {escape(req.title)}")
     console.print(f"  Status: {req.status.value}")
     console.print(f"  Severity: {req.severity.value}")
     console.print(f"  Source: {req.source.value}")
@@ -454,7 +457,7 @@ def waive(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     expiry_date = None
@@ -473,7 +476,7 @@ def waive(
         if expiry_date:
             console.print(f"  Expires: {expiry_date}")
     else:
-        console.print(f"[red]Error:[/red] Requirement {req_id} not found.")
+        console.print(f"[red]Error:[/red] Requirement {escape(req_id)} not found.")
         raise typer.Exit(1)
 
 
@@ -495,7 +498,7 @@ def status_cmd(
     try:
         workspace = get_workspace(workspace_path)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        print_error(e)
         raise typer.Exit(1)
 
     # Check for expired waivers first

--- a/codeframe/core/events.py
+++ b/codeframe/core/events.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from rich.console import Console
+from rich.markup import escape
 
 from codeframe.core.workspace import get_workspace, get_db_connection, Workspace
 
@@ -365,7 +366,9 @@ def print_event(event: Event) -> None:
         items = []
         for key in ["agent_event", "path", "task_id", "status", "name", "title"]:
             if key in event.payload:
-                items.append(f"{key}={event.payload[key]}")
+                # escape: payload values are user text (task titles, checkpoint
+                # names), and this line renders with markup enabled.
+                items.append(f"{key}={escape(str(event.payload[key]))}")
         if items:
             console.print(f" [dim]{' '.join(items)}[/dim]")
         else:

--- a/tests/cli/test_cli_hardening_935.py
+++ b/tests/cli/test_cli_hardening_935.py
@@ -11,12 +11,14 @@ Four separate problems:
    taught it, exposing keys through /proc/<pid>/cmdline and shell history.
 3. Task titles and blocker text were interpolated into Rich-rendered output with
    markup enabled, so a title containing '[/b]' raised MarkupError and crashed
-   `cf tasks list` and the TUI.
+   `cf tasks list` and the TUI. That half now lives in
+   ``test_rich_hostile_data_1054.py``, which runs the commands against hostile
+   text instead of scanning the source for free-text field names (#1054) — the
+   scanner was too narrow four times in one review cycle.
 4. README.md and CLAUDE.md advertised `cf tasks show <id>`, which did not exist.
 """
 
 import inspect
-import re
 from pathlib import Path
 
 import pytest
@@ -30,16 +32,6 @@ from codeframe.core.workspace import create_or_load_workspace
 pytestmark = pytest.mark.v2
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-
-#: Titles that are valid user input and also valid-looking Rich markup.
-HOSTILE_TITLES = [
-    "Fix the [/b] parser",
-    "Support [bold] tags",
-    "Handle [/] gracefully",
-    "Array indexing a[0] and b[1]",
-    "[red]not actually markup[/red]",
-]
-
 
 @pytest.fixture
 def workspace(tmp_path):
@@ -121,147 +113,6 @@ class TestCredentialsStayOffArgv:
         assert "--value sk-ant-" not in doc
         assert "-v ghp_" not in doc
         assert "--value-stdin" in doc, "the safe alternative must be shown"
-
-
-class TestRichMarkupIsEscaped:
-    """AC3 — a title containing '[/b]' must render, not raise."""
-
-    @pytest.mark.parametrize("title", HOSTILE_TITLES)
-    def test_tasks_list_renders_a_hostile_title(self, workspace, title, tmp_path):
-        tasks.create(workspace, title=title, description="d", status=TaskStatus.READY)
-
-        result = CliRunner().invoke(app, ["tasks", "list", "--workspace", str(tmp_path)])
-
-        assert result.exception is None, f"{title!r} crashed: {result.exception!r}"
-        assert result.exit_code == 0
-
-    @pytest.mark.parametrize("title", HOSTILE_TITLES)
-    def test_tasks_show_renders_a_hostile_title(self, workspace, title, tmp_path):
-        task = tasks.create(
-            workspace, title=title, description=f"see {title}", status=TaskStatus.READY
-        )
-
-        result = CliRunner().invoke(
-            app, ["tasks", "show", task.id[:8], "--workspace", str(tmp_path)]
-        )
-
-        assert result.exception is None, f"{title!r} crashed: {result.exception!r}"
-        assert result.exit_code == 0
-
-    @pytest.mark.parametrize(
-        "module",
-        [
-            "codeframe/cli/app.py",
-            # The TUI renders the same user text through RichLog/DataTable and
-            # was invisible to the first version of this scanner, which read only
-            # cli/app.py — the PR bot found req.title unescaped there.
-            "codeframe/tui/app.py",
-        ],
-    )
-    def test_no_unescaped_user_text_reaches_rich_output(self, module):
-        """Scanner, not a point check: a new render of user data should fail the
-        build rather than wait to be found in review.
-
-        Operates on whole *statements*, not lines. The line-based version missed
-        `log.write(\n    f"... {req.title} ...")` in the TUI because the call and
-        the f-string sit on different lines — which is how the reviewer found two
-        sites the scanner had just declared clean.
-        """
-        source = (REPO_ROOT / module).read_text()
-
-        # Join physical lines into logical ones by tracking paren depth. The
-        # line-based version missed `log.write(\n    f"... {req.title} ...")` in
-        # the TUI because the call and the f-string sit on different lines —
-        # which is how the reviewer found two sites the scanner had just
-        # declared clean. (Simple depth counting, not tokenize: 3.12 splits
-        # f-strings into separate tokens and the brace never survives.)
-        statements, buf, depth = [], "", 0
-        for line in source.splitlines():
-            stripped = line.strip()
-            buf = f"{buf} {stripped}" if buf else stripped
-            depth += line.count("(") - line.count(")")
-            if depth <= 0:
-                statements.append(buf)
-                buf, depth = "", 0
-
-        # A denylist of free-text FIELD names — deliberately, after trying the
-        # alternatives. Enumerating variable names failed (missed 17 sites);
-        # deny-by-default on every attribute over-fires on 89 statements that
-        # interpolate timestamps, counts and enum accessors, which would be
-        # churn rather than safety. This list covers the free-prose fields that
-        # actually exist in this codebase; a real lint rule is the durable
-        # answer and is filed as a follow-up.
-        FREE_TEXT = (
-            "title|description|question|answer|label|recommendation|message|"
-            "output|error|name|summary|content|text|reason|stderr|stdout|"
-            "source_node_title|feedback|detail|hint|notes"
-        )
-        # The field may appear ANYWHERE inside the interpolation, not only as a
-        # bare `{obj.field}` — `{', '.join(amb.questions)}` was the fifth gap
-        # found in this review cycle. Match `{...}` spans, then look inside.
-        interpolation = re.compile(r"\{[^{}]*\}")
-        # `s?`: the attribute is often plural (`amb.questions`), and \b after a
-        # singular name refuses to match it — which is why the reviewer found
-        # `', '.join(amb.questions)` still unescaped.
-        free_field = re.compile(r"\.(?:" + FREE_TEXT + r")s?\b")
-
-        def _has_unescaped_field(statement: str) -> bool:
-            return any(
-                free_field.search(span) and "escape(" not in span
-                for span in interpolation.findall(statement)
-            )
-        renders = ("console.print", "log.write", "add_row")
-
-        # A bare loop variable (`for q in amb.questions: ... {q}`) carries no
-        # field name, so the field regex above cannot see it. Collect the names
-        # bound by a `for` over a free-text collection and treat a bare
-        # interpolation of one as unescaped too. (The PR bot found exactly this
-        # shape after five earlier rounds.)
-        loop_bound = set()
-        for st in statements:
-            m = re.match(
-                # (?:...) — ungrouped, the `\.` prefix would bind only to the
-                # first alternative and the pattern would never match.
-                r"for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\s+[A-Za-z_][A-Za-z0-9_]*\.(?:"
-                + FREE_TEXT.replace("|", "s?|") + r"s?)\b",
-                st,
-            )
-            if m:
-                loop_bound.add(m.group(1))
-
-        def _bare_loop_var(statement: str) -> bool:
-            return any(
-                span.strip("{}").strip() in loop_bound and "escape(" not in span
-                for span in interpolation.findall(statement)
-            )
-
-        offenders = [
-            st for st in statements
-            if any(r in st for r in renders)
-            and (_has_unescaped_field(st) or _bare_loop_var(st))
-        ]
-
-        assert not offenders, (
-            f"unescaped user text rendered through Rich in {module}:\n"
-            + "\n".join(o[:160] for o in offenders)
-        )
-
-    def test_markup_is_shown_literally_not_interpreted(self, workspace, tmp_path):
-        tasks.create(
-            workspace, title="Fix [/b] now", description="d", status=TaskStatus.READY
-        )
-
-        result = CliRunner().invoke(app, ["tasks", "list", "--workspace", str(tmp_path)])
-
-        assert "[/b]" in result.output, "the literal text should survive escaping"
-
-    def test_rich_would_have_raised_without_escaping(self):
-        """Guard the guard: prove the hostile titles really are hostile."""
-        from rich.console import Console
-
-        console = Console(file=open("/dev/null", "w"))
-        with pytest.raises(Exception):
-            console.print(f"[cyan]Title:[/cyan] {HOSTILE_TITLES[0]}")
 
 
 class TestStdinValueNeverLeaks:

--- a/tests/cli/test_rich_hostile_data_1054.py
+++ b/tests/cli/test_rich_hostile_data_1054.py
@@ -1,0 +1,384 @@
+"""Rich markup safety, guarded by running the commands (#1054).
+
+User text is interpolated into markup-enabled Rich output all over the CLI, so
+a task titled ``Array indexing a[0]`` raises ``MarkupError`` and crashes the
+command. #935 guarded that with a source scanner keyed on free-text *field
+names*; it was too narrow four times in one review cycle, because the question
+"is this expression prose or a count?" is not one a name can answer.
+
+Measured on the real modules before replacing it:
+
+- deny-by-default over interpolations flags 511 of 663 → 411 statement edits;
+- a shape allowlist still cannot classify the 322 bare-``Name`` interpolations,
+  because ``{host}`` and ``{title}`` are the same shape;
+- f-string contents are invisible to mypy/pyright, so no type checker helps.
+
+And the shape that actually broke — found by this file on its first run, in
+code the field-name scanner declared clean — is a local bound one statement
+*earlier*::
+
+    question_str = b.question[:50] ...      # cf blocker list
+    table.add_row(b.id[:8], status_str, task_str, question_str)
+
+    title = task.title if task else ...     # cf schedule show
+    console.print(f"  [...] {title} {agent_str}")
+
+The render statement contains no field name at all, so no name- or shape-based
+scanner can ever see it. This file drives the real call sites with real values
+instead: seed hostile text into every user-supplied field, run the commands,
+and let Rich raise.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from codeframe.cli.app import app
+from codeframe.core import blockers, checkpoints, prd, tasks
+from codeframe.core.proof import capture as proof_capture
+from codeframe.core.proof.models import Severity, Source
+from codeframe.core.state_machine import TaskStatus
+from codeframe.core.workspace import create_or_load_workspace
+
+pytestmark = pytest.mark.v2
+
+
+#: Valid user input that is also valid-looking Rich markup. ``[/b]`` is an
+#: unmatched closing tag and ``a[0]`` an unknown style; both raise.
+HOSTILE = "Fix the [/b] parser, a[0] and [bold]b"
+
+
+#: Commands run against the hostile workspace, with the argv they need.
+#: ``{task}``/``{blocker}``/``{req}``/``{checkpoint}`` are substituted from the
+#: seeded fixture. The process chdirs into the workspace, so no --workspace
+#: flag is needed and the differing flag names across commands do not matter.
+RUN: dict[str, list[str]] = {
+    "status": [],
+    "summary": [],
+    "review": [],
+    "version": [],
+    "tasks list": [],
+    "tasks tree": [],
+    "tasks show": ["{task}"],
+    "tasks set": ["status", "{task}", "BLOCKED"],
+    "prd show": [],
+    "prd list": [],
+    "prd versions": ["{prd}"],
+    "prd templates list": [],
+    "blocker list": ["--all"],
+    "blocker show": ["{blocker}"],
+    "blocker answer": ["{blocker}", HOSTILE],
+    "checkpoint list": [],
+    "checkpoint show": ["{checkpoint}"],
+    "proof list": [],
+    "proof show": ["{req}"],
+    "proof status": [],
+    "schedule show": [],
+    "schedule predict": [],
+    "schedule bottlenecks": [],
+    "work status": [],
+    "work show": ["{task}"],
+    "work diagnose": ["{task}"],
+    "work update-description": ["{task}", HOSTILE],
+    "work batch status": [],
+    "patch list": [],
+    "patch status": [],
+    "stats tokens": [],
+    "stats costs": [],
+    "templates list": [],
+    "templates show": ["bug-fix"],  # built-in template, still a render path
+    "engines list": [],
+    "engines stats": [],
+    "hooks show": [],
+    "config telemetry": ["status"],
+}
+
+#: Commands deliberately not exercised, each with the reason. This is a
+#: classification, not a denylist of field names: the completeness test below
+#: fails when a new command belongs to neither set, so the coverage gap has to
+#: be stated rather than drifting in silently.
+#:
+#: The gap this leaves: a str-typed Typer parameter echoed back by an error
+#: message ("no such req: {req_id}") is user text too, and in an EXEMPT command
+#: nothing here runs it. 93 such renders remain across the CLI — see the #1054
+#: follow-up. They are latent, not open crashes: reaching one needs hostile
+#: text in the argument itself.
+EXEMPT: dict[str, str] = {
+    "init": "creates a workspace; renders the path, not stored user text",
+    "serve": "starts a long-running server",
+    "prd add": "reads a file argument; the stored text is covered by `prd show`",
+    "prd update": "same store as `prd add`",
+    "prd delete": "destroys the fixture the other prd commands render",
+    "prd export": "writes a file; renders no user text",
+    "prd diff": "needs two stored versions; covered by `prd versions`",
+    "prd generate": "LLM call",
+    "prd stress-test": "LLM call",
+    "prd templates show": "ships built-in templates, not user text",
+    "prd templates export": "writes a file; renders no user text",
+    "prd templates import": "reads a file argument",
+    "tasks generate": "LLM call",
+    "tasks delete": "destroys the fixture the other task commands render",
+    "work start": "runs an agent",
+    "work resume": "runs an agent",
+    "work rerun": "runs an agent",
+    "work retry": "runs an agent",
+    "work stop": "signals a running agent",
+    "work follow": "blocks tailing a live run",
+    "work replay": "needs a recorded trace",
+    "work diff": "needs a recorded trace",
+    "work export-trace": "needs a recorded trace",
+    "work batch run": "runs agents",
+    "work batch resume": "runs agents",
+    "work batch stop": "signals a running batch",
+    "work batch follow": "blocks tailing a live batch",
+    "events tail": "blocks following the event log",
+    "blocker create": "covered by the seeded blocker",
+    "blocker resolve": "covered by `blocker answer`",
+    "patch export": "writes a patch file; renders no user text",
+    "commit create": "writes a git commit",
+    "checkpoint create": "covered by the seeded checkpoint",
+    "checkpoint restore": "rewrites the workspace under the other commands",
+    "checkpoint delete": "destroys the fixture `checkpoint show` renders",
+    "gates run": "runs the project's test suite",
+    "templates apply": "writes template files into the workspace",
+    "proof capture": "covered by the seeded requirement",
+    "proof run": "runs the 9 gates, i.e. the project's test suite",
+    "proof waive": "mutates the seeded requirement `proof show` renders",
+    "import ralph": "reads an external Ralph export",
+    "hooks run": "executes repo-configured shell hooks",
+    "hooks set": "edits .codeframe/config.yaml",
+    "hooks clear": "edits .codeframe/config.yaml",
+    "hooks trust": "writes the machine-wide trust store",
+    "stats export": "writes a file; renders no user text",
+    "engines check": "probes the machine for installed agent CLIs",
+    "engines compare": "probes the machine for installed agent CLIs",
+    "env check": "probes the machine's environment",
+    "env doctor": "probes the machine's environment",
+    "env install-missing": "installs packages",
+    "env auto-install": "installs packages",
+    "pr create": "GitHub network call",
+    "pr list": "GitHub network call",
+    "pr get": "GitHub network call",
+    "pr merge": "GitHub network call",
+    "pr close": "GitHub network call",
+    "pr status": "GitHub network call",
+    "auth login": "server network call",
+    "auth logout": "server network call",
+    "auth register": "server network call",
+    "auth whoami": "server network call",
+    "auth setup": "writes the machine-wide credential store",
+    "auth list": "reads the machine-wide credential store, not workspace text",
+    "auth validate": "provider network call",
+    "auth rotate": "writes the machine-wide credential store",
+    "auth remove": "writes the machine-wide credential store",
+    "auth api-key-create": "writes the machine-wide platform store",
+    "auth api-key-list": "reads the machine-wide platform store",
+    "auth api-key-revoke": "writes the machine-wide platform store",
+    "auth api-key-rotate": "writes the machine-wide platform store",
+    "auth set-password":
+        "writes the machine-wide platform store",
+    "auth deactivate": "writes the machine-wide platform store",
+    "auth activate": "writes the machine-wide platform store",
+    "auth user-list": "reads the machine-wide platform store",
+}
+
+
+def _registered_commands(typer_app, prefix: str = "") -> list[str]:
+    """Every command path in the live Typer tree, e.g. ``work batch status``."""
+    found = []
+    for command in typer_app.registered_commands:
+        name = command.name or (
+            command.callback.__name__.replace("_", "-") if command.callback else "?"
+        )
+        found.append(prefix + name)
+    for group in typer_app.registered_groups:
+        sub = group.typer_instance
+        found += _registered_commands(sub, prefix + (group.name or sub.info.name) + " ")
+    return found
+
+
+@pytest.fixture
+def hostile_workspace(tmp_path, monkeypatch):
+    """A workspace whose every user-supplied text field is hostile markup."""
+    workspace = create_or_load_workspace(tmp_path)
+
+    dependency = tasks.create(
+        workspace, title=HOSTILE, description=HOSTILE, status=TaskStatus.DONE
+    )
+    task = tasks.create(
+        workspace,
+        title=HOSTILE,
+        description=HOSTILE,
+        status=TaskStatus.READY,
+        depends_on=[dependency.id],
+    )
+    blocker = blockers.create(workspace, question=HOSTILE, task_id=task.id)
+    prd_record = prd.store(
+        workspace, content=f"# {HOSTILE}\n\n{HOSTILE}\n", title=HOSTILE
+    )
+    checkpoint = checkpoints.create(workspace, name=HOSTILE, include_git_ref=False)
+    requirement, _ = proof_capture.capture_requirement(
+        workspace,
+        title=HOSTILE,
+        description=HOSTILE,
+        where="codeframe/cli/app.py",
+        severity=Severity.MEDIUM,
+        source=Source.USER_REPORT,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    return {
+        "workspace": workspace,
+        "task": task.id,
+        "blocker": blocker.id,
+        "prd": prd_record.id,
+        "checkpoint": checkpoint.id,
+        "req": requirement.id,
+    }
+
+
+def _is_placeholder(arg: str) -> bool:
+    return arg.startswith("{") and arg.endswith("}")
+
+
+def _invoke(command: str, argv: list[str], ids: dict):
+    resolved = [ids[a[1:-1]] if _is_placeholder(a) else a for a in argv]
+    return CliRunner().invoke(app, command.split() + resolved)
+
+
+@pytest.mark.parametrize("command", sorted(RUN), ids=lambda c: c.replace(" ", "-"))
+def test_command_survives_hostile_user_text(command, hostile_workspace):
+    """The property itself: hostile text renders, it does not crash the command."""
+    result = _invoke(command, RUN[command], hostile_workspace)
+
+    assert result.exit_code != 2, (
+        f"`cf {command}` rejected its argv — the RUN table is stale:\n{result.output}"
+    )
+    assert result.exception is None or isinstance(result.exception, SystemExit), (
+        f"`cf {command}` crashed on hostile user text: {result.exception!r}"
+    )
+    # A blanket `except Exception` turns the crash into an error message and a
+    # clean exit, which would pass the assertion above while the command is
+    # just as broken. `prd show` and `schedule show` did exactly that.
+    assert "doesn't match any open tag" not in result.output, (
+        f"`cf {command}` swallowed a MarkupError instead of rendering:\n{result.output}"
+    )
+
+
+#: The commands above that take an id, re-run with hostile text *as the id*.
+#: "not found" messages echo the argument back through the same markup-enabled
+#: console, so the argument is user text too.
+TAKES_AN_ID = sorted(
+    command
+    for command, argv in RUN.items()
+    if any(_is_placeholder(arg) for arg in argv)
+)
+
+
+@pytest.mark.parametrize("command", TAKES_AN_ID, ids=lambda c: c.replace(" ", "-"))
+def test_command_survives_a_hostile_argument(command, hostile_workspace):
+    """`cf proof show '[/b]'` must report a miss, not crash reporting it."""
+    argv = [HOSTILE if _is_placeholder(arg) else arg for arg in RUN[command]]
+    result = CliRunner().invoke(app, command.split() + argv)
+
+    assert result.exception is None or isinstance(result.exception, SystemExit), (
+        f"`cf {command}` crashed on a hostile argument: {result.exception!r}"
+    )
+    assert "doesn't match any open tag" not in result.output, (
+        f"`cf {command}` swallowed a MarkupError on a hostile argument:\n{result.output}"
+    )
+
+
+class TestTheGuardActuallyGuards:
+    """A smoke test that renders nothing would pass in silence."""
+
+    @pytest.mark.parametrize(
+        "command, argv",
+        [
+            ("tasks list", []),
+            ("tasks show", ["{task}"]),
+            ("blocker list", ["--all"]),
+            ("prd show", []),
+            ("checkpoint list", []),
+            ("proof list", []),
+            ("schedule show", []),
+        ],
+    )
+    def test_the_hostile_text_reaches_the_output_literally(
+        self, command, argv, hostile_workspace
+    ):
+        """Escaped, not stripped — and proof the seeding really landed."""
+        result = _invoke(command, argv, hostile_workspace)
+
+        assert "[/b]" in result.output, (
+            f"`cf {command}` rendered no hostile text, so it guards nothing:\n"
+            f"{result.output}"
+        )
+
+    def test_the_hostile_text_would_really_crash_rich(self):
+        """Guard the guard: prove the fixture's text is hostile."""
+        import io
+
+        from rich.console import Console
+
+        console = Console(file=io.StringIO())
+        with pytest.raises(Exception):
+            console.print(f"[cyan]Title:[/cyan] {HOSTILE}")
+
+
+class TestEveryCommandIsClassified:
+    """The anti-drift half: a new command cannot land unclassified."""
+
+    def test_run_and_exempt_cover_the_live_command_tree(self):
+        registered = set(_registered_commands(app))
+        classified = set(RUN) | set(EXEMPT)
+
+        assert registered - classified == set(), (
+            "new CLI commands are neither run against hostile data nor exempted "
+            "with a reason — add them to RUN or EXEMPT in this file"
+        )
+        assert classified - registered == set(), (
+            "these entries name commands the CLI no longer registers"
+        )
+
+    def test_no_command_is_in_both_sets(self):
+        assert set(RUN) & set(EXEMPT) == set()
+
+    def test_every_exemption_states_a_reason(self):
+        assert [name for name, reason in EXEMPT.items() if not reason.strip()] == []
+
+
+class TestTuiSurvivesHostileUserText:
+    """AC2's other half. The TUI renders the same rows through RichLog and
+    DataTable, and the first version of the #935 scanner did not read this
+    module at all."""
+
+    @pytest.mark.asyncio
+    async def test_dashboard_renders_a_hostile_workspace(self, hostile_workspace):
+        from codeframe.tui.app import DashboardApp
+
+        app = DashboardApp(workspace=hostile_workspace["workspace"])
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.press("r")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert app.query_one("#task-table") is not None
+
+    @pytest.mark.asyncio
+    async def test_the_hostile_title_reaches_the_task_table(self, hostile_workspace):
+        """Proof the panels actually rendered the seeded rows."""
+        from textual.widgets import DataTable
+
+        from codeframe.tui.app import DashboardApp
+
+        app = DashboardApp(workspace=hostile_workspace["workspace"])
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            table = app.query_one("#task-table", DataTable)
+
+            rendered = " ".join(
+                str(cell) for row in table.rows for cell in table.get_row(row)
+            )
+            assert "[/b]" in rendered, f"the TUI rendered no hostile text: {rendered!r}"


### PR DESCRIPTION
Closes #1054.

## Why the scanner had to go, and what replaced it

`test_no_unescaped_user_text_reaches_rich_output` keyed on a denylist of free-text **field names**. It was too narrow four times in one review cycle, because "is this expression prose or a count?" is not a question a name can answer.

I measured the issue's three alternatives against the real modules (800 Rich render calls, 663 interpolations) before choosing:

| Option | Measured cost / outcome |
|---|---|
| Deny-by-default over interpolations | 511 of 663 unsafe-shaped → **411 statement edits**. Churn, not safety. |
| Shape allowlist (`len`/`strftime`/numeric format spec) | Still cannot classify the **322 bare-`Name`** interpolations: `{host}` and `{title}` are the same shape. |
| Type-aware rule | f-string contents are invisible to mypy/pyright; a bespoke resolver needs whole-program inference. |
| `Console(markup=False)` | 344 of 800 render calls use markup deliberately — flipping the default breaks colour everywhere. |

So the guard now **seeds hostile text into every user-supplied field and runs the commands**. That is call-site-aware in the strongest sense — it drives the real call sites with real values — and costs no churn.

## What it found on its first run

**Nine crashing commands the field-name scanner declared clean**, in four shapes no name- or shape-based rule can ever see:

1. **A local bound one statement earlier**, so the render statement contains no field name at all:
   - `cf blocker list` — `question_str = b.question[:50] ...` then `add_row(..., question_str)`
   - `cf schedule show` — `title = task.title if task else ...` then `f"... {title} ..."`
2. **No f-string at all** — `cf prd show` rendered `console.print(record.content)`, the whole PRD body, straight into a markup-enabled console.
3. **Renders outside the two scanned modules** — `codeframe/core/events.py` (event payloads: task titles, checkpoint names) and `codeframe/cli/proof_commands.py` (`cf proof list`, `cf proof show`).
4. **The `except` handler itself** — `except Exception as e: console.print(f"[red]Error:[/red] {e}")` re-renders the `MarkupError` message, turning a caught error into an uncaught crash. `cf prd show` and `cf schedule show` did exactly that. All **91** occurrences collapse into `helpers.print_error`, which escapes once.

Also escapes the error messages that echo a `str`-typed argument back (`no task found matching '<id>'`), after adding hostile-**argument** coverage caught 7 more.

## Shape of the guard

- `RUN` — 38 commands invoked against the hostile workspace, with argv.
- `EXEMPT` — every other command, each with a one-line reason (network / LLM / server / destroys-the-fixture).
- A completeness test asserts `RUN | EXEMPT` **equals the live Typer tree**, so a new command fails CI until it is classified. That is a classification of ~113 commands, not a denylist of field names, and it cannot drift silently.
- Assertions go beyond "did not raise": a command that *swallows* the `MarkupError` via a blanket `except` and exits cleanly also fails, and the hostile text must appear **literally** in output (escaped, not stripped).
- TUI covered through `DashboardApp.run_test()`, asserting the hostile title actually reaches the `DataTable`.

## Acceptance criteria

- [x] **AC1** — type-/call-site-aware, not a field-name denylist. Zero field names appear in the new file.
- [x] **AC2** — covers `codeframe/cli/app.py` and `codeframe/tui/app.py`, and incidentally `core/events.py` + `cli/proof_commands.py`, which the scanner never read.
- [x] **AC3** — the scanner is deleted. So is the now-duplicated `TestRichMarkupIsEscaped` class it sat in; `test_cli_hardening_935.py` keeps its other three concerns and points here.
- [x] **AC4** — verified by mutation: adding `blurb = b.question; console.print(f"[dim]note[/dim] {blurb}")` — a bare local with a name no denylist contains — turns the suite red.

## Verification

- `uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"` → **6651 passed, 17 skipped, 0 failed**
- `uv run ruff check .` → clean
- Pre-PR third-party review: `codex review --base main` → no regressions identified.

## Known limitations

- **`EXEMPT` commands are not exercised.** The completeness test makes that a reasoned classification rather than silence, but it is coverage the guard does not have.
- **93 latent argv-echo renders remain** across the CLI: a `str`-typed Typer parameter echoed back by an error message (`"no such hook: {hook_name}"`) is user text too, and in an `EXEMPT` command nothing here runs it. These are latent, not open crashes — reaching one needs hostile text in the argument itself. Filed as a follow-up rather than fixed blind, because I cannot run those commands to verify the fix.
- `codeframe/core/events.py` renders through Rich at all, which sits awkwardly with "core must be headless". Pre-existing; not touched beyond the escape.

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua