### PR TITLE
fix(health): report the build that is actually running (#1160)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,12 @@ jobs:
         with:
           context: .
           push: true
+          # Stamps the build SHA into the image, which is the only way /health
+          # can name the running build: .dockerignore excludes .git, so the
+          # container has no git metadata to read (#1160). The verify step below
+          # compares what /health reports against this same SHA.
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
           tags: |
             ghcr.io/frankbria/codeframe-backend:${{ github.sha }}
             ghcr.io/frankbria/codeframe-backend:staging
@@ -135,6 +141,12 @@ jobs:
         with:
           context: .
           push: true
+          # Stamps the build SHA into the image, which is the only way /health
+          # can name the running build: .dockerignore excludes .git, so the
+          # container has no git metadata to read (#1160). The verify step below
+          # compares what /health reports against this same SHA.
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
           tags: |
             ghcr.io/frankbria/codeframe-backend:${{ github.sha }}
             ghcr.io/frankbria/codeframe-backend:production
@@ -446,11 +458,22 @@ jobs:
           MAX_ATTEMPTS=12
           SLEEP_SECONDS=5
 
+          # A 200 only proves *a* backend is up. If the pull silently left the
+          # old container running, the old one answers and the deploy passes
+          # having deployed nothing — so the reported commit must match the SHA
+          # this run built (#1160).
+          EXPECTED_COMMIT="${{ github.sha }}"
+
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             echo "Health check attempt $i/$MAX_ATTEMPTS..."
-            if ssh ${{ secrets.USER }}@${{ secrets.HOST }} "curl -sf http://localhost:${{ secrets.API_PORT }}/health"; then
-              echo "✅ Health check passed on attempt $i"
-              exit 0
+            BODY="$(ssh ${{ secrets.USER }}@${{ secrets.HOST }} "curl -sf http://localhost:${{ secrets.API_PORT }}/health" || true)"
+            if [ -n "$BODY" ]; then
+              RUNNING_COMMIT="$(printf '%s' "$BODY" | jq -r '.commit // "unknown"')"
+              if [ "$RUNNING_COMMIT" = "$EXPECTED_COMMIT" ]; then
+                echo "✅ Health check passed on attempt $i (commit $RUNNING_COMMIT)"
+                exit 0
+              fi
+              echo "⚠️  Healthy, but running commit is '$RUNNING_COMMIT', expected '$EXPECTED_COMMIT'"
             fi
             if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
               echo "⏳ Waiting ${SLEEP_SECONDS}s before retry..."
@@ -459,6 +482,7 @@ jobs:
           done
 
           echo "❌ Health check failed after $MAX_ATTEMPTS attempts"
+          echo "   (last response: ${BODY:-<no response>})"
           # Surface the cause: a silent `curl -sf` gave no reason. Same
           # diagnostics as before, translated from PM2 to compose (#1121) —
           # container state plus recent logs, so a crash-loop is diagnosable
@@ -877,11 +901,22 @@ jobs:
           MAX_ATTEMPTS=12
           SLEEP_SECONDS=5
 
+          # A 200 only proves *a* backend is up. If the pull silently left the
+          # old container running, the old one answers and the deploy passes
+          # having deployed nothing — so the reported commit must match the SHA
+          # this run built (#1160).
+          EXPECTED_COMMIT="${{ github.sha }}"
+
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             echo "Health check attempt $i/$MAX_ATTEMPTS..."
-            if ssh ${{ secrets.USER }}@${{ secrets.HOST }} "curl -sf http://localhost:${{ secrets.API_PORT }}/health"; then
-              echo "✅ Health check passed on attempt $i"
-              exit 0
+            BODY="$(ssh ${{ secrets.USER }}@${{ secrets.HOST }} "curl -sf http://localhost:${{ secrets.API_PORT }}/health" || true)"
+            if [ -n "$BODY" ]; then
+              RUNNING_COMMIT="$(printf '%s' "$BODY" | jq -r '.commit // "unknown"')"
+              if [ "$RUNNING_COMMIT" = "$EXPECTED_COMMIT" ]; then
+                echo "✅ Health check passed on attempt $i (commit $RUNNING_COMMIT)"
+                exit 0
+              fi
+              echo "⚠️  Healthy, but running commit is '$RUNNING_COMMIT', expected '$EXPECTED_COMMIT'"
             fi
             if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
               echo "⏳ Waiting ${SLEEP_SECONDS}s before retry..."
@@ -890,6 +925,7 @@ jobs:
           done
 
           echo "❌ Health check failed after $MAX_ATTEMPTS attempts"
+          echo "   (last response: ${BODY:-<no response>})"
           # Surface the cause: a silent `curl -sf` gave no reason. Same
           # diagnostics as before, translated from PM2 to compose (#1121) —
           # container state plus recent logs, so a crash-loop is diagnosable

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,14 @@ RUN uv sync --frozen --no-dev --no-install-project
 COPY codeframe/ ./codeframe/
 RUN uv sync --frozen --no-dev
 
+# What `/health` reports as the running build (#1160). Declared here, after the
+# dependency layers, so a new SHA does not invalidate the slow `uv sync` cache.
+# `.dockerignore` excludes `.git`, so the image cannot work this out for itself
+# — CI passes it in, and the default keeps a plain `docker build` honest rather
+# than having it claim someone else's commit.
+ARG GIT_COMMIT=unknown
+ENV GIT_COMMIT=${GIT_COMMIT}
+
 # Non-root. WORKSPACE_ROOT and the SQLite DB arrive as volumes owned by this
 # uid (compose sets it), so the app can still write where it must and nowhere
 # else.

--- a/codeframe/ui/server.py
+++ b/codeframe/ui/server.py
@@ -3,7 +3,6 @@
 # Standard library imports
 import logging
 import os
-import subprocess
 from contextlib import asynccontextmanager
 from datetime import datetime, UTC
 from enum import Enum
@@ -806,6 +805,12 @@ async def root():
     return {"status": "online", "service": "CodeFRAME API"}
 
 
+# Captured once, at import. A deploy replaces the container, so process start is
+# deploy time — and unlike a per-request clock read it goes stale when the deploy
+# does, which is the whole point of the field (#1160).
+_PROCESS_STARTED_AT = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
 @app.get(
     "/health",
     summary="Detailed health check",
@@ -819,30 +824,26 @@ async def health_check():
     Returns:
         - status: Service health status
         - version: API version from FastAPI app
-        - commit: Git commit hash (short)
-        - deployed_at: Server startup timestamp
+        - commit: Build SHA stamped into the image, or "unknown" outside Docker
+        - deployed_at: Process start timestamp — constant for this container
         - database: Database connection status
-    """
-    # Get git commit hash
-    try:
-        git_commit = (
-            subprocess.check_output(
-                ["git", "rev-parse", "--short", "HEAD"],
-                cwd=Path(__file__).parent.parent.parent,
-                stderr=subprocess.DEVNULL,
-            )
-            .decode()
-            .strip()
-        )
-    except Exception:
-        git_commit = "unknown"
 
+    Both deployment fields used to be derived at request time and both were
+    wrong in every container (#1160). ``deployed_at`` was ``datetime.now()``,
+    so it always read "deployed seconds ago" and could never surface the stale
+    deploy it exists to surface; ``commit`` shelled out to git against a source
+    tree the image does not carry (``.dockerignore`` excludes ``.git``), and the
+    ``except`` branch turned that into a permanent "unknown". Both are known at
+    image build time, so they are read from the environment instead of probed.
+    """
     return {
         "status": "healthy",
         "service": "CodeFRAME Status Server",
         "version": app.version,
-        "commit": git_commit,
-        "deployed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        # Read per request, not at import: the env arrives at container start,
+        # which is after this module is imported in some entrypoints (#963).
+        "commit": os.getenv("GIT_COMMIT", "unknown"),
+        "deployed_at": _PROCESS_STARTED_AT,
     }
 
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -261,7 +261,13 @@ built. There is nothing to rebuild:
 export IMAGE_TAG=<previous-sha>     # e.g. from `git log --oneline main`
 $COMPOSE pull && $COMPOSE up -d
 $COMPOSE ps                          # both services healthy
+curl -s localhost:$API_PORT/health | jq -r .commit   # == the sha you rolled to
 ```
+
+That last line is the confirmation, not `ps`: a pull that failed to replace the
+container leaves the previous one running and healthy. `/health` reports the SHA
+stamped into the image it is actually running (#1160), so it is the only local
+check that distinguishes the two.
 
 Volumes are untouched by a rollback — the database and workspaces are outside
 the image by design.

--- a/tests/api/test_health_endpoint.py
+++ b/tests/api/test_health_endpoint.py
@@ -38,3 +38,60 @@ def test_health_endpoint_structure(client):
     assert "version" in data
     assert "commit" in data
     assert "deployed_at" in data
+
+
+# ---------------------------------------------------------------------------
+# Deployment reporting (#1160)
+#
+# The old assertions were key-presence only, which is why both fields could be
+# wrong for a whole release cycle: `deployed_at` was `datetime.now()` evaluated
+# per request, and `commit` shelled out to git against a source tree the image
+# does not contain. These assert the values, not the keys.
+# ---------------------------------------------------------------------------
+
+
+def test_deployed_at_is_stable_across_requests(client):
+    """`deployed_at` must not move between two calls seconds apart.
+
+    It reported "deployed seconds ago" forever, so it could never show the one
+    thing it exists to show: a stale deploy.
+    """
+    first = client.get("/health").json()["deployed_at"]
+    second = client.get("/health").json()["deployed_at"]
+
+    assert first == second
+
+
+def test_deployed_at_is_iso_utc(client):
+    """Still a parseable UTC instant, not just any stable string."""
+    from datetime import datetime
+
+    value = client.get("/health").json()["deployed_at"]
+
+    assert value.endswith("Z")
+    datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def test_commit_comes_from_git_commit_env(client, monkeypatch):
+    """The image build stamps GIT_COMMIT; /health reports it verbatim."""
+    monkeypatch.setenv("GIT_COMMIT", "9024e44e1c0ffee0000000000000000000000000")
+
+    assert client.get("/health").json()["commit"] == (
+        "9024e44e1c0ffee0000000000000000000000000"
+    )
+
+
+def test_commit_is_read_per_request_not_at_import(client, monkeypatch):
+    """Read at call time (#963) — the env arrives at container start."""
+    monkeypatch.setenv("GIT_COMMIT", "aaaaaaa")
+    assert client.get("/health").json()["commit"] == "aaaaaaa"
+
+    monkeypatch.setenv("GIT_COMMIT", "bbbbbbb")
+    assert client.get("/health").json()["commit"] == "bbbbbbb"
+
+
+def test_commit_falls_back_to_unknown_outside_docker(client, monkeypatch):
+    """A local `uv run codeframe serve` has no GIT_COMMIT and must still work."""
+    monkeypatch.delenv("GIT_COMMIT", raising=False)
+
+    assert client.get("/health").json()["commit"] == "unknown"

--- a/tests/ci/test_deploy_build_metadata_1160.py
+++ b/tests/ci/test_deploy_build_metadata_1160.py
@@ -1,0 +1,75 @@
+"""#1160 — the deploy pipeline stamps the build SHA into the image and checks it.
+
+`/health` reported `commit: "unknown"` on every container for a full release
+cycle. The reader was fine; the *input* had gone. #1121 moved the deploy into
+Docker, `.dockerignore` excludes `.git`, and the `except` branch turned the
+missing git metadata into a plausible-looking string. Nothing failed.
+
+So testing `server.py` alone would not have caught it, and will not catch the
+next one. These pin the chain end to end: the Dockerfile declares the arg, the
+build passes it, and the verify step refuses a container whose reported commit
+is not the one just built — which is also what makes a pull that silently left
+the old container running fail the deploy instead of passing it.
+"""
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = ROOT / "Dockerfile"
+DEPLOY = ROOT / ".github" / "workflows" / "deploy.yml"
+
+BUILD_JOBS = ("docker-build-staging", "docker-build-production")
+DEPLOY_JOBS = ("deploy-staging", "deploy-production")
+
+
+def _steps(job: str) -> list[dict]:
+    return yaml.safe_load(DEPLOY.read_text())["jobs"][job]["steps"]
+
+
+def _backend_build_step(job: str) -> dict:
+    for step in _steps(job):
+        if "build-push-action" in step.get("uses", "") and step.get("with", {}).get(
+            "context"
+        ) in (".", "./"):
+            return step
+    raise AssertionError(f"{job} has no backend docker build step")
+
+
+def _verify_step(job: str) -> dict:
+    for step in _steps(job):
+        if step.get("name") == "Verify deployment":
+            return step
+    raise AssertionError(f"{job} has no 'Verify deployment' step")
+
+
+def test_dockerfile_declares_and_persists_git_commit():
+    """ARG alone is build-time only — it must survive into the container env."""
+    body = DOCKERFILE.read_text()
+
+    assert "ARG GIT_COMMIT" in body, "Dockerfile does not accept a GIT_COMMIT build arg"
+    assert "ENV GIT_COMMIT=" in body, "GIT_COMMIT is not persisted as a runtime env var"
+
+
+@pytest.mark.parametrize("job", BUILD_JOBS)
+def test_backend_build_passes_the_commit_sha(job: str):
+    build_args = _backend_build_step(job).get("with", {}).get("build-args", "")
+
+    assert "GIT_COMMIT=${{ github.sha }}" in build_args, (
+        f"{job} builds the backend image without stamping github.sha into it"
+    )
+
+
+@pytest.mark.parametrize("job", DEPLOY_JOBS)
+def test_verify_step_compares_the_running_commit(job: str):
+    """A 200 from /health only proves *a* backend is up, not the new one."""
+    run = _verify_step(job)["run"]
+
+    assert ".commit" in run, f"{job} verify step never reads the reported commit"
+    assert "${{ github.sha }}" in run, (
+        f"{job} verify step never compares the reported commit to the deployed SHA"
+    )


### PR DESCRIPTION
Closes #1160

## What was wrong

`GET /health` exists to answer "what is deployed right now". Since the Docker
migration (#1121) it could answer neither half, and neither failure surfaced as
an error.

- **`deployed_at` was request time.** `datetime.now(UTC)` evaluated per request,
  so it always read "deployed seconds ago" — it could never show the one thing
  it exists to show, a stale deploy.
- **`commit` was permanently `"unknown"` in every container.** It shelled out to
  `git rev-parse` against a source tree the image does not carry
  (`.dockerignore` excludes `.git`), and the bare `except` turned the missing
  input into a plausible-looking string. This worked pre-#1121 only because the
  PM2 deploy ran from a git checkout on the box; containerising removed the
  input without touching the code.

## What changed

Both values are known at image build time, so they are read from the environment
instead of probed at runtime.

| File | Change |
|---|---|
| `Dockerfile` | `ARG GIT_COMMIT=unknown` / `ENV GIT_COMMIT=${GIT_COMMIT}`, declared **after** the dependency layers so a new SHA does not bust the slow `uv sync` cache |
| `deploy.yml` | both backend build steps pass `build-args: GIT_COMMIT=${{ github.sha }}` |
| `server.py` | `commit` = `os.getenv("GIT_COMMIT", "unknown")`, read per request (#963 — the env arrives at container start); `deployed_at` = a module constant captured once at import; the `subprocess` probe and its now-unused import are gone |
| `deploy.yml` | `Verify deployment` compares the reported commit to the SHA the run built |
| `deploy/README.md` | the rollback recipe now ends with the `curl … \| jq -r .commit` that confirms it took effect |

The verify-step change is the operationally significant one: the old loop
accepted a 200 from *any* backend, so a pull that silently left the old
container running passed the deploy having deployed nothing.

## Demo — outcome evidence

Built the real `Dockerfile` with `--build-arg GIT_COMMIT=9024e44edeadbeef…` and
ran the resulting container:

```
$ curl -s localhost:14298/health
{"status":"healthy",…,"commit":"9024e44edeadbeef000000000000000000000000",
 "deployed_at":"2026-09-09T01:21:34.894873Z"}

$ sleep 5 && curl -s localhost:14298/health
{… "commit":"9024e44edeadbeef000000000000000000000000",
 "deployed_at":"2026-09-09T01:21:34.894873Z"}    # identical
```

Running the verify step's exact check against that container:

```
✅ matches built SHA: 9024e44edeadbeef000000000000000000000000

# stale-container simulation — same check, different expected SHA:
✅ deploy would FAIL: running '9024e44edeadbeef…', expected 'ffffffffff…'
```

Also confirmed outside Docker (`uv run python -m codeframe.ui.server`):
`deployed_at` stable across 5s, `commit` == the `GIT_COMMIT` env, and
`"unknown"` when it is unset.

| Acceptance criterion | Evidence |
|---|---|
| Two `/health` calls seconds apart return an identical `deployed_at` | ✅ container transcript above |
| `commit` on a deployed container equals the SHA that built the image | ✅ container transcript above |
| A test asserts `deployed_at` is stable across two requests | ✅ `test_deployed_at_is_stable_across_requests` |
| A test asserts `commit` comes from the env var when set | ✅ `test_commit_comes_from_git_commit_env` (+ per-request and fallback cases) |
| `Verify deployment` asserts the returned `commit` matches `IMAGE_TAG` | ✅ both deploy jobs; stale-container simulation above |

## Why the tests are shaped this way

`tests/api/test_health_endpoint.py` previously asserted only
`assert "deployed_at" in data`. Key-presence assertions pass against a hardcoded
wrong value, which is why both fields could be wrong for a full release cycle.
The new assertions check the values.

`tests/ci/test_deploy_build_metadata_1160.py` pins the whole chain — Dockerfile
arg → build-args → verify comparison — because #1121 removed the *input* and
nothing noticed. A test of `server.py` alone would not have caught this bug and
would not catch the next one of its shape.

## Known limitations

- **`deployed_at` is process start, not `BUILD_TIME`.** A bare container restart
  resets it without a deploy having happened. This satisfies the acceptance
  criterion with no extra build plumbing; add a `BUILD_TIME` build-arg if that
  distinction ever matters.
- **Frontend images are not stamped.** The frontend serves no health endpoint
  that reports a commit, and an undeclared build-arg is a build warning. The
  issue suggested stamping both; only the backend can currently report it.
- **`commit` is now the full 40-char SHA, not the ~7-char short hash.** The old
  value came from `git rev-parse --short HEAD`; it now comes from `github.sha`,
  which is what the verify step's exact string comparison needs. No web-ui or
  other consumer reads this field today, so nothing breaks — flagging it because
  it is a deliberate response-shape change, not an incidental one.
- **`commit` outside Docker is `"unknown"`.** A local `uv run codeframe serve`
  no longer reports its git SHA. Deliberate — dropping the `subprocess` probe is
  the fix, and the local case has `git log`.

## Verification

- Full CI gate (`uv run pytest tests/ --ignore=tests/e2e -m "not lifecycle"`): **6661 passed, 17 skipped, 0 failed** (9m47s)
- `uv run ruff check .`: clean
- `actionlint .github/workflows/deploy.yml`: clean
- Third-party review: `codex review --base main` — **no findings**
  (opencode/GLM skipped per the known tree-mutation/timeout issue; codex is the documented fallback)

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua
