### PR TITLE
ci: bump the GLM Review pin so a stuck request fails with evidence (#1199)

### DIFF
--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -8,16 +8,22 @@ on:
 
 jobs:
   review:
-    # Skip bot-authored PRs (Dependabot): the reusable GLM review workflow
-    # rejects non-human actors and hard-fails, which surfaced as a red X on
-    # every Dependabot PR touching 5+ files. Skipping is neutral, not a failure.
-    # Otherwise only review substantial changes (5+ files, or 20+ additions/deletions).
+    # Skip bot-authored PRs: claude-code-action rejects any run whose actor is
+    # not a User and hard-fails, painting a PR red that was never reviewed.
+    # Naming `dependabot[bot]` (the old form) was too narrow in one direction
+    # that matters here: the action resolves `github.actor`, which is the PR
+    # *author* on `opened` but the **pusher** on `synchronize`, so a
+    # human-authored PR that a bot pushed to still went red. Testing
+    # `user.type` and `sender.type` covers every bot and both events, and a
+    # null `sender` compares false, so it fails closed.
+    # Then: only review substantial changes (5+ files, or 20+ additions/deletions).
     if: |
-      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.user.type == 'User' &&
+      github.event.sender.type == 'User' &&
       (github.event.pull_request.changed_files >= 5 ||
        github.event.pull_request.additions >= 20 ||
        github.event.pull_request.deletions >= 20)
-    uses: frankbria/glm-review/.github/workflows/review.yml@77dfa9c6633712256edab41fd0db42663a9416b7 # main
+    uses: frankbria/glm-review/.github/workflows/review.yml@21fea324f518b964919709eebbbb9f5b3acde489 # main
     # `issues: write` and `id-token: write` are gone (#1167). They were not
     # optional on the old pin: GitHub fails a run when a caller grants less than
     # the called job requests, and b877d15's job declared both. Upstream dropped
@@ -31,17 +37,33 @@ jobs:
     # which are already public here. Set `upload_transcript: false` if that ever
     # stops being true.
     #
-    # This pin (#1167) stops the reviewer coin-flipping between its two limits.
-    # Turns bind first, not the clock — successful reviews finish in 6m44s-17m33s
-    # — so the cap is `--max-turns 60`, sized against measured cost. The
-    # 35-minute timeout now sits on the review *step*, with 40 minutes on the job
-    # as an outer backstop. That placement is the whole fix: a job timeout
-    # cancels every remaining step, `if: always()` included, which is why the old
-    # 20-minute kill uploaded no transcript and left nothing behind. A step
-    # timeout fails only that step, so the run can still replace its own
-    # "Reviewing..." stub with an explicit "GLM review did not complete" notice.
-    # A run that reviewed nothing is now distinguishable from one that found
-    # nothing.
+    # #1167's pin put a 35-minute timeout on the review *step* (40 on the job) so
+    # a failed review could still post its own "did not complete" notice. It did
+    # — but the notice could never say more than "the step was killed", because
+    # the SDK's own per-request timeout was still 50 minutes, i.e. ABOVE both
+    # clocks. A request that never came back could therefore only ever end as a
+    # wall-clock kill, and a kill writes no result message, so no execution file,
+    # so no transcript. Run 34298943458 on #1207 is the clean example: review
+    # step failed at 35m22s, `Upload review transcript` skipped, notice reading
+    # "the step was killed before the agent wrote a result".
+    #
+    # This pin (#1199) drops that per-request timeout to 20 minutes, below both
+    # clocks, leaving ~15 minutes of step budget for the SDK to surface the
+    # error, write its result, and upload the transcript. A stuck call now fails
+    # with evidence instead of silently eating the whole budget.
+    #
+    # It also stops reporting a cancellation as a timeout. This repo cancels
+    # in-progress reviews per PR, so every push during a review produced a notice
+    # blaming a timeout that had not happened — five in a row on #1205's branch,
+    # four on #1201's.
+    #
+    # Not fixed by this bump, and worth knowing: the 35m/40m limits are hardcoded
+    # upstream, not inputs, so this caller cannot raise them. Reviews here run
+    # long — the last success (run 34262672589) took 28 minutes — so the margin
+    # is thin regardless. If a review still times out after this, set
+    # `debug_full_output: true` below to get incremental per-message logging that
+    # survives the kill, read the failing run, then turn it back off: this repo
+    # is public and that log is too.
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -60,10 +60,17 @@ jobs:
     # Not fixed by this bump, and worth knowing: the 35m/40m limits are hardcoded
     # upstream, not inputs, so this caller cannot raise them. Reviews here run
     # long — the last success (run 34262672589) took 28 minutes — so the margin
-    # is thin regardless. If a review still times out after this, set
-    # `debug_full_output: true` below to get incremental per-message logging that
-    # survives the kill, read the failing run, then turn it back off: this repo
-    # is public and that log is too.
+    # is thin regardless. If a review still times out after this, flip the
+    # `debug_full_output` below to true for incremental per-message logging that
+    # survives the kill, read the failing run, then turn it back off.
+    with:
+      # Present and explicitly false so the incident lever above is a one-word
+      # edit rather than a "which input was it, and does this job even take a
+      # `with:` block?" at the time you least want that question. False is also
+      # the upstream default: this log is written to the workflow log, which is
+      # public on this repo, and the action's own input warns it may contain
+      # secrets.
+      debug_full_output: false
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Refs #1199

## The actual cause

`#1167` put a 35-minute timeout on the review **step** (40 on the job) so a
failed review could still post its own "did not complete" notice. That worked —
but the notice could never say more than *"the step was killed"*, because the
SDK's own per-request timeout (`API_TIMEOUT_MS`) was left at **50 minutes**,
i.e. **above both clocks**. A request that never came back could therefore only
ever end as a wall-clock kill, and a kill writes no result message → no
execution file → no transcript.

Run [34298943458](https://github.com/frankbria/codeframe/actions/runs/34298943458)
on #1207 is the clean example, and it is what reopened this:

```
3  GLM bug-hunting review      -> failure     (35m22s — the step timeout)
4  Upload review transcript    -> skipped     (no execution file to upload)
5  Report an incomplete review -> success
```

> ⚠️ Reason: the step was killed before the agent wrote a result — the step
> timeout, or a hung API call.

That PR was **6 files, +208/−25**. So upstream's size-correlation theory
(glm-review#9, drawn from a 1,715-line diff) does not explain this repo — the
per-request timeout does.

## What the new pin changes

`77dfa9c6` → `21fea324` (upstream `main` HEAD; glm-review #10/#11/#12):

| Change | Effect here |
|---|---|
| `API_TIMEOUT_MS` 50m → **20m**, below both clocks | a stuck call errors with ~15m of step budget left to surface the error, write the result and upload the transcript — it fails *with evidence* instead of silently eating the whole budget |
| Cancellation no longer reported as a timeout | this repo cancels in-progress reviews per PR, so every push during a review produced a notice blaming a timeout that never happened — **five in a row** on #1205's branch, **four** on #1201's |
| New `debug_full_output` input | incremental per-message logging that survives a kill — the escalation lever if this bump is not enough |

Also adopts the canonical caller's **bot guard**. Naming `dependabot[bot]` was
too narrow in the direction that bites: `claude-code-action` resolves
`github.actor`, which is the PR *author* on `opened` but the **pusher** on
`synchronize` — so a human-authored PR that any bot pushed to still went red.
`user.type` + `sender.type` covers every bot and both events, and a null
`sender` compares false, so it fails closed.

## Verification

- `actionlint` clean.
- The caller still satisfies both reusable-workflow invariants **against the new
  callee** — checked with upstream's own `scripts/check_workflow_calls.py`, and
  this repo's `check-workflow-calls` job re-checks it in CI.
- `tests/ci/test_glm_review_caller_1167.py` passes (permissions unchanged, pin
  is a full SHA).
- Pin equals `glm-review` `main` HEAD, per the standing rule for this caller.

**This PR exercises the change itself.** At 39 additions it clears the size gate
(`additions >= 20`), and `pull_request` runs the workflow as defined on the head
branch — so the `review` job on this PR runs under the new pin. Whatever it does
here is the downstream evidence.

## Not fixed by this

The 35m/40m limits are **hardcoded upstream**, not workflow inputs, so this
caller cannot raise them. Reviews in this repo run long — the last success
([34262672589](https://github.com/frankbria/codeframe/actions/runs/34262672589))
took **28 minutes** against a 35-minute step budget — so the margin stays thin
either way. This bump converts an undiagnosable black box into either a
completed review or a failure that says why and ships a transcript; it does not
make a genuinely slow review fast.

If a review still times out after this: set `debug_full_output: true` on the
job, read the failing run, then turn it back off — this repo is public and so is
that log.

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua