### PR TITLE
test(ci): pin that staging and production build the same images (#1210)

### DIFF
--- a/tests/ci/test_deploy_build_job_parity_1210.py
+++ b/tests/ci/test_deploy_build_job_parity_1210.py
@@ -1,0 +1,76 @@
+"""#1210 — the two image-build jobs must stay equivalent apart from their tag.
+
+`docker-build-staging` and `docker-build-production` build the same two
+contexts from the same Dockerfiles. That equivalence is load-bearing: production
+has never been deployed (it holds no secrets and has no host, so
+`deploy-production` stops at its preflight), which means the *only* evidence
+production's images are sound is that staging builds the identical thing.
+
+#1210 leaned on exactly that. A high advisory failed the frontend image's
+`npm audit --audit-level=high` and blocked every deploy; the fix was verified
+against staging, and applies to production solely because the two jobs are the
+same build. Nothing enforced that. Edit one job and not the other — bump the
+action pin, add a build-arg, change the context — and the inference silently
+stops holding, with no signal until production's first real deploy.
+
+These compare the whole `with:` block rather than enumerating fields, so a
+field added to one job and not the other fails here too.
+"""
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+DEPLOY = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy.yml"
+
+STAGING = "docker-build-staging"
+PRODUCTION = "docker-build-production"
+
+# (label, build context as written in the workflow)
+IMAGES = (("backend", "."), ("frontend", "./web-ui"))
+
+
+def _build_step(job: str, context: str) -> dict:
+    steps = yaml.safe_load(DEPLOY.read_text())["jobs"][job]["steps"]
+    for step in steps:
+        if "build-push-action" in step.get("uses", ""):
+            if step.get("with", {}).get("context") == context:
+                return step
+    raise AssertionError(f"{job} has no docker build step for context {context!r}")
+
+
+def _normalise(step: dict, environment: str) -> dict:
+    """The step with its environment-specific moving tag neutralised."""
+    with_block = dict(step["with"])
+    with_block["tags"] = with_block["tags"].replace(f":{environment}", ":<env>")
+    return {"uses": step["uses"], "with": with_block}
+
+
+@pytest.mark.parametrize(("label", "context"), IMAGES)
+def test_staging_and_production_build_the_same_image(label: str, context: str) -> None:
+    staging = _build_step(STAGING, context)
+    production = _build_step(PRODUCTION, context)
+
+    assert _normalise(staging, "staging") == _normalise(production, "production"), (
+        f"The {label} image is built differently for staging and production. "
+        "Production has no deploy target, so staging is the only place these "
+        "images are ever exercised — keep the two build steps identical apart "
+        "from the environment tag, or that evidence stops transferring (#1210)."
+    )
+
+
+@pytest.mark.parametrize(("label", "context"), IMAGES)
+def test_each_job_pushes_its_own_moving_tag(label: str, context: str) -> None:
+    """The failure the parity check alone would miss: a copy-paste that leaves
+    production tagging `:staging`, so a production deploy pulls staging's image.
+    """
+    for job, environment, wrong in (
+        (STAGING, "staging", "production"),
+        (PRODUCTION, "production", "staging"),
+    ):
+        tags = _build_step(job, context)["with"]["tags"]
+        assert f":{environment}" in tags, f"{job} does not tag {label} :{environment}"
+        assert f":{wrong}" not in tags, f"{job} tags {label} :{wrong}"

--- a/tests/ci/test_deploy_build_job_parity_1210.py
+++ b/tests/ci/test_deploy_build_job_parity_1210.py
@@ -9,12 +9,15 @@ production's images are sound is that staging builds the identical thing.
 #1210 leaned on exactly that. A high advisory failed the frontend image's
 `npm audit --audit-level=high` and blocked every deploy; the fix was verified
 against staging, and applies to production solely because the two jobs are the
-same build. Nothing enforced that. Edit one job and not the other — bump the
-action pin, add a build-arg, change the context — and the inference silently
-stops holding, with no signal until production's first real deploy.
+same build. Nothing enforced that. Edit one job and not the other — bump a
+pin, add a build-arg, change the context — and the inference silently stops
+holding, with no signal until production's first real deploy.
 
-These compare the whole `with:` block rather than enumerating fields, so a
-field added to one job and not the other fails here too.
+The parity check compares the jobs' entire step lists rather than enumerating
+fields or singling out the build steps. Anything that changes what gets built
+lives in there: the `build-push-action` invocations, but equally the
+`setup-buildx-action` pin above them, and any field or step that does not exist
+yet.
 """
 
 import pytest
@@ -33,39 +36,42 @@ PRODUCTION = "docker-build-production"
 IMAGES = (("backend", "."), ("frontend", "./web-ui"))
 
 
+def _steps(job: str) -> list[dict]:
+    return yaml.safe_load(DEPLOY.read_text())["jobs"][job]["steps"]
+
+
+def _normalised_steps(job: str, environment: str) -> str:
+    """The job's steps, serialised, with its own moving tag neutralised.
+
+    Each side rewrites only its own environment token, which is what keeps a
+    cross-tagged job (production pushing `:staging`) detectable instead of
+    cancelling out.
+    """
+    return yaml.safe_dump(_steps(job), sort_keys=True).replace(f":{environment}", ":<env>")
+
+
 def _build_step(job: str, context: str) -> dict:
-    steps = yaml.safe_load(DEPLOY.read_text())["jobs"][job]["steps"]
-    for step in steps:
+    for step in _steps(job):
         if "build-push-action" in step.get("uses", ""):
             if step.get("with", {}).get("context") == context:
                 return step
     raise AssertionError(f"{job} has no docker build step for context {context!r}")
 
 
-def _normalise(step: dict, environment: str) -> dict:
-    """The step with its environment-specific moving tag neutralised."""
-    with_block = dict(step["with"])
-    with_block["tags"] = with_block["tags"].replace(f":{environment}", ":<env>")
-    return {"uses": step["uses"], "with": with_block}
-
-
-@pytest.mark.parametrize(("label", "context"), IMAGES)
-def test_staging_and_production_build_the_same_image(label: str, context: str) -> None:
-    staging = _build_step(STAGING, context)
-    production = _build_step(PRODUCTION, context)
-
-    assert _normalise(staging, "staging") == _normalise(production, "production"), (
-        f"The {label} image is built differently for staging and production. "
-        "Production has no deploy target, so staging is the only place these "
-        "images are ever exercised — keep the two build steps identical apart "
-        "from the environment tag, or that evidence stops transferring (#1210)."
+def test_staging_and_production_run_the_same_build_steps() -> None:
+    assert _normalised_steps(STAGING, "staging") == _normalised_steps(PRODUCTION, "production"), (
+        "The staging and production image builds have drifted apart. Production "
+        "has no deploy target, so staging is the only place these images are "
+        "ever exercised — keep the two jobs' steps identical apart from the "
+        "environment tag, or that evidence stops transferring (#1210)."
     )
 
 
 @pytest.mark.parametrize(("label", "context"), IMAGES)
 def test_each_job_pushes_its_own_moving_tag(label: str, context: str) -> None:
-    """The failure the parity check alone would miss: a copy-paste that leaves
-    production tagging `:staging`, so a production deploy pulls staging's image.
+    """The failure the parity check alone would report confusingly: a
+    copy-paste that leaves production tagging `:staging`, so a production
+    deploy pulls staging's image.
     """
     for job, environment, wrong in (
         (STAGING, "staging", "production"),


### PR DESCRIPTION
Follow-up to #1212 (#1210). One new test file, no production code.

## Why

`docker-build-staging` and `docker-build-production` build the same two contexts
from the same Dockerfiles, differing only in the moving tag they push:

| | staging | production |
|---|---|---|
| context | `.` / `./web-ui` | `.` / `./web-ui` |
| Dockerfile + lockfile | same | same |
| build-args | same | same |
| action pin | same | same |
| tag | `:staging` | `:production` |

That equivalence is load-bearing, and nothing enforced it.

Production has never been deployed — it holds no secrets and has no host, so
`deploy-production` stops at its preflight (#1143). The only evidence its images are
sound is therefore that **staging builds the identical thing**.

#1210 leaned on exactly that. A high advisory failed the frontend image's
`npm audit --audit-level=high` and blocked every deploy; the fix was verified against a
staging deploy, and applies to production *solely* because the two jobs are the same
build. I wrote that down as an inference at the time. This makes it a checked property.

Edit one job and not the other — bump the action pin, add a build-arg, change the
context — and the inference silently stops holding, with no signal until production's
first real deploy.

## What it checks

- **Parity**: the two jobs' **entire step lists**, serialised, with each side's own
  environment tag neutralised. Anything that changes what gets built lives in there —
  the `build-push-action` invocations, but equally the `setup-buildx-action` /
  `checkout` / `login-action` pins above them, and any step or field that does not
  exist yet.
- **Own moving tag**: the failure parity alone would report confusingly — a copy-paste
  that leaves production tagging `:staging`, so a production deploy pulls staging's
  image. Separate assertion, clearer message.

> **Updated after review.** The first version compared only the two `build-push-action`
> steps. GLM's review flagged that a pin drifting on one side anywhere *else* in the job
> would change the build without the guard noticing — and since both jobs share those
> pins today, that drift is reachable. Comparing whole step lists closes it, and is less
> code than the per-image check it replaces.

## Verified by mutation

Each of these turns the suite red (workflow restored after each). The first two are the
gap the review found — they passed against the original version:

| Mutation | Result |
|---|---|
| `setup-buildx-action` pin drift, production only | ❌ *(missed by v1)* |
| `checkout` pin drift, production only | ❌ *(missed by v1)* |
| `build-push-action` pin drift, production only | ❌ |
| Build-arg added to production's frontend build only | ❌ |
| Production's frontend retagged `:staging` | ❌ both checks fail |
| An extra step inserted into the production job | ❌ |

Clean tree: 3 passed. `ruff check` and `ruff format --check` clean.

## Scope

Deliberately does not touch the deploy workflow, and does not attempt to make production
deployable — that is a configuration gap (#1143's preflight documents it), not something
a test can close. This only ensures that while production is un-deployed, staging remains
honest evidence for it.

Refs #1210

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua