### PR TITLE
ci: surface a new web-ui advisory before it becomes a deploy outage (#1213)

### DIFF
--- a/.github/workflows/web-ui-audit.yml
+++ b/.github/workflows/web-ui-audit.yml
@@ -62,6 +62,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build the deps stage — npm ci + the audit gate, in-image
+        # Deliberately uncached. `deploy.yml` builds this image with
+        # `cache-from: type=gha`, so an unchanged lockfile makes the audit layer
+        # a cache hit and the audit does not re-execute there — a real gap in the
+        # gate, tracked in #1216. A fresh, cacheless build is the
+        # only way this job actually re-runs the audit against today's
+        # advisories, which is the entire point of running it daily.
+        #
         # No --target of our own invention: `deps` is the stage that carries both
         # `npm ci` (the #1194 lockfile oracle) and the audit gate, pinned by
         # tests/ci/test_web_ui_audit_guard_1213.py. Nothing later in the image is

--- a/.github/workflows/web-ui-audit.yml
+++ b/.github/workflows/web-ui-audit.yml
@@ -1,0 +1,93 @@
+name: Web UI Audit
+
+# The frontend image's supply-chain gate, on a schedule (#1213).
+#
+# web-ui/Dockerfile's `deps` stage runs `npm ci` then
+# `npm audit --audit-level=high`. That gate is correct and stays — it is what
+# guarantees no image carrying a high advisory is ever built. What it is bad at is
+# *telling anyone*: its trigger is an upstream publication, not a commit, and its
+# failure takes out `Build images (staging)` and therefore the whole `Deploy`
+# workflow, staging and production together, since both build the same image.
+#
+# #1210 was exactly that. Two transitive advisories (js-yaml, sharp) landed, no
+# code changed, and staging was un-deployable for a day — discovered by a human
+# noticing an unrelated red run. Both fixing Dependabot PRs were already open and
+# green the whole time.
+#
+# So this job separates the signal from the blast radius: the advisory shows up as
+# a red run named for what actually broke, before the next deploy discovers it.
+# The image gate remains the backstop — nothing here stops a build.
+#
+# It builds that Dockerfile stage rather than re-running `npm audit` on the
+# runner. Two reasons, both of which cost a review cycle to learn:
+#   - No second copy of the audit level to drift out of sync with. A scheduled
+#     check set laxer than the gate reports green while the deploy still breaks.
+#   - Same environment. `npm ci` on alpine/musl resolves different optional
+#     platform packages than glibc on ubuntu-latest (sharp is exactly such a
+#     dependency), so an advisory against the musl variant is invisible to an
+#     audit run outside the image.
+#
+# Known limitation, same as Unlocked Resolution (#1169): a red scheduled run
+# notifies through GitHub's normal workflow notifications; it does not open an
+# issue or page anyone. Deliberate — one moving part. The step summary is written
+# to be self-explanatory so the run needs no archaeology.
+
+on:
+  schedule:
+    # Daily, 06:30 UTC — half an hour after Unlocked Resolution, so the two
+    # upstream-drift checks report separately rather than as one pile.
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "web-ui/package.json"
+      - "web-ui/package-lock.json"
+      - "web-ui/Dockerfile"
+      - "tests/ci/test_web_ui_audit_guard_1213.py"
+      - ".github/workflows/web-ui-audit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    name: web-ui image audit gate
+    runs-on: ubuntu-latest
+    # Around a minute in practice. The cap is for the unattended schedule, so a
+    # stalled registry call does not sit on a runner until the 6h default.
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build the deps stage — npm ci + the audit gate, in-image
+        # No --target of our own invention: `deps` is the stage that carries both
+        # `npm ci` (the #1194 lockfile oracle) and the audit gate, pinned by
+        # tests/ci/test_web_ui_audit_guard_1213.py. Nothing later in the image is
+        # built, so this is the cheapest slice that reproduces the failure.
+        run: |
+          set -o pipefail
+          if docker build --target deps --progress plain ./web-ui \
+              2>&1 | tee "$RUNNER_TEMP/audit.txt"; then
+            echo "### web-ui image audit gate: clean" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "### web-ui image audit gate failed"
+            echo
+            echo "This is the same step the frontend image build runs, so **the next"
+            echo "deploy will fail** — staging and production together. If no web-ui"
+            echo "dependency changed, no commit caused this: an advisory was published"
+            echo "upstream, or a fresh install of the pinned tree no longer resolves."
+            echo
+            echo "**Follow the recovery recipe, not your reflex.** The obvious fix"
+            echo "regenerates the lockfile, which fails \`npm ci\` (#1194) and replaces"
+            echo "this break with a worse one. The procedure is in"
+            echo "\`deploy/README.md\` → \"The frontend image audit gate failed\"."
+            echo
+            echo '```'
+            tail -60 "$RUNNER_TEMP/audit.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/web-ui-audit.yml
+++ b/.github/workflows/web-ui-audit.yml
@@ -46,6 +46,14 @@ on:
       - "tests/ci/test_web_ui_audit_guard_1213.py"
       - ".github/workflows/web-ui-audit.yml"
 
+concurrency:
+  # A PR touching the lockfile can push several times in a minute, and each push
+  # queues a fresh uncached image build. Superseded PR runs are worthless — only
+  # the newest tree matters. Scheduled runs are never cancelled: the group key
+  # includes the ref, and cancel-in-progress is limited to pull_request.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,17 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   replaced was too narrow four times in one review cycle — a local bound one
   statement earlier carries no field name at all. Every registered command must
   appear in its `RUN` or `EXEMPT` table; a new command fails CI until classified.
+- **Don't run `npm audit fix` (or plain `npm install`) in `web-ui`.** Any lockfile
+  npm regenerates there fails `npm ci` with a misleading `@emnapi` error (#1194),
+  so the reflexive fix for a red audit gate produces a differently broken build.
+  `web-ui/Dockerfile` runs `npm audit --audit-level=high` during the image build,
+  which means an advisory published upstream — no commit of ours — fails
+  `Build images (staging)` and takes staging *and* production down together
+  (#1210 cost a day of that). The daily `Web UI Audit` workflow (#1213) exists to
+  surface it first; the in-image gate stays as the backstop and must not be
+  weakened. Recovery recipe: `deploy/README.md` → "The frontend image audit gate
+  failed" — take Dependabot's surgical lock diff verbatim and treat `npm ci`
+  exit 0 as the oracle.
 - **Don't leave a CI gate disabled when its feature area becomes active.** Re-enable `DISABLED:` / `# COMMENTED OUT:` jobs before the first PR in that area. Verify `frontend-tests` is wired into `test-summary`.
 - **A CI run that fails with ZERO jobs and no logs means the workflow file will not compile** (#1122). `gh run view --log-failed` returns `log not found`, the jobs API is empty, and the run ignores its own trigger filters — so it looks like an unrelated trigger bug rather than an outage. YAML validity is not enough: `yaml.safe_load()` parses these files fine; it is GitHub's expression pass that rejects them. Run `actionlint .github/workflows/*.yml` first — the `workflow-lint` job in `test.yml` now enforces this on every PR, but it is the first thing to run locally when a workflow misbehaves. This shipped twice undetected: `deploy.yml` (staging down for a week, an empty `${{ }}` inside a `run:` block) and `claude-review` (#1011).
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -282,6 +282,50 @@ $COMPOSE logs --tail 30 frontend
 
 The deploy job prints exactly these when its health check fails.
 
+### The frontend image audit gate failed
+
+Symptom: `Build images (staging)` is red, the `Deploy` workflow never runs, and
+the failing step is `npm audit --audit-level=high` in `web-ui/Dockerfile`. No
+commit caused it — an advisory was published upstream against a transitive
+dependency, so the same commit that built yesterday does not build today. Both
+environments are affected at once, because they build the same image.
+
+This gate is intentional (#1131, #1121) and the fix is to bump the dependency,
+not to loosen the gate. A daily `Web UI Audit` workflow (#1213) runs the same
+check on a schedule so this normally surfaces there first.
+
+**Do not run `npm audit fix`** — nor `npm install`, nor anything else that
+regenerates the lock. Any lockfile npm regenerates in `web-ui` fails `npm ci`
+with a misleading `@emnapi` error (#1194), so the reflexive fix replaces one
+broken build with a differently broken one.
+
+The working recipe:
+
+```bash
+# 1. Dependabot has almost certainly already produced the exact diff you need.
+gh pr list --state open --search "author:app/dependabot" --json number,title
+
+# 2. Take its lockfile change verbatim — it is surgical (no packages added or
+#    removed, no new install scripts, every resolved URL still
+#    registry.npmjs.org), so npm ci still succeeds from it. `gh pr diff` takes
+#    no path arguments, so scope it with git apply instead.
+gh pr diff <N> > /tmp/dep.patch
+git apply --include='web-ui/package*.json' --stat --apply /tmp/dep.patch
+
+# 3. Verify, in this order. npm ci is the #1194 oracle.
+cd web-ui
+npm ci                          # exit 0, or the lock is unusable
+npm audit --audit-level=high    # exit 0, 0 vulnerabilities
+npm test && npm run build
+docker build --target deps .    # the gate step passes in-image; `deps` is
+                                # the only stage that carries it
+```
+
+If no Dependabot PR exists yet, `npm audit` names the advisory and its fixed
+version; hand-edit only the `version`/`resolved`/`integrity` fields for that one
+package in `package-lock.json` and re-run the same three checks. Merging
+Dependabot's PR directly is the cheapest path of all when one is open and green.
+
 ### Two things to know
 
 - **`NEXT_PUBLIC_*` are baked at build time.** Next.js inlines them into the

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -321,10 +321,21 @@ docker build --target deps .    # the gate step passes in-image; `deps` is
                                 # the only stage that carries it
 ```
 
-If no Dependabot PR exists yet, `npm audit` names the advisory and its fixed
-version; hand-edit only the `version`/`resolved`/`integrity` fields for that one
-package in `package-lock.json` and re-run the same three checks. Merging
-Dependabot's PR directly is the cheapest path of all when one is open and green.
+Merging Dependabot's PR directly is the cheapest path of all when one is open
+and green. If none exists yet, get Dependabot to produce one rather than
+hand-writing the lockfile change: the repo's Dependabot alerts page has a
+*Create security update* button per advisory, and `@dependabot recreate` on a
+stale PR refreshes it. Its diff is the artifact you want — surgical, and already
+proven to survive `npm ci`.
+
+Hand-editing `package-lock.json` is a last resort, and only defensible for a
+patch bump whose own dependency set is unchanged: bumping a package whose
+dependencies, engines, binaries or optional/platform packages moved leaves the
+rest of the lock stale while pointing at a different tarball, so `npm ci`
+installs a tree npm would never resolve. If you do it, change
+`version`/`resolved`/`integrity` for that one package only and verify with all
+three of `npm ci`, `npm ls <package>` (the tree really is what you edited), and
+a re-run of the audit.
 
 ### Two things to know
 

--- a/tests/ci/test_web_ui_audit_guard_1213.py
+++ b/tests/ci/test_web_ui_audit_guard_1213.py
@@ -64,7 +64,12 @@ def _stage_body(stage: str) -> str:
     """
     body: list[str] = []
     inside = False
-    for line in DOCKERFILE.read_text().splitlines():
+    # Backslash continuations are joined first, so a directive split across
+    # physical lines is scanned as the one command it actually is. Without this,
+    # `RUN npm audit --audit-level=high \\` + `    || true` reads as an intact
+    # gate to every check below while building green on a high advisory.
+    source = re.sub(r"\\\n\s*", " ", DOCKERFILE.read_text())
+    for line in source.splitlines():
         stripped = line.strip()
         if stripped.startswith("#"):
             continue

--- a/tests/ci/test_web_ui_audit_guard_1213.py
+++ b/tests/ci/test_web_ui_audit_guard_1213.py
@@ -1,0 +1,173 @@
+"""#1213 — the early signal for a new high advisory against `web-ui`.
+
+`web-ui/Dockerfile`'s `deps` stage runs `npm ci` then
+`npm audit --audit-level=high`. That gate is correct (#1131) but its failure mode
+is disproportionate to its trigger: no commit is required — a newly published
+advisory against any transitive dependency flips it — and the blast radius is the
+whole `Deploy` workflow, both environments at once, since they build the same
+image. #1210 was exactly that: staging un-deployable for a day, found by a human
+noticing a red run, while both fixing Dependabot PRs sat green and unmerged.
+
+`.github/workflows/web-ui-audit.yml` builds that same Dockerfile stage on a daily
+schedule so a new advisory arrives as a targeted failure instead of as a deploy
+outage. These assertions pin the properties that make it worth having — and, just
+as importantly, that it neither *replaced* the gate it front-runs nor drifted into
+checking something laxer.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+REPO = Path(__file__).resolve().parents[2]
+AUDIT = REPO / ".github" / "workflows" / "web-ui-audit.yml"
+DOCKERFILE = REPO / "web-ui" / "Dockerfile"
+DEPLOY_README = REPO / "deploy" / "README.md"
+CLAUDE_MD = REPO / "CLAUDE.md"
+
+# The stage the workflow targets and the gate must both live in.
+GATE_STAGE = "deps"
+
+
+def _load(path: Path) -> dict:
+    # PyYAML parses the bare `on:` key as the boolean True.
+    return yaml.safe_load(path.read_text())
+
+
+def _runs(workflow: dict) -> str:
+    """Every executable line of every step, comment-only lines dropped.
+
+    A shell comment cannot run anything, and this same scanner-vs-comment trap
+    misfired twice while #1213 was written — once here and once in the #969
+    guard. Only a line whose first non-space character is `#` is dropped, so an
+    inline `#` inside a quoted string cannot hide a real command.
+    """
+    return " ".join(
+        line
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        for line in step.get("run", "").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def _stage_body(stage: str) -> str:
+    """The executable lines of one Dockerfile stage, comments dropped.
+
+    Scoped to the stage on purpose: a gate sitting in a stage no build target
+    reaches is not a gate, and `--target deps` would silently stop running it.
+    """
+    body: list[str] = []
+    inside = False
+    for line in DOCKERFILE.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if re.match(r"^FROM\s", stripped, re.IGNORECASE):
+            inside = bool(re.search(rf"\bAS\s+{re.escape(stage)}\b", stripped, re.IGNORECASE))
+            continue
+        if inside:
+            body.append(stripped)
+    return "\n".join(body)
+
+
+def _gate_line() -> str:
+    for line in _stage_body(GATE_STAGE).splitlines():
+        if line.startswith("RUN") and "npm audit" in line:
+            return line
+    return ""
+
+
+def test_it_runs_on_a_schedule():
+    """The trigger is an upstream publication, not a commit of ours."""
+    triggers = _load(AUDIT)[True]
+    assert "schedule" in triggers, (
+        "without a schedule the check only ever runs when someone pushes, which is "
+        "exactly the blind spot that kept staging down for a day in #1210"
+    )
+
+
+def test_it_runs_the_real_gate_rather_than_its_own_copy_of_it():
+    """A re-implemented audit is a second copy of the threshold, free to drift.
+
+    It is also a different environment: `npm ci` on alpine/musl resolves
+    different optional platform packages than glibc does (`sharp` is exactly
+    such a dependency), so an advisory against the musl variant is invisible to
+    an audit run on the bare runner.
+    """
+    runs = _runs(_load(AUDIT))
+    assert "docker build" in runs, (
+        "the workflow no longer builds the image stage that carries the gate, so "
+        "whatever it checks instead can pass while the deploy still fails"
+    )
+    assert f"--target {GATE_STAGE}" in runs, (
+        f"the workflow does not target the {GATE_STAGE!r} stage; a broader target "
+        "builds the whole frontend for no added signal, a narrower one skips the gate"
+    )
+    assert "npm audit" not in runs, (
+        "the workflow runs its own `npm audit` again — that is the duplicated "
+        "threshold this check exists to prevent"
+    )
+
+
+def test_the_gate_lives_in_the_stage_the_workflow_targets():
+    """`--target deps` only runs the gate while the gate is actually in `deps`."""
+    assert _gate_line(), (
+        f"no `RUN npm audit ...` in the Dockerfile's {GATE_STAGE!r} stage, so "
+        f"`docker build --target {GATE_STAGE}` no longer exercises the gate at all"
+    )
+    assert "npm ci" in _stage_body(GATE_STAGE), (
+        f"the {GATE_STAGE!r} stage no longer runs `npm ci`, so the scheduled build "
+        "has stopped being the #1194 lockfile oracle as well"
+    )
+
+
+def test_the_gate_is_set_at_high_and_is_not_neutralised():
+    """#1131: at `critical`, six high findings accumulated unnoticed.
+
+    And a gate is only a gate while it can fail the build — `RUN npm audit ... ||
+    true` type-checks as a gate and enforces nothing.
+    """
+    gate = _gate_line()
+    assert re.search(r"--audit-level[= ]high\b", gate), (
+        f"the audit gate is not set at `high`: {gate!r}. See #1131 — `critical` let "
+        "six high-severity findings through."
+    )
+    for swallow in ("|| true", "|| :", "|| exit 0", "; true", "|| echo"):
+        assert swallow not in gate, (
+            f"the gate swallows its own failure ({swallow!r} in {gate!r}), so an "
+            "image carrying a high advisory would build cleanly"
+        )
+
+
+def test_nothing_here_regenerates_the_lockfile():
+    """#1194: any regenerated web-ui lock fails `npm ci` with a misleading error.
+
+    `npm audit fix` is the reflex and it is wrong — a job that "fixes" the tree it
+    is checking breaks the build it guards.
+    """
+    haystack = _runs(_load(AUDIT)) + "\n" + _stage_body(GATE_STAGE)
+    for forbidden in ("npm audit fix", "npm install", "npm update"):
+        assert forbidden not in haystack, (
+            f"{forbidden!r} rewrites web-ui/package-lock.json into a state npm ci rejects (#1194)"
+        )
+
+
+@pytest.mark.parametrize("doc", [DEPLOY_README, CLAUDE_MD], ids=lambda p: p.name)
+def test_the_recovery_procedure_is_written_down(doc: Path):
+    """#1210's fix was non-obvious and the obvious move (`npm audit fix`) is wrong.
+
+    Both places matter: `deploy/README.md` is where a human whose deploy went red
+    looks, and `CLAUDE.md` is where an agent looks first.
+    """
+    text = doc.read_text()
+    assert "npm audit fix" in text, (
+        f"{doc.name} does not warn against `npm audit fix`, so the next person "
+        "reaches for it first and lands a lockfile npm ci rejects (#1194)"
+    )
+    assert "#1194" in text, f"{doc.name} does not name #1194 as the reason"

--- a/tests/test_ops_hygiene_969.py
+++ b/tests/test_ops_hygiene_969.py
@@ -193,6 +193,20 @@ class TestDeployWorkflowDoesNotResolveDependenciesFreely:
         assert workflows, "no workflows found — this check would pass vacuously"
 
         project_install = re.compile(r"\bnpm install\b(?!\s+(?:-g\b|--global\b))")
-        offenders = sorted(w.name for w in workflows if project_install.search(w.read_text()))
+
+        def executable_text(workflow: Path) -> str:
+            # Comment-only lines cannot run anything, and a workflow that
+            # *explains* why it uses `npm ci` rather than `npm install` is doing
+            # the right thing — flagging it inverts the check (#1213). Only a
+            # line whose first non-space character is `#` is dropped, so an
+            # inline `#` inside a quoted shell string can never hide a real
+            # install from this scan.
+            return "\n".join(
+                line
+                for line in workflow.read_text().splitlines()
+                if not line.lstrip().startswith("#")
+            )
+
+        offenders = sorted(w.name for w in workflows if project_install.search(executable_text(w)))
 
         assert not offenders, f"workflows using `npm install` instead of `npm ci`: {offenders}"


### PR DESCRIPTION
Closes #1213

## The problem

`web-ui/Dockerfile`'s `deps` stage runs `npm audit --audit-level=high`. That gate is correct
(#1131) and stays. Its *failure mode* is what is disproportionate:

- **The trigger is external and unannounced.** No commit is required — a newly published
  advisory against any transitive dependency flips it.
- **The blast radius is total.** Frontend image build fails → `Build images (staging)` fails →
  the whole `Deploy` workflow fails. Staging and production together, since both build the
  same image.
- **Nothing alerts.** #1210 was found by a human noticing a red run while merging something
  unrelated. Staging had been un-deployable for a day, and both fixing Dependabot PRs
  (#1208, #1209) were open and green the entire time.

## What this does

**`Web UI Audit`** (`.github/workflows/web-ui-audit.yml`) runs that gate daily — the
scheduled-check pattern from #1169 — so a new advisory shows up as a red run named for what
actually broke, before the next deploy discovers it. The in-image gate is untouched and
remains the backstop: this is a signal, not a barrier.

It **builds the Dockerfile stage** (`docker build --target deps ./web-ui`) rather than
re-running `npm audit` on the runner. Both reasons came out of pre-PR review:

- No second copy of the threshold to drift out of sync. A scheduled check set laxer than the
  gate reports green while the deploy still breaks.
- Same environment. `npm ci` on alpine/musl resolves different optional platform packages than
  glibc does — `sharp`, one of #1210's two advisories, is exactly such a dependency, so an
  advisory against the musl variant is invisible to an audit run outside the image.

**Recovery is written down** in `deploy/README.md` → "The frontend image audit gate failed",
pointed at from `CLAUDE.md`'s *What NOT to do*. This matters because the obvious move is the
wrong one: `npm audit fix` regenerates the lockfile, and any regenerated web-ui lock fails
`npm ci` with a misleading `@emnapi` error (#1194). The recipe is Dependabot's surgical lock
diff, verbatim — and it was executed end-to-end against #1212's actual patch before being
written down.

**Drive-by fix**: #969's `npm install` guard scanned raw workflow text, so a workflow
*explaining* why it uses `npm ci` rather than `npm install` was flagged as using
`npm install` — the check inverted. It now drops comment-only lines (first non-space `#`
only, so an inline `#` inside a quoted string cannot hide a real command). Fixed rather than
worked around.

## Acceptance criteria

| Criterion | Evidence |
|---|---|
| A new high advisory signals as something other than "the next deploy failed" | `Web UI Audit`, daily at 06:30 UTC. Demoed against the pre-#1212 lockfile: exit 1, step summary carries the log tail naming both high advisories |
| Recovery procedure written where the next person looks | `deploy/README.md` (human, mid-outage) + `CLAUDE.md` (agent). Recipe executed end-to-end against #1212's patch — `git apply`, `npm ci`, `npm audit` all exit 0 |
| The image-build audit gate is still present and still fails on a genuine high finding | Unchanged in `web-ui/Dockerfile`; guard test rejects deletion, `\|\| true`, and a lowered threshold |

## Verification

```
docker build --target deps ./web-ui   exit 0 on HEAD; summary "gate: clean"
same, on the pre-#1212 lockfile       exit 1; summary carries the failing RUN line
                                      and "2 high severity vulnerabilities"
guard mutations                       5/5 caught — gate `|| true`, level lowered to
                                      critical, gate deleted, workflow re-implementing
                                      the audit, schedule removed
#969 guard negative control           still flags a real `npm install`
uv run pytest (the CI gate)           6670 passed, 17 skipped
ruff check . / actionlint             clean
```

## Review

Pre-PR third-party review: `codex review` (opencode/GLM skipped — it mutates the tree and
returns empty on timeout in this repo). It raised four findings; all four were verified
before acting and all four are fixed in this diff:

1. `gh pr diff <N> -- <paths>` is invalid (`accepts at most 1 arg(s)`) — confirmed against the
   live CLI, recipe rewritten to `gh pr diff | git apply --include=`.
2. Runner audit ≠ in-image audit (alpine/musl optional deps) — root cause of 2 and 3; fixed by
   building the Dockerfile stage instead.
3. The level-parity regex could match summary `echo` text rather than a real command — the
   duplicated level no longer exists.
4. The Dockerfile-gate assertion accepted `RUN npm audit ... || true` — the guard now rejects
   failure-swallowing suffixes and pins the threshold at `high`.

## Known limitations

- **A red scheduled run notifies through GitHub's normal workflow notifications; it does not
  open an issue or page anyone.** Same deliberate limitation as Unlocked Resolution (#1169) —
  one moving part. The step summary is written to be self-explanatory so the run needs no
  archaeology.
- **Direction (2) from the issue — auto-merging Dependabot security PRs for `web-ui` — is not
  implemented here.** It is the direct fix for #1210's proximate cause (the diff was ready and
  unmerged), but it is constrained by #1189 and by the supply-chain review the
  `reviewing-dependabot-prs` skill exists to perform. Filed as a follow-up rather than
  smuggled into a CI-visibility change.
- The daily cadence means an advisory published just after a run can still reach a deploy
  within the window. The in-image gate is what makes that safe.

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua
