### PR TITLE
fix(ci): stop the frontend audit gate being served from the build cache (#1216)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,16 @@ jobs:
             ghcr.io/frankbria/codeframe-frontend:${{ github.sha }}
             ghcr.io/frankbria/codeframe-frontend:staging
           cache-from: type=gha
+          # The `deps` stage carries `npm audit --audit-level=high` (#1131). A
+          # layer's cache key is its parent layers plus the command string, and
+          # an advisory published upstream changes neither — so with an unchanged
+          # lockfile the audit was a cache hit and never ran, and the deploy
+          # pushed an image carrying the advisory while reporting nothing (#1216).
+          # Excluding only this stage keeps the gate's guarantee that the image
+          # itself was audited. Measured cost of doing so: a fully-cached frontend
+          # build goes 1.3s -> 24s. `npm run build` still cache-hits, because
+          # `COPY --from=deps` is content-addressed and node_modules is unchanged.
+          no-cache-filters: deps
           cache-to: type=gha,mode=max
 
   docker-build-production:
@@ -167,6 +177,16 @@ jobs:
             ghcr.io/frankbria/codeframe-frontend:${{ github.sha }}
             ghcr.io/frankbria/codeframe-frontend:production
           cache-from: type=gha
+          # The `deps` stage carries `npm audit --audit-level=high` (#1131). A
+          # layer's cache key is its parent layers plus the command string, and
+          # an advisory published upstream changes neither — so with an unchanged
+          # lockfile the audit was a cache hit and never ran, and the deploy
+          # pushed an image carrying the advisory while reporting nothing (#1216).
+          # Excluding only this stage keeps the gate's guarantee that the image
+          # itself was audited. Measured cost of doing so: a fully-cached frontend
+          # build goes 1.3s -> 24s. `npm run build` still cache-hits, because
+          # `COPY --from=deps` is content-addressed and node_modules is unchanged.
+          no-cache-filters: deps
           cache-to: type=gha,mode=max
 
   # ============================================

--- a/.github/workflows/web-ui-audit.yml
+++ b/.github/workflows/web-ui-audit.yml
@@ -70,11 +70,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build the deps stage — npm ci + the audit gate, in-image
-        # Deliberately uncached. `deploy.yml` builds this image with
-        # `cache-from: type=gha`, so an unchanged lockfile makes the audit layer
-        # a cache hit and the audit does not re-execute there — a real gap in the
-        # gate, tracked in #1216. A fresh, cacheless build is the
-        # only way this job actually re-runs the audit against today's
+        # Deliberately uncached, and pinned that way by
+        # tests/ci/test_deploy_audit_cache_1216.py. `deploy.yml` reads the GHA
+        # layer cache, which used to make the audit a cache hit there whenever
+        # the lockfile was unchanged — #1216, now closed by excluding the `deps`
+        # stage from that cache. These are the only two places the gate runs, so
+        # if this job ever grows a cache both of them go stale together. A fresh,
+        # cacheless build is what makes this a real re-run against today's
         # advisories, which is the entire point of running it daily.
         #
         # No --target of our own invention: `deps` is the stage that carries both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,14 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   weakened. Recovery recipe: `deploy/README.md` → "The frontend image audit gate
   failed" — take Dependabot's surgical lock diff verbatim and treat `npm ci`
   exit 0 as the oracle.
+  **The gate only fires because `deploy.yml` excludes the `deps` stage from the
+  layer cache** (`no-cache-filters: deps`, #1216). A layer's cache key is its
+  parent layers plus the command string, and an upstream advisory changes
+  neither — so without that exclusion an unchanged lockfile makes `npm audit` a
+  cache hit and the deploy ships the advisory silently, the exact inverse of
+  #1210. Don't delete it to save the ~23s it costs; both it and the daily
+  check's cachelessness are pinned by
+  `tests/ci/test_deploy_audit_cache_1216.py`.
 - **Don't leave a CI gate disabled when its feature area becomes active.** Re-enable `DISABLED:` / `# COMMENTED OUT:` jobs before the first PR in that area. Verify `frontend-tests` is wired into `test-summary`.
 - **A CI run that fails with ZERO jobs and no logs means the workflow file will not compile** (#1122). `gh run view --log-failed` returns `log not found`, the jobs API is empty, and the run ignores its own trigger filters — so it looks like an unrelated trigger bug rather than an outage. YAML validity is not enough: `yaml.safe_load()` parses these files fine; it is GitHub's expression pass that rejects them. Run `actionlint .github/workflows/*.yml` first — the `workflow-lint` job in `test.yml` now enforces this on every PR, but it is the first thing to run locally when a workflow misbehaves. This shipped twice undetected: `deploy.yml` (staging down for a week, an empty `${{ }}` inside a `run:` block) and `claude-review` (#1011).
 

--- a/tests/ci/test_deploy_audit_cache_1216.py
+++ b/tests/ci/test_deploy_audit_cache_1216.py
@@ -46,12 +46,17 @@ def _frontend_build_step(job: str) -> dict:
 @pytest.mark.parametrize("job", BUILD_JOBS)
 def test_the_deploy_build_cannot_serve_the_gate_stage_from_cache(job: str) -> None:
     with_ = _frontend_build_step(job)
-    if "type=gha" not in str(with_.get("cache-from", "")):
-        pytest.skip("frontend build no longer reads the GHA cache; nothing to bust")
+    # Deliberately backend-agnostic: the property is "any layer cache read implies
+    # the gate stage is excluded from it", not "type=gha implies it". Keyed on the
+    # backend, swapping `type=gha` for `type=registry,ref=...` — a normal move for a
+    # bigger cache — would skip this guard while serving the audit layer exactly the
+    # same way, leaving `no-cache-filters` free to be dropped in a later refactor.
+    if not str(with_.get("cache-from", "")).strip():
+        pytest.skip("frontend build reads no layer cache; nothing to bust")
 
     filters = [f.strip() for f in str(with_.get("no-cache-filters", "")).splitlines() if f.strip()]
     assert GATE_STAGE in filters, (
-        f"{job}'s frontend build reads the GHA layer cache but does not exclude the "
+        f"{job}'s frontend build reads a layer cache but does not exclude the "
         f"{GATE_STAGE!r} stage from it. An unchanged lockfile makes `npm audit` a cache "
         "hit, so a high advisory published since the last build ships unreported (#1216)."
     )

--- a/tests/ci/test_deploy_audit_cache_1216.py
+++ b/tests/ci/test_deploy_audit_cache_1216.py
@@ -1,0 +1,77 @@
+"""#1216 — the frontend image's audit gate must actually execute on the deploy path.
+
+`web-ui/Dockerfile`'s `deps` stage runs `npm ci` then
+`npm audit --audit-level=high`, and the gate's stated guarantee is that "an image
+carrying a high advisory does not get built at all". `deploy.yml` builds that
+image with `cache-from: type=gha`, and a BuildKit layer's cache key is its parent
+layers plus the command string — neither of which changes when an advisory is
+published upstream. So an unchanged `package-lock.json` makes the audit layer a
+cache hit and the audit never runs: the deploy pushes an image carrying the
+advisory and the gate reports nothing.
+
+Note this is the *opposite* failure from #1210, where the gate fired and took both
+deploys down. Same gate, both directions, because it had no execution guarantee of
+its own.
+
+These assertions pin that the deploy build re-runs the gate stage, and that the
+daily cacheless check (#1213) that front-runs it has not quietly grown a cache.
+"""
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+REPO = Path(__file__).resolve().parents[2]
+DEPLOY = REPO / ".github" / "workflows" / "deploy.yml"
+AUDIT = REPO / ".github" / "workflows" / "web-ui-audit.yml"
+
+BUILD_JOBS = ("docker-build-staging", "docker-build-production")
+FRONTEND_CONTEXT = "./web-ui"
+# The Dockerfile stage carrying `npm ci` + the audit gate, per #1213's guard.
+GATE_STAGE = "deps"
+
+
+def _frontend_build_step(job: str) -> dict:
+    steps = yaml.safe_load(DEPLOY.read_text())["jobs"][job]["steps"]
+    for step in steps:
+        with_ = step.get("with", {})
+        if "build-push-action" in step.get("uses", "") and with_.get("context") == FRONTEND_CONTEXT:
+            return with_
+    raise AssertionError(f"{job} has no frontend build step (context {FRONTEND_CONTEXT!r})")
+
+
+@pytest.mark.parametrize("job", BUILD_JOBS)
+def test_the_deploy_build_cannot_serve_the_gate_stage_from_cache(job: str) -> None:
+    with_ = _frontend_build_step(job)
+    if "type=gha" not in str(with_.get("cache-from", "")):
+        pytest.skip("frontend build no longer reads the GHA cache; nothing to bust")
+
+    filters = [f.strip() for f in str(with_.get("no-cache-filters", "")).splitlines() if f.strip()]
+    assert GATE_STAGE in filters, (
+        f"{job}'s frontend build reads the GHA layer cache but does not exclude the "
+        f"{GATE_STAGE!r} stage from it. An unchanged lockfile makes `npm audit` a cache "
+        "hit, so a high advisory published since the last build ships unreported (#1216)."
+    )
+
+
+def test_the_scheduled_check_stays_cacheless() -> None:
+    """#1213's daily run is the only other place the gate re-executes.
+
+    It builds the stage on a fresh runner with no `--cache-from`. Give it one and
+    both executions of the gate become cache hits at the same time.
+    """
+    runs = " ".join(
+        line
+        for job in yaml.safe_load(AUDIT.read_text())["jobs"].values()
+        for step in job.get("steps", [])
+        for line in step.get("run", "").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert "docker build" in runs, "the scheduled check no longer builds the image stage (#1213)"
+    assert "--cache-from" not in runs, (
+        "the scheduled audit build has grown a cache, so it can hit the same stale "
+        "`npm audit` layer the deploy path does — then neither place runs the gate (#1216)"
+    )


### PR DESCRIPTION
Closes #1216

## The problem

`web-ui/Dockerfile`'s `deps` stage runs `npm audit --audit-level=high`, and the gate's
stated guarantee is that "an image carrying a high advisory does not get built at all".
`deploy.yml` builds that image with `cache-from: type=gha`. A BuildKit layer's cache key
is its parent layers plus the command string — and an advisory published upstream changes
neither. So with an unchanged `package-lock.json` the audit layer was a cache hit and the
audit **never executed**: the deploy pushed an image carrying the advisory and the gate
reported nothing.

This is the *opposite* failure from #1210, where the same gate fired and took staging and
production down together. Both come from the gate having no execution guarantee of its own.

## The fix

Direction (1) from the issue: exclude only the `deps` stage from the layer cache, via
buildx's own `no-cache-filters`, on both frontend build steps.

Rejected (2) — moving the audit out of the image into a separate deploy step. It loses the
property that makes the in-image gate worth having (the image that ships is the image that
was audited) and creates a second copy of the `high` threshold, free to drift. That drift
is exactly what `tests/ci/test_web_ui_audit_guard_1213.py` already exists to prevent.

Rejected (3) — accept and document. Does not satisfy the first acceptance criterion.

## Evidence (measured against the real Dockerfile, not asserted)

| Build | Shape | `RUN npm audit --audit-level=high` |
|---|---|---|
| 1 | populate cache | ran |
| 2 | `--cache-from` — **today's deploy.yml** | `#10 CACHED` — the bug |
| 3 | `--cache-from --no-cache-filter deps` — **the fix** | `#10 0.862 found 0 vulnerabilities` / `DONE 0.9s` |

Failure still propagates through the filter — a failing gate stage under
`--no-cache-filter` exits 1, it is not swallowed.

**Cost, measured on a full frontend build:** fully cached 1.3s → **24.2s**. Not the 87s of a
cold build, because `npm run build` still reports `CACHED`: `COPY --from=deps` is
content-addressed and node_modules is unchanged. Only `npm ci` + the audit re-run.

The pinned action SHA (`53b7df9`, v7.3.0) supports the input — its `context.ts` maps
`no-cache-filters` to `--no-cache-filter <stage>`, the exact flag demonstrated above.

## Guard

`tests/ci/test_deploy_audit_cache_1216.py` pins that both frontend build steps exclude the
gate stage while they read the GHA cache, and that #1213's daily check stays cacheless —
give that one a cache too and both executions of the gate go stale at the same time.

`tests/ci/test_deploy_build_job_parity_1210.py` still passes: the change is identical in
staging and production.

## Acceptance criteria

- [x] A deploy build cannot reuse a cached `npm audit` layer from a previous day
- [x] The gate still fails a genuine high finding (failure propagates through the filter;
      the audit `RUN` itself is untouched)
- [x] The `Web UI Audit` scheduled check (#1213) stays cacheless — now pinned by a test

## Known limitations

- The exclusion is unconditional, so every deploy pays ~23s. Cheaper than a date build-arg,
  which invalidates on a schedule of its own rather than on the property we actually want.
- The backend image is untouched — it carries no audit gate.
- The demo could not produce a *genuine* high advisory to fail: the current tree reports
  `found 0 vulnerabilities` at every audit level. The gate's ability to fail a real finding
  is unchanged by this diff and is evidenced by #1210 in the field.

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua
