### PR TITLE
fix(ci): skip claude-review on bot PRs instead of failing on them (#1189)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,19 @@ on:
 
 jobs:
   claude-review:
+    # Skip bot PRs (#1189). GitHub withholds regular `secrets.*` from
+    # `pull_request` runs on Dependabot PRs — they are only readable from the
+    # separate Dependabot secrets scope — so the credential preflight below
+    # failed on every dependency bump, permanently and unfixably. Making the
+    # token reachable instead would undo #875, which hardened this workflow
+    # against reviewing Dependabot-controlled content with a credential.
+    # The condition is glm-review.yml's, not `github.actor != 'dependabot[bot]'`:
+    # `github.actor` is the PR author on `opened` but the **pusher** on
+    # `synchronize`, so the actor form misses a bot push to a human PR (#1167).
+    # A null `sender` compares false, so it fails closed.
+    if: |
+      github.event.pull_request.user.type == 'User' &&
+      github.event.sender.type == 'User'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,9 +82,6 @@ jobs:
         uses: anthropics/claude-code-action@24dcd50c0568f0fc9e9211213a4fd2d9eb15c4e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Allow Dependabot PRs to be reviewed (default policy rejects bot actors
-          # and fails the check on every dependency PR).
-          allowed_bots: "dependabot[bot]"
           # Defense-in-depth: don't feed Dependabot's own comment prose to the
           # reviewer as if it were instructions (the PR body is handled by the
           # untrusted-content clause in the prompt below).

--- a/tests/ci/test_claude_review_bot_gate_1189.py
+++ b/tests/ci/test_claude_review_bot_gate_1189.py
@@ -1,0 +1,53 @@
+"""#1189 — claude-review skips bot PRs instead of failing on them.
+
+GitHub withholds regular `secrets.*` from `pull_request` runs on Dependabot PRs
+(they live in the separate Dependabot secrets scope), so the #1011 credential
+preflight — correct on a human PR — flagged a permanent, unfixable condition as
+a failure on every dependency bump. A check that is always red and never
+blocking trains everyone to ignore the check column.
+
+Both halves matter, so both are pinned here: the gate must be present, and the
+preflight it protects must NOT have been deleted to achieve it.
+"""
+
+import pytest
+import yaml
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "claude-code-review.yml"
+)
+
+
+def _review_job() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]["claude-review"]
+
+
+def test_bot_authored_and_bot_pushed_prs_are_gated_out():
+    """`github.actor` alone is too narrow — it is the pusher on `synchronize`.
+
+    That is the mistake #1167 fixed in glm-review.yml; this workflow uses the
+    same condition so the two reviewers cannot drift apart.
+    """
+    condition = _review_job()["if"]
+    assert "github.event.pull_request.user.type == 'User'" in condition
+    assert "github.event.sender.type == 'User'" in condition
+
+
+def test_the_dead_dependabot_opt_in_is_gone():
+    """`allowed_bots` opted in PRs that can never authenticate."""
+    assert "allowed_bots" not in WORKFLOW.read_text()
+
+
+def test_the_credential_preflight_still_fails_loudly():
+    """A human PR with a rotated secret must still go red (#1011 AC3)."""
+    preflight = next(
+        step
+        for step in _review_job()["steps"]
+        if step["name"] == "Verify the review credential is present"
+    )
+    assert "CLAUDE_CODE_OAUTH_TOKEN" in preflight["env"]["OAUTH_TOKEN"]
+    assert "exit 1" in preflight["run"]


### PR DESCRIPTION
## Problem

`claude-review` failed on **every** Dependabot PR and succeeded on every human one. GitHub withholds regular `secrets.*` from `pull_request`-triggered runs on Dependabot PRs — they are only readable from the separate Dependabot secrets scope — so `secrets.CLAUDE_CODE_OAUTH_TOKEN` is *always* empty there, by design. The #1011 credential preflight, which is correct on a human PR, therefore flagged a permanent and unfixable condition as a failure.

`claude-review` is not in branch protection's required checks, so it never blocked. It just sat red on every dependency PR forever, had to be explained away by hand on every merge, and was documented in the operator's local notes as "always fails on bot PRs, ignore it". That is the pathology #1167 was filed about: a check that must be routinely ignored is worse than no check, because the habit generalises.

## Change

Option 1 from the issue. Gate the job on a human author *and* a human sender, and drop the now-dead `allowed_bots: "dependabot[bot]"` line — it opted in PRs that could never authenticate.

The condition is `glm-review.yml`'s, **not** the issue's literal `github.actor != 'dependabot[bot]'` suggestion:

```yaml
if: |
  github.event.pull_request.user.type == 'User' &&
  github.event.sender.type == 'User'
```

`github.actor` is the PR *author* on `opened` but the **pusher** on `synchronize`, so the actor form misses a bot push to a human PR — exactly the narrowing #1167 had to fix in the sibling workflow. A null `sender` compares false, so it fails closed. Using the same condition in both review workflows also means they cannot drift apart.

The preflight step is **kept, not deleted**. A human PR with a missing or rotated secret still goes red with the #1011 annotation.

`exclude_comments_by_actor: "dependabot[bot]"` stays. It is a #875 defense-in-depth measure, and removing an anti-injection setting to tidy up is not a trade worth making.

Option 2 (make the credential reachable via the Dependabot secrets scope or `pull_request_target`) was rejected for the reason the issue gives: it reintroduces precisely what #875 hardened against — a credentialed reviewer reading content an attacker can influence through package metadata and release notes. Supply-chain risk on a dependency bump is triaged by the `reviewing-dependabot-prs` flow (lockfile diff, lifecycle scripts, maintainer changes), which is a different question from the code review `claude-review` performs.

## Acceptance criteria

- [x] **A Dependabot PR shows `claude-review` as skipped, never failure** — the gate reads `pull_request.user.type`, which the live payload for the open Dependabot PR #1204 reports as `Bot` (vs `User` for human PR #1218), so the job is skipped rather than run. Before this change, #1187 and #1185 both recorded `claude-review: failure`.
- [x] **A human PR with a genuinely missing/rotated secret still fails loudly** — the `Verify the review credential is present` step is untouched and still `exit 1`s with the #1011 annotation; a guard test pins that it was not deleted to achieve the skip.
- [x] **No dead configuration left behind** — `allowed_bots` is gone, and a guard test asserts the string does not reappear anywhere in the file.
- [x] **The approach is recorded in the workflow** — a comment block in the style of the existing `id-token` one, naming why the credential is structurally absent, why option 2 was rejected, and why the condition is not `github.actor`.

## Tests

`tests/ci/test_claude_review_bot_gate_1189.py` — three assertions, written RED first: the bot gate is present in both halves, `allowed_bots` is gone, and the preflight still fails loudly.

This file is also what makes the fix testable in CI at all: the workflow's own `paths-ignore` covers `.github/**`, so a workflow-only PR would never trigger `claude-review`. The `.py` file in this diff is what gives the human path a real run.

`actionlint .github/workflows/claude-code-review.yml` passes (per CLAUDE.md — a workflow that will not compile fails with zero jobs and no logs).

## Known limitations

- **A human PR that a bot pushed to is now also skipped.** Same trade `glm-review.yml` already makes. A skip is neutral; the alternative is a condition that goes red on a case it cannot review.
- **Fork PRs from humans are untouched.** GitHub also withholds secrets from fork `pull_request` runs, so a human fork PR would still hit the preflight failure. No fork contributions exist on this repo today, and it is out of scope for this issue — worth a follow-up if that changes.
- **AC1 is verified by payload inspection, not by observing a live Dependabot run.** A new Dependabot run cannot be manufactured on demand; the open Dependabot PR #1204 will exercise it on its next push.

Closes #1189

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua
