### PR TITLE
fix(web-ui): name npm 11.6.x as the lockfile corruptor, not the lockfile (#1194)

### DIFF
--- a/.github/workflows/web-ui-audit.yml
+++ b/.github/workflows/web-ui-audit.yml
@@ -80,7 +80,7 @@ jobs:
         # advisories, which is the entire point of running it daily.
         #
         # No --target of our own invention: `deps` is the stage that carries both
-        # `npm ci` (the #1194 lockfile oracle) and the audit gate, pinned by
+        # `npm ci` (the lockfile oracle, #1194) and the audit gate, pinned by
         # tests/ci/test_web_ui_audit_guard_1213.py. Nothing later in the image is
         # built, so this is the cheapest slice that reproduces the failure.
         run: |
@@ -98,9 +98,9 @@ jobs:
             echo "dependency changed, no commit caused this: an advisory was published"
             echo "upstream, or a fresh install of the pinned tree no longer resolves."
             echo
-            echo "**Follow the recovery recipe, not your reflex.** The obvious fix"
-            echo "regenerates the lockfile, which fails \`npm ci\` (#1194) and replaces"
-            echo "this break with a worse one. The procedure is in"
+            echo "**Follow the recovery recipe, not your reflex.** The reflexive"
+            echo "auto-fix rewrites the very tree this job checks, and replaces this"
+            echo "break with a worse one. The procedure is in"
             echo "\`deploy/README.md\` → \"The frontend image audit gate failed\"."
             echo
             echo '```'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,17 +333,27 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   replaced was too narrow four times in one review cycle — a local bound one
   statement earlier carries no field name at all. Every registered command must
   appear in its `RUN` or `EXEMPT` table; a new command fails CI until classified.
-- **Don't run `npm audit fix` (or plain `npm install`) in `web-ui`.** Any lockfile
-  npm regenerates there fails `npm ci` with a misleading `@emnapi` error (#1194),
-  so the reflexive fix for a red audit gate produces a differently broken build.
+- **Don't run `npm audit fix` in `web-ui` to clear a red audit gate** — a job that
+  rewrites the tree it is checking produces a differently broken build. Plain
+  `npm install` is fine **unless you are on npm 11.6.x**, which is the whole of
+  #1194: that npm's `npm install` drops the peer-installed optional
+  `@emnapi/core` and `@emnapi/runtime` entries from `package-lock.json`, and
+  `npm ci` then correctly demands them back with an `@emnapi` error that names
+  nothing you touched. The committed lockfile is **not** corrupt — it matches the
+  registry, and npm 10.8.2, 11.0.0, 11.4.0, 11.5.0, 11.7.0, 11.9.0, 11.10.0 and
+  11.19.0 all round-trip it cleanly. So the fix is `npm i -g npm@latest`, not
+  hand-pruning the lock. `web-ui/package.json` declares the range in `engines`,
+  which makes npm print `EBADENGINE` naming the version; it is deliberately not
+  enforced with `engine-strict`, because that validates every dependency's
+  engines and `@testing-library/jest-dom` requires node >=22 while CI and the
+  image run Node 20.
   `web-ui/Dockerfile` runs `npm audit --audit-level=high` during the image build,
   which means an advisory published upstream — no commit of ours — fails
   `Build images (staging)` and takes staging *and* production down together
   (#1210 cost a day of that). The daily `Web UI Audit` workflow (#1213) exists to
   surface it first; the in-image gate stays as the backstop and must not be
   weakened. Recovery recipe: `deploy/README.md` → "The frontend image audit gate
-  failed" — take Dependabot's surgical lock diff verbatim and treat `npm ci`
-  exit 0 as the oracle.
+  failed" — and `npm ci` exit 0 is the oracle either way.
   **The gate only fires because `deploy.yml` excludes the `deps` stage from the
   layer cache** (`no-cache-filters: deps`, #1216). A layer's cache key is its
   parent layers plus the command string, and an upstream advisory changes

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -294,10 +294,20 @@ This gate is intentional (#1131, #1121) and the fix is to bump the dependency,
 not to loosen the gate. A daily `Web UI Audit` workflow (#1213) runs the same
 check on a schedule so this normally surfaces there first.
 
-**Do not run `npm audit fix`** — nor `npm install`, nor anything else that
-regenerates the lock. Any lockfile npm regenerates in `web-ui` fails `npm ci`
-with a misleading `@emnapi` error (#1194), so the reflexive fix replaces one
-broken build with a differently broken one.
+**Do not run `npm audit fix`** — it rewrites the tree it is checking and
+replaces one broken build with a differently broken one.
+
+`npm install` is a different matter, and #1194 narrowed it: it is safe **unless
+you are on npm 11.6.x**. That npm drops the peer-installed optional
+`@emnapi/core` and `@emnapi/runtime` entries from `package-lock.json`, and
+`npm ci` then correctly demands them back with an `@emnapi` error naming nothing
+you touched. The committed lockfile is not corrupt — npm 10.8.2, 11.0.0, 11.4.0,
+11.5.0, 11.7.0, 11.9.0, 11.10.0 and 11.19.0 all round-trip it cleanly. Check with
+`npm --version` first; if it is 11.6.x, `npm i -g npm@latest` and carry on.
+
+Dependabot's diff is still the cheapest path when one is open, because it is
+surgical and already proven — but it is now a convenience, not a workaround for
+a broken lockfile.
 
 The working recipe:
 
@@ -312,7 +322,7 @@ gh pr list --state open --search "author:app/dependabot" --json number,title
 gh pr diff <N> > /tmp/dep.patch
 git apply --include='web-ui/package*.json' --stat --apply /tmp/dep.patch
 
-# 3. Verify, in this order. npm ci is the #1194 oracle.
+# 3. Verify, in this order. npm ci exit 0 is the oracle (#1194).
 cd web-ui
 npm ci                          # exit 0, or the lock is unusable
 npm audit --audit-level=high    # exit 0, 0 vulnerabilities
@@ -326,7 +336,8 @@ and green. If none exists yet, get Dependabot to produce one rather than
 hand-writing the lockfile change: the repo's Dependabot alerts page has a
 *Create security update* button per advisory, and `@dependabot recreate` on a
 stale PR refreshes it. Its diff is the artifact you want — surgical, and already
-proven to survive `npm ci`.
+proven to survive `npm ci`. Regenerating the lock yourself is also fine on a
+supported npm; verify it the same way.
 
 Hand-editing `package-lock.json` is a last resort, and only defensible for a
 patch bump whose own dependency set is unchanged: bumping a package whose

--- a/tests/ci/test_web_ui_audit_guard_1213.py
+++ b/tests/ci/test_web_ui_audit_guard_1213.py
@@ -151,15 +151,18 @@ def test_the_gate_is_set_at_high_and_is_not_neutralised():
 
 
 def test_nothing_here_regenerates_the_lockfile():
-    """#1194: any regenerated web-ui lock fails `npm ci` with a misleading error.
+    """A job that "fixes" the tree it is checking is not checking anything.
 
-    `npm audit fix` is the reflex and it is wrong — a job that "fixes" the tree it
-    is checking breaks the build it guards.
+    `npm audit fix` is the reflex and it is wrong for that reason alone. (#1194
+    originally recorded a second reason — that *any* regenerated lock fails
+    `npm ci` — which turned out to be false: only npm 11.6.x corrupts it. The
+    assertion stands on the first reason, which is unconditional.)
     """
     haystack = _runs(_load(AUDIT)) + "\n" + _stage_body(GATE_STAGE)
     for forbidden in ("npm audit fix", "npm install", "npm update"):
         assert forbidden not in haystack, (
-            f"{forbidden!r} rewrites web-ui/package-lock.json into a state npm ci rejects (#1194)"
+            f"{forbidden!r} rewrites web-ui/package-lock.json, so this job would be "
+            "auditing a tree it just changed rather than the one that ships"
         )
 
 
@@ -173,6 +176,6 @@ def test_the_recovery_procedure_is_written_down(doc: Path):
     text = doc.read_text()
     assert "npm audit fix" in text, (
         f"{doc.name} does not warn against `npm audit fix`, so the next person "
-        "reaches for it first and lands a lockfile npm ci rejects (#1194)"
+        "reaches for it first and audits a tree it has already rewritten"
     )
     assert "#1194" in text, f"{doc.name} does not name #1194 as the reason"

--- a/tests/ci/test_web_ui_lockfile_guard_1194.py
+++ b/tests/ci/test_web_ui_lockfile_guard_1194.py
@@ -1,0 +1,139 @@
+"""#1194 — the web-ui lockfile is fine; one npm version is not.
+
+The issue was filed believing `web-ui/package-lock.json` was internally
+inconsistent — that it recorded `@napi-rs/wasm-runtime@1.2.3` with an older
+release's dependency set. Measured against the registry, it does not: 1.2.3's
+`dependencies` really is just `{"@tybys/wasm-util":"^0.10.3"}`, the `@emnapi/*`
+packages arrive as *peerDependencies*, and every `@emnapi/*` entry in the lock
+matches what the registry publishes — `@emnapi/core@1.10.0` pins
+`@emnapi/wasi-threads: "1.2.1"` exactly, which is what is recorded.
+
+What actually differs is npm. Run against the untouched lock (`npm install`, then
+`npm ci`), 10.8.2, 11.0.0, 11.4.0, 11.5.0, 11.7.0, 11.9.0, 11.10.0 and 11.19.0 all
+round-trip cleanly; only **11.6.2** produces a lock that `npm ci` then rejects,
+because its `npm install` drops the peer-installed optional `@emnapi/core` and
+`@emnapi/runtime` entries and `npm ci` correctly demands them back. libc is not a
+variable — glibc and musl behave identically at the same npm.
+
+So there is no lockfile to repair. What is worth pinning is that the constraint
+stays *written down*, in the two places someone lands when this next goes wrong.
+"""
+
+import json
+
+import pytest
+
+from pathlib import Path
+
+pytestmark = pytest.mark.v2
+
+REPO = Path(__file__).resolve().parents[2]
+PACKAGE_JSON = REPO / "web-ui" / "package.json"
+NPMRC = REPO / "web-ui" / ".npmrc"
+CLAUDE_MD = REPO / "CLAUDE.md"
+DEPLOY_README = REPO / "deploy" / "README.md"
+
+# Measured, not guessed. Only 11.6.x is affected: 11.5.0 and 11.7.0 both pass.
+KNOWN_BAD_NPM = "11.6.2"
+# The docs name the whole excluded minor line rather than the one build tested.
+KNOWN_BAD_NPM_LINE = "11.6"
+
+
+def _engines() -> dict:
+    return json.loads(PACKAGE_JSON.read_text()).get("engines", {})
+
+
+def test_the_npm_range_is_declared():
+    """Without it npm says nothing at all when a bad version rewrites the lock."""
+    assert "npm" in _engines(), (
+        "web-ui/package.json declares no `engines.npm`, so nothing records which "
+        f"npm versions may generate the lockfile — npm {KNOWN_BAD_NPM} corrupts it"
+    )
+
+
+def test_the_range_excludes_the_measured_bad_version_and_admits_its_neighbours():
+    """A range is only worth having if it draws the line where the data does.
+
+    11.5.0 and 11.7.0 both round-trip cleanly, so excluding them would be
+    superstition; 11.6.2 does not, so admitting it would be decoration.
+    """
+    from packaging.version import Version
+
+    npm_range = _engines()["npm"]
+
+    def allows(version: str) -> bool:
+        # engines syntax here is `>=A <B || >=C` — evaluate each ||-clause.
+        for clause in npm_range.split("||"):
+            if all(
+                _cmp(Version(version), part) for part in clause.split() if part.strip()
+            ):
+                return True
+        return False
+
+    assert not allows(KNOWN_BAD_NPM), (
+        f"engines.npm is {npm_range!r}, which still admits npm {KNOWN_BAD_NPM} — "
+        "the one version measured to corrupt the lockfile"
+    )
+    for good in ("10.8.2", "11.5.0", "11.7.0", "11.19.0"):
+        assert allows(good), (
+            f"engines.npm is {npm_range!r}, which rejects npm {good} — measured "
+            "to round-trip the lockfile cleanly, so this over-blocks"
+        )
+
+
+def _cmp(version, constraint: str) -> bool:
+    from packaging.version import Version
+
+    for op in (">=", "<=", "<", ">", "="):
+        if constraint.startswith(op):
+            other = Version(constraint[len(op) :])
+            return {
+                ">=": version >= other,
+                "<=": version <= other,
+                "<": version < other,
+                ">": version > other,
+                "=": version == other,
+            }[op]
+    raise AssertionError(f"unparsed engines constraint {constraint!r}")
+
+
+def test_the_node_range_admits_the_version_ci_and_the_image_run():
+    """CI's NODE_VERSION and web-ui/Dockerfile are both on Node 20."""
+    node_range = _engines().get("node", "")
+    assert "20" in node_range, (
+        f"engines.node is {node_range!r}; CI and web-ui/Dockerfile both run Node 20, "
+        "so this would declare the project's own build environment unsupported"
+    )
+
+
+def test_engine_strict_is_not_reintroduced():
+    """It is the obvious next step, and it breaks the build (verified, #1194).
+
+    `engine-strict=true` validates *every* package's engines, not just the root's,
+    and `@testing-library/jest-dom@7.0.1` already requires node >=22 while CI and
+    web-ui/Dockerfile run Node 20 — so it turns `npm ci` into `npm error notsup`
+    on the environment the project actually builds in. `engines` stays advisory
+    here on purpose: an `EBADENGINE` warning naming the npm version is the signal,
+    and the docs carry the rest.
+    """
+    if not NPMRC.exists():
+        return
+    assert "engine-strict=true" not in NPMRC.read_text(), (
+        "web-ui/.npmrc sets engine-strict=true, which fails `npm ci` on Node 20 via "
+        "@testing-library/jest-dom's node>=22 requirement — see #1194"
+    )
+
+
+@pytest.mark.parametrize("doc", [CLAUDE_MD, DEPLOY_README], ids=lambda p: p.name)
+def test_the_docs_name_the_npm_version_not_the_lockfile(doc: Path):
+    """The original diagnosis is written into both docs, and it is wrong.
+
+    Left uncorrected it tells the next reader that *any* regenerated lock fails
+    `npm ci`, which sends them to hand-prune a lockfile that does not need it —
+    the practice the issue itself says must not become the house pattern.
+    """
+    text = doc.read_text()
+    assert f"npm {KNOWN_BAD_NPM_LINE}" in text, (
+        f"{doc.name} does not name npm {KNOWN_BAD_NPM_LINE}.x as the actual cause, so "
+        "it still reads as though the committed lockfile were the problem"
+    )

--- a/tests/ci/test_web_ui_lockfile_guard_1194.py
+++ b/tests/ci/test_web_ui_lockfile_guard_1194.py
@@ -57,44 +57,58 @@ def test_the_range_excludes_the_measured_bad_version_and_admits_its_neighbours()
     11.5.0 and 11.7.0 both round-trip cleanly, so excluding them would be
     superstition; 11.6.2 does not, so admitting it would be decoration.
     """
-    from packaging.version import Version
-
     npm_range = _engines()["npm"]
 
-    def allows(version: str) -> bool:
-        # engines syntax here is `>=A <B || >=C` — evaluate each ||-clause.
-        for clause in npm_range.split("||"):
-            if all(
-                _cmp(Version(version), part) for part in clause.split() if part.strip()
-            ):
-                return True
-        return False
-
-    assert not allows(KNOWN_BAD_NPM), (
+    assert not _allows(npm_range, KNOWN_BAD_NPM), (
         f"engines.npm is {npm_range!r}, which still admits npm {KNOWN_BAD_NPM} — "
         "the one version measured to corrupt the lockfile"
     )
     for good in ("10.8.2", "11.5.0", "11.7.0", "11.19.0"):
-        assert allows(good), (
+        assert _allows(npm_range, good), (
             f"engines.npm is {npm_range!r}, which rejects npm {good} — measured "
             "to round-trip the lockfile cleanly, so this over-blocks"
         )
 
 
-def _cmp(version, constraint: str) -> bool:
-    from packaging.version import Version
+def _parts(version: str) -> tuple:
+    """`"11.10.0"` -> `(11, 10, 0)`, so 11.10 sorts above 11.6 rather than below.
 
-    for op in (">=", "<=", "<", ">", "="):
-        if constraint.startswith(op):
-            other = Version(constraint[len(op) :])
-            return {
-                ">=": version >= other,
-                "<=": version <= other,
-                "<": version < other,
-                ">": version > other,
-                "=": version == other,
-            }[op]
-    raise AssertionError(f"unparsed engines constraint {constraint!r}")
+    Every version this compares is a plain npm `X.Y.Z`, so a tuple of ints is the
+    whole of the semantics — no need to reach for a version-parsing library.
+    """
+    return tuple(int(n) for n in version.split("."))
+
+
+def _allows(npm_range: str, version: str) -> bool:
+    """Evaluate an npm engines range of the shape `>=A <B || >=C`."""
+    ops = {
+        ">=": lambda a, b: a >= b,
+        "<=": lambda a, b: a <= b,
+        "<": lambda a, b: a < b,
+        ">": lambda a, b: a > b,
+        "=": lambda a, b: a == b,
+    }
+
+    def satisfies(constraint: str) -> bool:
+        # `>=`/`<=` before `>`/`<`, or the two-character forms mis-parse.
+        for op, compare in ops.items():
+            if constraint.startswith(op):
+                return compare(_parts(version), _parts(constraint[len(op) :]))
+        raise AssertionError(f"unparsed engines constraint {constraint!r}")
+
+    return any(
+        all(satisfies(c) for c in clause.split() if c.strip())
+        for clause in npm_range.split("||")
+    )
+
+
+def test_the_range_evaluator_itself_is_not_lying():
+    """The assertions above are only as good as this parser."""
+    assert _parts("11.10.0") > _parts("11.6.2"), "numeric ordering, not string"
+    assert _allows(">=1.0.0", "1.0.0") and not _allows(">=1.0.1", "1.0.0")
+    assert _allows(">=1.0.0 <2.0.0", "1.5.0") and not _allows(">=1.0.0 <2.0.0", "2.0.0")
+    assert _allows(">=1.0.0 <2.0.0 || >=3.0.0", "3.1.0")
+    assert not _allows(">=1.0.0 <2.0.0 || >=3.0.0", "2.5.0")
 
 
 def test_the_node_range_admits_the_version_ci_and_the_image_run():

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -54,6 +54,10 @@
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.68.0"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10.8.2 <11.6.0 || >=11.7.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -2,6 +2,10 @@
   "name": "codeframe-web-ui",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20",
+    "npm": ">=10.8.2 <11.6.0 || >=11.7.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## The issue's premise does not hold, and that changes the fix

#1194 was filed believing `web-ui/package-lock.json` is internally inconsistent — that it records `@napi-rs/wasm-runtime@1.2.3` with an older release's dependency set, so any re-resolution surfaces the drift. Checked against the registry, it does not:

- `@napi-rs/wasm-runtime@1.2.3` really does declare `dependencies` of exactly `{"@tybys/wasm-util":"^0.10.3"}` — what the lock records. The `@emnapi/*` packages arrive as **peerDependencies**, which a lockfile entry does not carry.
- Every `@emnapi/*` entry matches what the registry publishes. `@emnapi/core@1.10.0` pins `@emnapi/wasi-threads: "1.2.1"` **exactly**, and 1.2.1 is what is recorded. There is nothing to repair.

The variable is **npm**. Nine versions run against the untouched lock (`npm install`, then `npm ci`):

| npm | lock rewrite | `npm ci` after |
|---|---|---|
| 10.8.2 (Node 20 — CI + Dockerfile) | 108 lines | exit 0 |
| 11.0.0 / 11.4.0 / 11.5.0 | 108 lines | exit 0 |
| **11.6.2** | **184 lines** | **exit 1** |
| 11.7.0 / 11.9.0 / 11.10.0 | 108 lines | exit 0 |
| 11.19.0 | 0 lines | exit 0 |

Only **11.6.x** is affected — 11.5.0 and 11.7.0 both bracket it cleanly. Its `npm install` **deletes** the peer-installed optional `node_modules/@emnapi/core` and `node_modules/@emnapi/runtime` entries, and `npm ci` then correctly demands them back with the `@emnapi` error that names nothing the developer touched. libc is not a variable: glibc and musl behave identically at the same npm.

**The repository's lockfile is not broken. One npm version is.**

## Change

- **`web-ui/package.json`** — `engines: { node: ">=20", npm: ">=10.8.2 <11.6.0 || >=11.7.0" }`. The range is drawn where the measurements are, so it excludes 11.6.x and admits its neighbours rather than blocking a version out of caution.
- **`web-ui/package-lock.json`** — the only change is the four lines npm itself writes to mirror that `engines` block into the root entry, generated with npm 11.19.0 so the lock stays a fixed point instead of producing churn on the next install. No dependency entry is touched.
- **`CLAUDE.md`, `deploy/README.md`, `.github/workflows/web-ui-audit.yml`** — corrected. All three said *any* regenerated lock fails `npm ci`, which sends the reader to hand-prune a lockfile that does not need it — the practice the issue itself says must not become the house pattern. They now name npm 11.6.x and say the fix is `npm i -g npm@latest`.
- **`tests/ci/test_web_ui_audit_guard_1213.py`** — its assertions stand (an audit job still must not rewrite the tree it checks) but its stated *reason* cited the same false diagnosis; corrected to the reason that is unconditional.

## `engine-strict` was tried and rejected — with a guard against reintroducing it

It is the obvious next step, and it breaks the build. `engine-strict=true` validates **every** package's engines, not just the root's, and `@testing-library/jest-dom@7.0.1` already requires `node >=22` while CI and `web-ui/Dockerfile` run Node 20:

```
npm error notsup Not compatible with your version of node/npm: @testing-library/jest-dom@7.0.1
npm error notsup Required: {"node":">=22","npm":">=6","yarn":">=1"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

So `engines` stays advisory here on purpose. `test_engine_strict_is_not_reintroduced` records that, because the next person to read this will otherwise reach for it exactly as I did.

## Acceptance criteria

- [x] **`npm install && npm ci` both exit 0 on a clean checkout, no hand-editing** — true on all nine npm versions measured except 11.6.x, which is now declared unsupported and warned about. Genuinely unfixable *within* 11.6.x: that npm is the defect. Verified end-to-end on Node 20 / npm 10.8.2.
- [x] **The lock records `@napi-rs/wasm-runtime`'s real dependency set, and the `@emnapi/*` versions satisfy it** — already true; verified against the registry rather than assumed. Nothing to change.
- [x] **`npm test && npm run build` still pass** — on Node 20 / npm 10.8.2: `npm ci` exit 0, **1290 tests passed** (106 suites), `npm run build` exit 0.
- [x] **A note (or CI check) so the next regeneration is verified with `npm ci`** — both docs now carry it, plus a guard test that fails if either stops naming npm 11.6.
- [x] **Confirm whether the repo should pin an npm/Node version** — **yes, and it now does**, declaratively. Hard enforcement is not available (see `engine-strict` above); `EBADENGINE` at install time plus the guard test is the enforceable maximum.

## Known limitations

- **`engines` is a warning, not a wall.** A developer on npm 11.6.x who ignores `EBADENGINE` can still commit a corrupt lock. CI catches it — `npm ci` runs in Frontend Unit Tests and again in the Dockerfile `deps` stage — but the first signal is advisory.
- **Only 11.6.2 was measured, not 11.6.0/11.6.1.** The whole 11.6.x line is excluded on that basis. Conservative in the safe direction.
- **No new CI round-trip job.** `npm ci` already runs twice per PR, so a bad lock is already caught twice; a third copy would be redundant. AC4 is met by the notes plus the guard.
- **The 108-line rewrite on npm 10.8.2 is untouched.** Every one of those versions produces a lock `npm ci` accepts, so it is benign churn, not corruption — but it does mean the lock is a fixed point only under npm 11.19.x.

Closes #1194

https://claude.ai/code/session_018Cs189BcKKhPSzdGK3Njua
