### PR TITLE
refactor(web-ui): close the #971 de-duplication leftovers (#1195)

### DIFF
--- a/web-ui/src/__tests__/components/blockers/BlockerCard.test.tsx
+++ b/web-ui/src/__tests__/components/blockers/BlockerCard.test.tsx
@@ -70,7 +70,7 @@ describe('BlockerCard', () => {
       <BlockerCard blocker={makeBlocker()} workspacePath={workspacePath} onAnswered={onAnswered} />
     );
 
-    expect(screen.getByText('30m ago')).toBeInTheDocument();
+    expect(screen.getByText('30 minutes ago')).toBeInTheDocument();
   });
 
   it('shows the answer form for OPEN blockers', () => {

--- a/web-ui/src/__tests__/components/blockers/ResolvedBlockersSection.test.tsx
+++ b/web-ui/src/__tests__/components/blockers/ResolvedBlockersSection.test.tsx
@@ -128,7 +128,7 @@ describe('ResolvedBlockersSection', () => {
     render(<ResolvedBlockersSection blockers={[blocker]} />);
     await user.click(screen.getByRole('button'));
 
-    expect(screen.getByText('2h ago')).toBeInTheDocument();
+    expect(screen.getByText('about 2 hours ago')).toBeInTheDocument();
   });
 
   it('falls back to created_at when answered_at is null', async () => {
@@ -139,7 +139,7 @@ describe('ResolvedBlockersSection', () => {
     render(<ResolvedBlockersSection blockers={[blocker]} />);
     await user.click(screen.getByRole('button'));
 
-    expect(screen.getByText('5m ago')).toBeInTheDocument();
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
   });
 
   it('renders multiple blockers when expanded', async () => {

--- a/web-ui/src/__tests__/components/review/PRHistoryPanel.test.tsx
+++ b/web-ui/src/__tests__/components/review/PRHistoryPanel.test.tsx
@@ -153,9 +153,7 @@ describe('PRHistoryPanel', () => {
       withData(SAMPLE_HISTORY);
       render(<PRHistoryPanel workspacePath={WORKSPACE} />);
 
-      // Check that date text is present (formatted by toLocaleDateString)
-      const dateText = new Date('2026-04-10T12:00:00Z').toLocaleDateString();
-      expect(screen.getByText(new RegExp(dateText))).toBeInTheDocument();
+      expect(screen.getByText(/Apr 10, 2026/)).toBeInTheDocument();
       expect(screen.getByText(/by alice/)).toBeInTheDocument();
     });
 

--- a/web-ui/src/__tests__/lib/format.test.ts
+++ b/web-ui/src/__tests__/lib/format.test.ts
@@ -1,4 +1,12 @@
-import { formatUsd, formatCount, formatRelativeTime } from '@/lib/format';
+import {
+  formatUsd,
+  formatCount,
+  formatRelativeTime,
+  formatCompactAge,
+  formatDate,
+  formatDateTime,
+  formatTime,
+} from '@/lib/format';
 
 describe('formatUsd', () => {
   it('defaults to 4 fraction digits', () => {
@@ -27,8 +35,59 @@ describe('formatCount', () => {
   });
 });
 
-describe('formatRelativeTime', () => {
-  it('still works after the module gained currency helpers', () => {
-    expect(formatRelativeTime(new Date().toISOString())).toBe('just now');
+describe('formatRelativeTime (#1195)', () => {
+  const minutesAgo = (n: number) => new Date(Date.now() - n * 60_000).toISOString();
+
+  it('uses the date-fns wording with a suffix', () => {
+    expect(formatRelativeTime(minutesAgo(30))).toBe('30 minutes ago');
+    expect(formatRelativeTime(minutesAgo(2 * 60))).toBe('about 2 hours ago');
+    expect(formatRelativeTime(minutesAgo(0))).toBe('less than a minute ago');
+  });
+
+  it('returns an empty string for unparseable input', () => {
+    expect(formatRelativeTime('not a date')).toBe('');
+    expect(formatRelativeTime('')).toBe('');
+  });
+});
+
+describe('formatCompactAge (#1195)', () => {
+  const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+  it('abbreviates the unit and drops the suffix', () => {
+    expect(formatCompactAge(ago(3 * 86_400_000))).toBe('3d');
+    expect(formatCompactAge(ago(60_000))).toBe('1m');
+    expect(formatCompactAge(ago(400 * 86_400_000))).toBe('1y');
+  });
+
+  it('returns an empty string for unparseable input', () => {
+    expect(formatCompactAge('')).toBe('');
+    expect(formatCompactAge('garbage')).toBe('');
+  });
+});
+
+describe('absolute timestamp formatters (#1195)', () => {
+  // Noon UTC keeps the calendar day stable in every timezone within ±11h.
+  const ISO = '2026-04-10T12:00:05Z';
+  const local = new Date(ISO);
+  const hour12 = ((local.getHours() + 11) % 12) + 1;
+  const ampm = local.getHours() < 12 ? 'AM' : 'PM';
+  const mm = String(local.getMinutes()).padStart(2, '0');
+
+  it('formatDate renders a short month, day and year', () => {
+    expect(formatDate(ISO)).toBe('Apr 10, 2026');
+  });
+
+  it('formatDateTime appends the time to the date', () => {
+    expect(formatDateTime(ISO)).toBe(`Apr 10, 2026, ${hour12}:${mm} ${ampm}`);
+  });
+
+  it('formatTime renders the time of day with seconds', () => {
+    expect(formatTime(ISO)).toBe(`${String(hour12).padStart(2, '0')}:${mm}:05 ${ampm}`);
+  });
+
+  it('all three return an empty string for unparseable input', () => {
+    expect(formatDate('garbage')).toBe('');
+    expect(formatDateTime('garbage')).toBe('');
+    expect(formatTime('garbage')).toBe('');
   });
 });

--- a/web-ui/src/__tests__/lib/sharedConstants.guard.test.ts
+++ b/web-ui/src/__tests__/lib/sharedConstants.guard.test.ts
@@ -1,12 +1,14 @@
 /**
- * Guard test for issue #971.
+ * Guard test for issues #971 and #1195.
  *
  * The status maps, the USD formatter and the workspace-storage key were each
  * duplicated verbatim across several components, and nothing linked the copies
  * together — so adding a status, or changing a storage key, silently left one
- * surface behind. These are source scans rather than behavioural tests on
- * purpose: what regressed was the *absence* of a single definition, which no
- * render test can observe. Precedent: `api.contract.test.ts`.
+ * surface behind. #1195 closed the same class of leftover for badge-variant
+ * typing, proof status colours and timestamp formatting. These are source
+ * scans rather than behavioural tests on purpose: what regressed was the
+ * *absence* of a single definition, which no render test can observe.
+ * Precedent: `api.contract.test.ts`.
  */
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
@@ -29,57 +31,99 @@ function sourceFiles(dir: string): string[] {
 
 const ALL_SOURCES = sourceFiles(SRC);
 const rel = (f: string) => f.slice(SRC.length + 1);
+const FORMAT_TS = join('lib', 'format.ts');
+
+/** Files (relative) whose source matches `pattern`, excluding `allowed`. */
+function offenders(pattern: RegExp, allowed: string[] = []): string[] {
+  return ALL_SOURCES.filter(
+    (f) => !allowed.includes(rel(f)) && pattern.test(readFileSync(f, 'utf8'))
+  ).map(rel);
+}
+
+/** `file:line` for every line matching `pattern`, excluding `allowed` files. */
+function offendingLines(pattern: RegExp, allowed: string[] = [], under = ''): string[] {
+  const out: string[] = [];
+  for (const file of ALL_SOURCES) {
+    if (allowed.includes(rel(file)) || !rel(file).startsWith(under)) continue;
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, i) => {
+        if (pattern.test(line)) out.push(`${rel(file)}:${i + 1}`);
+      });
+  }
+  return out;
+}
 
 describe('#971 — status maps have a single definition', () => {
   it('is declared only in lib/taskStatusInfo.ts', () => {
-    const offenders = ALL_SOURCES.filter(
-      (f) =>
-        rel(f) !== join('lib', 'taskStatusInfo.ts') &&
-        /^\s*(export\s+)?const\s+(STATUS_LABEL|STATUS_BADGE_VARIANT)\b/m.test(readFileSync(f, 'utf8'))
-    ).map(rel);
-
-    expect(offenders).toEqual([]);
+    expect(
+      offenders(/^\s*(export\s+)?const\s+(STATUS_LABEL|STATUS_BADGE_VARIANT)\b/m, [
+        join('lib', 'taskStatusInfo.ts'),
+      ])
+    ).toEqual([]);
   });
 });
 
-describe('#971 — one USD formatter', () => {
-  it('has no hand-rolled currency toFixed in components or pages', () => {
-    const offenders: string[] = [];
-    for (const file of ALL_SOURCES) {
-      const source = readFileSync(file, 'utf8');
-      source.split('\n').forEach((line, i) => {
-        // `toFixed(4)` is only ever a USD amount here. Deliberately not
-        // matching a `$` next to a toFixed: `${(ms / 1000).toFixed(1)}` is a
-        // template sigil, not a currency sign, and the two are
-        // indistinguishable by regex. Non-USD precision (durations) is fine.
-        if (/toFixed\(4\)/.test(line)) {
-          offenders.push(`${rel(file)}:${i + 1}`);
-        }
-      });
-    }
+// The thing the duplication actually looks like: an Intl currency option.
+// Matching on function *names* (the #971 rule this replaces) missed any
+// formatter not called format(Currency|Cost|Usd) — see #1195 item 5.
+const CURRENCY_OPTION = /style:\s*['"]currency['"]/;
 
-    expect(offenders).toEqual([]);
+describe('#971 / #1195 — one USD formatter', () => {
+  it('has no hand-rolled currency toFixed in components or pages', () => {
+    // `toFixed(4)` is only ever a USD amount here. Deliberately not
+    // matching a `$` next to a toFixed: `${(ms / 1000).toFixed(1)}` is a
+    // template sigil, not a currency sign, and the two are
+    // indistinguishable by regex. Non-USD precision (durations) is fine.
+    expect(offendingLines(/toFixed\(4\)/)).toEqual([]);
   });
 
-  it('declares no local currency formatter outside lib/format.ts', () => {
-    const offenders = ALL_SOURCES.filter(
-      (f) =>
-        rel(f) !== join('lib', 'format.ts') &&
-        /function\s+format(Currency|Cost|BadgeCost|Usd|USD)\b/.test(readFileSync(f, 'utf8'))
-    ).map(rel);
+  it('the currency rule recognises the Intl option it is guarding against', () => {
+    // Self-check so the rule below cannot rot into a vacuous pass.
+    expect(CURRENCY_OPTION.test("toLocaleString('en-US', { style: 'currency' })")).toBe(true);
+    expect(CURRENCY_OPTION.test('new Intl.NumberFormat("en", {style: "currency"})')).toBe(true);
+    expect(CURRENCY_OPTION.test("{ style: 'percent' }")).toBe(false);
+  });
 
-    expect(offenders).toEqual([]);
+  it('uses the Intl currency option only in lib/format.ts', () => {
+    expect(offendingLines(CURRENCY_OPTION, [FORMAT_TS])).toEqual([]);
+    expect(CURRENCY_OPTION.test(readFileSync(join(SRC, FORMAT_TS), 'utf8'))).toBe(true);
   });
 });
 
 describe('#971 — workspace storage key has a single definition', () => {
   it('appears as a literal only in lib/workspace-storage.ts', () => {
-    const offenders = ALL_SOURCES.filter(
-      (f) =>
-        rel(f) !== join('lib', 'workspace-storage.ts') &&
-        readFileSync(f, 'utf8').includes('codeframe_workspace_path')
-    ).map(rel);
+    expect(
+      offenders(/codeframe_workspace_path/, [join('lib', 'workspace-storage.ts')])
+    ).toEqual([]);
+  });
+});
 
-    expect(offenders).toEqual([]);
+describe('#1195 — badge variants are type-checked, not cast', () => {
+  it('no Badge variant prop is cast with `as never`', () => {
+    expect(offendingLines(/variant=\{[^}]*as never\}/)).toEqual([]);
+  });
+
+  it('STATUS_BADGE_VARIANT is typed against badgeVariants, not string', () => {
+    const source = readFileSync(join(SRC, 'lib', 'taskStatusInfo.ts'), 'utf8');
+    expect(source).toMatch(/STATUS_BADGE_VARIANT:\s*Record<TaskStatus,\s*BadgeVariant>/);
+  });
+});
+
+describe('#1195 — proof status colours come from badge variants', () => {
+  it('has no raw status colour literal in src/components/proof', () => {
+    expect(
+      offendingLines(/\bbg-(red|green|gray|amber)-\d+ text-(red|green|gray|amber)-\d+\b/, [], join('components', 'proof'))
+    ).toEqual([]);
+  });
+});
+
+describe('#1195 — one timestamp formatter set', () => {
+  it('formats displayed timestamps only through lib/format.ts', () => {
+    expect(offendingLines(/\.toLocale(Date|Time)?String\(/, [FORMAT_TS])).toEqual([]);
+  });
+
+  it('imports the date-fns relative-time helpers only in lib/format.ts', () => {
+    expect(offenders(/formatDistanceToNow(Strict)?/, [FORMAT_TS])).toEqual([]);
   });
 });

--- a/web-ui/src/__tests__/lib/sharedConstants.guard.test.ts
+++ b/web-ui/src/__tests__/lib/sharedConstants.guard.test.ts
@@ -111,7 +111,10 @@ describe('#1195 — badge variants are type-checked, not cast', () => {
 });
 
 describe('#1195 — proof status colours come from badge variants', () => {
-  it('has no raw status colour literal in src/components/proof', () => {
+  // Scope: a status *badge or pill* — a `bg-<hue>-N text-<hue>-N` pair, which
+  // is what a copied badge variant looks like. GateRunBanner's live-run dots
+  // and WaiveDialog's warning box are not badges and keep their own colours.
+  it('has no raw status badge colour pair in src/components/proof', () => {
     expect(
       offendingLines(/\bbg-(red|green|gray|amber)-\d+ text-(red|green|gray|amber)-\d+\b/, [], join('components', 'proof'))
     ).toEqual([]);

--- a/web-ui/src/app/costs/page.tsx
+++ b/web-ui/src/app/costs/page.tsx
@@ -10,7 +10,7 @@ import { TopTasksTable } from '@/components/costs/TopTasksTable';
 import { AgentCostBars } from '@/components/costs/AgentCostBars';
 import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
 import { costsApi } from '@/lib/api';
-import { formatUsd } from '@/lib/format';
+import { formatUsd, formatCount } from '@/lib/format';
 import { useWorkspaceSelection } from '@/hooks/useWorkspaceSelection';
 import type {
   CostSummaryResponse,
@@ -137,7 +137,7 @@ export default function CostsPage() {
                     data-testid="total-tasks"
                     className="text-2xl font-bold"
                   >
-                    {data.total_tasks.toLocaleString('en-US')}
+                    {formatCount(data.total_tasks)}
                   </p>
                 </CardContent>
               </Card>

--- a/web-ui/src/app/proof/[req_id]/page.tsx
+++ b/web-ui/src/app/proof/[req_id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import { formatDate, formatDateTime } from '@/lib/format';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -274,7 +275,7 @@ export default function ProofDetailPage() {
                 </div>
               )}
               <div className="mt-3 flex flex-wrap gap-4 text-xs text-muted-foreground">
-                {req.created_at && <span>Created {new Date(req.created_at).toLocaleDateString()}</span>}
+                {req.created_at && <span>Created {formatDate(req.created_at)}</span>}
                 {req.source && <span>Source: {req.source}</span>}
                 {req.source_issue && (() => {
                   let isGitHubPr = false;
@@ -516,7 +517,7 @@ export default function ProofDetailPage() {
                           </td>
                           <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{ev.run_id}</td>
                           <td className="px-4 py-2 text-muted-foreground">
-                            {new Date(ev.timestamp).toLocaleString()}
+                            {formatDateTime(ev.timestamp)}
                           </td>
                           <td className="max-w-xs px-4 py-2 font-mono text-xs text-muted-foreground">
                             <span className="line-clamp-1">{ev.artifact_path || '—'}</span>
@@ -540,7 +541,7 @@ export default function ProofDetailPage() {
                     <p className="mt-1 text-sm text-muted-foreground">Approved by: {req.waiver.approved_by}</p>
                   )}
                   {req.waiver.waived_at && (
-                    <p className="mt-1 text-sm text-muted-foreground">Waived: {new Date(req.waiver.waived_at).toLocaleString()}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">Waived: {formatDateTime(req.waiver.waived_at)}</p>
                   )}
                   {req.waiver.expires && (
                     <p className="mt-1 text-sm text-muted-foreground">Expires: {req.waiver.expires}</p>

--- a/web-ui/src/app/proof/page.tsx
+++ b/web-ui/src/app/proof/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef, Suspense } from 'react';
+import { formatDate } from '@/lib/format';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
@@ -510,7 +511,7 @@ function ProofPageContent() {
                         <ProofStatusBadge status={req.status} />
                       </td>
                       <td className="px-4 py-3 text-muted-foreground">
-                        {req.created_at ? new Date(req.created_at).toLocaleDateString() : '—'}
+                        {req.created_at ? formatDate(req.created_at) : '—'}
                       </td>
                       <td className="px-4 py-3">
                         {req.status !== 'waived' && (

--- a/web-ui/src/components/execution/EventItem.tsx
+++ b/web-ui/src/components/execution/EventItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@/lib/utils';
+import { formatTime } from '@/lib/format';
 import {
   deriveAgentState,
   agentStateBadgeStyles,
@@ -24,16 +25,6 @@ interface EventItemProps {
   event: ExecutionEvent;
   workspacePath: string;
   onBlockerAnswered?: () => void;
-}
-
-/** Format ISO timestamp to HH:mm:ss for display. */
-function formatTime(iso: string): string {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-  } catch {
-    return '';
-  }
 }
 
 /**

--- a/web-ui/src/components/execution/EventStream.tsx
+++ b/web-ui/src/components/execution/EventStream.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import { formatTime } from '@/lib/format';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { ArrowDown01Icon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
@@ -100,7 +101,7 @@ function ReadGroupRow({
           className={`h-3 w-3 shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
         />
         <span className="font-mono text-[11px]">
-          {new Date(group.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+          {formatTime(group.timestamp)}
         </span>
         <span>
           Read {group.count} file{group.count !== 1 ? 's' : ''}
@@ -122,7 +123,7 @@ function EditGroupRow({ group }: { group: Extract<EventGroup, { type: 'edit_grou
   return (
     <div className="flex items-baseline gap-2 py-1.5">
       <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
-        {new Date(group.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+        {formatTime(group.timestamp)}
       </span>
       <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none ${editGroupBadgeStyles}`}>
         edit

--- a/web-ui/src/components/layout/NotificationCenter.tsx
+++ b/web-ui/src/components/layout/NotificationCenter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { formatRelativeTime } from '@/lib/format';
 import type { IconSvgElement } from '@hugeicons/react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
@@ -9,7 +10,6 @@ import {
   Alert02Icon,
   CheckmarkCircle01Icon,
 } from '@hugeicons/core-free-icons';
-import { formatDistanceToNow } from 'date-fns';
 import { useNotificationContext } from '@/contexts/NotificationContext';
 import type { AppNotification } from '@/types';
 
@@ -20,14 +20,6 @@ function iconForNotification(n: AppNotification): { icon: IconSvgElement; color:
   if (n.type === 'batch.completed') return { icon: CheckmarkCircle01Icon, color: 'text-green-600' };
   if (n.type === 'blocker.created') return { icon: Alert02Icon, color: 'text-amber-600' };
   return { icon: Alert02Icon, color: 'text-red-600' };
-}
-
-function formatTimestamp(iso: string): string {
-  try {
-    return formatDistanceToNow(new Date(iso), { addSuffix: true });
-  } catch {
-    return '';
-  }
 }
 
 export function NotificationCenter() {
@@ -138,7 +130,7 @@ function NotificationRow({
       <HugeiconsIcon icon={icon} className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden="true" />
       <div className="min-w-0 flex-1">
         <p className="break-words">{notification.message}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">{formatTimestamp(notification.timestamp)}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{formatRelativeTime(notification.timestamp)}</p>
       </div>
       {!notification.read && (
         <button

--- a/web-ui/src/components/prd/PRDHeader.tsx
+++ b/web-ui/src/components/prd/PRDHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { HugeiconsIcon } from '@hugeicons/react';
+import { formatDate } from '@/lib/format';
 import { FileEditIcon, Upload04Icon, MessageSearch01Icon, TaskEdit01Icon, TestTube01Icon, Loading03Icon, Time01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import type { PrdResponse } from '@/types';
@@ -35,7 +36,7 @@ export function PRDHeader({
           {prd && (
             <p className="text-sm text-muted-foreground">
               Version {prd.version} &middot;{' '}
-              {new Date(prd.created_at).toLocaleDateString()}
+              {formatDate(prd.created_at)}
             </p>
           )}
         </div>

--- a/web-ui/src/components/prd/PRDVersionHistoryModal.tsx
+++ b/web-ui/src/components/prd/PRDVersionHistoryModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { formatDateTime } from '@/lib/format';
 import useSWR from 'swr';
 import { toast } from 'sonner';
 import { HugeiconsIcon } from '@hugeicons/react';
@@ -191,7 +192,7 @@ function VersionList({ versions, currentVersion, isLoading, error, onViewVersion
                   )}
                 </div>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  {new Date(v.created_at).toLocaleString()}
+                  {formatDateTime(v.created_at)}
                 </p>
                 <p className="mt-0.5 text-xs italic text-muted-foreground">
                   {v.change_summary ?? 'No summary'}

--- a/web-ui/src/components/prd/UploadPRDModal.tsx
+++ b/web-ui/src/components/prd/UploadPRDModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef } from 'react';
+import { formatCount } from '@/lib/format';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Upload04Icon, Loading03Icon } from '@hugeicons/core-free-icons';
 import {
@@ -190,7 +191,7 @@ export function UploadPRDModal({
               </Button>
               {content && (
                 <p className="text-xs text-muted-foreground">
-                  {content.length.toLocaleString()} characters loaded
+                  {formatCount(content.length)} characters loaded
                 </p>
               )}
             </div>

--- a/web-ui/src/components/proof/GateEvidencePanel.tsx
+++ b/web-ui/src/components/proof/GateEvidencePanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import type { ProofEvidenceWithContent } from '@/types';
 
@@ -40,23 +41,13 @@ function GateEvidenceRow({ ev }: GateEvidenceRowProps) {
       >
         <span className="font-mono text-xs text-muted-foreground w-16 shrink-0 capitalize">{ev.gate}</span>
         {ev.verified === false ? (
-          <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">
-            tampered
-          </span>
+          <Badge variant="failed">tampered</Badge>
         ) : ev.status === 'unverifiable' ? (
-          <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
-            cannot verify
-          </span>
+          <Badge variant="unverifiable">cannot verify</Badge>
         ) : (
-          <span
-            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-              ev.satisfied
-                ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-            }`}
-          >
+          <Badge variant={ev.satisfied ? 'done' : 'failed'}>
             {ev.satisfied ? 'pass' : 'fail'}
-          </span>
+          </Badge>
         )}
         <span className="ml-auto text-xs text-muted-foreground">{expanded ? '▲' : '▼'}</span>
       </button>

--- a/web-ui/src/components/proof/GateRunPanel.tsx
+++ b/web-ui/src/components/proof/GateRunPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge } from '@/components/ui/badge';
+import { Badge, type BadgeVariant } from '@/components/ui/badge';
 import type { GateRunEntry, GateRunStatus } from '@/types';
 
 interface GateRunPanelProps {
@@ -8,7 +8,7 @@ interface GateRunPanelProps {
 }
 
 // Map GateRunStatus to Badge variant names from the shared design system
-const STATUS_VARIANT: Record<GateRunStatus, 'backlog' | 'in-progress' | 'done' | 'failed' | 'unverifiable'> = {
+const STATUS_VARIANT: Record<GateRunStatus, BadgeVariant> = {
   pending: 'backlog',
   running: 'in-progress',
   passed: 'done',

--- a/web-ui/src/components/proof/ProofStatusBadge.tsx
+++ b/web-ui/src/components/proof/ProofStatusBadge.tsx
@@ -1,22 +1,19 @@
 'use client';
 
-import { Badge } from '@/components/ui/badge';
+import { Badge, type BadgeVariant } from '@/components/ui/badge';
 import type { ProofReqStatus } from '@/types';
+
+/** Requirement status → shared badge variant, so proof badges restyle with every other status badge. */
+export const PROOF_STATUS_VARIANT: Record<ProofReqStatus, BadgeVariant> = {
+  open: 'blocked',
+  satisfied: 'done',
+  waived: 'backlog',
+};
 
 interface ProofStatusBadgeProps {
   status: ProofReqStatus;
 }
 
 export function ProofStatusBadge({ status }: ProofStatusBadgeProps) {
-  const styles: Record<ProofReqStatus, string> = {
-    open: 'bg-red-100 text-red-900',
-    satisfied: 'bg-green-100 text-green-900',
-    waived: 'bg-gray-100 text-gray-600',
-  };
-
-  return (
-    <Badge className={styles[status]}>
-      {status}
-    </Badge>
-  );
+  return <Badge variant={PROOF_STATUS_VARIANT[status]}>{status}</Badge>;
 }

--- a/web-ui/src/components/proof/ProofStatusWidget.tsx
+++ b/web-ui/src/components/proof/ProofStatusWidget.tsx
@@ -6,6 +6,7 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import { CheckmarkCircle01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { PROOF_STATUS_VARIANT } from '@/components/proof/ProofStatusBadge';
 import { proofApi } from '@/lib/api';
 import type { ProofStatusResponse } from '@/types';
 
@@ -40,13 +41,13 @@ export function ProofStatusWidget({ workspacePath }: ProofStatusWidgetProps) {
           <>
             <div className="flex flex-wrap gap-2">
               {data.open > 0 && (
-                <Badge className="bg-red-100 text-red-900">{data.open} open</Badge>
+                <Badge variant={PROOF_STATUS_VARIANT.open}>{data.open} open</Badge>
               )}
               {data.satisfied > 0 && (
-                <Badge className="bg-green-100 text-green-900">{data.satisfied} satisfied</Badge>
+                <Badge variant={PROOF_STATUS_VARIANT.satisfied}>{data.satisfied} satisfied</Badge>
               )}
               {data.waived > 0 && (
-                <Badge className="bg-gray-100 text-gray-600">{data.waived} waived</Badge>
+                <Badge variant={PROOF_STATUS_VARIANT.waived}>{data.waived} waived</Badge>
               )}
             </div>
             <Link

--- a/web-ui/src/components/proof/RunHistoryPanel.tsx
+++ b/web-ui/src/components/proof/RunHistoryPanel.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import useSWR from 'swr';
+import { Badge } from '@/components/ui/badge';
+import { formatDateTime } from '@/lib/format';
 import { proofApi } from '@/lib/api';
 import type { ProofRunSummary } from '@/types';
 
@@ -14,14 +16,6 @@ function formatDuration(ms: number | null): string {
   if (ms == null) return '—';
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
-}
-
-function formatTimestamp(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
 }
 
 export function RunHistoryPanel({ workspacePath, onSelectRun, selectedRunId }: RunHistoryPanelProps) {
@@ -82,18 +76,12 @@ export function RunHistoryPanel({ workspacePath, onSelectRun, selectedRunId }: R
                     }`}
                   >
                     <td className="px-4 py-2 text-muted-foreground">
-                      {formatTimestamp(run.started_at)}
+                      {formatDateTime(run.started_at)}
                     </td>
                     <td className="px-4 py-2">
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                          run.overall_passed
-                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-                        }`}
-                      >
+                      <Badge variant={run.overall_passed ? 'done' : 'failed'}>
                         {run.overall_passed ? 'pass' : 'fail'}
-                      </span>
+                      </Badge>
                     </td>
                     <td className="px-4 py-2 text-muted-foreground">
                       {formatDuration(run.duration_ms)}

--- a/web-ui/src/components/review/PRHistoryPanel.tsx
+++ b/web-ui/src/components/review/PRHistoryPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { formatDate } from '@/lib/format';
 import useSWR from 'swr';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { ArrowDown01Icon, ArrowUp01Icon, ArrowUpRight01Icon, CheckmarkCircle01Icon, Cancel01Icon, Alert02Icon } from '@hugeicons/core-free-icons';
@@ -115,7 +116,7 @@ export function PRHistoryPanel({ workspacePath }: PRHistoryPanelProps) {
                       {pr.title}
                     </span>
                     <span className="text-xs text-muted-foreground">
-                      {new Date(pr.merged_at).toLocaleDateString()}
+                      {formatDate(pr.merged_at)}
                       {pr.author && ` by ${pr.author}`}
                     </span>
                   </div>

--- a/web-ui/src/components/sessions/SessionCard.tsx
+++ b/web-ui/src/components/sessions/SessionCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { formatDistanceToNow } from 'date-fns';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Cancel01Icon } from '@hugeicons/core-free-icons';
 import { Card, CardContent } from '@/components/ui/card';
@@ -17,7 +16,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { formatUsd } from '@/lib/format';
+import { formatUsd, formatRelativeTime } from '@/lib/format';
 import type { Session } from '@/types';
 
 interface SessionCardProps {
@@ -29,7 +28,7 @@ export function SessionCard({ session, onEnd }: SessionCardProps) {
   const shortId = session.id.slice(-8);
   const workspaceName = session.workspace_path.split('/').pop() || session.workspace_path;
   const isActive = session.state === 'active';
-  const relativeTime = formatDistanceToNow(new Date(session.created_at), { addSuffix: true });
+  const relativeTime = formatRelativeTime(session.created_at);
 
   return (
     <Card className="transition-colors hover:border-primary/50">

--- a/web-ui/src/components/tasks/GitHubIssueImportModal.tsx
+++ b/web-ui/src/components/tasks/GitHubIssueImportModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { formatCompactAge } from '@/lib/format';
 import useSWR from 'swr';
-import { formatDistanceToNowStrict } from 'date-fns';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Search01Icon, ArrowLeft01Icon, ArrowRight01Icon, Cancel01Icon, Loading03Icon, Alert02Icon } from '@hugeicons/core-free-icons';
 import {
@@ -259,7 +259,7 @@ export function GitHubIssueImportModal({
                     {issue.assignee ? `@${issue.assignee}` : '—'}
                   </span>
                   <span className="w-16 shrink-0 text-right text-xs text-muted-foreground">
-                    {formatAge(issue.created_at)}
+                    {formatCompactAge(issue.created_at)}
                   </span>
                 </label>
               );
@@ -322,31 +322,4 @@ export function GitHubIssueImportModal({
       </DialogContent>
     </Dialog>
   );
-}
-
-const AGE_UNIT_ABBR: Record<string, string> = {
-  second: 's',
-  minute: 'm',
-  hour: 'h',
-  day: 'd',
-  week: 'w',
-  month: 'mo',
-  year: 'y',
-};
-
-/** Render an ISO timestamp as a compact relative age (e.g. "3d", "2mo").
- *
- * Uses the *strict* formatter so there are no "about "/"almost "/"less than a
- * minute" prefixes to mangle; output is always "<n> <unit>" which we then
- * abbreviate. Tolerates empty/invalid input by returning "".
- */
-function formatAge(iso: string): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '';
-  const strict = formatDistanceToNowStrict(d); // e.g. "3 days", "1 minute"
-  const match = strict.match(/^(\d+)\s+(\w+?)s?$/);
-  if (!match) return strict;
-  const [, count, unit] = match;
-  return `${count}${AGE_UNIT_ABBR[unit] ?? unit}`;
 }

--- a/web-ui/src/components/tasks/TaskCard.tsx
+++ b/web-ui/src/components/tasks/TaskCard.tsx
@@ -91,7 +91,7 @@ export function TaskCard({
             )}
             <Tooltip>
               <TooltipTrigger asChild>
-                <Badge variant={STATUS_BADGE_VARIANT[task.status] as never}>
+                <Badge variant={STATUS_BADGE_VARIANT[task.status]}>
                   {STATUS_LABEL[task.status]}
                 </Badge>
               </TooltipTrigger>

--- a/web-ui/src/components/tasks/TaskDetailModal.tsx
+++ b/web-ui/src/components/tasks/TaskDetailModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { formatDate } from '@/lib/format';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { HugeiconsIcon } from '@hugeicons/react';
@@ -145,7 +146,7 @@ export function TaskDetailModal({
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Badge variant={STATUS_BADGE_VARIANT[task.status] as never}>
+                      <Badge variant={STATUS_BADGE_VARIANT[task.status]}>
                         {STATUS_LABEL[task.status]}
                       </Badge>
                     </TooltipTrigger>
@@ -191,7 +192,7 @@ export function TaskDetailModal({
               {task.updated_at && (
                 <span className="flex items-center gap-1">
                   <HugeiconsIcon icon={Time01Icon} className="h-3.5 w-3.5" />
-                  Last changed: {new Date(task.updated_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                  Last changed: {formatDate(task.updated_at)}
                 </span>
               )}
             </div>
@@ -228,7 +229,7 @@ export function TaskDetailModal({
                     return (
                       <li key={depId} className="flex items-center gap-2 text-xs">
                         {dep && (
-                          <Badge variant={STATUS_BADGE_VARIANT[dep.status] as never} className="shrink-0 text-[10px]">
+                          <Badge variant={STATUS_BADGE_VARIANT[dep.status]} className="shrink-0 text-[10px]">
                             {dep.status}
                           </Badge>
                         )}

--- a/web-ui/src/components/tasks/TaskFilters.tsx
+++ b/web-ui/src/components/tasks/TaskFilters.tsx
@@ -4,11 +4,11 @@ import { useRef, useEffect, useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Search01Icon } from '@hugeicons/core-free-icons';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
+import { Badge, type BadgeVariant } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { TaskStatus } from '@/types';
 
-const FILTERABLE_STATUSES: { value: TaskStatus; label: string; variant: string }[] = [
+const FILTERABLE_STATUSES: { value: TaskStatus; label: string; variant: BadgeVariant }[] = [
   { value: 'BACKLOG', label: 'Backlog', variant: 'backlog' },
   { value: 'READY', label: 'Ready', variant: 'ready' },
   { value: 'IN_PROGRESS', label: 'In Progress', variant: 'in-progress' },
@@ -70,7 +70,7 @@ export function TaskFilters({
               className="focus-visible:outline-hidden focus-visible:ring-[3px] focus-visible:ring-ring rounded-md"
             >
               <Badge
-                variant={variant as never}
+                variant={variant}
                 className={cn(
                   'cursor-pointer transition-opacity',
                   !isActive && statusFilter !== null && 'opacity-40'

--- a/web-ui/src/components/ui/badge.tsx
+++ b/web-ui/src/components/ui/badge.tsx
@@ -43,4 +43,6 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   );
 }
 
+export type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>['variant']>;
+
 export { Badge, badgeVariants };

--- a/web-ui/src/components/workspace/RecentActivityFeed.tsx
+++ b/web-ui/src/components/workspace/RecentActivityFeed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { IconSvgElement } from '@hugeicons/react';
+import { formatRelativeTime } from '@/lib/format';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Time01Icon,
@@ -9,7 +10,6 @@ import {
   Alert02Icon,
   Folder01Icon,
 } from '@hugeicons/core-free-icons';
-import { formatDistanceToNow } from 'date-fns';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { ActivityItem, ActivityType } from '@/types';
 
@@ -74,9 +74,7 @@ export function RecentActivityFeed({ activities }: RecentActivityFeedProps) {
                       data-testid="activity-timestamp"
                       className="mt-1 text-xs text-muted-foreground"
                     >
-                      {formatDistanceToNow(new Date(activity.timestamp), {
-                        addSuffix: true,
-                      })}
+                      {formatRelativeTime(activity.timestamp)}
                     </p>
                   </div>
                 </div>

--- a/web-ui/src/components/workspace/WorkspaceSelector.tsx
+++ b/web-ui/src/components/workspace/WorkspaceSelector.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { formatRelativeTime } from '@/lib/format';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Folder01Icon, Time01Icon, Cancel01Icon, Loading03Icon, Alert02Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
-import { formatDistanceToNow } from 'date-fns';
 
 interface WorkspaceSelectorProps {
   onSelectWorkspace: (path: string) => Promise<void>;
@@ -184,9 +184,7 @@ export function WorkspaceSelector({
                       <div className="flex items-center gap-2 flex-shrink-0 ml-4">
                         {workspace.last_opened_at && (
                           <span className="text-xs text-muted-foreground">
-                            {formatDistanceToNow(new Date(workspace.last_opened_at), {
-                              addSuffix: true,
-                            })}
+                            {formatRelativeTime(workspace.last_opened_at)}
                           </span>
                         )}
                         <button

--- a/web-ui/src/lib/format.ts
+++ b/web-ui/src/lib/format.ts
@@ -1,18 +1,76 @@
+import { formatDistanceToNow, formatDistanceToNowStrict } from 'date-fns';
+
 /**
- * Format an ISO date string as a human-readable relative time.
- * Returns strings like "just now", "5m ago", "2h ago", or "3d ago".
+ * The single set of display formatters for the app. Two surfaces showing the
+ * same value must agree on it (#971, #1195), so every displayed timestamp,
+ * count and USD amount goes through here — the guard test in
+ * `__tests__/lib/sharedConstants.guard.test.ts` enforces it.
  */
-export function formatRelativeTime(isoDate: string): string {
-  const now = new Date();
-  const date = new Date(isoDate);
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  const diffHours = Math.floor(diffMins / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-  const diffDays = Math.floor(diffHours / 24);
-  return `${diffDays}d ago`;
+
+const LOCALE = 'en-US';
+
+function parse(iso: string): Date | null {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** "Apr 10, 2026" — or "" when `iso` does not parse. */
+export function formatDate(iso: string): string {
+  return (
+    parse(iso)?.toLocaleDateString(LOCALE, { month: 'short', day: 'numeric', year: 'numeric' }) ?? ''
+  );
+}
+
+/** "Apr 10, 2026, 12:00 PM" — or "" when `iso` does not parse. */
+export function formatDateTime(iso: string): string {
+  return (
+    parse(iso)?.toLocaleString(LOCALE, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }) ?? ''
+  );
+}
+
+/** "12:00:05 PM" — time of day with seconds, for event streams. "" when unparseable. */
+export function formatTime(iso: string): string {
+  return (
+    parse(iso)?.toLocaleTimeString(LOCALE, { hour: '2-digit', minute: '2-digit', second: '2-digit' }) ??
+    ''
+  );
+}
+
+/** "30 minutes ago", "about 2 hours ago", "3 days ago". "" when unparseable. */
+export function formatRelativeTime(iso: string): string {
+  const d = parse(iso);
+  return d ? formatDistanceToNow(d, { addSuffix: true }) : '';
+}
+
+const AGE_UNIT_ABBR: Record<string, string> = {
+  second: 's',
+  minute: 'm',
+  hour: 'h',
+  day: 'd',
+  week: 'w',
+  month: 'mo',
+  year: 'y',
+};
+
+/**
+ * "3d", "1m", "2mo" — compact age for dense list columns. The strict variant
+ * never emits "about"/"almost" qualifiers, so the output is always
+ * "<n> <unit>" which is then abbreviated. "" when unparseable.
+ */
+export function formatCompactAge(iso: string): string {
+  const d = parse(iso);
+  if (!d) return '';
+  const strict = formatDistanceToNowStrict(d); // e.g. "3 days", "1 minute"
+  const match = strict.match(/^(\d+)\s+(\w+?)s?$/);
+  if (!match) return strict;
+  const [, count, unit] = match;
+  return `${count}${AGE_UNIT_ABBR[unit] ?? unit}`;
 }
 
 /**
@@ -30,7 +88,7 @@ export function formatUsd(
     maximumFractionDigits = minimumFractionDigits,
   }: { minimumFractionDigits?: number; maximumFractionDigits?: number } = {}
 ): string {
-  return value.toLocaleString('en-US', {
+  return value.toLocaleString(LOCALE, {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits,
@@ -40,5 +98,5 @@ export function formatUsd(
 
 /** Format a plain count (tokens, rows) with thousands separators. */
 export function formatCount(n: number): string {
-  return n.toLocaleString('en-US');
+  return n.toLocaleString(LOCALE);
 }

--- a/web-ui/src/lib/taskStatusInfo.ts
+++ b/web-ui/src/lib/taskStatusInfo.ts
@@ -1,3 +1,4 @@
+import type { BadgeVariant } from '@/components/ui/badge';
 import type { TaskStatus } from '@/types';
 
 export interface StatusInfo {
@@ -48,7 +49,7 @@ export const STATUS_INFO: Record<TaskStatus, StatusInfo> = {
 };
 
 /** Map backend TaskStatus to badge variant name. */
-export const STATUS_BADGE_VARIANT: Record<TaskStatus, string> = {
+export const STATUS_BADGE_VARIANT: Record<TaskStatus, BadgeVariant> = {
   BACKLOG: 'backlog',
   READY: 'ready',
   IN_PROGRESS: 'in-progress',


### PR DESCRIPTION
Closes #1195

## Summary

Closes the de-duplication leftovers from #971 in the web UI: badge-variant typing, proof status colours, timestamp formatting, one stray count formatter, and the naming-based currency guard rule.

## Changes

- **Badge typing** — `badge.tsx` exports `BadgeVariant` (derived from `badgeVariants`); `STATUS_BADGE_VARIANT` is `Record<TaskStatus, BadgeVariant>`. The four `as never` casts (`TaskCard`, `TaskDetailModal` ×2, `TaskFilters`) are gone and `GateRunPanel` reuses the type. Renaming a variant in `badge.tsx` is now a compile error (verified by mutation).
- **Proof colours** — `ProofStatusBadge` exports `PROOF_STATUS_VARIANT` (open→`blocked`, satisfied→`done`, waived→`backlog`), `ProofStatusWidget` reuses it, and the hand-rolled pass/fail/tampered/cannot-verify pills in `GateEvidencePanel` and `RunHistoryPanel` are `<Badge variant>`s.
- **Timestamps** — one formatter set in `lib/format.ts` (en-US, `""` on unparseable input): `formatDate`, `formatDateTime`, `formatTime`, `formatRelativeTime` (date-fns `formatDistanceToNow`) and `formatCompactAge` (moved out of `GitHubIssueImportModal`). All 15 raw `toLocale*String` timestamp sites and 5 direct date-fns sites now go through it; the hand-rolled compact relative formatter is deleted.
- **Counts** — `UploadPRDModal` and the costs page use `formatCount`.
- **Guard test** — the currency rule matches the Intl `style: 'currency'` option (with a positive self-check) instead of function names; new #1195 rules pin the badge typing, proof badge colour pairs, `toLocale*String` and date-fns single-definition properties. Every rule was mutation-checked (9/9 mutations killed).

## Contract change

Blocker surfaces now read **"30 minutes ago"** (date-fns wording, matching the notification center and sessions) instead of "30m ago". `BlockerCard`, `ResolvedBlockersSection` and `PRHistoryPanel` test expectations follow.

## Verification

- `cd web-ui && npm test` — 106 suites, 1303 tests passed
- `npm run build`, `npx tsc --noEmit`, `eslint --max-warnings 0` — clean
- Diff coverage 96% (61 changed lines, 2 uncovered: a JSX ternary branch and an import line)
- Cross-family review: `codex review` — "no actionable correctness issues" (posted below). opencode/GLM was not used (it has previously written to the tree and timed out on this repo).
- Internal review: one Major finding (guard scope narrower than the criterion wording) — addressed by stating the rule's scope on the test; see Known Limitations.

## Demo

See the evidence table in the PR comments (Phase 11 gate) (screenshots + DOM class captures from a seeded workspace).

## Known limitations

- **Proof colour scope** — the guard rule targets status *badges/pills* (`bg-<hue>-N text-<hue>-N` pairs). `GateRunBanner`'s live-run status dots and `WaiveDialog`'s amber warning box are not badges and keep their own colours; the rule's comment says so.
- `formatDate`'s one hardcoded test expectation uses noon UTC, so it is stable for any runner within ±11h of UTC.
- No dependency changes; the lockfile is untouched (#1194).
- The hand-rolled pills in `GateEvidencePanel` / `RunHistoryPanel` carried `dark:` classes that the shared badge variants do not. The claude-review bot checked and found no theme toggle ever adds `dark` to an ancestor, so those utilities were inert; nothing visible changes.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
