### PR TITLE
refactor(core): collapse cancel_batch into stop_batch(force=False) (#1197)

### DIFF
--- a/codeframe/core/conductor.py
+++ b/codeframe/core/conductor.py
@@ -1050,47 +1050,6 @@ def find_batch_by_prefix(workspace: Workspace, prefix: str) -> list[BatchRun]:
     return [_row_to_batch(row) for row in rows]
 
 
-def cancel_batch(workspace: Workspace, batch_id: str) -> BatchRun:
-    """Cancel a running batch.
-
-    Marks the batch CANCELLED and emits ``BATCH_CANCELLED``. It does **not**
-    signal anything already running: in-flight tasks run to completion, and the
-    worker pool notices the terminal status on its next check. Use
-    ``stop_batch(force=True)`` if you need the harder stop.
-
-    Args:
-        workspace: Target workspace
-        batch_id: Batch to cancel
-
-    Returns:
-        Updated BatchRun
-
-    Raises:
-        ValueError: If batch not found or not in a cancellable state
-    """
-    batch = get_batch(workspace, batch_id)
-    if not batch:
-        raise ValueError(f"Batch not found: {batch_id}")
-
-    if batch.status not in (BatchStatus.PENDING, BatchStatus.RUNNING):
-        raise ValueError(f"Batch cannot be cancelled: {batch.status}")
-
-    # Update status
-    batch.status = BatchStatus.CANCELLED
-    batch.completed_at = _utc_now()
-    _save_batch(workspace, batch)
-
-    # Emit event
-    events.emit_for_workspace(
-        workspace,
-        events.EventType.BATCH_CANCELLED,
-        {"batch_id": batch_id},
-        print_event=True,
-    )
-
-    return batch
-
-
 def stop_batch(workspace: Workspace, batch_id: str, force: bool = False) -> BatchRun:
     """Stop a running batch.
 
@@ -2704,7 +2663,7 @@ def _save_batch(
 
             # Cancellation is authoritative (#726): don't let a whole-row write
             # from a still-running worker resurrect a batch a concurrent
-            # cancel_batch/stop_batch already marked CANCELLED.
+            # stop_batch already marked CANCELLED.
             if preserve_terminal_cancel and batch.status != BatchStatus.CANCELLED:
                 cursor.execute(
                     "SELECT status FROM batch_runs WHERE id = ?", (batch.id,)

--- a/codeframe/ui/routers/batches_v2.py
+++ b/codeframe/ui/routers/batches_v2.py
@@ -288,9 +288,12 @@ async def cancel_batch(
     batch_id: str,
     workspace: Workspace = Depends(get_v2_workspace),
 ) -> BatchResponse:
-    """Cancel a running batch.
+    """Cancel a running batch — the graceful stop, kept as its own route.
 
-    Similar to stop but with explicit cancel semantics.
+    Identical to ``POST /{batch_id}/stop`` with ``force=false`` (#1197): the
+    batch is marked CANCELLED, in-flight tasks finish naturally, and
+    ``BATCH_CANCELLED`` is emitted. The route survives only for API
+    compatibility — the web UI's batch monitor calls it.
 
     Args:
         batch_id: Batch to cancel
@@ -305,7 +308,9 @@ async def cancel_batch(
             - 400: Batch not in cancellable state
     """
     try:
-        batch = await run_in_threadpool(conductor.cancel_batch, workspace, batch_id)
+        batch = await run_in_threadpool(
+            conductor.stop_batch, workspace, batch_id, force=False
+        )
         return _batch_to_response(batch)
 
     except ValueError as e:

--- a/tests/core/test_conductor.py
+++ b/tests/core/test_conductor.py
@@ -12,7 +12,6 @@ from codeframe.core.conductor import (
     start_batch,
     get_batch,
     list_batches,
-    cancel_batch,
     stop_batch,
     resume_batch,
     _save_batch,
@@ -258,53 +257,6 @@ class TestListBatches:
         assert len(result) == 2
 
 
-class TestCancelBatch:
-    """Tests for cancel_batch function."""
-
-    def test_cancel_nonexistent_batch_raises(self, temp_workspace):
-        """Should raise ValueError for non-existent batch."""
-        with pytest.raises(ValueError, match="Batch not found"):
-            cancel_batch(temp_workspace, "non-existent-id")
-
-    def test_cancel_completed_batch_raises(self, workspace_with_tasks):
-        """Should raise ValueError for completed batch."""
-        workspace, task_list = workspace_with_tasks
-        task_ids = [t.id for t in task_list]
-
-        batch = start_batch(workspace, task_ids, dry_run=True)
-        # Batch is COMPLETED after dry run
-
-        with pytest.raises(ValueError, match="cannot be cancelled"):
-            cancel_batch(workspace, batch.id)
-
-    def test_cancel_pending_batch(self, workspace_with_tasks):
-        """Should cancel a pending batch."""
-        workspace, task_list = workspace_with_tasks
-
-        # Create a batch and manually set it to PENDING
-        from datetime import datetime, timezone
-        now = datetime.now(timezone.utc)
-
-        batch = BatchRun(
-            id="test-cancel-batch",
-            workspace_id=workspace.id,
-            task_ids=[task_list[0].id],
-            status=BatchStatus.PENDING,
-            strategy="serial",
-            max_parallel=4,
-            on_failure=OnFailure.CONTINUE,
-            started_at=now,
-            completed_at=None,
-            results={},
-        )
-        _save_batch(workspace, batch)
-
-        cancelled = cancel_batch(workspace, batch.id)
-
-        assert cancelled.status == BatchStatus.CANCELLED
-        assert cancelled.completed_at is not None
-
-
 class TestCancellationIsAuthoritative:
     """#726 / P0.15: a concurrent cancel must not be resurrected by a
     still-running worker's whole-row save."""
@@ -332,7 +284,7 @@ class TestCancellationIsAuthoritative:
         worker_view = self._running_batch(workspace, [task_list[0].id])
 
         # A concurrent cancel marks the persisted batch CANCELLED.
-        cancel_batch(workspace, worker_view.id)
+        stop_batch(workspace, worker_view.id)
 
         # The still-running worker finishes a task and saves the whole row with
         # its stale RUNNING in-memory status.
@@ -348,7 +300,7 @@ class TestCancellationIsAuthoritative:
     def test_resume_can_still_transition_cancelled_to_running(self, workspace_with_tasks):
         workspace, task_list = workspace_with_tasks
         batch = self._running_batch(workspace, [task_list[0].id])
-        cancel_batch(workspace, batch.id)
+        stop_batch(workspace, batch.id)
 
         # resume_batch bypasses the guard (preserve_terminal_cancel=False).
         batch.status = BatchStatus.RUNNING

--- a/tests/ui/test_v2_untested_routers_947.py
+++ b/tests/ui/test_v2_untested_routers_947.py
@@ -154,14 +154,14 @@ class TestBatchStopResumeCancelErrorMapping:
 
         `resume_batch` re-runs a task when its result is FAILED/BLOCKED/RUNNING
         **or when it is absent from `results` entirely**. Neither create_batch
-        nor cancel_batch populates `results`, so a freshly-cancelled batch
+        nor stop_batch populates `results`, so a freshly-cancelled batch
         re-runs everything through the real `cf work start --execute`. Recording
         a COMPLETED result first is what makes `tasks_to_run` empty and the
         early return the path taken.
         """
         task = tasks.create(workspace, title="t", description="")
         b = conductor.create_batch(workspace, [task.id])
-        conductor.cancel_batch(workspace, b.id)
+        conductor.stop_batch(workspace, b.id)
         resolved = conductor.get_batch(workspace, b.id)
         resolved.results = {task.id: "COMPLETED"}
         conductor._save_batch(workspace, resolved, preserve_terminal_cancel=False)
@@ -185,11 +185,39 @@ class TestBatchStopResumeCancelErrorMapping:
         spawning an agent inside the suite."""
         task = tasks.create(workspace, title="t", description="")
         b = conductor.create_batch(workspace, [task.id])
-        conductor.cancel_batch(workspace, b.id)
+        conductor.stop_batch(workspace, b.id)
 
         assert conductor.get_batch(workspace, b.id).results == {}, (
-            "cancel_batch now records results; the happy-path setup needs review"
+            "stop_batch now records results; the happy-path setup needs review"
         )
+
+
+class TestCancelIsGracefulStop:
+    """#1197: `cancel_batch` duplicated `stop_batch(force=False)` in core — same
+    status flip, same save, same event. Core keeps one function; the
+    `/cancel` route stays as a documented alias because the web UI calls it."""
+
+    def test_core_has_no_cancel_batch(self):
+        assert not hasattr(conductor, "cancel_batch")
+
+    def test_cancel_route_is_stop_batch_without_force(self, client, workspace):
+        from codeframe.core import events
+
+        task = tasks.create(workspace, title="t", description="")
+        b = conductor.create_batch(workspace, [task.id])
+
+        res = client.post(f"/api/v2/batches/{b.id}/cancel")
+
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "CANCELLED"
+        assert conductor.get_batch(workspace, b.id).completed_at is not None
+        # stop_batch's payload carries `force`; the deleted cancel_batch's did
+        # not — so this is what proves the route now delegates.
+        cancelled = [
+            e for e in events.list_recent(workspace, limit=20)
+            if e.event_type == events.EventType.BATCH_CANCELLED
+        ]
+        assert cancelled and cancelled[0].payload == {"batch_id": b.id, "force": False}
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #1197

## Summary

`conductor.cancel_batch` and `stop_batch(force=False)` did observably the same thing (flip to CANCELLED, set `completed_at`, save, emit `BATCH_CANCELLED`), differing only in error text. #1196 exposed it by correcting `cancel_batch`'s docstring, which had claimed the SIGTERM only `stop_batch(force=True)` performs. Core now has one function.

## Callers enumerated (acceptance criterion 1)

| Surface | Caller | Disposition |
|---|---|---|
| core | `conductor.py:1053` definition; comment at `:2707` | function deleted; comment updated |
| CLI | none — `cf work batch stop` already calls `stop_batch` | unchanged |
| API | `POST /api/v2/batches/{id}/cancel` (`batches_v2.py`) | now delegates to `stop_batch(force=False)`; docstring states it is the graceful-stop alias kept for API compatibility |
| web UI | `batchesApi.cancel` ← `BatchExecutionMonitor.tsx` | unchanged (route kept) |
| tests | `test_conductor.py` TestCancelBatch ×3 + #726 race tests ×2; `test_v2_untested_routers_947.py` ×2 | TestCancelBatch dropped (TestStopBatch already covers all three cases); the rest call `stop_batch` |
| docs | `docs/archive/BATCH_EXECUTION_PLAN.md` | archived — left alone |

## Verification

- New test `TestCancelIsGracefulStop`: core has no `cancel_batch`; `POST /cancel` on a pending batch returns CANCELLED with a `BATCH_CANCELLED` payload of `{"batch_id", "force": false}` — `stop_batch`'s payload shape, which the deleted function never emitted, so the test proves delegation. Mutation-checked: switching the route to `force=True` fails it.
- `tests/core/test_conductor.py` + `tests/ui/test_v2_untested_routers_947.py`: 156 passed; `ruff check` clean.
- Full CI gate (`tests/ --ignore=tests/e2e -m "not lifecycle"`): 6683 passed, 17 skipped locally (3m 54s); CI on this PR is green.

## Known limitations

- The route is deliberately kept: removing a public v2 route is a contract break for no gain. It can be retired together with `batchesApi.cancel` if the web UI ever stops calling it.
- The 400 `detail.message` for a non-stoppable batch on `/cancel` now reads `Batch cannot be stopped (status=…)` instead of `Batch cannot be cancelled: …` (flagged by claude-review). The error `code` is unchanged (`INVALID_STATE`) and nothing in the tree matches on the text.
- Cross-family review is `codex review` (opencode/GLM has previously mutated the tree and timed out on this repo); posted as a PR comment.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
