### PR TITLE
test(ci): widen the assertion-quality guard to all of tests/ (#1200)

### DIFF
--- a/tests/ci/test_assertion_quality_guard_973.py
+++ b/tests/ci/test_assertion_quality_guard_973.py
@@ -21,14 +21,13 @@ pytestmark = pytest.mark.v2
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-#: Weak-assertion checks are scoped to the CliRunner/TestClient suites #973
-#: named. The e2e suites run outside the CI gate and are not in scope.
-WEAK_ASSERT_DIRS = ("tests/cli", "tests/ui")
-
-#: The retired-skip check covers the whole tree. Two of the suites #973 retired
-#: lived in tests/blockers and tests/integration, so scoping this to cli+ui
-#: would leave the exact directories the issue emptied unguarded.
-SKIP_SCAN_DIRS = ("tests",)
+#: Every check covers the whole tree (#1200). #973 scoped the weak-assertion
+#: checks to the CliRunner/TestClient suites it named; the retired-skip check
+#: was widened first because two of the suites #973 retired lived in
+#: tests/blockers and tests/integration. tests/e2e runs outside the CI gate
+#: (``--ignore=tests/e2e``), which is exactly where weak assertions accumulate
+#: unnoticed — so it is scanned too, and this file is what catches them.
+SCAN_DIRS = ("tests",)
 
 
 def _files(dirs: tuple[str, ...]) -> list[Path]:
@@ -79,7 +78,7 @@ def test_no_exit_code_accepts_both_success_and_failure():
     inline ``(0, 1)``.
     """
     offenders = []
-    for path in _files(WEAK_ASSERT_DIRS):
+    for path in _files(SCAN_DIRS):
         for node in ast.walk(_parse(path)):
             if not isinstance(node, ast.Assert):
                 continue
@@ -121,7 +120,7 @@ def test_no_test_asserts_only_that_the_runner_returned_something():
     making one claim regardless of how deeply it is indented.
     """
     offenders = []
-    for path in _files(WEAK_ASSERT_DIRS):
+    for path in _files(SCAN_DIRS):
         for node in _tests_in(_parse(path)):
             asserts = [n for n in ast.walk(node) if isinstance(n, ast.Assert)]
             if len(asserts) != 1:
@@ -167,7 +166,7 @@ def test_no_module_level_skip_anywhere_in_the_suite():
     long after its stated reason stopped being true.
     """
     offenders = []
-    for path in _files(SKIP_SCAN_DIRS):
+    for path in _files(SCAN_DIRS):
         for node in _parse(path).body:
             if not isinstance(node, ast.Assign):
                 continue

--- a/tests/e2e/cli/test_engines_cli.py
+++ b/tests/e2e/cli/test_engines_cli.py
@@ -40,7 +40,13 @@ class TestEnginesCheck:
         assert result.exit_code == 1
         assert "Error" in result.output
 
-    def test_check_missing_requirements(self):
+    def test_check_missing_requirements(self, monkeypatch, tmp_path):
+        # The CLI loads ~/.env and ./.env (env_provenance.load_env_files), so
+        # clearing os.environ is not enough: from the repo root, the repo's own
+        # .env put ANTHROPIC_API_KEY straight back and this passed only when
+        # run from a directory without one (#1200). Point both at an empty dir.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
         with patch.dict("os.environ", {}, clear=True):
             import os
             os.environ.pop("ANTHROPIC_API_KEY", None)

--- a/tests/e2e/cli/test_engines_cli.py
+++ b/tests/e2e/cli/test_engines_cli.py
@@ -46,10 +46,10 @@ class TestEnginesCheck:
         # .env put ANTHROPIC_API_KEY straight back and this passed only when
         # run from a directory without one (#1200). Point both at an empty dir.
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("HOME", str(tmp_path))
-        with patch.dict("os.environ", {}, clear=True):
-            import os
-            os.environ.pop("ANTHROPIC_API_KEY", None)
+        # HOME is set *inside* the cleared environ: `clear=True` would wipe a
+        # monkeypatch.setenv, and Path.home() then falls back to the real
+        # home directory (codex review of #1200 caught exactly that).
+        with patch.dict("os.environ", {"HOME": str(tmp_path)}, clear=True):
             result = runner.invoke(app, ["engines", "check", "react"])
             assert result.exit_code == 1
             assert "not set" in result.output

--- a/tests/e2e/cli/test_engines_cli.py
+++ b/tests/e2e/cli/test_engines_cli.py
@@ -52,6 +52,11 @@ class TestEnginesCheck:
 class TestEnginesNoArgs:
     def test_no_args_shows_help(self):
         result = runner.invoke(app, ["engines"])
-        # Typer no_args_is_help exits with code 0 or 2 depending on version
-        assert result.exit_code in (0, 2)
-        assert "list" in result.output or "check" in result.output or "Usage" in result.output
+        # no_args_is_help exits 2 on the Typer pinned in uv.lock (0.19.2). If a
+        # bump changes it, update this — don't widen it back to `in (0, 2)`,
+        # which is what tests/ci/test_assertion_quality_guard_973.py rejects.
+        assert result.exit_code == 2
+        assert "Usage" in result.output
+        # Both subcommands must be listed, not just any one of them.
+        assert "list" in result.output
+        assert "check" in result.output


### PR DESCRIPTION
Closes #1200

## Summary

`tests/ci/test_assertion_quality_guard_973.py` now runs all three checks (module-level skip, `exit_code in (0, N)`, lone `assert result is not None`) over the whole of `tests/` through one `SCAN_DIRS` constant. The e2e suites run outside the CI gate, which is where weak assertions accumulate unnoticed — the widened guard is what catches them there.

## What the widened scan found

Exactly the instance the issue predicted, and nothing else:

- `tests/e2e/cli/test_engines_cli.py::test_no_args_shows_help` accepted exit code 0 **or** 2 and any one of three substrings. Typer is pinned (0.19.2) and `no_args_is_help` exits 2 there — measured with both `CliRunner` and the shell — so the test asserts `== 2`, `"Usage"`, and **both** subcommands.

## Bug found on the way (fixed, second commit)

Running `tests/e2e/cli` from the repo root exposed `test_check_missing_requirements` failing on `main`: the CLI loads `~/.env` and `./.env` (`env_provenance.load_env_files`), so `patch.dict(os.environ, clear=True)` was not enough — the repo's own `.env` put `ANTHROPIC_API_KEY` straight back and the "not set" path never ran. It passed in CI only because CI has no `.env`. The test now runs from an empty cwd and `HOME`.

## Verification

- `uv run pytest tests/ci/test_assertion_quality_guard_973.py tests/e2e/cli/test_engines_cli.py` — 10 passed; `ruff` clean
- Mutation: with the old `in (0, 2)` restored, the guard fails naming `test_engines_cli.py:56` (this is the RED step of the change)
- Cross-family review (`codex review`) found one real defect in the isolation commit (`HOME` set before `patch.dict(clear=True)` wiped it) — fixed in the third commit and proven against a seeded `~/.env`; both passes posted as comments

## Known limitations

- `assert result.exit_code in EXPECTED_CODES` (a named container) is still not resolved — unchanged from #973, documented in the guard's docstring.
- No exclusion list was needed: no directory under `tests/` had a reason to be exempt.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
