### PR TITLE
fix(discovery): close the single-active-slot follow-ups from #1042 (#1202)

### DIFF
--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1668,6 +1668,11 @@ def prd_generate(
         "--resume", "-r",
         help="Resume from a paused session (blocker ID)",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="With --resume: close whichever session currently holds the workspace's active slot",
+    ),
     template: str = typer.Option(
         "standard",
         "--template", "-t",
@@ -1732,6 +1737,7 @@ def prd_generate(
     from codeframe.core.prd_discovery import (
         PrdDiscoverySession,
         DiscoveryError,
+        ActiveSessionExistsError,
         NoApiKeyError,
         ValidationError,
         IncompleteSessionError,
@@ -1789,8 +1795,8 @@ def prd_generate(
             console.print("\n[cyan]Resuming discovery session...[/cyan]")
             try:
                 session = PrdDiscoverySession(workspace)
-                session.resume_discovery(resume)
-            except (ValueError, NoApiKeyError) as e:
+                session.resume_discovery(resume, evict=force)
+            except (ValueError, NoApiKeyError, ActiveSessionExistsError) as e:
                 print_error(e)
                 raise typer.Exit(1)
             console.print(f"[green]✓[/green] Loaded {session.answered_count} previous answers")

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -1670,7 +1670,7 @@ def prd_generate(
     ),
     force: bool = typer.Option(
         False,
-        "--force",
+        "--force", "-f",
         help="With --resume: close whichever session currently holds the workspace's active slot",
     ),
     template: str = typer.Option(

--- a/codeframe/core/blockers.py
+++ b/codeframe/core/blockers.py
@@ -423,6 +423,25 @@ def resolve(workspace: Workspace, blocker_id: str) -> Blocker:
     return blocker
 
 
+def delete(workspace: Workspace, blocker_id: str) -> None:
+    """Delete a blocker outright, whatever its status.
+
+    Exists to unwind a blocker that must not be seen: `pause_discovery` creates
+    one and then finds its session was reset out from under it (#1202).
+    `resolve()` cannot do that — it refuses an OPEN blocker.
+
+    Raises:
+        ValueError: If blocker not found
+    """
+    blocker = get(workspace, blocker_id)
+    if not blocker:
+        raise ValueError(f"Blocker not found: {blocker_id}")
+
+    with closing(get_db_connection(workspace)) as conn:
+        conn.execute("DELETE FROM blockers WHERE id = ?", (blocker.id,))
+        conn.commit()
+
+
 def count_by_status(workspace: Workspace) -> dict[str, int]:
     """Count blockers by status.
 

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -90,6 +90,14 @@ class SessionResetError(DiscoveryError):
     pass
 
 
+#: The workspace's single active-session slot: what the partial UNIQUE index
+#: guards and what the migration backfill reconciles. Written once here (#1202)
+#: — the two used to be hand-copied, with nothing keeping them identical.
+#: `get_active_session`/`reset_discovery` deliberately use the looser
+#: `state != 'completed'` (reset must still close a finished-Q&A session).
+ACTIVE_SLOT_PREDICATE = "state != 'completed' AND COALESCE(is_complete, 0) = 0"
+
+
 class SessionState(str, Enum):
     """State of a discovery session."""
 
@@ -709,22 +717,31 @@ Be warm and encouraging. Just output the question, nothing else."""
         )
         self._blocker_id = blocker.id
         # Guarded for the same reason. A reset landing between these two writes
-        # leaves the blocker open with nothing pointing at it — but that window
-        # is the microseconds between two local writes, not the minutes of an
-        # LLM call, and there is no blocker-delete to unwind it with.
-        self._require_still_active()
+        # would leave the blocker open with nothing pointing at it, so unwind
+        # it before reporting the reset (#1202).
+        try:
+            self._require_still_active()
+        except SessionResetError:
+            self._blocker_id = None
+            blockers.delete(self.workspace, blocker.id)
+            raise
 
         logger.info(f"Session paused with blocker {blocker.id}")
         return blocker.id
 
-    def resume_discovery(self, blocker_id: str) -> None:
+    def resume_discovery(self, blocker_id: str, evict: bool = False) -> None:
         """Resume discovery from a blocker.
 
         Args:
             blocker_id: Blocker ID to resume from
+            evict: If the workspace's active slot is held by another session,
+                close that session first. Off by default: resuming refuses
+                rather than silently abandoning someone else's session (#1202).
 
         Raises:
             ValueError: If blocker not found or not a discovery blocker
+            ActiveSessionExistsError: If another session holds the slot and
+                ``evict`` is False
         """
         blocker = blockers.get(self.workspace, blocker_id)
         if not blocker:
@@ -747,7 +764,34 @@ Be warm and encouraging. Just output the question, nothing else."""
         # Load the session
         self.load_session(session_id)
         self.state = SessionState.DISCOVERING
-        self._save_session()
+
+        if evict:
+            # Close every *other* row holding the slot. Targeted rather than
+            # `reset_discovery(workspace)`, which picks by recency and could
+            # close this very session when it is the newest non-completed row.
+            conn = get_db_connection(self.workspace)
+            try:
+                conn.execute(
+                    f"""
+                    UPDATE discovery_sessions
+                    SET state = 'completed', updated_at = ?
+                    WHERE workspace_id = ? AND id != ? AND {ACTIVE_SLOT_PREDICATE}
+                    """,
+                    (_utc_now().isoformat(), self.workspace.id, session_id),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        try:
+            self._save_session()
+        except ActiveSessionExistsError as exc:
+            self.state = SessionState.PAUSED
+            raise ActiveSessionExistsError(
+                "Another discovery session is already active for this workspace. "
+                "Resume with evict=True (`cf prd generate --resume <id> --force`) "
+                "to close it and continue this one."
+            ) from exc
 
         logger.info(f"Resumed session {session_id} from blocker {blocker_id}")
 
@@ -1058,6 +1102,10 @@ def _ensure_discovery_schema(workspace: Workspace) -> None:
     # would fail outright on them — so complete all but the newest per workspace
     # first. (SQLite returns the bare `id` from the row supplying `MAX`, which is
     # what picks the newest here.)
+    # The backfill and the CREATE UNIQUE INDEX below are atomic only because
+    # sqlite3's implicit transaction spans both; `isolation_level=None` on
+    # `get_db_connection` would split them (pinned by
+    # tests/core/test_prd_discovery_slot_followups_1202.py).
     index_exists = cursor.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
         ("idx_discovery_sessions_one_active",),
@@ -1073,15 +1121,15 @@ def _ensure_discovery_schema(workspace: Workspace) -> None:
         # every row — the backfill would update nothing and the index build would
         # then fail on the duplicates it was supposed to clear.
         cursor.execute(
-            """
+            f"""
             UPDATE discovery_sessions
             SET state = 'completed', updated_at = ?
-            WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0
+            WHERE {ACTIVE_SLOT_PREDICATE}
               AND NOT EXISTS (
                   SELECT 1 FROM (
                       SELECT id AS keep_id, MAX(updated_at)
                       FROM discovery_sessions
-                      WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0
+                      WHERE {ACTIVE_SLOT_PREDICATE}
                       GROUP BY workspace_id
                   ) AS newest
                   WHERE newest.keep_id IS discovery_sessions.id
@@ -1093,7 +1141,7 @@ def _ensure_discovery_schema(workspace: Workspace) -> None:
             cursor.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_sessions_one_active "
                 "ON discovery_sessions(workspace_id) "
-                "WHERE state != 'completed' AND COALESCE(is_complete, 0) = 0"
+                f"WHERE {ACTIVE_SLOT_PREDICATE}"
             )
         except sqlite3.DatabaseError:
             # This function runs on every discovery entry point, so letting the
@@ -1114,6 +1162,10 @@ def _ensure_discovery_schema(workspace: Workspace) -> None:
 def get_active_session(workspace: Workspace) -> Optional[PrdDiscoverySession]:
     """Get the most recent active (non-completed) discovery session.
 
+    A finished-Q&A row (``is_complete=1``) is in scope — its PRD can still be
+    generated — but it does not hold the slot, so a row that does is preferred
+    over it regardless of which was touched last (#1202).
+
     Args:
         workspace: Workspace to query
 
@@ -1132,7 +1184,7 @@ def get_active_session(workspace: Workspace) -> Optional[PrdDiscoverySession]:
         """
         SELECT id FROM discovery_sessions
         WHERE workspace_id = ? AND state != 'completed'
-        ORDER BY updated_at DESC
+        ORDER BY COALESCE(is_complete, 0) ASC, updated_at DESC
         LIMIT 1
         """,
         (workspace.id,),

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -766,9 +766,15 @@ Be warm and encouraging. Just output the question, nothing else."""
         self.state = SessionState.DISCOVERING
 
         if evict:
-            # Close every *other* row holding the slot. Targeted rather than
+            # Close every *other* row holding the slot and re-activate this one
+            # in ONE transaction: committing the eviction first would open a
+            # window for a concurrent start to win the vacated slot, leaving
+            # the holder closed for nothing. Targeted rather than
             # `reset_discovery(workspace)`, which picks by recency and could
             # close this very session when it is the newest non-completed row.
+            # load_session() just read the row, so state is the only field
+            # that differs from what is stored.
+            now = _utc_now().isoformat()
             conn = get_db_connection(self.workspace)
             try:
                 conn.execute(
@@ -777,21 +783,35 @@ Be warm and encouraging. Just output the question, nothing else."""
                     SET state = 'completed', updated_at = ?
                     WHERE workspace_id = ? AND id != ? AND {ACTIVE_SLOT_PREDICATE}
                     """,
-                    (_utc_now().isoformat(), self.workspace.id, session_id),
+                    (now, self.workspace.id, session_id),
+                )
+                conn.execute(
+                    "UPDATE discovery_sessions SET state = ?, updated_at = ? "
+                    "WHERE id = ? AND workspace_id = ?",
+                    (SessionState.DISCOVERING.value, now, session_id, self.workspace.id),
                 )
                 conn.commit()
+            except sqlite3.IntegrityError as exc:
+                conn.rollback()
+                self.state = SessionState.PAUSED
+                if not _is_unique_violation(exc):
+                    raise
+                raise ActiveSessionExistsError(
+                    "Another discovery session claimed the workspace's slot while "
+                    "this one was being resumed; retry."
+                ) from exc
             finally:
                 conn.close()
-
-        try:
-            self._save_session()
-        except ActiveSessionExistsError as exc:
-            self.state = SessionState.PAUSED
-            raise ActiveSessionExistsError(
-                "Another discovery session is already active for this workspace. "
-                "Resume with evict=True (`cf prd generate --resume <id> --force`) "
-                "to close it and continue this one."
-            ) from exc
+        else:
+            try:
+                self._save_session()
+            except ActiveSessionExistsError as exc:
+                self.state = SessionState.PAUSED
+                raise ActiveSessionExistsError(
+                    "Another discovery session is already active for this workspace. "
+                    "Resume with evict=True (`cf prd generate --resume <id> --force`) "
+                    "to close it and continue this one."
+                ) from exc
 
         logger.info(f"Resumed session {session_id} from blocker {blocker_id}")
 

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -1479,6 +1479,10 @@ def reset_discovery(
         # the session in front of the user also closed unrelated in-flight
         # sessions belonging to other PRDs — silently destroying that work,
         # and contradicting this function's own docstring.
+        #
+        # Same selection as get_active_session (#1202): the row the UI shows as
+        # active is the one reset must close, so the slot holder comes before a
+        # finished-Q&A row whatever their updated_at order.
         cursor.execute(
             """
             UPDATE discovery_sessions
@@ -1486,7 +1490,7 @@ def reset_discovery(
             WHERE id = (
                 SELECT id FROM discovery_sessions
                 WHERE workspace_id = ? AND state != 'completed'
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY COALESCE(is_complete, 0) ASC, updated_at DESC, created_at DESC
                 LIMIT 1
             )
             """,

--- a/codeframe/core/prd_discovery.py
+++ b/codeframe/core/prd_discovery.py
@@ -741,7 +741,8 @@ Be warm and encouraging. Just output the question, nothing else."""
         Raises:
             ValueError: If blocker not found or not a discovery blocker
             ActiveSessionExistsError: If another session holds the slot and
-                ``evict`` is False
+                ``evict`` is False — or, with ``evict=True``, if a concurrent
+                start wins the slot inside the evict transaction (retry).
         """
         blocker = blockers.get(self.workspace, blocker_id)
         if not blocker:

--- a/tests/cli/test_prd_generate_active_slot_1042.py
+++ b/tests/cli/test_prd_generate_active_slot_1042.py
@@ -138,3 +138,63 @@ class TestFinishedSessionIsPreserved:
         assert states[seeded] == "discovering", (
             f"a finished-Q&A session must survive; got {states} / {result.output}"
         )
+
+
+@patch("codeframe.core.llm_resolution.create_provider")
+class TestResumeIntoATakenSlot:
+    """#1202: `--resume` into a workspace whose slot is held refuses by
+    default and names `--force`; `--force` evicts the holder and resumes."""
+
+    def _pause_then_take(self, workspace: Workspace) -> tuple[str, str, str]:
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        with patch("codeframe.core.prd_discovery.AnthropicProvider") as cls:
+            cls.return_value = _provider()
+            paused = PrdDiscoverySession(workspace, api_key="test-key")
+            paused.start_discovery()
+            blocker_id = paused.pause_discovery("stepping away")
+            conn = get_db_connection(workspace)
+            conn.execute(
+                "UPDATE discovery_sessions SET state = 'completed' WHERE id = ?",
+                (paused.session_id,),
+            )
+            conn.commit()
+            conn.close()
+            holder = PrdDiscoverySession(workspace, api_key="test-key")
+            holder.start_discovery()
+        return paused.session_id, blocker_id, holder.session_id
+
+    def test_refused_resume_exits_1_and_names_force(
+        self, mock_create_provider, workspace: Workspace, monkeypatch
+    ):
+        mock_create_provider.return_value = _provider()
+        monkeypatch.chdir(workspace.repo_path)
+        _paused, blocker_id, holder = self._pause_then_take(workspace)
+
+        result = runner.invoke(
+            app,
+            ["prd", "generate", "-w", str(workspace.repo_path), "--resume", blocker_id],
+            env={"ANTHROPIC_API_KEY": "test-key"},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "--force" in result.output, result.output
+        assert _states(workspace)[holder] != "completed"
+
+    def test_force_evicts_the_holder_and_resumes(
+        self, mock_create_provider, workspace: Workspace, monkeypatch
+    ):
+        mock_create_provider.return_value = _provider()
+        monkeypatch.chdir(workspace.repo_path)
+        paused, blocker_id, holder = self._pause_then_take(workspace)
+
+        result = runner.invoke(
+            app,
+            ["prd", "generate", "-w", str(workspace.repo_path), "--resume", blocker_id, "--force"],
+            input="/quit\ny\n",
+            env={"ANTHROPIC_API_KEY": "test-key"},
+        )
+
+        states = _states(workspace)
+        assert states[holder] == "completed", f"{states} / {result.output}"
+        assert "Resuming" in result.output, result.output

--- a/tests/core/test_prd_discovery_slot_followups_1202.py
+++ b/tests/core/test_prd_discovery_slot_followups_1202.py
@@ -248,6 +248,51 @@ class TestActivePredicateIsWrittenOnce:
         assert active is not None
         assert active.session_id == fresh.session_id
 
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_reset_without_an_id_closes_what_get_active_session_returns(
+        self, mock_provider_class, workspace, monkeypatch
+    ):
+        """codex on #1227: with the holder-first ordering in get_active_session,
+        a reset that still picked by recency would close the finished row the
+        UI is not showing and leave the session it *is* showing untouched."""
+        from codeframe.core.prd_discovery import (
+            PrdDiscoverySession,
+            get_active_session,
+            reset_discovery,
+        )
+
+        mock_provider_class.return_value = _provider_returning()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        holder = PrdDiscoverySession(workspace, api_key="test-key")
+        holder.start_discovery()
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET state = 'completed' WHERE id = ?", (holder.session_id,)
+        )
+        conn.commit()
+        conn.close()
+        finished = PrdDiscoverySession(workspace, api_key="test-key")
+        finished.start_discovery()
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET is_complete = 1, updated_at = '9999-01-01' WHERE id = ?",
+            (finished.session_id,),
+        )
+        conn.execute(
+            "UPDATE discovery_sessions SET state = 'discovering' WHERE id = ?", (holder.session_id,)
+        )
+        conn.commit()
+        conn.close()
+        shown = get_active_session(workspace).session_id
+        assert shown == holder.session_id, "the premise"
+
+        assert reset_discovery(workspace) is True
+
+        states = _states(workspace)
+        assert states[shown] == "completed", "reset must close the session the UI shows"
+        assert states[finished.session_id] != "completed"
+
 
 def test_db_connections_use_implicit_transactions(workspace):
     """`_ensure_discovery_schema`'s backfill and its CREATE UNIQUE INDEX are

--- a/tests/core/test_prd_discovery_slot_followups_1202.py
+++ b/tests/core/test_prd_discovery_slot_followups_1202.py
@@ -1,0 +1,225 @@
+"""Single-active-slot follow-ups from #1042 (#1202).
+
+Three loose ends #1201 disclosed and left: resuming into a taken slot could
+only fail, a reset landing between pause's two writes orphaned a blocker with
+no way to unwind it, and the "active session" predicate was written by hand in
+three places with nothing keeping them identical.
+"""
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeframe.core import blockers
+from codeframe.core.workspace import Workspace, create_or_load_workspace, get_db_connection
+
+pytestmark = pytest.mark.v2
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    return create_or_load_workspace(tmp_path)
+
+
+def _provider_returning(content: str = "What are you building?") -> MagicMock:
+    provider = MagicMock()
+    response = MagicMock()
+    response.content = content
+    response.input_tokens = 10
+    response.output_tokens = 5
+    provider.complete.return_value = response
+    return provider
+
+
+def _states(workspace: Workspace) -> dict[str, str]:
+    conn = get_db_connection(workspace)
+    rows = conn.execute("SELECT id, state FROM discovery_sessions").fetchall()
+    conn.close()
+    return dict(rows)
+
+
+@patch("codeframe.core.prd_discovery.AnthropicProvider")
+class TestResumeIntoATakenSlot:
+    def _paused_then_taken(self, workspace: Workspace):
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        paused = PrdDiscoverySession(workspace, api_key="test-key")
+        paused.start_discovery()
+        blocker_id = paused.pause_discovery("stepping away")
+        # A paused row still holds the slot; the holder can only start once
+        # the paused one is out of the way — which is what a user who never
+        # comes back looks like.
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET state = 'completed' WHERE id = ?",
+            (paused.session_id,),
+        )
+        conn.commit()
+        conn.close()
+        holder = PrdDiscoverySession(workspace, api_key="test-key")
+        holder.start_discovery()
+        return paused.session_id, blocker_id, holder.session_id
+
+    def test_refuses_by_default_and_names_the_way_out(self, mock_provider_class, workspace):
+        from codeframe.core.prd_discovery import ActiveSessionExistsError, PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+        paused_id, blocker_id, holder_id = self._paused_then_taken(workspace)
+
+        with pytest.raises(ActiveSessionExistsError, match="evict"):
+            PrdDiscoverySession(workspace, api_key="test-key").resume_discovery(blocker_id)
+
+        states = _states(workspace)
+        assert states[holder_id] != "completed", "a refused resume must not touch the holder"
+        assert states[paused_id] == "completed"
+
+    def test_evict_closes_the_holder_and_resumes(self, mock_provider_class, workspace):
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+        paused_id, blocker_id, holder_id = self._paused_then_taken(workspace)
+
+        resumed = PrdDiscoverySession(workspace, api_key="test-key")
+        resumed.resume_discovery(blocker_id, evict=True)
+
+        states = _states(workspace)
+        assert resumed.session_id == paused_id
+        assert states[paused_id] == "discovering"
+        assert states[holder_id] == "completed", "evict must close the holder, not error"
+
+    def test_evict_without_a_holder_is_a_plain_resume(self, mock_provider_class, workspace):
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+        paused = PrdDiscoverySession(workspace, api_key="test-key")
+        paused.start_discovery()
+        blocker_id = paused.pause_discovery("stepping away")
+
+        resumed = PrdDiscoverySession(workspace, api_key="test-key")
+        resumed.resume_discovery(blocker_id, evict=True)
+
+        assert _states(workspace) == {paused.session_id: "discovering"}
+
+
+class TestBlockerDelete:
+    def test_delete_removes_an_open_blocker(self, workspace):
+        created = blockers.create(workspace, question="orphan?", task_id=None, created_by="system")
+
+        blockers.delete(workspace, created.id)
+
+        assert blockers.get(workspace, created.id) is None
+        assert blockers.list_all(workspace) == []
+
+    def test_delete_of_an_unknown_blocker_raises(self, workspace):
+        with pytest.raises(ValueError, match="not found"):
+            blockers.delete(workspace, "nope")
+
+
+@patch("codeframe.core.prd_discovery.AnthropicProvider")
+class TestPauseUnwindsTheBlockerWhenTheSecondWriteIsRefused:
+    def test_a_reset_between_the_two_writes_leaves_no_blocker(
+        self, mock_provider_class, workspace, monkeypatch
+    ):
+        """Pause writes `paused`, creates the blocker, writes `blocker_id`. A
+        reset landing between the two writes refuses the second; the blocker
+        it just created must not survive with nothing pointing at it."""
+        from codeframe.core import prd_discovery
+        from codeframe.core.prd_discovery import (
+            PrdDiscoverySession,
+            SessionResetError,
+            reset_discovery,
+        )
+
+        mock_provider_class.return_value = _provider_returning()
+        session = PrdDiscoverySession(workspace, api_key="test-key")
+        session.start_discovery()
+
+        real_create = blockers.create
+        created: list[str] = []
+
+        def create_then_reset(*args, **kwargs):
+            blocker = real_create(*args, **kwargs)
+            created.append(blocker.id)
+            reset_discovery(workspace, session_id=session.session_id)  # lands in the window
+            return blocker
+
+        monkeypatch.setattr(prd_discovery.blockers, "create", create_then_reset)
+
+        with pytest.raises(SessionResetError):
+            session.pause_discovery("user interrupted")
+
+        assert created, "the premise: a blocker was created before the refused write"
+        assert blockers.get(workspace, created[0]) is None, "orphaned blocker survived"
+        assert _states(workspace)[session.session_id] == "completed"
+
+
+class TestActivePredicateIsWrittenOnce:
+    def test_the_unique_index_is_built_from_the_shared_predicate(self, workspace):
+        from codeframe.core.prd_discovery import ACTIVE_SLOT_PREDICATE, _ensure_discovery_schema
+
+        _ensure_discovery_schema(workspace)
+        conn = get_db_connection(workspace)
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            ("idx_discovery_sessions_one_active",),
+        ).fetchone()[0]
+        conn.close()
+
+        assert ACTIVE_SLOT_PREDICATE in sql
+
+    def test_the_predicate_literal_appears_exactly_once_in_the_module(self):
+        from codeframe.core import prd_discovery
+
+        source = inspect.getsource(prd_discovery)
+        # The definition of ACTIVE_SLOT_PREDICATE, and nowhere else by hand.
+        assert source.count("COALESCE(is_complete, 0) = 0") == 1
+
+    @patch("codeframe.core.prd_discovery.AnthropicProvider")
+    def test_get_active_session_prefers_the_slot_holder_over_a_newer_finished_row(
+        self, mock_provider_class, workspace, monkeypatch
+    ):
+        """#1201 pinned that a finished row's `updated_at` is never later than
+        the holder's. This pins the stronger property: even when it *is*, the
+        slot holder is returned."""
+        from codeframe.core.prd_discovery import PrdDiscoverySession, get_active_session
+
+        mock_provider_class.return_value = _provider_returning()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        finished = PrdDiscoverySession(workspace, api_key="test-key")
+        finished.start_discovery()
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET is_complete = 1 WHERE id = ?", (finished.session_id,)
+        )
+        conn.commit()
+        conn.close()
+
+        fresh = PrdDiscoverySession(workspace, api_key="test-key")
+        fresh.start_discovery()
+
+        conn = get_db_connection(workspace)
+        conn.execute(
+            "UPDATE discovery_sessions SET updated_at = '9999-01-01T00:00:00' WHERE id = ?",
+            (finished.session_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        active = get_active_session(workspace)
+        assert active is not None
+        assert active.session_id == fresh.session_id
+
+
+def test_db_connections_use_implicit_transactions(workspace):
+    """`_ensure_discovery_schema`'s backfill and its CREATE UNIQUE INDEX are
+    atomic only because sqlite3's implicit transaction spans both statements.
+    `isolation_level=None` (autocommit) would split them, and a concurrent
+    INSERT could land between. Nothing else records that dependency."""
+    conn = get_db_connection(workspace)
+    try:
+        assert conn.isolation_level is not None
+    finally:
+        conn.close()

--- a/tests/core/test_prd_discovery_slot_followups_1202.py
+++ b/tests/core/test_prd_discovery_slot_followups_1202.py
@@ -89,6 +89,42 @@ class TestResumeIntoATakenSlot:
         assert states[paused_id] == "discovering"
         assert states[holder_id] == "completed", "evict must close the holder, not error"
 
+    def test_evict_and_reactivation_are_one_transaction(self, mock_provider_class, workspace):
+        """Committing the eviction before the re-activating write would let a
+        concurrent start win the vacated slot (claude-review on #1227). The
+        evict path must therefore not use `_save_session`, which opens its own
+        connection — both writes go through one connection and one commit."""
+        from codeframe.core import prd_discovery
+        from codeframe.core.prd_discovery import PrdDiscoverySession
+
+        mock_provider_class.return_value = _provider_returning()
+        _paused_id, blocker_id, _holder_id = self._paused_then_taken(workspace)
+
+        resumed = PrdDiscoverySession(workspace, api_key="test-key")
+        commits: list[int] = []
+        real_get = prd_discovery.get_db_connection
+
+        class CountingConn:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def commit(self):
+                commits.append(id(self._conn))
+                return self._conn.commit()
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        def counting_get(ws):
+            return CountingConn(real_get(ws))
+
+        with patch.object(prd_discovery, "get_db_connection", counting_get), patch.object(
+            resumed, "_save_session", side_effect=AssertionError("second transaction")
+        ):
+            resumed.resume_discovery(blocker_id, evict=True)
+
+        assert len(commits) == 1, "evict + re-activate must be a single commit"
+
     def test_evict_without_a_holder_is_a_plain_resume(self, mock_provider_class, workspace):
         from codeframe.core.prd_discovery import PrdDiscoverySession
 


### PR DESCRIPTION
Closes #1202

## Summary

The three follow-ups #1201 disclosed and left, plus the transaction dependency it noted.

| # | Item | Change |
|---|---|---|
| 1 | `resume_discovery` fails rather than evicting | Still refuses by default, but the `ActiveSessionExistsError` now names the way out. New `evict=True` closes every *other* slot holder first (a targeted UPDATE — `reset_discovery()` picks by recency and could close the very session being resumed). CLI: `cf prd generate --resume <id> --force`; the refusal is caught and exits 1 naming `--force`. |
| 2 | Pause can orphan a blocker between its two writes | `blockers.delete()` added (hard delete, any status; the blocker was never shown to anyone). `pause_discovery` unwinds the blocker when the second guarded write is refused, then re-raises `SessionResetError`. |
| 3 | "Active" predicate written three times | One `ACTIVE_SLOT_PREDICATE` constant feeds the backfill (both places) and the unique index. `get_active_session` now orders by `COALESCE(is_complete, 0)` first, so the slot holder wins over a finished-Q&A row regardless of `updated_at`. |
| + | Backfill + `CREATE UNIQUE INDEX` atomic only via the implicit transaction | Comment at the site; a test pins that `get_db_connection` is not autocommit. |

## Decision taken (the product fork in item 1)

The issue lists refuse / evict-with-confirmation / both-via-flag. This PR ships **both via a flag**: the safe default is unchanged (refuse, no silent loss of someone else's session) and the opt-in is explicit and reversible. Posted on the issue before implementation.

## Verification

- New `tests/core/test_prd_discovery_slot_followups_1202.py` (10 tests) + 2 CLI tests in `test_prd_generate_active_slot_1042.py`. All written first and failing (11 RED).
- Mutations killed: evict made a no-op; pause's unwind removed; `get_active_session` reverted to recency-only; index built from a hand-written predicate.
- `tests/core/test_prd_discovery*`, `test_blockers*`, `tests/cli/test_prd_generate*`, `tests/ui/test_discovery*`: 142 passed. Full CI gate result below.
- Cross-family review (`codex review`): four passes posted as comments; pass three found that `reset_discovery()` without an id still picked by recency once `get_active_session` preferred the slot holder — fixed, tested, mutation-checked. claude-review found a real race in the evict path (eviction and re-activation on separate commits) — fixed in the second commit, single-commit property tested and mutation-checked.

## Known limitations

- `evict` closes the holder without confirmation at the core level; the CLI's `--force` is the confirmation. Eviction and re-activation are one transaction; if a concurrent start still wins the slot in that transaction, the error says "retry" rather than repeating the evict hint. The web UI does not expose resume-from-blocker, so no UI change.
- `reset_discovery`/`get_active_session` keep the deliberately looser `state != 'completed'` scope (reset must still close a finished-Q&A session); the constant's comment says so.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
