### PR TITLE
fix(cli): escape every Typer str argument a Rich render echoes back (#1206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,11 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   replaced was too narrow four times in one review cycle — a local bound one
   statement earlier carries no field name at all. Every registered command must
   appear in its `RUN` or `EXEMPT` table; a new command fails CI until classified.
+  The `EXEMPT` commands it cannot run are covered statically by
+  `tests/cli/test_typer_arg_markup_1206.py`: a Typer command's `str`-annotated
+  parameters are user input by definition, and any `console.print` / `.write` /
+  `.add_row` in that command that interpolates one without `escape()` fails CI.
+  Wrap the argument (`escape(str(x))` if it is Optional); do not add to `ALLOWED`.
 - **Don't run `npm audit fix` in `web-ui` to clear a red audit gate** — a job that
   rewrites the tree it is checking produces a differently broken build. Plain
   `npm install` is fine **unless you are on npm 11.6.x**, which is the whole of

--- a/codeframe/cli/app.py
+++ b/codeframe/cli/app.py
@@ -991,7 +991,7 @@ def serve(
 
     _warn_if_exposed(host)
 
-    console.print(f"Starting CodeFRAME API server on {host}:{port}")
+    console.print(f"Starting CodeFRAME API server on {escape(host)}:{port}")
     console.print(f"  Swagger UI: http://localhost:{port}/docs")
     console.print(f"  ReDoc:      http://localhost:{port}/redoc")
     console.print("  Press Ctrl+C to stop\n")
@@ -1066,7 +1066,7 @@ def prd_templates_show(
     template = manager.get_template(template_id)
 
     if not template:
-        console.print(f"[red]Error:[/red] Template '{template_id}' not found.")
+        console.print(f"[red]Error:[/red] Template '{escape(template_id)}' not found.")
         console.print("\nAvailable templates:")
         for t in manager.list_templates():
             console.print(f"  {t.id}")
@@ -1104,7 +1104,7 @@ def prd_templates_export(
 
     try:
         manager.export_template(template_id, output_path)
-        console.print(f"[green]✓[/green] Exported template '{template_id}' to {output_path}")
+        console.print(f"[green]✓[/green] Exported template '{escape(template_id)}' to {output_path}")
     except ValueError as e:
         print_error(e)
         console.print("\nAvailable templates:")
@@ -1546,7 +1546,7 @@ def prd_diff(
         diff = prd.diff_versions(workspace, prd_id, version1, version2)
 
         if diff is None:
-            console.print(f"[red]Error:[/red] Version not found for PRD {prd_id}")
+            console.print(f"[red]Error:[/red] Version not found for PRD {escape(prd_id)}")
             raise typer.Exit(1)
 
         if not diff:
@@ -1644,7 +1644,7 @@ def prd_update(
 
         console.print(f"[green]PRD updated to version {new_version.version}[/green]")
         console.print(f"  New ID: {new_version.id}")
-        console.print(f"  Changes: {message}")
+        console.print(f"  Changes: {escape(message)}")
 
     except FileNotFoundError as e:
         print_error(e)
@@ -1755,7 +1755,7 @@ def prd_generate(
     template_manager = PrdTemplateManager(workspace_path=workspace_path)
     template_obj = template_manager.get_template(template)
     if template_obj is None:
-        console.print(f"[red]Error:[/red] Template '{template}' not found.")
+        console.print(f"[red]Error:[/red] Template '{escape(template)}' not found.")
         console.print("\nAvailable templates:")
         for t in template_manager.list_templates():
             console.print(f"  {t.id} - {escape(t.name)}")
@@ -1936,7 +1936,7 @@ def prd_generate(
                     # Loud and specific, rather than an EOF traceback out of
                     # Prompt.ask that says nothing about where it stopped (#1114).
                     console.print(
-                        f"\n[red]Error:[/red] --answers-file {e}.\n"
+                        f"\n[red]Error:[/red] --answers-file {escape(str(e))}.\n"
                         f"Discovery was still on question "
                         f"{question.get('question_number', '?')} at "
                         f"{progress.get('percentage', 0)}% coverage.\n"
@@ -1964,7 +1964,7 @@ def prd_generate(
 
         # Generate PRD
         console.print("\n[bold green]Discovery complete![/bold green]")
-        console.print(f"\nGenerating PRD using '{template}' template...")
+        console.print(f"\nGenerating PRD using '{escape(template)}' template...")
 
         try:
             prd_record = session.generate_prd(template_id=template)
@@ -2172,7 +2172,7 @@ def prd_stress_test(
             # (#961). Failing here must not lose the answers silently, nor
             # print a traceback.
             console.print(
-                f"[red]Error:[/red] Could not apply your answers to the PRD: {e}"
+                f"[red]Error:[/red] Could not apply your answers to the PRD: {escape(str(e))}"
             )
             console.print(
                 "[dim]Your answers were not saved and no new version was "
@@ -3358,7 +3358,7 @@ def work_status(
                 console.print(f"  Status: {run.status.value}")
                 console.print(f"  Started: {run.started_at.strftime('%Y-%m-%d %H:%M:%S')}")
             else:
-                console.print(f"[dim]No active run for task {task_id}[/dim]")
+                console.print(f"[dim]No active run for task {escape(str(task_id))}[/dim]")
         else:
             # Show all active runs
             running = runtime.list_runs(workspace, status=RunStatus.RUNNING)
@@ -3411,7 +3411,7 @@ def work_show(
             console.print(f"[dim]No run found for task {escape(task_id)}[/dim]")
             raise typer.Exit(0)
 
-        console.print(f"\n[bold]Run Details[/bold] — {task_id[:8]}")
+        console.print(f"\n[bold]Run Details[/bold] — {escape(task_id[:8])}")
         console.print(f"  Run ID:    [dim]{run.id}[/dim]")
         console.print(f"  Status:    {run.status.value}")
         console.print(f"  Started:   {run.started_at.strftime('%Y-%m-%d %H:%M:%S') if run.started_at else '—'}")
@@ -4024,7 +4024,7 @@ def work_replay(
         trace = load_execution_trace(workspace, run_id)
 
         if not trace:
-            console.print(f"[red]Error:[/red] No trace found for run '{run_id}'")
+            console.print(f"[red]Error:[/red] No trace found for run '{escape(run_id)}'")
             raise typer.Exit(1)
 
         # Header
@@ -4130,7 +4130,7 @@ def work_diff(
         trace = load_execution_trace(workspace, run_id)
 
         if not trace:
-            console.print(f"[red]Error:[/red] No trace found for run '{run_id}'")
+            console.print(f"[red]Error:[/red] No trace found for run '{escape(run_id)}'")
             raise typer.Exit(1)
 
         step_a = from_step if from_step is not None else 0
@@ -4228,7 +4228,7 @@ def work_export_trace(
         trace = load_execution_trace(workspace, run_id)
 
         if not trace:
-            console.print(f"[red]Error:[/red] No trace found for run '{run_id}'")
+            console.print(f"[red]Error:[/red] No trace found for run '{escape(run_id)}'")
             raise typer.Exit(1)
 
         if output_format == "json":
@@ -4280,7 +4280,7 @@ def work_rerun(
         workspace = get_workspace(path)
         rerun_info = prepare_rerun(workspace, run_id, from_step)
 
-        console.print(f"[bold]Re-run preparation for run {run_id}[/bold]\n")
+        console.print(f"[bold]Re-run preparation for run {escape(run_id)}[/bold]\n")
         console.print(f"[bold]Resume from:[/bold] Step {from_step}")
         console.print(f"[bold]Task:[/bold] {rerun_info['task_id']}")
 
@@ -4495,9 +4495,9 @@ def batch_run(
 
         # Show execution plan
         console.print("\n[bold]Batch Execution Plan[/bold]")
-        console.print(f"  Strategy: {strategy}")
+        console.print(f"  Strategy: {escape(strategy)}")
         console.print(f"  Tasks: {len(ids_to_execute)}")
-        console.print(f"  On failure: {on_failure}")
+        console.print(f"  On failure: {escape(on_failure)}")
 
         # Ahead of the dry-run return: a preview of an engine that would be
         # refused is misleading, and this is also the pre-run guard that keeps
@@ -4636,11 +4636,11 @@ def batch_status(
             matching = conductor.find_batch_by_prefix(workspace, batch_id)
 
             if not matching:
-                console.print(f"[red]Error:[/red] No batch found matching '{batch_id}'")
+                console.print(f"[red]Error:[/red] No batch found matching '{escape(str(batch_id))}'")
                 raise typer.Exit(1)
 
             if len(matching) > 1:
-                console.print(f"[red]Error:[/red] Multiple batches match '{batch_id}':")
+                console.print(f"[red]Error:[/red] Multiple batches match '{escape(str(batch_id))}':")
                 for b in matching[:5]:
                     console.print(f"  {b.id[:8]} ({b.status.value})")
                 raise typer.Exit(1)
@@ -4786,11 +4786,11 @@ def batch_stop(
         matching = conductor.find_batch_by_prefix(workspace, batch_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No batch found matching '{batch_id}'")
+            console.print(f"[red]Error:[/red] No batch found matching '{escape(batch_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple batches match '{batch_id}':")
+            console.print(f"[red]Error:[/red] Multiple batches match '{escape(batch_id)}':")
             for b in matching[:5]:
                 console.print(f"  {b.id[:8]} ({b.status.value})")
             raise typer.Exit(1)
@@ -4860,11 +4860,11 @@ def batch_resume(
         matching = conductor.find_batch_by_prefix(workspace, batch_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No batch found matching '{batch_id}'")
+            console.print(f"[red]Error:[/red] No batch found matching '{escape(batch_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple batches match '{batch_id}':")
+            console.print(f"[red]Error:[/red] Multiple batches match '{escape(batch_id)}':")
             for b in matching[:5]:
                 console.print(f"  {b.id[:8]} ({b.status.value})")
             raise typer.Exit(1)
@@ -5058,11 +5058,11 @@ ETA: {eta} | Elapsed: {elapsed}"""
         matching = conductor.find_batch_by_prefix(workspace, batch_id)
 
         if not matching:
-            console.print(f"[red]Error:[/red] No batch found matching '{batch_id}'")
+            console.print(f"[red]Error:[/red] No batch found matching '{escape(batch_id)}'")
             raise typer.Exit(1)
 
         if len(matching) > 1:
-            console.print(f"[red]Error:[/red] Multiple batches match '{batch_id}':")
+            console.print(f"[red]Error:[/red] Multiple batches match '{escape(batch_id)}':")
             for b in matching[:5]:
                 console.print(f"  {b.id[:8]} ({b.status.value})")
             raise typer.Exit(1)
@@ -5421,7 +5421,7 @@ def blocker_create(
 
         console.print("\n[bold green]Blocker created[/bold green]")
         console.print(f"  ID: {blocker.id[:8]}")
-        console.print(f"  Question: {question[:60]}{'...' if len(question) > 60 else ''}")
+        console.print(f"  Question: {escape(question[:60])}{'...' if len(question) > 60 else ''}")
 
     except FileNotFoundError:
         console.print(f"[red]Error:[/red] No workspace found at {path}")
@@ -5854,7 +5854,7 @@ def checkpoint_show(
         checkpoint = checkpoints.get(workspace, name_or_id)
 
         if not checkpoint:
-            console.print(f"[red]Error:[/red] Checkpoint not found: {name_or_id}")
+            console.print(f"[red]Error:[/red] Checkpoint not found: {escape(name_or_id)}")
             raise typer.Exit(1)
 
         summary = checkpoint.snapshot.get("summary", {})
@@ -5952,7 +5952,7 @@ def checkpoint_delete(
         if deleted:
             console.print("[green]Checkpoint deleted[/green]")
         else:
-            console.print(f"[red]Error:[/red] Checkpoint not found: {name_or_id}")
+            console.print(f"[red]Error:[/red] Checkpoint not found: {escape(name_or_id)}")
             raise typer.Exit(1)
 
     except FileNotFoundError:
@@ -6347,7 +6347,7 @@ def templates_show(
     template = manager.get_template(template_id)
 
     if not template:
-        console.print(f"[red]Error:[/red] Template '{template_id}' not found.")
+        console.print(f"[red]Error:[/red] Template '{escape(template_id)}' not found.")
         console.print("\nAvailable templates:")
         for t in manager.list_templates():
             console.print(f"  {t.id}")
@@ -6418,7 +6418,7 @@ def templates_apply(
 
         console.print(
             f"\n[green]Created {result.tasks_created} tasks from template "
-            f"'{template_id}'[/green]\n"
+            f"'{escape(template_id)}'[/green]\n"
         )
         for i, task_id in enumerate(result.task_ids, 1):
             created = tasks.get(workspace, task_id)

--- a/codeframe/cli/auth_commands.py
+++ b/codeframe/cli/auth_commands.py
@@ -42,6 +42,7 @@ from typing import Optional, Tuple
 import requests
 import typer
 from rich.table import Table
+from rich.markup import escape
 
 from codeframe.cli.auth import store_token, clear_token, is_authenticated
 from codeframe.cli.api_client import (
@@ -315,7 +316,7 @@ def login(
 
             if token:
                 store_token(token)
-                console.print(f"[green]✓ Successfully logged in as {email}[/green]")
+                console.print(f"[green]✓ Successfully logged in as {escape(str(email))}[/green]")
             else:
                 console.print("[red]Error:[/red] No token received from server")
                 raise typer.Exit(1)
@@ -430,7 +431,7 @@ def register(
         )
 
         if response.status_code == 201:
-            console.print(f"[green]✓ Account registered successfully for {email}[/green]")
+            console.print(f"[green]✓ Account registered successfully for {escape(str(email))}[/green]")
 
             # Auto-login after registration
             console.print("Logging in...")
@@ -1073,7 +1074,7 @@ def api_key_revoke(
     success = service.revoke_api_key(key_id, user_id=user_id)
 
     if success:
-        console.print(f"[green]API key {key_id} revoked successfully.[/green]")
+        console.print(f"[green]API key {escape(key_id)} revoked successfully.[/green]")
     else:
         console.print("[red]Error:[/red] API key not found or not owned by user")
         raise typer.Exit(1)
@@ -1191,7 +1192,7 @@ def set_password(
         print_error(e)
         raise typer.Exit(1)
 
-    console.print(f"[green]✓ Password updated for {email}[/green]")
+    console.print(f"[green]✓ Password updated for {escape(email)}[/green]")
 
 
 @auth_app.command("deactivate")
@@ -1213,7 +1214,7 @@ def deactivate_user(
         print_error(e)
         raise typer.Exit(1)
 
-    console.print(f"[green]✓ {email} deactivated; its API keys no longer authenticate[/green]")
+    console.print(f"[green]✓ {escape(email)} deactivated; its API keys no longer authenticate[/green]")
 
 
 @auth_app.command("activate")
@@ -1232,7 +1233,7 @@ def activate_user(
         print_error(e)
         raise typer.Exit(1)
 
-    console.print(f"[green]✓ {email} activated[/green]")
+    console.print(f"[green]✓ {escape(email)} activated[/green]")
 
 
 @auth_app.command("user-list")

--- a/codeframe/cli/config_commands.py
+++ b/codeframe/cli/config_commands.py
@@ -4,6 +4,7 @@ import os
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from codeframe.core import telemetry as telemetry_core
 
@@ -27,7 +28,7 @@ def telemetry(
     """
     action = action.strip().lower()
     if action not in ("on", "off", "status"):
-        console.print(f"[red]Error:[/red] unknown action '{action}' (expected on|off|status)")
+        console.print(f"[red]Error:[/red] unknown action '{escape(action)}' (expected on|off|status)")
         raise typer.Exit(1)
 
     if action == "status":

--- a/codeframe/cli/engines_commands.py
+++ b/codeframe/cli/engines_commands.py
@@ -15,6 +15,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 from rich.table import Table
+from rich.markup import escape
 
 from codeframe.cli.helpers import print_error
 from codeframe.core import engine_stats
@@ -109,7 +110,7 @@ def engines_check(
         raise typer.Exit(1)
 
     if not reqs:
-        console.print(f"[green]Engine '{name}' has no additional requirements.[/green]")
+        console.print(f"[green]Engine '{escape(name)}' has no additional requirements.[/green]")
         return
 
     all_satisfied = True
@@ -121,9 +122,9 @@ def engines_check(
             all_satisfied = False
 
     if all_satisfied:
-        console.print(f"\n[green]Engine '{name}' is ready.[/green]")
+        console.print(f"\n[green]Engine '{escape(name)}' is ready.[/green]")
     else:
-        console.print(f"\n[red]Engine '{name}' has unmet requirements.[/red]")
+        console.print(f"\n[red]Engine '{escape(name)}' has unmet requirements.[/red]")
         raise typer.Exit(1)
 
 

--- a/codeframe/cli/env_commands.py
+++ b/codeframe/cli/env_commands.py
@@ -21,6 +21,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.markup import escape
 
 from codeframe.core.environment import (
     EnvironmentValidator,
@@ -58,7 +59,7 @@ def check(
     if project:
         project_path = Path(project)
         if not project_path.exists():
-            console.print(f"[red]Error:[/red] Project path not found: {project}")
+            console.print(f"[red]Error:[/red] Project path not found: {escape(str(project))}")
             raise typer.Exit(1)
     else:
         project_path = Path.cwd()
@@ -139,7 +140,7 @@ def doctor(
     if project:
         project_path = Path(project)
         if not project_path.exists():
-            console.print(f"[red]Error:[/red] Project path not found: {project}")
+            console.print(f"[red]Error:[/red] Project path not found: {escape(str(project))}")
             raise typer.Exit(1)
     else:
         project_path = Path.cwd()
@@ -286,15 +287,15 @@ def install_missing(
 
     # Check if we can install this tool
     if not installer.can_install(tool):
-        console.print(f"[red]Error:[/red] Cannot install '{tool}' - no installer available")
+        console.print(f"[red]Error:[/red] Cannot install '{escape(tool)}' - no installer available")
         console.print()
         console.print("This tool may need manual installation.")
-        console.print(f"Try: [dim]{installer.get_install_command(tool) or f'Install {tool} manually'}[/dim]")
+        console.print(f"Try: [dim]{escape(str(installer.get_install_command(tool) or f'Install {tool} manually'))}[/dim]")
         raise typer.Exit(1)
 
     # Show install command
     install_cmd = installer.get_install_command(tool)
-    console.print(f"[bold]Tool:[/bold] {tool}")
+    console.print(f"[bold]Tool:[/bold] {escape(tool)}")
     console.print(f"[bold]Command:[/bold] {install_cmd}")
     console.print()
 
@@ -353,7 +354,7 @@ def auto_install(
     if project:
         project_path = Path(project)
         if not project_path.exists():
-            console.print(f"[red]Error:[/red] Project path not found: {project}")
+            console.print(f"[red]Error:[/red] Project path not found: {escape(str(project))}")
             raise typer.Exit(1)
     else:
         project_path = Path.cwd()

--- a/codeframe/cli/hooks_commands.py
+++ b/codeframe/cli/hooks_commands.py
@@ -14,6 +14,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 from rich.table import Table
+from rich.markup import escape
 
 console = Console()
 
@@ -99,7 +100,7 @@ def hooks_run(
     from codeframe.core.hooks import HookContext, execute_hook
 
     if hook_name not in VALID_HOOK_NAMES:
-        console.print(f"[red]Error:[/red] Invalid hook name '{hook_name}'")
+        console.print(f"[red]Error:[/red] Invalid hook name '{escape(hook_name)}'")
         console.print(f"Valid hooks: {', '.join(VALID_HOOK_NAMES)}")
         raise typer.Exit(1)
 
@@ -126,13 +127,13 @@ def hooks_run(
     result = execute_hook(hook_name, config, path, ctx, abort_on_failure=False)
 
     if result is None:
-        console.print(f"[yellow]Hook '{hook_name}' is not configured.[/yellow]")
+        console.print(f"[yellow]Hook '{escape(hook_name)}' is not configured.[/yellow]")
         return
 
     if result.success:
-        console.print(f"[green]Hook '{hook_name}' succeeded[/green] ({result.duration_ms}ms)")
+        console.print(f"[green]Hook '{escape(hook_name)}' succeeded[/green] ({result.duration_ms}ms)")
     else:
-        console.print(f"[red]Hook '{hook_name}' failed[/red] ({result.duration_ms}ms)")
+        console.print(f"[red]Hook '{escape(hook_name)}' failed[/red] ({result.duration_ms}ms)")
         if result.timed_out:
             console.print("  [yellow]Timed out[/yellow]")
 
@@ -162,7 +163,7 @@ def hooks_set(
     )
 
     if hook_name not in VALID_HOOK_NAMES:
-        console.print(f"[red]Error:[/red] Invalid hook name '{hook_name}'")
+        console.print(f"[red]Error:[/red] Invalid hook name '{escape(hook_name)}'")
         console.print(f"Valid hooks: {', '.join(VALID_HOOK_NAMES)}")
         raise typer.Exit(1)
 
@@ -179,7 +180,7 @@ def hooks_set(
     save_environment_config(path, config)
     _record_trust(path, config)
 
-    console.print(f"[green]Hook '{hook_name}' set to:[/green] {command}")
+    console.print(f"[green]Hook '{escape(hook_name)}' set to:[/green] {escape(command)}")
 
 
 @hooks_app.command("clear")
@@ -197,7 +198,7 @@ def hooks_clear(
     )
 
     if hook_name not in VALID_HOOK_NAMES:
-        console.print(f"[red]Error:[/red] Invalid hook name '{hook_name}'")
+        console.print(f"[red]Error:[/red] Invalid hook name '{escape(hook_name)}'")
         console.print(f"Valid hooks: {', '.join(VALID_HOOK_NAMES)}")
         raise typer.Exit(1)
 
@@ -218,7 +219,7 @@ def hooks_clear(
     save_environment_config(path, config)
     _record_trust(path, config)
 
-    console.print(f"[green]Hook '{hook_name}' cleared.[/green]")
+    console.print(f"[green]Hook '{escape(hook_name)}' cleared.[/green]")
 
 
 def _record_trust(path: Path, config: "object") -> None:

--- a/codeframe/cli/pr_commands.py
+++ b/codeframe/cli/pr_commands.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 import typer
 from rich.table import Table
+from rich.markup import escape
 
 from codeframe.cli.helpers import console, print_error
 from codeframe.git.github_integration import GitHubAPIError, GitHubIntegration
@@ -228,7 +229,7 @@ def create_pr(
 
         # Validate not on base branch
         if branch == base:
-            console.print(f"[red]Error:[/red] Cannot create PR from '{branch}' to itself.")
+            console.print(f"[red]Error:[/red] Cannot create PR from '{escape(str(branch))}' to itself.")
             console.print("Please checkout a feature branch first.")
             raise typer.Exit(1)
 
@@ -326,7 +327,7 @@ def list_prs(
 
         # Table format
         if not prs:
-            console.print(f"[yellow]No {status} pull requests found.[/yellow]")
+            console.print(f"[yellow]No {escape(status)} pull requests found.[/yellow]")
             return
 
         table = Table(title=f"Pull Requests ({status})")
@@ -582,7 +583,7 @@ def merge_pr(
             console.print(f"[green]✓ PR #{pr_number} merged successfully[/green]")
             if result.sha:
                 console.print(f"[bold]Merge commit:[/bold] {result.sha[:7]}")
-            console.print(f"[bold]Strategy:[/bold] {strategy}")
+            console.print(f"[bold]Strategy:[/bold] {escape(strategy)}")
         else:
             console.print(f"[red]Error:[/red] Merge failed: {result.message}")
             raise typer.Exit(1)

--- a/codeframe/cli/proof_commands.py
+++ b/codeframe/cli/proof_commands.py
@@ -92,13 +92,13 @@ def capture(
     try:
         sev = Severity(severity)
     except ValueError:
-        console.print(f"[red]Error:[/red] Invalid severity: {severity}")
+        console.print(f"[red]Error:[/red] Invalid severity: {escape(str(severity))}")
         raise typer.Exit(1)
 
     try:
         src = Source(source)
     except ValueError:
-        console.print(f"[red]Error:[/red] Invalid source: {source}")
+        console.print(f"[red]Error:[/red] Invalid source: {escape(str(source))}")
         raise typer.Exit(1)
 
     req, stubs = capture_requirement(
@@ -178,7 +178,7 @@ def run(
         try:
             gate_filter = Gate(gate.lower())
         except ValueError:
-            console.print(f"[red]Error:[/red] Unknown gate: {gate}")
+            console.print(f"[red]Error:[/red] Unknown gate: {escape(str(gate))}")
             console.print(f"Valid gates: {', '.join(g.value for g in Gate)}")
             raise typer.Exit(1)
 
@@ -330,7 +330,7 @@ def list_reqs(
         try:
             status_filter = ReqStatus(status.lower())
         except ValueError:
-            console.print(f"[red]Error:[/red] Invalid status: {status}")
+            console.print(f"[red]Error:[/red] Invalid status: {escape(str(status))}")
             raise typer.Exit(1)
 
     reqs = ledger.list_requirements(workspace, status=status_filter)
@@ -465,14 +465,14 @@ def waive(
         try:
             expiry_date = date.fromisoformat(expires)
         except ValueError:
-            console.print(f"[red]Error:[/red] Invalid date format: {expires} (use YYYY-MM-DD)")
+            console.print(f"[red]Error:[/red] Invalid date format: {escape(str(expires))} (use YYYY-MM-DD)")
             raise typer.Exit(1)
 
     waiver_obj = Waiver(reason=reason, expires=expiry_date, approved_by="cli-user")
     updated = ledger.waive_requirement(workspace, req_id, waiver_obj)
 
     if updated:
-        console.print(f"[green]✓[/green] {req_id} waived: {reason}")
+        console.print(f"[green]✓[/green] {escape(req_id)} waived: {escape(reason)}")
         if expiry_date:
             console.print(f"  Expires: {expiry_date}")
     else:

--- a/codeframe/cli/stats_commands.py
+++ b/codeframe/cli/stats_commands.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 import typer
 from rich.table import Table
+from rich.markup import escape
 
 from codeframe.cli.helpers import console
 
@@ -121,7 +122,7 @@ def tokens(
             # Per-task summary
             summary = tracker.get_task_token_summary(task)
 
-            console.print(f"\n[bold]Token Usage for Task {task}[/bold]\n")
+            console.print(f"\n[bold]Token Usage for Task {escape(str(task))}[/bold]\n")
 
             table = Table(show_header=True, title=None)
             table.add_column("Metric", style="cyan")
@@ -215,7 +216,7 @@ def costs(
             start_date = now - timedelta(days=30)
         elif period is not None:
             console.print(
-                f"[red]Error:[/red] Unknown period '{period}'. Use 'day', 'week', or 'month'."
+                f"[red]Error:[/red] Unknown period '{escape(str(period))}'. Use 'day', 'week', or 'month'."
             )
             raise typer.Exit(1)
 
@@ -288,7 +289,7 @@ def export_data(
     db = _get_db()
     try:
         if format not in ("csv", "json"):
-            console.print(f"[red]Error:[/red] Unknown format '{format}'. Use 'csv' or 'json'.")
+            console.print(f"[red]Error:[/red] Unknown format '{escape(format)}'. Use 'csv' or 'json'.")
             raise typer.Exit(1)
 
         if task is not None:
@@ -302,6 +303,6 @@ def export_data(
         else:
             n = MetricsTracker.export_to_json(records, output)
 
-        console.print(f"Exported {n} records to {output}")
+        console.print(f"Exported {n} records to {escape(output)}")
     finally:
         db.close()

--- a/tests/cli/test_typer_arg_markup_1206.py
+++ b/tests/cli/test_typer_arg_markup_1206.py
@@ -1,0 +1,217 @@
+"""Command arguments are user text; rendering one through Rich needs escape() (#1206).
+
+#1054 guards the CLI by *running* commands against hostile stored data, but it
+cannot run the commands it classifies EXEMPT — network, LLM, server,
+machine-mutating — and an error message in one of those that echoes an
+argument back (``Invalid hook name '{hook_name}'``) crashes on ``[/b]``.
+
+This rule reaches them statically without a name denylist, because a Typer
+command's parameters are user input *by definition* and carry their own
+annotations: for every ``@*.command()`` function, the ``str``-annotated
+parameters are untrusted, and any ``console.print`` / ``.write`` /
+``.add_row`` inside that function that interpolates one of them into an
+f-string without ``escape()`` is a violation. Nothing here is inferred from
+what a variable is called, so it cannot drift the way #935's field-name list
+did.
+
+Known blind spots, shared with every static rule here: a parameter copied into
+another local first (``name = hook_name.strip()``) and rendered from that, and
+``%``/``.format`` formatting. #1054's runtime guard covers those where the
+command is runnable.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.v2
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_DIR = REPO_ROOT / "codeframe" / "cli"
+
+#: Rich renderers that treat their string as markup.
+RENDERERS = {"print", "write", "add_row"}
+
+#: ``module:function:parameter`` → reason. A site may be listed only when
+#: escaping it is wrong, not merely inconvenient.
+ALLOWED: dict[str, str] = {}
+
+
+def _is_str_annotation(node: ast.expr | None) -> bool:
+    """``str``, ``Optional[str]``, ``str | None``, ``Annotated[str, ...]``."""
+    if node is None:
+        return False
+    if isinstance(node, ast.Name):
+        return node.id == "str"
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return _is_str_annotation(ast.parse(node.value, mode="eval").body)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _is_str_annotation(node.left) or _is_str_annotation(node.right)
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+        if node.value.id == "Optional":
+            return _is_str_annotation(node.slice)
+        if node.value.id == "Annotated":
+            first = node.slice.elts[0] if isinstance(node.slice, ast.Tuple) else node.slice
+            return _is_str_annotation(first)
+    return False
+
+
+def _is_typer_command(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for dec in func.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(target, ast.Attribute) and target.attr == "command":
+            return True
+    return False
+
+
+def _untrusted_params(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    args = func.args
+    every = args.posonlyargs + args.args + args.kwonlyargs
+    return {a.arg for a in every if _is_str_annotation(a.annotation)}
+
+
+def _is_escape_call(node: ast.expr) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    return (isinstance(f, ast.Name) and f.id == "escape") or (
+        isinstance(f, ast.Attribute) and f.attr == "escape"
+    )
+
+
+def _unescaped_names(node: ast.expr, untrusted: set[str]) -> set[str]:
+    """Untrusted names referenced by ``node`` outside any ``escape(...)``.
+
+    ``len(name)`` is not the text: an ``'...' if len(desc) > 100 else ''``
+    renders a literal, so names inside ``len()`` are not counted.
+    """
+    if _is_escape_call(node):
+        return set()
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "len":
+        return set()
+    found: set[str] = set()
+    if isinstance(node, ast.Name) and node.id in untrusted:
+        found.add(node.id)
+    for child in ast.iter_child_nodes(node):
+        found |= _unescaped_names(child, untrusted)
+    return found
+
+
+def _rendered_expressions(call: ast.Call):
+    """Every expression a renderer call would format as markup."""
+    for arg in list(call.args) + [kw.value for kw in call.keywords]:
+        if isinstance(arg, ast.JoinedStr):
+            for part in arg.values:
+                if isinstance(part, ast.FormattedValue):
+                    yield part.value
+        elif isinstance(arg, (ast.Name, ast.Subscript, ast.Call, ast.Attribute)):
+            yield arg
+
+
+def find_violations(path: Path) -> list[tuple[str, int, str, str]]:
+    """``(function, lineno, parameter, source)`` for every unescaped render."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    out = []
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _is_typer_command(func):
+            continue
+        untrusted = _untrusted_params(func)
+        if not untrusted:
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (isinstance(node.func, ast.Attribute) and node.func.attr in RENDERERS):
+                continue
+            for expr in _rendered_expressions(node):
+                for name in sorted(_unescaped_names(expr, untrusted)):
+                    out.append((func.name, node.lineno, name, ast.unparse(expr)))
+    return out
+
+
+def _cli_modules() -> list[Path]:
+    modules = sorted(p for p in CLI_DIR.glob("*.py") if p.name != "__init__.py")
+    assert modules, "no CLI modules found — did codeframe/cli move?"
+    return modules
+
+
+@pytest.mark.parametrize("module", _cli_modules(), ids=lambda p: p.stem)
+def test_command_arguments_are_escaped_before_rich_renders_them(module: Path):
+    offenders = []
+    for func, lineno, param, source in find_violations(module):
+        key = f"{module.stem}:{func}:{param}"
+        if key in ALLOWED:
+            continue
+        offenders.append(f"{module.name}:{lineno} {func}({param}): {{{source}}}")
+
+    assert not offenders, (
+        "command arguments rendered through Rich without escape():\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_every_allowlist_entry_still_matches_a_site():
+    live = {
+        f"{m.stem}:{func}:{param}"
+        for m in _cli_modules()
+        for func, _, param, _ in find_violations(m)
+    }
+    stale = sorted(set(ALLOWED) - live)
+    assert not stale, f"allowlist entries no longer match anything: {stale}"
+
+
+class TestTheRuleActuallyFires:
+    """Mutation checks in miniature: the rule must catch each shape it claims to."""
+
+    def _violations(self, source: str, tmp_path: Path) -> list[str]:
+        path = tmp_path / "probe.py"
+        path.write_text(source)
+        return [f"{f}({p})" for f, _, p, _ in find_violations(path)]
+
+    def test_plain_interpolation_is_flagged(self, tmp_path):
+        src = (
+            "@app.command()\n"
+            "def run(hook_name: str):\n"
+            "    console.print(f\"[red]Error:[/red] Invalid hook name '{hook_name}'\")\n"
+        )
+        assert self._violations(src, tmp_path) == ["run(hook_name)"]
+
+    def test_optional_and_union_annotations_count(self, tmp_path):
+        src = (
+            "@app.command('x')\n"
+            "def run(a: Optional[str] = None, b: 'str | None' = None, c: str | None = None):\n"
+            "    console.print(f'{a} {b} {c}')\n"
+        )
+        assert self._violations(src, tmp_path) == ["run(a)", "run(b)", "run(c)"]
+
+    def test_escaped_interpolation_passes(self, tmp_path):
+        src = (
+            "@app.command()\n"
+            "def run(hook_name: str):\n"
+            "    console.print(f\"Invalid hook name '{escape(hook_name)}'\")\n"
+            "    table.add_row(escape(hook_name[:8]))\n"
+        )
+        assert self._violations(src, tmp_path) == []
+
+    def test_non_str_parameters_and_non_commands_are_ignored(self, tmp_path):
+        src = (
+            "@app.command()\n"
+            "def run(pr_number: int, output: Path):\n"
+            "    console.print(f'{pr_number} {output}')\n"
+            "def helper(name: str):\n"
+            "    console.print(f'{name}')\n"
+        )
+        assert self._violations(src, tmp_path) == []
+
+    def test_bare_argument_and_sliced_argument_are_flagged(self, tmp_path):
+        src = (
+            "@app.command()\n"
+            "def run(name: str):\n"
+            "    console.print(name)\n"
+            "    table.add_row(name[:8], 'x')\n"
+            "    log.write(f'{name.upper()}')\n"
+        )
+        assert self._violations(src, tmp_path) == ["run(name)", "run(name)", "run(name)"]


### PR DESCRIPTION
Closes #1206

## Summary

An error message that echoes a command argument was rendering user text through a markup-enabled Rich console, so `cf hooks run '[/b]'` reported the miss by crashing on it. #1054 fixed the sites its runtime guard could reach; this closes the rest with a static rule and fixes everything it finds.

## The rule — `tests/cli/test_typer_arg_markup_1206.py`

For every `@*.command()` function in `codeframe/cli/*.py`, the parameters annotated `str` / `Optional[str]` / `str | None` / `Annotated[str, …]` are untrusted. Any `console.print` / `.write` / `.add_row` in that function that interpolates one into an f-string (or passes it bare) without `escape()` is a violation. Names inside `len()` are not text (`'...' if len(desc) > 100 else ''` renders a literal) and are ignored. Nothing is inferred from a variable's name, so it cannot drift the way #935's field-name list did. `ALLOWED` exists and is **empty**; a stale entry fails its own test.

Measured: **67 sites** across nine modules (the issue estimated 93 from a prototype that also counted `len()`-only interpolations and non-renderers). Distribution: `app.py` 28, `hooks_commands` 9, `proof_commands` 7, `auth_commands` 6, `env_commands` 6, `stats_commands` 4, `engines_commands` 3, `pr_commands` 3, `config_commands` 1.

## The fix

Every site is wrapped in `escape()`; where the parameter is `Optional`, `escape(str(…))` so a `None` still renders as `None` the way the f-string did (17 sites). Applied by an AST-position rewriter and reviewed line by line. Two exception echoes with static prose around them (`--answers-file {e}`, `Could not apply your answers to the PRD: {e}`) are escaped the same way — neither is "just an exception", which is `print_error`'s case and was completed in #1054.

## Verification

- The rule: RED on 9 modules (67 findings) → GREEN after the fix. Its shape tests (`TestTheRuleActuallyFires`) pin plain / Optional / union / escaped / non-str / bare / sliced cases.
- `tests/cli` — 696 passed (includes the #1054 runtime guard, which still drives every runnable command with hostile text); `ruff` clean.
- Full CI gate result and cross-family review posted below.

## Known limitations

- Static blind spots shared with any AST rule: a parameter copied into another local first and rendered from that, and `%` / `.format` formatting. The #1054 runtime guard covers those where the command is runnable.
- Escaping happens at each render; a parameter reaching Rich through a helper (`print_error`) is already covered by that helper.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
