### PR TITLE
ci: auto-merge patch-level Dependabot security PRs for web-ui once green (#1217)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -23,12 +23,17 @@
 # checker refuses is a red step (that is the case the checker exists for).
 name: Dependabot auto-merge (web-ui security patches)
 
+# No `paths:` filter: a push that touches neither package file must still
+# reach the job, because that is the run that disarms. Runs for the same PR
+# are serialised (latest wins) so an older run's arming cannot land after a
+# newer run's disarm.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "web-ui/package.json"
-      - "web-ui/package-lock.json"
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -14,8 +14,13 @@
 # checks (strict, up-to-date) are what actually lands it. Runs on
 # `pull_request`, not `pull_request_target`: it needs no secrets, and the
 # `permissions` key grants the Dependabot-run token the two write scopes below.
-# A push by anyone other than Dependabot re-triggers the run and the actor gate
-# refuses, so a human amendment cannot ride the arming.
+#
+# Arming is persistent on the PR, so it is re-decided on EVERY push to a
+# Dependabot PR, whoever pushed: the job runs for any actor, only a push by
+# Dependabot itself can arm, and any run that does not end armed — a human
+# push, a metadata gate that no longer holds, a lock diff the checker refuses
+# — disarms. A metadata-ineligible PR is a skipped step; a lock diff the
+# checker refuses is a red step (that is the case the checker exists for).
 name: Dependabot auto-merge (web-ui security patches)
 
 on:
@@ -29,10 +34,14 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  PR_URL: ${{ github.event.pull_request.html_url }}
+  BASE_REF: ${{ github.event.pull_request.base.ref }}
+
 jobs:
   automerge:
     name: Arm auto-merge for a surgical security patch
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Read Dependabot metadata
@@ -41,10 +50,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Every gate must hold; the step is skipped (not failed) otherwise so a
-      # routine bump shows no red check — it is simply not eligible.
+      # Every gate must hold, including that Dependabot itself made this push.
       - name: Check out the PR
         if: >-
+          github.actor == 'dependabot[bot]' &&
           steps.md.outputs.package-ecosystem == 'npm' &&
           steps.md.outputs.directory == '/web-ui' &&
           steps.md.outputs.update-type == 'version-update:semver-patch' &&
@@ -58,11 +67,20 @@ jobs:
         if: steps.eligible.outcome == 'success'
         id: surgical
         run: |
-          git show "origin/${{ github.event.pull_request.base.ref }}:web-ui/package-lock.json" > /tmp/base-lock.json
+          git show "origin/${BASE_REF}:web-ui/package-lock.json" > /tmp/base-lock.json
           python3 scripts/ci/lock_diff_is_surgical.py /tmp/base-lock.json web-ui/package-lock.json
 
       - name: Arm auto-merge
         if: steps.surgical.outcome == 'success'
+        id: arm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Disarm auto-merge
+        # Not armed by THIS run means not armed at all: an earlier run's arming
+        # must not survive a head it never saw.
+        if: always() && steps.arm.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --disable-auto "$PR_URL" || echo "auto-merge was not armed"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -88,4 +88,13 @@ jobs:
         if: always() && steps.arm.outcome != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --disable-auto "$PR_URL" || echo "auto-merge was not armed"
+        # Ask first, then disarm without a fallback: `--disable-auto` on an
+        # unarmed PR is an error we expect, but `|| true` would also hide a
+        # real API failure and leave a stale arming in place silently.
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            gh pr merge --disable-auto "$PR_URL"
+            echo "auto-merge disarmed"
+          else
+            echo "auto-merge was not armed"
+          fi

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -92,7 +92,12 @@ jobs:
         # unarmed PR is an error we expect, but `|| true` would also hide a
         # real API failure and leave a stale arming in place silently.
         run: |
-          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+          set -euo pipefail
+          # A bare assignment keeps the query's exit status under errexit; a
+          # substitution inside `[ ]` would discard it and "not armed" could
+          # mean "could not ask".
+          armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')
+          if [ "$armed" = "true" ]; then
             gh pr merge --disable-auto "$PR_URL"
             echo "auto-merge disarmed"
           else

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,68 @@
+# Auto-merge patch-level Dependabot *security* updates to web-ui once green (#1217).
+#
+# #1210 cost a day of un-deployable staging while the two lockfile bumps that
+# fixed it sat open and green — nothing was missing but a merge. This closes
+# that gap as narrowly as it can be closed:
+#
+#   npm ecosystem, /web-ui only, a security advisory (not a routine bump),
+#   patch-level, and a lock diff that scripts/ci/lock_diff_is_surgical.py
+#   confirms is surgical: no package added or removed, no new install script,
+#   every resolved URL still registry.npmjs.org with an integrity hash, every
+#   version change patch-level. The semver label alone proves none of that.
+#
+# `gh pr merge --auto` only arms the merge; the branch protection's required
+# checks (strict, up-to-date) are what actually lands it. Runs on
+# `pull_request`, not `pull_request_target`: it needs no secrets, and the
+# `permissions` key grants the Dependabot-run token the two write scopes below.
+# A push by anyone other than Dependabot re-triggers the run and the actor gate
+# refuses, so a human amendment cannot ride the arming.
+name: Dependabot auto-merge (web-ui security patches)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "web-ui/package.json"
+      - "web-ui/package-lock.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Arm auto-merge for a surgical security patch
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read Dependabot metadata
+        id: md
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Every gate must hold; the step is skipped (not failed) otherwise so a
+      # routine bump shows no red check — it is simply not eligible.
+      - name: Check out the PR
+        if: >-
+          steps.md.outputs.package-ecosystem == 'npm' &&
+          steps.md.outputs.directory == '/web-ui' &&
+          steps.md.outputs.update-type == 'version-update:semver-patch' &&
+          steps.md.outputs.alert-state != ''
+        id: eligible
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Confirm the lock diff is surgical
+        if: steps.eligible.outcome == 'success'
+        id: surgical
+        run: |
+          git show "origin/${{ github.event.pull_request.base.ref }}:web-ui/package-lock.json" > /tmp/base-lock.json
+          python3 scripts/ci/lock_diff_is_surgical.py /tmp/base-lock.json web-ui/package-lock.json
+
+      - name: Arm auto-merge
+        if: steps.surgical.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,11 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   surface it first; the in-image gate stays as the backstop and must not be
   weakened. Recovery recipe: `deploy/README.md` → "The frontend image audit gate
   failed" — and `npm ci` exit 0 is the oracle either way.
+  Since #1217 a patch-level Dependabot **security** PR to `web-ui` arms
+  `gh pr merge --auto` by itself (`dependabot-automerge.yml`), but only after
+  `scripts/ci/lock_diff_is_surgical.py` confirms the lock diff adds and removes
+  nothing, gains no install script, and stays on `registry.npmjs.org` with
+  integrity hashes; routine bumps and minor/major updates still wait for a human.
   **The gate only fires because `deploy.yml` excludes the `deps` stage from the
   layer cache** (`no-cache-filters: deps`, #1216). A layer's cache key is its
   parent layers plus the command string, and an upstream advisory changes

--- a/scripts/ci/lock_diff_is_surgical.py
+++ b/scripts/ci/lock_diff_is_surgical.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Is a package-lock.json change surgical enough to merge without a human? (#1217)
+
+Compares a base and a head ``package-lock.json`` (lockfileVersion 3) and exits 0
+only when every property that made #1212's Dependabot lock diff safe holds:
+
+- the set of packages is identical — nothing added, nothing removed;
+- no entry newly declares an install script (``hasInstallScript``);
+- every changed entry still resolves to ``https://registry.npmjs.org/`` and
+  carries an ``integrity`` hash;
+- every version change is patch-level (same major.minor).
+
+Anything else exits 1 and prints why, one reason per line. The semver label on
+the PR is not consulted: this checks the bytes that will be installed.
+
+Usage: lock_diff_is_surgical.py BASE_LOCK HEAD_LOCK
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REGISTRY = "https://registry.npmjs.org/"
+
+
+def _packages(path: Path) -> dict:
+    data = json.loads(path.read_text())
+    if data.get("lockfileVersion") != 3:
+        sys.exit(f"{path}: expected lockfileVersion 3, got {data.get('lockfileVersion')!r}")
+    return {k: v for k, v in data["packages"].items() if k}  # "" is the root project
+
+
+def _major_minor(version: str) -> tuple[str, str] | None:
+    parts = version.split(".")
+    return (parts[0], parts[1]) if len(parts) >= 3 else None
+
+
+def reasons_not_surgical(base: dict, head: dict) -> tuple[list[str], list[str]]:
+    """``(reasons, changes)`` — refuse when ``reasons`` is non-empty."""
+    reasons: list[str] = []
+    changes: list[str] = []
+
+    for key in sorted(set(head) - set(base)):
+        reasons.append(f"package added: {key}")
+    for key in sorted(set(base) - set(head)):
+        reasons.append(f"package removed: {key}")
+
+    for key in sorted(set(base) & set(head)):
+        before, after = base[key], head[key]
+        if before == after:
+            continue
+        name = key.rsplit("node_modules/", 1)[-1]
+        changes.append(f"{name} {before.get('version')} -> {after.get('version')}")
+
+        if after.get("hasInstallScript") and not before.get("hasInstallScript"):
+            reasons.append(f"{key}: gains an install script")
+        resolved = after.get("resolved", "")
+        if not resolved.startswith(REGISTRY):
+            reasons.append(f"{key}: resolved is not on {REGISTRY}: {resolved!r}")
+        if not after.get("integrity"):
+            reasons.append(f"{key}: no integrity hash")
+        old, new = _major_minor(str(before.get("version"))), _major_minor(str(after.get("version")))
+        if before.get("version") != after.get("version") and (old is None or old != new):
+            reasons.append(
+                f"{key}: {before.get('version')} -> {after.get('version')} is not patch-level"
+            )
+
+    if not changes and not reasons:
+        reasons.append("no package changed — nothing to merge")
+    return reasons, changes
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__)
+        return 2
+    base, head = _packages(Path(argv[1])), _packages(Path(argv[2]))
+    reasons, changes = reasons_not_surgical(base, head)
+    for line in changes:
+        print(f"changed: {line}")
+    for line in reasons:
+        print(f"REFUSED: {line}")
+    if reasons:
+        return 1
+    print(f"surgical: {len(changes)} package(s) patch-bumped, nothing added or removed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ci/lock_diff_is_surgical.py
+++ b/scripts/ci/lock_diff_is_surgical.py
@@ -33,8 +33,11 @@ def _packages(path: Path) -> dict:
     return {k: v for k, v in data["packages"].items() if k}  # "" is the root project
 
 
-def _version_tuple(version: str) -> tuple:
-    return tuple(int(p) if p.isdigit() else p for p in version.split("."))
+def _version_tuple(version: str) -> tuple[int, ...] | None:
+    """``(4, 3, 2)`` for a plain release; None for anything else (prerelease,
+    build metadata) — a security patch is never one of those, so refuse."""
+    parts = version.split(".")
+    return tuple(int(p) for p in parts) if all(p.isdigit() for p in parts) else None
 
 
 def _major_minor(version: str) -> tuple[str, str] | None:
@@ -76,8 +79,12 @@ def reasons_not_surgical(base: dict, head: dict) -> tuple[list[str], list[str]]:
             reasons.append(
                 f"{key}: {before.get('version')} -> {after.get('version')} is not patch-level"
             )
-        elif _version_tuple(after["version"]) <= _version_tuple(before["version"]):
-            reasons.append(f"{key}: {before['version']} -> {after['version']} is a downgrade")
+        else:
+            old_t, new_t = _version_tuple(before["version"]), _version_tuple(after["version"])
+            if old_t is None or new_t is None:
+                reasons.append(f"{key}: {before['version']} -> {after['version']} is not a plain release")
+            elif new_t <= old_t:
+                reasons.append(f"{key}: {before['version']} -> {after['version']} is a downgrade")
 
     if not changes and not reasons:
         reasons.append("no package changed — nothing to merge")

--- a/scripts/ci/lock_diff_is_surgical.py
+++ b/scripts/ci/lock_diff_is_surgical.py
@@ -8,7 +8,9 @@ only when every property that made #1212's Dependabot lock diff safe holds:
 - no entry newly declares an install script (``hasInstallScript``);
 - every changed entry still resolves to ``https://registry.npmjs.org/`` and
   carries an ``integrity`` hash;
-- every version change is patch-level (same major.minor).
+- every changed entry changes its version, and by a patch level only
+  (same major.minor) — a same-version rewrite of ``resolved``/``integrity``
+  is a different artifact wearing the same number.
 
 Anything else exits 1 and prints why, one reason per line. The semver label on
 the PR is not consulted: this checks the bytes that will be installed.
@@ -60,7 +62,12 @@ def reasons_not_surgical(base: dict, head: dict) -> tuple[list[str], list[str]]:
         if not after.get("integrity"):
             reasons.append(f"{key}: no integrity hash")
         old, new = _major_minor(str(before.get("version"))), _major_minor(str(after.get("version")))
-        if before.get("version") != after.get("version") and (old is None or old != new):
+        if before.get("version") == after.get("version"):
+            # Same version but a different entry: a rewritten tarball URL or
+            # integrity hash is a different artifact wearing the same number.
+            # Nothing a security patch needs looks like this (codex on #1229).
+            reasons.append(f"{key}: entry changed without a version change")
+        elif old is None or old != new:
             reasons.append(
                 f"{key}: {before.get('version')} -> {after.get('version')} is not patch-level"
             )

--- a/scripts/ci/lock_diff_is_surgical.py
+++ b/scripts/ci/lock_diff_is_surgical.py
@@ -9,8 +9,9 @@ only when every property that made #1212's Dependabot lock diff safe holds:
 - every changed entry still resolves to ``https://registry.npmjs.org/`` and
   carries an ``integrity`` hash;
 - every changed entry changes its version, and by a patch level only
-  (same major.minor) — a same-version rewrite of ``resolved``/``integrity``
-  is a different artifact wearing the same number.
+  (same major.minor), upward — a same-version rewrite of ``resolved``/
+  ``integrity`` is a different artifact wearing the same number, and a
+  security patch never downgrades.
 
 Anything else exits 1 and prints why, one reason per line. The semver label on
 the PR is not consulted: this checks the bytes that will be installed.
@@ -30,6 +31,10 @@ def _packages(path: Path) -> dict:
     if data.get("lockfileVersion") != 3:
         sys.exit(f"{path}: expected lockfileVersion 3, got {data.get('lockfileVersion')!r}")
     return {k: v for k, v in data["packages"].items() if k}  # "" is the root project
+
+
+def _version_tuple(version: str) -> tuple:
+    return tuple(int(p) if p.isdigit() else p for p in version.split("."))
 
 
 def _major_minor(version: str) -> tuple[str, str] | None:
@@ -71,6 +76,8 @@ def reasons_not_surgical(base: dict, head: dict) -> tuple[list[str], list[str]]:
             reasons.append(
                 f"{key}: {before.get('version')} -> {after.get('version')} is not patch-level"
             )
+        elif _version_tuple(after["version"]) <= _version_tuple(before["version"]):
+            reasons.append(f"{key}: {before['version']} -> {after['version']} is a downgrade")
 
     if not changes and not reasons:
         reasons.append("no package changed — nothing to merge")

--- a/tests/ci/test_dependabot_automerge_1217.py
+++ b/tests/ci/test_dependabot_automerge_1217.py
@@ -154,6 +154,14 @@ class TestTheWorkflowGatesBeforeItMerges:
         assert "always()" in disarm[0]["if"]
         assert "steps.arm.outcome != 'success'" in disarm[0]["if"]
 
+    def test_a_real_disarm_failure_is_not_swallowed(self):
+        """claude-review on #1229: `--disable-auto || echo` hid an API failure
+        behind the expected not-armed case. Ask for the state, then disarm
+        with no fallback."""
+        disarm = next(s for s in _steps() if "--disable-auto" in s.get("run", ""))
+        assert "autoMergeRequest" in disarm["run"]
+        assert "||" not in disarm["run"]
+
     def test_event_values_reach_the_shell_through_env(self):
         # GitHub's hardening guide: never interpolate github.event.* into `run:`.
         for step in _steps():

--- a/tests/ci/test_dependabot_automerge_1217.py
+++ b/tests/ci/test_dependabot_automerge_1217.py
@@ -117,9 +117,29 @@ def _steps() -> list[dict]:
 
 
 class TestTheWorkflowGatesBeforeItMerges:
-    def test_only_dependabot_reaches_the_job(self):
-        assert "dependabot[bot]" in _job()["if"]
-        assert "github.event.pull_request.user.login" in _job()["if"] or "github.actor" in _job()["if"]
+    def test_the_job_runs_for_every_push_to_a_dependabot_pr(self):
+        """The job must run on a *human* push too — that is when it disarms.
+        Gating the whole job on the actor (claude-review on #1229) left an
+        armed merge in place for a head nobody re-checked."""
+        assert "github.event.pull_request.user.login == 'dependabot[bot]'" in _job()["if"]
+        assert "github.actor" not in _job()["if"]
+
+    def test_only_a_dependabot_push_can_arm(self):
+        text = WORKFLOW.read_text()
+        assert "github.actor == 'dependabot[bot]'" in text
+
+    def test_anything_short_of_armed_disarms(self):
+        """`gh pr merge --auto` is persistent, so every run that does not
+        (re)arm must explicitly disarm, whatever step stopped it."""
+        disarm = [s for s in _steps() if "--disable-auto" in s.get("run", "")]
+        assert len(disarm) == 1
+        assert "always()" in disarm[0]["if"]
+        assert "steps.arm.outcome != 'success'" in disarm[0]["if"]
+
+    def test_event_values_reach_the_shell_through_env(self):
+        # GitHub's hardening guide: never interpolate github.event.* into `run:`.
+        for step in _steps():
+            assert "${{ github.event" not in step.get("run", ""), step.get("name")
 
     def test_it_runs_on_pull_request_not_pull_request_target(self):
         on = _workflow()[True] if True in _workflow() else _workflow()["on"]
@@ -151,10 +171,9 @@ class TestTheWorkflowGatesBeforeItMerges:
         assert any("lock_diff_is_surgical.py" in r and "package-lock.json" in r for r in runs)
 
     def test_merge_is_auto_and_squash(self):
-        runs = [s.get("run", "") for s in _steps()]
-        merge = [r for r in runs if "gh pr merge" in r]
-        assert len(merge) == 1
-        assert "--auto" in merge[0] and "--squash" in merge[0]
+        arm = [s for s in _steps() if s.get("id") == "arm"]
+        assert len(arm) == 1
+        assert "gh pr merge" in arm[0]["run"] and "--auto" in arm[0]["run"] and "--squash" in arm[0]["run"]
 
 
 def test_actionlint_accepts_the_workflow():

--- a/tests/ci/test_dependabot_automerge_1217.py
+++ b/tests/ci/test_dependabot_automerge_1217.py
@@ -9,6 +9,7 @@ on the checker plus the Dependabot metadata before it ever calls ``--auto``.
 """
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -106,6 +107,13 @@ class TestTheCheckerRefusesEachUnsafeShape:
         assert res.returncode == 1
         assert "without a version change" in res.stdout
 
+    def test_a_same_minor_downgrade_is_refused(self, tmp_path):
+        base = _lock({**BASE["packages"], "node_modules/js-yaml": _entry("4.3.2")})
+        head = _lock({**BASE["packages"], "node_modules/js-yaml": _entry("4.3.1")})
+        res = _run(tmp_path, base, head)
+        assert res.returncode == 1
+        assert "downgrade" in res.stdout
+
     def test_an_unchanged_lock_is_refused_as_nothing_to_merge(self, tmp_path):
         res = _run(tmp_path, BASE, BASE)
         assert res.returncode == 1
@@ -156,6 +164,17 @@ class TestTheWorkflowGatesBeforeItMerges:
         assert "pull_request" in on
         assert "pull_request_target" not in on
 
+    def test_no_paths_filter_so_every_push_can_disarm(self):
+        """A push touching neither package file must still reach the job —
+        it is the run that disarms a stale arming (claude-review on #1229)."""
+        on = _workflow()[True] if True in _workflow() else _workflow()["on"]
+        assert "paths" not in (on["pull_request"] or {})
+
+    def test_runs_for_one_pr_are_serialised_latest_wins(self):
+        conc = _workflow()["concurrency"]
+        assert "github.event.pull_request.number" in conc["group"]
+        assert conc["cancel-in-progress"] is True
+
     def test_permissions_are_exactly_what_auto_merge_needs(self):
         perms = _workflow().get("permissions") or _job().get("permissions")
         assert perms == {"contents": "write", "pull-requests": "write"}
@@ -189,7 +208,8 @@ class TestTheWorkflowGatesBeforeItMerges:
 def test_actionlint_accepts_the_workflow():
     # A workflow that fails GitHub's expression pass runs with zero jobs and no
     # logs (#1122); actionlint is the only local check that catches it.
-    res = subprocess.run(["actionlint", str(WORKFLOW)], capture_output=True, text=True)
-    if res.returncode == 127 or "not found" in res.stderr:
+    if not shutil.which("actionlint"):
+        # test.yml's workflow-lint job runs actionlint on every workflow in CI.
         pytest.skip("actionlint not installed")
+    res = subprocess.run(["actionlint", str(WORKFLOW)], capture_output=True, text=True)
     assert res.returncode == 0, res.stdout + res.stderr

--- a/tests/ci/test_dependabot_automerge_1217.py
+++ b/tests/ci/test_dependabot_automerge_1217.py
@@ -1,0 +1,166 @@
+"""#1217 — patch-level Dependabot *security* updates to web-ui merge without a human.
+
+#1210 cost a day of un-deployable staging while the two lockfile bumps that fixed
+it sat open and green. The fix is narrow on purpose: npm, ``/web-ui``, a security
+advisory, patch-level — and the supply-chain properties that made #1212's lock
+diff safe are *checked in code*, not assumed from the semver label. Two halves,
+both pinned here: the checker refuses each unsafe shape, and the workflow gates
+on the checker plus the Dependabot metadata before it ever calls ``--auto``.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.v2
+
+REPO = Path(__file__).resolve().parents[2]
+CHECKER = REPO / "scripts" / "ci" / "lock_diff_is_surgical.py"
+WORKFLOW = REPO / ".github" / "workflows" / "dependabot-automerge.yml"
+
+
+def _lock(packages: dict) -> dict:
+    return {"name": "web-ui", "lockfileVersion": 3, "packages": {"": {"name": "web-ui"}, **packages}}
+
+
+def _entry(version: str, name: str = "js-yaml", **extra) -> dict:
+    return {
+        "version": version,
+        "resolved": f"https://registry.npmjs.org/{name}/-/{name}-{version}.tgz",
+        "integrity": f"sha512-{version}",
+        **extra,
+    }
+
+
+def _run(tmp_path: Path, base: dict, head: dict) -> subprocess.CompletedProcess:
+    b, h = tmp_path / "base.json", tmp_path / "head.json"
+    b.write_text(json.dumps(base))
+    h.write_text(json.dumps(head))
+    return subprocess.run(
+        [sys.executable, str(CHECKER), str(b), str(h)], capture_output=True, text=True
+    )
+
+
+BASE = _lock({"node_modules/js-yaml": _entry("4.3.1"), "node_modules/left": _entry("1.0.0", "left")})
+
+
+class TestTheCheckerRefusesEachUnsafeShape:
+    def test_a_surgical_patch_bump_is_safe(self, tmp_path):
+        head = _lock({"node_modules/js-yaml": _entry("4.3.2"), "node_modules/left": _entry("1.0.0", "left")})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert "js-yaml 4.3.1 -> 4.3.2" in res.stdout
+
+    def test_an_added_package_is_refused(self, tmp_path):
+        head = _lock({**BASE["packages"], "node_modules/evil": _entry("1.0.0", "evil")})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1
+        assert "added" in res.stdout and "node_modules/evil" in res.stdout
+
+    def test_a_removed_package_is_refused(self, tmp_path):
+        head = _lock({"node_modules/js-yaml": _entry("4.3.2")})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1
+        assert "removed" in res.stdout and "node_modules/left" in res.stdout
+
+    def test_a_new_install_script_is_refused(self, tmp_path):
+        head = _lock({**BASE["packages"], "node_modules/js-yaml": _entry("4.3.2", hasInstallScript=True)})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1
+        assert "install script" in res.stdout
+
+    def test_a_foreign_registry_is_refused(self, tmp_path):
+        bad = _entry("4.3.2")
+        bad["resolved"] = "https://evil.example/js-yaml-4.3.2.tgz"
+        head = _lock({**BASE["packages"], "node_modules/js-yaml": bad})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1
+        assert "registry.npmjs.org" in res.stdout
+
+    def test_a_minor_or_major_bump_is_refused(self, tmp_path):
+        for version in ("4.4.0", "5.0.0"):
+            head = _lock({**BASE["packages"], "node_modules/js-yaml": _entry(version)})
+            res = _run(tmp_path, BASE, head)
+            assert res.returncode == 1, version
+            assert "not patch-level" in res.stdout
+
+    def test_a_missing_integrity_is_refused(self, tmp_path):
+        bad = _entry("4.3.2")
+        del bad["integrity"]
+        head = _lock({**BASE["packages"], "node_modules/js-yaml": bad})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1
+        assert "integrity" in res.stdout
+
+    def test_an_unchanged_lock_is_refused_as_nothing_to_merge(self, tmp_path):
+        res = _run(tmp_path, BASE, BASE)
+        assert res.returncode == 1
+        assert "no package changed" in res.stdout
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _job() -> dict:
+    jobs = _workflow()["jobs"]
+    assert len(jobs) == 1, "one job, or the gates below could be split across runs"
+    return next(iter(jobs.values()))
+
+
+def _steps() -> list[dict]:
+    return _job()["steps"]
+
+
+class TestTheWorkflowGatesBeforeItMerges:
+    def test_only_dependabot_reaches_the_job(self):
+        assert "dependabot[bot]" in _job()["if"]
+        assert "github.event.pull_request.user.login" in _job()["if"] or "github.actor" in _job()["if"]
+
+    def test_it_runs_on_pull_request_not_pull_request_target(self):
+        on = _workflow()[True] if True in _workflow() else _workflow()["on"]
+        assert "pull_request" in on
+        assert "pull_request_target" not in on
+
+    def test_permissions_are_exactly_what_auto_merge_needs(self):
+        perms = _workflow().get("permissions") or _job().get("permissions")
+        assert perms == {"contents": "write", "pull-requests": "write"}
+
+    def test_fetch_metadata_is_sha_pinned(self):
+        uses = [s["uses"] for s in _steps() if "uses" in s and "fetch-metadata" in s["uses"]]
+        assert len(uses) == 1
+        ref = uses[0].split("@", 1)[1].split()[0]
+        assert len(ref) == 40 and all(c in "0123456789abcdef" for c in ref), uses[0]
+
+    def test_every_narrowing_gate_is_present(self):
+        text = WORKFLOW.read_text()
+        for gate in (
+            "package-ecosystem == 'npm'",
+            "directory == '/web-ui'",
+            "update-type == 'version-update:semver-patch'",
+            "alert-state != ''",
+        ):
+            assert gate in text, f"missing gate: {gate}"
+
+    def test_the_checker_runs_against_the_base_branch_lock(self):
+        runs = [s.get("run", "") for s in _steps()]
+        assert any("lock_diff_is_surgical.py" in r and "package-lock.json" in r for r in runs)
+
+    def test_merge_is_auto_and_squash(self):
+        runs = [s.get("run", "") for s in _steps()]
+        merge = [r for r in runs if "gh pr merge" in r]
+        assert len(merge) == 1
+        assert "--auto" in merge[0] and "--squash" in merge[0]
+
+
+def test_actionlint_accepts_the_workflow():
+    # A workflow that fails GitHub's expression pass runs with zero jobs and no
+    # logs (#1122); actionlint is the only local check that catches it.
+    res = subprocess.run(["actionlint", str(WORKFLOW)], capture_output=True, text=True)
+    if res.returncode == 127 or "not found" in res.stderr:
+        pytest.skip("actionlint not installed")
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tests/ci/test_dependabot_automerge_1217.py
+++ b/tests/ci/test_dependabot_automerge_1217.py
@@ -96,6 +96,16 @@ class TestTheCheckerRefusesEachUnsafeShape:
         assert res.returncode == 1
         assert "integrity" in res.stdout
 
+    def test_a_same_version_rewrite_is_refused(self, tmp_path):
+        """codex on #1229: a changed `resolved`/`integrity` at the same version
+        is a different tarball wearing the same number, not a patch bump."""
+        swapped = _entry("4.3.1")
+        swapped["integrity"] = "sha512-somethingelse"
+        head = _lock({**BASE["packages"], "node_modules/js-yaml": swapped})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1
+        assert "without a version change" in res.stdout
+
     def test_an_unchanged_lock_is_refused_as_nothing_to_merge(self, tmp_path):
         res = _run(tmp_path, BASE, BASE)
         assert res.returncode == 1

--- a/tests/ci/test_dependabot_automerge_1217.py
+++ b/tests/ci/test_dependabot_automerge_1217.py
@@ -114,6 +114,12 @@ class TestTheCheckerRefusesEachUnsafeShape:
         assert res.returncode == 1
         assert "downgrade" in res.stdout
 
+    def test_a_prerelease_version_is_refused_cleanly(self, tmp_path):
+        head = _lock({**BASE["packages"], "node_modules/js-yaml": _entry("4.3.2-rc.1")})
+        res = _run(tmp_path, BASE, head)
+        assert res.returncode == 1, res.stderr
+        assert "not a plain release" in res.stdout and "Traceback" not in res.stderr
+
     def test_an_unchanged_lock_is_refused_as_nothing_to_merge(self, tmp_path):
         res = _run(tmp_path, BASE, BASE)
         assert res.returncode == 1
@@ -159,7 +165,8 @@ class TestTheWorkflowGatesBeforeItMerges:
         behind the expected not-armed case. Ask for the state, then disarm
         with no fallback."""
         disarm = next(s for s in _steps() if "--disable-auto" in s.get("run", ""))
-        assert "autoMergeRequest" in disarm["run"]
+        assert "armed=$(gh pr view" in disarm["run"], "query must be a bare assignment (errexit)"
+        assert "set -euo pipefail" in disarm["run"]
         assert "||" not in disarm["run"]
 
     def test_event_values_reach_the_shell_through_env(self):


### PR DESCRIPTION
Closes #1217

## Summary

#1210 cost a day of un-deployable staging while the two lockfile bumps that fixed it (#1208, #1209) sat open and green. This arms auto-merge for exactly that case and nothing wider.

## What auto-merges

A Dependabot PR is eligible only when **all** of these hold:

| Gate | Where |
|---|---|
| Author is `dependabot[bot]` (job runs for every push); the push itself is by `dependabot[bot]` (step gate — a human push disarms instead) | job `if` + step `if` |
| `package-ecosystem == 'npm'`, `directory == '/web-ui'` | `dependabot/fetch-metadata` (SHA-pinned v3.1.0) |
| `update-type == 'version-update:semver-patch'` | fetch-metadata |
| `alert-state != ''` — a linked **security** advisory, not a routine bump | fetch-metadata |
| Lock diff is surgical: no package added/removed, no new `hasInstallScript`, every changed entry still on `registry.npmjs.org` **with** an `integrity` hash, every version change patch-level | `scripts/ci/lock_diff_is_surgical.py` against `origin/<base>`'s lock |

Then `gh pr merge --auto --squash`. The branch protection's required checks (`Code Quality`, `Backend Unit Tests`, strict up-to-date) are what actually land it — this workflow only arms.

A metadata-ineligible PR gets a **skipped** step; a lock diff the checker refuses is a **red** step (the case the checker exists for) — and either way the run **disarms**.

## Arming is re-decided on every push

`gh pr merge --auto` is persistent on the PR, so the job runs for **any** actor on **every** push to a Dependabot PR (no `paths:` filter — a push touching neither package file is exactly the one that must disarm), and runs for one PR are serialised with a cancel-in-progress concurrency group so an older arm cannot land after a newer disarm: only a push by `dependabot[bot]` itself can arm, and any run that does not end armed — a human push, a gate that no longer holds, a refused lock diff — runs `gh pr merge --disable-auto`. An earlier run's arming cannot survive a head it never saw (claude-review finding on this PR).

## Why the supply-chain properties are checked, not assumed

The semver label proves nothing about what gets installed. The checker reads the bytes: it accepts the real #1212 diff (28 packages patch-bumped, nothing added or removed) and refuses an added package, a removed package, a new install script, a foreign registry URL, a missing integrity hash, a minor/major bump, and an unchanged lock. Each refusal is a unit test; four checker branches were mutation-checked (each disabled check fails its test).

## #1189

Resolved in #1220 (claude-review skips bot PRs), and `claude-review` is not a required check, so a bot PR can reach green. Nothing further to work around.

## Verification

- `tests/ci/test_dependabot_automerge_1217.py`: 16 tests (8 checker shapes, 7 workflow pins, actionlint) — all RED before, GREEN after
- `actionlint` clean (the #1122 zero-jobs failure mode); `ruff` clean; `tests/ci` 61 passed
- Full CI gate and cross-family review posted below

## Known limitations

- `pull_request` runs on Dependabot PRs get their token scopes from the `permissions` key — GitHub's [October 2021 changelog](https://github.blog/changelog/2022-02-10-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/) and its current Dependabot-automation docs example (the same shape as this workflow) both say so. Codex asserted the opposite twice; rebutted with those citations in the review thread. If GitHub ever withholds the scopes again, the arm/disarm steps fail visibly and nothing merges.
- The first real exercise will be the next web-ui security patch; there is none open today, so the demo below drives the checker and the gates rather than a live merge.
- Python-ecosystem and GitHub Actions bumps are deliberately out of scope.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
