### PR TITLE
fix(config): a zero-length read of a populated AGENTS.md is mid-write, not a reload (#1219)

### DIFF
--- a/codeframe/core/config_watcher.py
+++ b/codeframe/core/config_watcher.py
@@ -99,9 +99,15 @@ class ConfigFileWatcher:
         self,
         workspace_path: Path,
         poll_interval_s: float = 2.0,
+        empty_settle_polls: int = 3,
     ) -> None:
         self._workspace_path = workspace_path
         self._poll_interval_s = poll_interval_s
+        #: A zero-byte read of a populated file is mid-write until it has held
+        #: for this many consecutive polls; then it is an intentional clear and
+        #: reloads like any other change (codex on #1230).
+        self._empty_settle_polls = empty_settle_polls
+        self._empty_streak: dict[Path, int] = {}
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._state: Optional[ConfigReloadState] = None
@@ -179,10 +185,15 @@ class ConfigFileWatcher:
             prev_mtime = self._watched_mtimes.get(path, 0.0)
             if current_mtime > prev_mtime:
                 if current_size == 0 and self._watched_sizes.get(path, 0) > 0:
-                    # Mid-write: leave the snapshot alone so the next poll
-                    # re-examines it once the write half has landed.
-                    logger.debug("%s read as empty mid-write; re-polling", path.name)
-                    continue
+                    streak = self._empty_streak.get(path, 0) + 1
+                    self._empty_streak[path] = streak
+                    if streak < self._empty_settle_polls:
+                        # Mid-write: leave the snapshot alone so the next poll
+                        # re-examines it once the write half has landed.
+                        logger.debug("%s read as empty mid-write; re-polling", path.name)
+                        continue
+                    logger.info("%s has stayed empty; treating as an intentional clear", path.name)
+                self._empty_streak.pop(path, None)
                 self._watched_mtimes[path] = current_mtime
                 self._watched_sizes[path] = current_size
                 changed = True

--- a/codeframe/core/config_watcher.py
+++ b/codeframe/core/config_watcher.py
@@ -165,55 +165,49 @@ class ConfigFileWatcher:
             self._check_for_changes()
 
     def _check_for_changes(self) -> None:
-        """Compare current mtimes against snapshots."""
-        changed = False
+        """Compare current mtimes against snapshots.
+
+        Decided as a whole pass: while any previously populated file reads as
+        zero bytes (an editor mid-write), nothing is snapshotted and nothing
+        reloads, so a change to a *second* file in the same pass cannot drive a
+        reload that reads the first one empty (codex on #1230). The pass is
+        simply retried next poll.
+        """
+        updates: dict[Path, tuple[float, int]] = {}
+        unsettled = False
 
         for name in _CONFIG_FILES:
             path = self._workspace_path / name
-            if not path.is_file():
-                # File might have been created since start
-                if path not in self._watched_mtimes:
-                    continue
-                # File was deleted — skip
-                continue
-
             try:
+                if not path.is_file():
+                    continue  # never existed, or deleted — neither is a reload
                 st = path.stat()
             except OSError:
                 continue
             current_mtime, current_size = st.st_mtime, st.st_size
 
-            prev_mtime = self._watched_mtimes.get(path, 0.0)
-            if current_mtime > prev_mtime:
-                if current_size == 0 and self._watched_sizes.get(path, 0) > 0:
-                    streak = self._empty_streak.get(path, 0) + 1
-                    self._empty_streak[path] = streak
-                    if streak < self._empty_settle_polls:
-                        # Mid-write: leave the snapshot alone so the next poll
-                        # re-examines it once the write half has landed.
-                        logger.debug("%s read as empty mid-write; re-polling", path.name)
-                        continue
-                    logger.info("%s has stayed empty; treating as an intentional clear", path.name)
-                self._empty_streak.pop(path, None)
-                self._watched_mtimes[path] = current_mtime
-                self._watched_sizes[path] = current_size
-                changed = True
-
-        # Also detect newly created config files
-        for name in _CONFIG_FILES:
-            path = self._workspace_path / name
-            try:
-                if path.is_file() and path not in self._watched_mtimes:
-                    st = path.stat()
-                    self._watched_mtimes[path] = st.st_mtime
-                    self._watched_sizes[path] = st.st_size
-                    changed = True
-            except OSError:
+            if path not in self._watched_mtimes:
+                updates[path] = (current_mtime, current_size)  # created since start
                 continue
+            if current_mtime <= self._watched_mtimes[path]:
+                continue
+            if current_size == 0 and self._watched_sizes.get(path, 0) > 0:
+                streak = self._empty_streak.get(path, 0) + 1
+                self._empty_streak[path] = streak
+                if streak < self._empty_settle_polls:
+                    logger.debug("%s read as empty mid-write; re-polling", path.name)
+                    unsettled = True
+                    continue
+                logger.info("%s has stayed empty; treating as an intentional clear", path.name)
+            self._empty_streak.pop(path, None)
+            updates[path] = (current_mtime, current_size)
 
-        if changed:
-            self._reload()
-
+        if unsettled or not updates:
+            return
+        for path, (mtime, size) in updates.items():
+            self._watched_mtimes[path] = mtime
+            self._watched_sizes[path] = size
+        self._reload()
     def _reload(self) -> None:
         """Re-parse config files and update shared state."""
         try:

--- a/codeframe/core/config_watcher.py
+++ b/codeframe/core/config_watcher.py
@@ -136,6 +136,7 @@ class ConfigFileWatcher:
         # Snapshot current mtimes
         self._watched_mtimes = {}
         self._watched_sizes = {}
+        self._empty_streak = {}
         for name in _CONFIG_FILES:
             path = self._workspace_path / name
             if path.is_file():

--- a/codeframe/core/config_watcher.py
+++ b/codeframe/core/config_watcher.py
@@ -106,6 +106,11 @@ class ConfigFileWatcher:
         self._thread: Optional[threading.Thread] = None
         self._state: Optional[ConfigReloadState] = None
         self._watched_mtimes: dict[Path, float] = {}
+        #: Last seen size per file. A file that had content and now reads as
+        #: zero bytes is an editor mid-write (truncate, then write), not a
+        #: change: committing a reload there silently empties that tier for
+        #: the rest of the batch (#1219). Such a poll is skipped and retried.
+        self._watched_sizes: dict[Path, int] = {}
         self._workspace_ref: Optional[object] = None  # Cached workspace for event emission
 
     def start(self, initial_prefs: AgentPreferences) -> ConfigReloadState:
@@ -124,10 +129,13 @@ class ConfigFileWatcher:
 
         # Snapshot current mtimes
         self._watched_mtimes = {}
+        self._watched_sizes = {}
         for name in _CONFIG_FILES:
             path = self._workspace_path / name
             if path.is_file():
-                self._watched_mtimes[path] = path.stat().st_mtime
+                st = path.stat()
+                self._watched_mtimes[path] = st.st_mtime
+                self._watched_sizes[path] = st.st_size
 
         self._thread = threading.Thread(
             target=self._poll_loop,
@@ -163,13 +171,20 @@ class ConfigFileWatcher:
                 continue
 
             try:
-                current_mtime = path.stat().st_mtime
+                st = path.stat()
             except OSError:
                 continue
+            current_mtime, current_size = st.st_mtime, st.st_size
 
             prev_mtime = self._watched_mtimes.get(path, 0.0)
             if current_mtime > prev_mtime:
+                if current_size == 0 and self._watched_sizes.get(path, 0) > 0:
+                    # Mid-write: leave the snapshot alone so the next poll
+                    # re-examines it once the write half has landed.
+                    logger.debug("%s read as empty mid-write; re-polling", path.name)
+                    continue
                 self._watched_mtimes[path] = current_mtime
+                self._watched_sizes[path] = current_size
                 changed = True
 
         # Also detect newly created config files
@@ -177,7 +192,9 @@ class ConfigFileWatcher:
             path = self._workspace_path / name
             try:
                 if path.is_file() and path not in self._watched_mtimes:
-                    self._watched_mtimes[path] = path.stat().st_mtime
+                    st = path.stat()
+                    self._watched_mtimes[path] = st.st_mtime
+                    self._watched_sizes[path] = st.st_size
                     changed = True
             except OSError:
                 continue

--- a/tests/core/test_config_reload_integration.py
+++ b/tests/core/test_config_reload_integration.py
@@ -38,11 +38,45 @@ def wait_until(predicate, timeout_s: float = 10.0, poll_s: float = 0.02) -> bool
     return predicate()
 
 
+#: Content of the decoy machine-wide file. Sections merge per tier with the
+#: workspace winning, so the decoy uses a section the workspace never sets:
+#: it must merge in (that is the tier's job) but never be *all* that does.
+DECOY_RULE = "Decoy machine-wide rule"
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin HOME so the machine-wide tier is never the operator's real file.
+
+    load_preferences merges ``~/.codeframe/AGENTS.md``; on a developer machine
+    that file exists and its contents leaked into this module's assertions
+    (#1219). A decoy stands in for it so the merge path is still exercised,
+    deterministically.
+    """
+    home = tmp_path / "home"
+    (home / ".codeframe").mkdir(parents=True)
+    (home / ".codeframe" / "AGENTS.md").write_text(f"# Ask First\n- {DECOY_RULE}\n")
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Replace ``path`` in one step so no reader ever sees it truncated."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
+
+
 @pytest.fixture
 def workspace(tmp_path: Path):
     repo_path = tmp_path / "test_repo"
     repo_path.mkdir()
     return create_or_load_workspace(repo_path)
+
+
+def test_home_is_isolated_from_the_operator(isolated_home: Path):
+    assert Path.home() == isolated_home
+    assert (Path.home() / ".codeframe" / "AGENTS.md").exists()
 
 
 class TestConfigReloadLifecycle:
@@ -75,9 +109,12 @@ class TestConfigReloadLifecycle:
             assert "Run tests after changes" in prefs.always_do
             assert state.last_reload_at is None
 
-            # Step 5: Modify config (simulating operator change during batch)
+            # Step 5: Modify config (simulating operator change during batch).
+            # Atomic: write_text truncates first, and a poll landing in that
+            # window read an empty workspace tier (#1219).
             time.sleep(0.3)
-            agents_path.write_text(
+            atomic_write(
+                agents_path,
                 "# Always Do\n"
                 "- Run tests after changes\n"
                 "- Use type hints\n"
@@ -85,7 +122,7 @@ class TestConfigReloadLifecycle:
                 "\n"
                 "# Never Do\n"
                 "- Delete production data\n"
-                "- Modify database schema directly\n"
+                "- Modify database schema directly\n",
             )
             future_time = time.time() + 1
             os.utime(agents_path, (future_time, future_time))
@@ -97,6 +134,7 @@ class TestConfigReloadLifecycle:
             assert state.last_reload_at is not None
             new_prefs = state.get_prefs()
             assert "Log all API calls" in new_prefs.always_do
+            assert DECOY_RULE in new_prefs.ask_first, "machine-wide tier still merges"
             assert "Modify database schema directly" in new_prefs.never_do
             assert len(state.reload_timestamps) == 1
 
@@ -212,3 +250,38 @@ class TestConfigReloadLifecycle:
         time.sleep(0.2)
         active_after = threading.active_count()
         assert active_after <= active_before
+
+
+class TestATruncatedWriteDoesNotEmptyATier:
+    """#1219, the product half: an editor that truncates before it writes
+    leaves a window in which the workspace file reads as zero bytes. A poll in
+    that window used to commit a reload whose workspace tier was empty — silent
+    for the rest of the batch whenever the machine-wide tier had content."""
+
+    def test_zero_length_read_of_a_populated_file_is_not_a_reload(self, workspace):
+        agents_path = workspace.repo_path / "AGENTS.md"
+        agents_path.write_text("# Always Do\n- Run tests after changes\n")
+        initial_prefs = load_preferences(workspace.repo_path)
+        assert DECOY_RULE in initial_prefs.ask_first, "the premise: the merge is non-empty"
+
+        watcher = ConfigFileWatcher(workspace.repo_path, poll_interval_s=0.05)
+        state = watcher.start(initial_prefs)
+        try:
+            time.sleep(0.15)
+            # The truncate half of a non-atomic write, held open for many polls.
+            agents_path.write_text("")
+            future = time.time() + 1
+            os.utime(agents_path, (future, future))
+            time.sleep(0.5)
+
+            assert state.last_reload_at is None, "a mid-write poll committed a reload"
+            assert "Run tests after changes" in state.get_prefs().always_do
+
+            # The write half lands; now it is a real change.
+            agents_path.write_text("# Always Do\n- Run tests after changes\n- Log all API calls\n")
+            os.utime(agents_path, (future + 1, future + 1))
+            assert wait_until(lambda: state.last_reload_at is not None)
+            assert "Log all API calls" in state.get_prefs().always_do
+            assert len(state.reload_timestamps) == 1
+        finally:
+            watcher.stop()

--- a/tests/core/test_config_reload_integration.py
+++ b/tests/core/test_config_reload_integration.py
@@ -264,7 +264,10 @@ class TestATruncatedWriteDoesNotEmptyATier:
         initial_prefs = load_preferences(workspace.repo_path)
         assert DECOY_RULE in initial_prefs.ask_first, "the premise: the merge is non-empty"
 
-        watcher = ConfigFileWatcher(workspace.repo_path, poll_interval_s=0.05)
+        # A huge settle threshold: this test is about the transient window only.
+        watcher = ConfigFileWatcher(
+            workspace.repo_path, poll_interval_s=0.05, empty_settle_polls=1000
+        )
         state = watcher.start(initial_prefs)
         try:
             time.sleep(0.15)
@@ -282,6 +285,32 @@ class TestATruncatedWriteDoesNotEmptyATier:
             os.utime(agents_path, (future + 1, future + 1))
             assert wait_until(lambda: state.last_reload_at is not None)
             assert "Log all API calls" in state.get_prefs().always_do
+            assert len(state.reload_timestamps) == 1
+        finally:
+            watcher.stop()
+
+    def test_a_file_that_stays_empty_is_an_intentional_clear(self, workspace):
+        """codex on #1230: skipping the zero-byte read forever would mean a
+        deliberately emptied AGENTS.md never reloads. Once it has held empty
+        for `empty_settle_polls` polls it is a change like any other."""
+        agents_path = workspace.repo_path / "AGENTS.md"
+        agents_path.write_text("# Always Do\n- Run tests after changes\n")
+        initial_prefs = load_preferences(workspace.repo_path)
+
+        watcher = ConfigFileWatcher(
+            workspace.repo_path, poll_interval_s=0.05, empty_settle_polls=3
+        )
+        state = watcher.start(initial_prefs)
+        try:
+            time.sleep(0.15)
+            agents_path.write_text("")
+            future = time.time() + 1
+            os.utime(agents_path, (future, future))
+
+            assert wait_until(lambda: state.last_reload_at is not None, timeout_s=5)
+            prefs = state.get_prefs()
+            assert prefs.always_do == [], "the cleared workspace tier must win"
+            assert DECOY_RULE in prefs.ask_first, "the machine-wide tier still merges"
             assert len(state.reload_timestamps) == 1
         finally:
             watcher.stop()

--- a/tests/core/test_config_reload_integration.py
+++ b/tests/core/test_config_reload_integration.py
@@ -314,3 +314,39 @@ class TestATruncatedWriteDoesNotEmptyATier:
             assert len(state.reload_timestamps) == 1
         finally:
             watcher.stop()
+
+    def test_a_second_file_changing_does_not_reload_around_the_empty_one(self, workspace):
+        """codex on #1230: a change to CLAUDE.md in the same poll as AGENTS.md's
+        truncate must not drive a reload that reads AGENTS.md empty. The whole
+        pass is deferred until every file has settled."""
+        agents_path = workspace.repo_path / "AGENTS.md"
+        claude_path = workspace.repo_path / "CLAUDE.md"
+        agents_path.write_text("# Always Do\n- Run tests after changes\n")
+        claude_path.write_text("# Never Do\n- Delete production data\n")
+        initial_prefs = load_preferences(workspace.repo_path)
+
+        watcher = ConfigFileWatcher(
+            workspace.repo_path, poll_interval_s=0.05, empty_settle_polls=1000
+        )
+        state = watcher.start(initial_prefs)
+        try:
+            time.sleep(0.15)
+            future = time.time() + 1
+            agents_path.write_text("")
+            claude_path.write_text("# Never Do\n- Delete production data\n- Force-push main\n")
+            os.utime(agents_path, (future, future))
+            os.utime(claude_path, (future, future))
+            time.sleep(0.5)
+
+            assert state.last_reload_at is None, "reloaded around a mid-write file"
+            assert "Run tests after changes" in state.get_prefs().always_do
+
+            agents_path.write_text("# Always Do\n- Run tests after changes\n- Log all API calls\n")
+            os.utime(agents_path, (future + 1, future + 1))
+            assert wait_until(lambda: state.last_reload_at is not None)
+            prefs = state.get_prefs()
+            assert "Log all API calls" in prefs.always_do
+            assert "Force-push main" in prefs.never_do, "the deferred CLAUDE.md change lands too"
+            assert len(state.reload_timestamps) == 1
+        finally:
+            watcher.stop()


### PR DESCRIPTION
Closes #1219

## Summary

`test_full_reload_cycle` failed once under full-suite load and passed alone. `Path.write_text` truncates before it writes; a 0.1s poll landed in that window; the watcher committed a merge whose workspace tier was empty — visible only because the operator's real `~/.codeframe/AGENTS.md` filled the gap. Two problems, both fixed.

## Test side (acceptance criterion 1)

- The module pins `HOME` to a per-test directory holding a **decoy** `~/.codeframe/AGENTS.md`. Sections merge per tier with the workspace winning, so the decoy uses a section the workspace never sets (`Ask First`): the machine-wide merge path is still exercised, deterministically, and the test can no longer read the developer's home directory. A test pins that `Path.home()` is the isolated one.
- The mid-run rewrite is atomic (temp file + `os.replace`).

Isolation is module-scoped on purpose: several suites `git commit` and lean on the global git identity, and credential/keyring tests carry their own isolation. The suite-wide guard the issue floats is a separate change with a much larger blast radius.

## Product side (acceptance criterion 2 — direction 3, taken on its merits)

An operator's non-atomic editor hits the same window for real and would silently lose the workspace tier for the rest of the batch. `ConfigFileWatcher` now snapshots sizes next to mtimes; a file whose mtime advanced but reads as **zero bytes while it previously had content** is treated as not settled — snapshot untouched, no reload, re-examined next poll. Once the write half lands, that poll reloads with the new content.

Documented limitation: a *partial* (non-empty) read is still the editor's atomicity to guarantee. The zero-length case is the one that silently empties a tier, and it is now closed.

## Verification

- RED reproduced deterministically before the fix: truncate the workspace file against a running watcher with the decoy present → `a mid-write poll committed a reload`. GREEN after; mutation-checked by disabling the skip.
- `tests/core/test_config_reload_integration.py` + `test_config_watcher*`: 17 passed. Full CI gate and cross-family review posted below.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
