### PR TITLE
ci: skip the bot reviewers on fork PRs instead of failing the credential preflight (#1221)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,9 +22,19 @@ jobs:
     # `github.actor` is the PR author on `opened` but the **pusher** on
     # `synchronize`, so the actor form misses a bot push to a human PR (#1167).
     # A null `sender` compares false, so it fails closed.
+    #
+    # Same-repo head only (#1221). `secrets.*` are withheld from `pull_request`
+    # runs on fork PRs for the same structural reason as on Dependabot PRs, so
+    # a human fork PR passed the gate above and then failed the preflight with
+    # a misdiagnosis ("unset or rotated"). A fork PR now skips, like a bot PR;
+    # reaching the token instead would mean `pull_request_target`, which #875
+    # hardened against. The day fork contributions matter, the better shape is
+    # a distinct "secrets are not offered to fork runs" annotation so an
+    # unreviewed fork PR is not silent.
     if: |
       github.event.pull_request.user.type == 'User' &&
-      github.event.sender.type == 'User'
+      github.event.sender.type == 'User' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -17,9 +17,12 @@ jobs:
     # `user.type` and `sender.type` covers every bot and both events, and a
     # null `sender` compares false, so it fails closed.
     # Then: only review substantial changes (5+ files, or 20+ additions/deletions).
+    # Same-repo head only (#1221): fork PRs are not offered `secrets.*` either,
+    # so ZHIPU_API_KEY would be empty; skip rather than misreport it.
     if: |
       github.event.pull_request.user.type == 'User' &&
       github.event.sender.type == 'User' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.changed_files >= 5 ||
        github.event.pull_request.additions >= 20 ||
        github.event.pull_request.deletions >= 20)

--- a/tests/ci/test_claude_review_bot_gate_1189.py
+++ b/tests/ci/test_claude_review_bot_gate_1189.py
@@ -51,3 +51,18 @@ def test_the_credential_preflight_still_fails_loudly():
     )
     assert "CLAUDE_CODE_OAUTH_TOKEN" in preflight["env"]["OAUTH_TOKEN"]
     assert "exit 1" in preflight["run"]
+
+
+def test_fork_prs_are_gated_out():
+    """#1221: `secrets.*` are withheld from `pull_request` runs on fork PRs for
+    the same structural reason as on Dependabot PRs, so a human fork PR passed
+    the #1189 gate and then failed the preflight with a misdiagnosis ("unset
+    or rotated"). Same-repo head only; a fork PR skips, like a bot PR does.
+    """
+    condition = _review_job()["if"]
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in condition
+
+
+def test_the_fork_rationale_is_recorded_next_to_the_bot_one():
+    text = WORKFLOW.read_text()
+    assert "#1221" in text and "fork" in text.lower()

--- a/tests/ci/test_glm_review_caller_1167.py
+++ b/tests/ci/test_glm_review_caller_1167.py
@@ -36,3 +36,14 @@ def test_the_reusable_workflow_is_pinned_to_a_full_sha():
     assert len(ref) == 40 and all(
         c in "0123456789abcdef" for c in ref
     ), f"glm-review is pinned to {ref!r}; pin a full commit SHA"
+
+
+def test_fork_prs_are_gated_out_here_too():
+    """#1221: the same secret-withholding applies to ZHIPU_API_KEY on a fork
+    PR; the two reviewers keep the same gate so they cannot drift apart."""
+    import yaml
+    from pathlib import Path
+
+    wf = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "glm-review.yml"
+    job = next(iter(yaml.safe_load(wf.read_text())["jobs"].values()))
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in job["if"]


### PR DESCRIPTION
Closes #1221

## Summary

`secrets.*` are withheld from `pull_request` runs on fork PRs for the same structural reason as on Dependabot PRs. A human fork PR passed the #1189 gate (`user.type == 'User' && sender.type == 'User'`) and then failed the credential preflight with a **misdiagnosis** — the secret is not unset or rotated, it is simply not offered to fork runs.

**Option 1 from the issue**: both reviewer workflows now also require `github.event.pull_request.head.repo.full_name == github.repository`. A fork PR skips, exactly as a bot PR does. `glm-review.yml` is included because it has the identical gate and its own secret (`ZHIPU_API_KEY`), and the #1167 test already pins that the two reviewers share one condition.

## Acceptance criteria

| Criterion | How |
|---|---|
| A human fork PR does not show `claude-review` as failure | The job is skipped by the `if` before the preflight runs |
| A same-repo human PR with a missing/rotated secret still fails loudly with the #1011 annotation | Preflight unchanged; `test_the_credential_preflight_still_fails_loudly` still pins `exit 1` |
| The option is recorded in the workflow comment block alongside the #1189 rationale | Comment block in `claude-code-review.yml`, including why not `pull_request_target` (#875) and the better shape for the day fork contributions matter |
| `test_claude_review_bot_gate_1189.py` extended | Two new tests (gate expression; rationale recorded), plus one in `test_glm_review_caller_1167.py` |

## Verification

- RED → GREEN on the new tests; `actionlint` clean on both workflows (#1122 zero-jobs failure mode)
- No fork PR exists to exercise live; the demo evaluates the gate expression against real `pull_request` event payload shapes (same-repo vs fork) and shows the outcome each way.

## Known limitations

- A fork PR is now **silently** unreviewed by the bots (skip, not a distinct annotation). That is option 2 from the issue, deliberately deferred until the repo takes outside contributions; the comment block says so.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
