### PR TITLE
docs(web-ui): name the npm that generated the lock, and what older npm rewrites (#1223)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,13 @@ Note: `codeframe serve` exists but Golden Path does not depend on it.
   enforced with `engine-strict`, because that validates every dependency's
   engines and `@testing-library/jest-dom` requires node >=22 while CI and the
   image run Node 20.
+  **Regenerate the lock with npm >= 11.19** (#1223): that is what generated it,
+  and it is a fixed point only there. Every other supported npm — CI's 10.8.2
+  included — rewrites 108 lines on any install: the 36 `libc` fields
+  (`["glibc"]`/`["musl"]`) that 11.19 records on platform-specific optional
+  packages such as `@img/sharp-libvips-*`. Nothing is added, removed or
+  re-versioned and `npm ci` passes either way, so if you see exactly that diff
+  after touching nothing, it is your npm, not the lock; do not commit it.
   `web-ui/Dockerfile` runs `npm audit --audit-level=high` during the image build,
   which means an advisory published upstream — no commit of ours — fails
   `Build images (staging)` and takes staging *and* production down together

--- a/tests/ci/test_web_ui_lockfile_guard_1194.py
+++ b/tests/ci/test_web_ui_lockfile_guard_1194.py
@@ -151,3 +151,23 @@ def test_the_docs_name_the_npm_version_not_the_lockfile(doc: Path):
         f"{doc.name} does not name npm {KNOWN_BAD_NPM_LINE}.x as the actual cause, so "
         "it still reads as though the committed lockfile were the problem"
     )
+
+
+# #1223 — the lock is a fixed point only under the npm that generated it.
+# Measured: npm 11.19.0 rewrites 0 lines; 10.8.2 and every 11.x below it
+# rewrite 108 — the 36 `libc` fields 11.19 records on platform-specific
+# optional packages. Benign, but shaped exactly like the #1194 bug, so the
+# generating npm has to be written down where a contributor will look.
+LOCK_NPM_LINE = "11.19"
+
+
+def test_the_lock_generation_npm_is_stated_beside_engines():
+    pkg = json.loads(PACKAGE_JSON.read_text())
+    note = pkg.get("//", "")
+    assert LOCK_NPM_LINE in note and "libc" in note, note
+
+
+def test_the_lock_generation_npm_is_stated_in_claude_md():
+    text = (REPO / "CLAUDE.md").read_text()
+    assert f"npm >= {LOCK_NPM_LINE}" in text and "#1223" in text
+    assert "libc" in text, "the churn must be characterised, not just named"

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -6,6 +6,7 @@
     "node": ">=20",
     "npm": ">=10.8.2 <11.6.0 || >=11.7.0"
   },
+  "//": "package-lock.json was generated with npm >= 11.19 and is a fixed point only there (#1223). Older npm, including CI's 10.8.2, rewrites 108 lines on any install: the 36 `libc` fields on platform-specific optional packages. Benign — nothing added, removed or re-versioned, and `npm ci` passes — but regenerate with npm >= 11.19 or that churn lands in your diff.",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Closes #1223

## Summary

The committed `web-ui/package-lock.json` is a fixed point only under npm ≥ 11.19, which generated it. **Option 1** from the issue: the generating npm is now stated where a contributor will look, and what older npm rewrites is characterised, so the choice rests on evidence.

## What the 108 lines are (acceptance criterion 4)

Regenerated the lock on scratch copies with `npm install --package-lock-only`:

| npm | lock rewrite | what changed |
|---|---|---|
| 10.8.2 (CI + `web-ui/Dockerfile`) | 108 lines | **36 entries, all one field: `libc`** (`["glibc"]` / `["musl"]`) dropped from platform-specific optional packages such as `@img/sharp-libvips-linux-x64` |
| 11.19.0 | 0 lines | — |

Top-level keys changed: `packages` only. Packages added: none. Removed: none. Versions changed: none. npm 11.19 records the `libc` field that older npm does not know; that is the whole diff. Benign — but shaped exactly like the #1194 bug, hence the note.

## Where it is stated (criterion 1)

- `web-ui/package.json`: a `"//"` key beside `engines` (JSON has no comments; npm ignores the field).
- `CLAUDE.md`: next to the #1194 note, with the characterisation and "if you see exactly that diff after touching nothing, it is your npm, not the lock; do not commit it".
- `tests/ci/test_web_ui_lockfile_guard_1194.py`: two tests pin both statements name the 11.19 line and the `libc` characterisation (mutation-checked: removing the note fails them).

## `npm ci` on Node 20 / npm 10.8.2 (criterion 2)

Unchanged lock, so unchanged result; CI's **Frontend Unit Tests** job is exactly that environment and runs `npm ci` on this PR. Criterion 3 does not apply: the lock is not regenerated.

https://claude.ai/code/session_01JqsQLLMDS27xuSVGTjZRyu
